### PR TITLE
#103 fix production selection

### DIFF
--- a/source/game.screen.supermarket.production.bmx
+++ b/source/game.screen.supermarket.production.bmx
@@ -253,7 +253,8 @@ Type TScreenHandler_SupermarketProduction Extends TScreenHandler
 
 
 		ResetProductionConceptGUI()
-		ReloadProductionConceptContent()
+		'Reloading not necessary - it destoys selection and scroll position
+		'ReloadProductionConceptContent()
 
 		'=== TAKE OVER OLD CONCEPT VALUES ===
 		If currentProductionConcept


### PR DESCRIPTION
Wie im Ticket bemerkt, tritt das Problem nicht nur beim Abschließen einer Produktion auf, sondern schon beim Selektieren. Der aktuell gewählte Ansatz ist, die Liste nicht so oft neu aufzubauen. Warum das gemacht wurde, konnte ich nicht nachvollziehen.

Ich habe auch versucht, die Selektion und den Scroll-Zustand nach dem Neuaufbauen der Liste wiederherzustellen. Das war aber vergleichsweise viel Code und der Scroll-Balken war an der falchen Stelle. Eine API-Funktion "selectAndRevealItem" für Gui-Listen wäre hier hilfreich.