### PR TITLE
Fix: [CustomProduction] resize concept list size

### DIFF
--- a/source/game.screen.supermarket.production.bmx
+++ b/source/game.screen.supermarket.production.bmx
@@ -1018,7 +1018,7 @@ Type TScreenHandler_SupermarketProduction Extends TScreenHandler
 			Local scrollPosition:Float = productionConceptList.GetScrollPercentageY()
 			productionConceptList.SetPosition(contentX + 5, contentY + 3)
 			productionConceptList.SetSize(contentW - 10, listH - 6)
-			If Not currentProductionConcept Then productionConceptList.SetScrollPercentageY(scrollPosition)
+			If productionConceptList.guiScrollerV.isVisible() And Not currentProductionConcept Then productionConceptList.SetScrollPercentageY(scrollPosition)
 		EndIf
 		contentY :+ listH
 


### PR DESCRIPTION
Beim Vergrößern der Liste und Setzen der Scroll-Position gibt es ein subtiles Problem. Wenn 4 oder 5 Einträge vorhanden sind, d.h. die größere Liste verwendet aber kein Scrollbalken benötigt wird, führt das Setzen der Scroll-Position dazu, dass Einträge nach oben aus der Liste verschwinden.
Das Setzen der Scroll-Position sollte nur erfolgen, wenn der Scrollbalken sichtbar ist