### PR TITLE
#171 no selling of used scripts

### DIFF
--- a/source/game.roomhandler.scriptagency.bmx
+++ b/source/game.roomhandler.scriptagency.bmx
@@ -376,6 +376,8 @@ Type RoomHandler_ScriptAgency extends TRoomHandler
 	Method BuyScriptFromPlayer:int(script:TScript)
 		'remove from player (lists and suitcase) - and give him money
 		if GetPlayerBaseCollection().IsPlayer(script.owner)
+			'TODO remove when implementing Dialogue for scripts
+			If script.getProductionsCount() > 0 Then Return False
 			local pc:TPlayerProgrammeCollection = GetPlayerProgrammeCollection(script.owner)
 			'try to remove it from the suitcase
 			if pc.RemoveScriptFromSuitcase(script)
@@ -829,6 +831,7 @@ endrem
 		'and try to add it back to the shelf
 		if senderList = GuiListSuitcase
 			if not GetInstance().BuyScriptFromPlayer(guiBlock.script)
+				'TODO hint that selling is not possible
 				triggerEvent.setVeto()
 				return FALSE
 			endif
@@ -925,7 +928,8 @@ endrem
 			'if not GetPlayerProgrammeCollection(GetPlayerCollection().playerID).HasScriptInSuitcase(draggedGuiScript.script)
 			if draggedGuiScript.script.owner <= 0
 				highlightSuitcase = True
-			else
+			'TODO remove condition when sell-rewrite-dialogue gets implemented
+			else if draggedGuiScript.script.getProductionsCount() = 0
 				highlightVendor = True
 			endif
 		endif

--- a/source/game.roomhandler.studio.bmx
+++ b/source/game.roomhandler.studio.bmx
@@ -1142,9 +1142,9 @@ Type RoomHandler_Studio Extends TRoomHandler
 		If draggedGuiScript And draggedGuiScript.isDragged()
 			If draggedGuiScript.script = GetCurrentStudioScript(roomGUID)
 				highlightSuitcase = True
-			Else
-				highlightStudioManager = True
 			EndIf
+			highlightStudioManager = True
+			highlightTrashBin = True
 		EndIf
 		
 		If draggedGuiProductionConcept and draggedGuiProductionConcept.isDragged()
@@ -1246,6 +1246,9 @@ Type RoomHandler_Studio Extends TRoomHandler
 					draggedGuiProductionConcept = null
 			
 					'handled left click
+					MouseManager.SetClickHandled(1)
+				ElseIf draggedGuiScript and programmeCollection.RemoveScript(draggedGuiScript.script, FALSE)
+					draggedGuiScript = null
 					MouseManager.SetClickHandled(1)
 				EndIf
 			EndIf


### PR DESCRIPTION
Verhindern des Verkaufs gebrauchter Drehbücher implementiert. Es ist mir aber nicht gelungen, in der Drehbuchagentur einen Dialog anzuzeigen, warum der Drop des Drehbuchs nicht klappt. Sollte der Drehbuchautor in dem Fall ggf. gar nich mehr hervorgehoben werden?
Wegwerfen im Studio geht.