### PR TITLE
#134, #147 add API enable/disable hotkeys

### DIFF
--- a/source/game.player.base.bmx
+++ b/source/game.player.base.bmx
@@ -107,6 +107,9 @@ End Function
 Function GetObservedPlayerID:int()
 	Return TPlayerBaseCollection.GetInstance().GetObservedPlayerID()
 End Function
+Function GetCurrentPlayer:TPlayerBase()
+	Return GetPlayerBase(GetPlayerBaseCollection().playerID)
+End Function
 
 
 
@@ -155,6 +158,8 @@ Type TPlayerBase {_exposeToLua="selected"}
 	Field newsabonnementsDayMax:Int[] = [-1,-1,-1,-1,-1,-1]
 	'when was the level set
 	Field newsabonnementsSetTime:Double[6]
+
+	Field hotKeysEnabled:Int = True
 
 	'distinguishing between LOCAL and REMOTE ai allows multiple players
 	'to control multiple AI without needing to share "THEIR" AI files
@@ -570,6 +575,13 @@ endrem
 		'implement in real class
 	End Method
 
+	Method IsHotKeysEnabled:Int()
+		return hotKeysEnabled
+	End Method
+
+	Method setHotKeysEnabled:Int(enabled:int)
+		hotKeysEnabled=enabled
+	End Method
 
 	'override
 	Method RemoveFromCollection:Int(collection:object = null)

--- a/source/game.screen.stationmap.bmx
+++ b/source/game.screen.stationmap.bmx
@@ -2703,6 +2703,14 @@ Type TScreenHandler_StationMap
 		endif
 	End Function
 
+	Function Navigate:Int(key:Int, xDelta:Int, yDelta:Int)
+		If KEYMANAGER.IsDown(key)
+			MoveMouse(MouseManager.evMousePosX+xDelta, MouseManager.evMousePosY+yDelta)
+			KEYMANAGER.blockKey(key, 100)
+			Return True
+		EndIf
+		Return False
+	End Function
 
 	Function onUpdateStationMap:Int( triggerEvent:TEventBase )
 		'local screen:TScreen	= TScreen(triggerEvent._sender)
@@ -2778,7 +2786,14 @@ endrem
 
 		'buying stations using the mouse
 		'1. searching
+		GetCurrentPlayer().setHotKeysEnabled(True)
 		If actionMode = MODE_BUY_ANTENNA
+			GetCurrentPlayer().setHotKeysEnabled(False)
+			Navigate(KEY_UP, 0, -1)
+			Navigate(KEY_DOWN, 0, 1) 
+			Navigate(KEY_LEFT, -1, 0)
+			Navigate(KEY_RIGHT, 1, 0)
+
 			'create a temporary station if not done yet
 			If Not mouseoverStation Then mouseoverStation = GetStationMap(room.owner).GetTemporaryAntennaStation( MouseManager.GetPosition().GetIntX(), MouseManager.GetPosition().GetIntY() )
 			Local mousePos:TVec2D = New TVec2D.Init( MouseManager.x, MouseManager.y)

--- a/source/game.screen.supermarket.production.bmx
+++ b/source/game.screen.supermarket.production.bmx
@@ -323,6 +323,7 @@ Type TScreenHandler_SupermarketProduction Extends TScreenHandler
 	Method OpenEditTextsWindow()
 		If editTextsWindow Then editTextsWindow.Remove()
 
+		GetCurrentPlayer().setHotKeysEnabled(False)
 		editTextsWindow = New TGUIProductionEditTextsModalWindow.Create(New TVec2D.Init(250,60), New TVec2D.Init(300,220), "supermarket_customproduction_productionbox_modal")
 		editTextsWindow.SetZIndex(100000)
 		editTextsWindow.SetConcept(GetInstance().currentProductionConcept)
@@ -354,6 +355,7 @@ Type TScreenHandler_SupermarketProduction Extends TScreenHandler
 
 
 	Function onCloseEditTextsWindow:Int( triggerEvent:TEventBase )
+		GetCurrentPlayer().setHotKeysEnabled(True)
 		Local closeButton:Int = triggerEvent.GetData().GetInt("closeButton", -1)
 		If closeButton <> 1 Then Return False
 

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -670,8 +670,9 @@ Type TApp
 		'ignore shortcuts if a gui object listens to keystrokes
 		'eg. the active chat input field
 		'also ignore if there is a modal window opened
-		If Not GUIManager.GetKeystrokeReceiver() And ..
-		   Not (App.ExitAppDialogue Or App.EscapeMenuWindow)
+		If GetCurrentPlayer() AND GetCurrentPlayer().isHotKeysEnabled() AND ..
+			Not GUIManager.GetKeystrokeReceiver() And ..
+			Not (App.ExitAppDialogue Or App.EscapeMenuWindow)
 
 			If GameRules.devConfig.GetBool(keyLS_DevKeys, False)
 				If KEYMANAGER.IsHit(KEY_MINUS) And KEYMANAGER.IsDown(KEY_RCONTROL)


### PR DESCRIPTION
Ich glaube, es wäre sinnvoll, die Sondertasten explizit aktivieren/deaktivieren zu können, damit eine abweichende Tastatur-Steuerung je nach Situation einfach und robust umgesetzt werden kann. Ich habe dafür hier die Player-API erweitert (und an zwei Stellen verwendet - entsprechend der verlinkten Tickets).

Für den Sendemastkauf ist es mir nicht gelungen, die Mausposition explizit zu setzen. Setzen der Variablen im Mousemanager führt nur zu einem kurzzeitigen Positionswackler; dann gewinnt aber sofort wieder die Position der "Virtuellen Maus".