### PR TITLE
fix experience percentage for amateurs

### DIFF
--- a/source/game.production.productioncompany.base.bmx
+++ b/source/game.production.productioncompany.base.bmx
@@ -163,7 +163,7 @@ Type TProductionCompanyBase Extends TGameObject
 
 
 	Method GetExperiencePercentage:Float()
-		If GetMaxXP() = 0 Then Return 1.0
+		If GetMaxXP() = 0 Then Return 0.0
 
 		Return GetExperience() / Float(GetMaxXP())
 	End Method


### PR DESCRIPTION
As noted in #153, the amateur production company was the most expensive.
This was caused by always returning 100% if max experience is 0.