### PR TITLE
Station map

### DIFF
--- a/source/game.screen.stationmap.bmx
+++ b/source/game.screen.stationmap.bmx
@@ -2977,6 +2977,7 @@ endrem
 					antennaPanel.UpdateLayout()
 
 					antennaPanel.SetSelectedStation(station)
+					selectAndReveal(station)
 
 					MouseManager.SetClickHandled(1)
 				endif
@@ -3018,6 +3019,15 @@ endrem
 		GUIManager.Update( LS_stationmap )
 	End Function
 
+	Function selectAndReveal:Int(station:TStationBase)
+		For Local listItem:TGUISelectListItem = EachIn antennaPanel.list.entries
+			If listItem.data.get("station") = station
+				antennaPanel.list.ScrollAndSelectItem(listItem)
+				Return True
+			EndIf
+		Next
+		Return False
+	End Function
 
 	Function OnOpenOrCloseAccordeonPanel:Int( triggerEvent:TEventBase )
 		Local accordeon:TGameGUIAccordeon = TGameGUIAccordeon(triggerEvent.GetSender())


### PR DESCRIPTION
Dieser PR beinhaltet 2 Commits zum Schließen der Tickets #134 (Fixieren der gewählten Sendemastposition mit Leertaste möglich) und #129 (Markieren des über die Karte gewählten Sendemasts in der Liste).
Ich denke, dass das Markieren und Anzeigen API-Funktionalität der GUI-Liste sein könnte. Es gibt schon den Aufruf für das Setzen der Auswahl, aber wenn man dann von Hand dafür sorgen muss, dass dieser Eintrag auch in der GUI sichtbar ist, ist das nicht komfortabel. Ich könnte mit eine GUI.Option an der Liste vorstellen (REVEAL_ON_SELECTION/PRESERVE_VISIBLE_SELECTION_ON_RESIZE), die dann automatisch dafür sorgen, dass beim Selektieren eines Eintrags an die richtige Stelle gescrollt wird oder dass beim Ändern der größe ein bereits selektierter Eintrag sichtbar bleibt.