### PR TITLE
#140 reach level alert

### DIFF
--- a/res/lang/lang_de.txt
+++ b/res/lang/lang_de.txt
@@ -1212,6 +1212,7 @@ NEWGAMESETTINGS_GAME_SEED = Spielnummer
 NEWGAMESETTINGS_GAME_SEED_DETAIL = Gleiche Spielnummern bewirken gleiche Spielstartbedingungen (Programmauswahl).
 
 
+AUDIENCE_REACH_LEVEL_WILL_INCREASE = Reichweitenlevel wird erhöht!
 AUDIENCE_REACH_LEVEL_INCREASED = Reichweitenlevel erhöht
 LEVEL_INCREASED_FROM_X_TO_Y = Level erhöht sich von %X% auf %Y%.
 PRICES_WILL_RISE = Die Preise für Programme und Nachrichten steigen an.

--- a/res/lang/lang_en.txt
+++ b/res/lang/lang_en.txt
@@ -1184,6 +1184,7 @@ NEWGAMESETTINGS_GAME_SEED = Game number / seed
 NEWGAMESETTINGS_GAME_SEED_DETAIL = Same game numbers lead to similar starting conditions (offers at vendors).
 
 
+AUDIENCE_REACH_LEVEL_WILL_INCREASE =  Audience Reach Level will increase!
 AUDIENCE_REACH_LEVEL_INCREASED = Audience Reach Level increased
 LEVEL_INCREASED_FROM_X_TO_Y = Level increases from %X% to %Y%.
 PRICES_WILL_RISE = Prices for programmes and news will rise.


### PR DESCRIPTION
Der englische Text könnte etwas zu breit sein. Für Satellitenanbindung habe ich die Warnung nicht implementiert; da sollte man es sich eher denken können.

Tatsächlich habe ich nicht geprüft, was passiert, wenn man schon einen Satelliten hat und in ein neues Bundesland vorstößt. In diesem Fall könnten ja neben dem Zuwachs des Senders noch weitere Satellitenzuschauer dazukommen!?