### PR TITLE
#141 show correct achievement sprite

### DIFF
--- a/source/game.screen.achievements.bmx
+++ b/source/game.screen.achievements.bmx
@@ -463,7 +463,11 @@ Type TGUIAchievementListItem Extends TGUISelectListItem
 		local sprite:TSprite = GetSpriteFromRegistry("gfx_datasheet_achievement_bg")
 		sprite.DrawArea(x,y,w,h)
 		local achievementSprite:TSprite
-		if 1=1 or achievement.IsCompleted( GetPlayerBaseCollection().playerID )
+
+		textLeft = GetAchievementText()
+		textRight = GetAchievementRewardText()
+
+		if achievement.IsCompleted( GetPlayerBaseCollection().playerID )
 			if achievement.spriteFinished
 				achievementSprite = GetSpriteFromRegistry( achievement.spriteFinished )
 			endif
@@ -471,18 +475,10 @@ Type TGUIAchievementListItem Extends TGUISelectListItem
 			if not achievementSprite
 				achievementSprite = GetSpriteFromRegistry( "gfx_datasheet_achievement_img_ok" )
 			endif
-
-			textLeft = GetAchievementText()
-			textRight = GetAchievementRewardText()
 		else
 			if achievement.spriteUnfinished
 				achievementSprite = GetSpriteFromRegistry( achievement.spriteUnfinished )
 			endif
-
-			'reset title / text
-			title = "? ? ? ? ? ?"
-			textLeft = ""
-			textRight = ""
 		endif
 
 		'draw background-icon (question mark)


### PR DESCRIPTION
Ich denke, die Logik für das Ermitteln der zu verwendenden Erfolgs-Sprites war falsch. "1=1 or" führte dazu, dass immer die Erfolgs-Sprites angezeigt wurden (und damit faktisch nicht erkennbar war, welche Aufgaben erledigt waren).

Ich konnte den Fix aber nur halb testen, da es auch einen Fehler in der Ermittlung der Erfüllung zu geben scheint. Obwohl ich 3 Wetterberichte und 3 Show-Business-Meldungen gesendet habe, wurde der Erfolg nicht anerkannt (keine Nachricht und das isComplete-Flag ist weiterhin false).

Ich bin aber noch nicht so tief eingestiegen, dass ich erkennen kann wo und wann die Prüfung stattfindet...