### PR TITLE
fix setting production speed has no effect

### DIFF
--- a/source/game.production.productionconcept.bmx
+++ b/source/game.production.productionconcept.bmx
@@ -890,7 +890,7 @@ Type TProductionConcept Extends TOwnedGameObject
 			' 1 point = 93%
 			' 2 points = 87% ...
 			'10 points = 50%
-			local speedPointTimeMod:Float = 0.933 ^ speedPoints
+			speedPointTimeMod = 0.933 ^ speedPoints
 
 
 			'TEAM (good teams work a bit more efficient)
@@ -899,7 +899,7 @@ Type TProductionConcept Extends TOwnedGameObject
 			' 1 point = 97%
 			' 2 points = 94% ...
 			'10 points = 75%
-			local teamPointTimeMod:Float = 0.5 + 0.5 * 0.933 ^ teamPoints
+			teamPointTimeMod = 0.5 + 0.5 * 0.933 ^ teamPoints
 
 
 			'with a good team, you can record multiple scenes simultaneously


### PR DESCRIPTION
Beim Versuch eine Produktion zu beschleunigen war mir aufgefallen, dass sich bei der Vergabe von Tempo-Punkten nichts an der Zeit ändert. Tatsächlich wurden die Faktoren gar nicht geändert, sondern unter dem selben Namen nochmal deklariert.

Langfristig könnte man darüber nachdenken, ob nicht auch die Studiogröße über die Dauer entscheiden sollte (aufwändige Kulissen = häufigere Kulissenwechsel in kleinem Studio aber paralleles Kulissenaufbauen in größeren Studios möglich).
Als Konsequenz wäre die Produktionszeit zum Zeitpunkt der Konzeption nicht festgelegt. Das finde ich aber auch realistisch. Z.B. müsste die Produkionszeit auch steigen, wenn die selben Personen gleichzeitig in mehreren Studios arbeiten.