### PR TITLE
Job-Info anzeigen, wenn die Person im Supermarkt wegbewegt wird

### DIFF
--- a/source/game.screen.supermarket.production.bmx
+++ b/source/game.screen.supermarket.production.bmx
@@ -2346,6 +2346,11 @@ Type TGUICastListItem Extends TGUISelectListItem
 			displayName = name
 		EndIf
 
+		'remove item from list so job info becomes visible
+		If isDragged()
+			TGUIListBase.FindGUIListBaseParent(self).removeItem(self)
+		EndIF
+
 		Local face:TImage = TImage(person.GetPersonalityData().GetFigureImage())
 		DrawCast(GetScreenRect().GetX(), GetScreenRect().GetY(), GetScreenRect().GetW(), name, "", face, xpPercentage, sympathyPercentage, 1)
 


### PR DESCRIPTION
Die Person schon beim Drag aus der Liste zu entfernen ist zwar krude, hat aber das gewünschte Ergebnis. Die Job-Beschreibung erscheint wieder in der Liste.

Closes #146