### PR TITLE
Vorbereitung Spielanleitung in mehreren Sprachen

### DIFF
--- a/source/game.misc.ingamehelp.bmx
+++ b/source/game.misc.ingamehelp.bmx
@@ -149,8 +149,8 @@ Type TIngameHelpWindow
 	Field _eventListeners:TEventListenerBase[]
 	Field active:Int = False
 	Field helpGUID:String = "" 'id of the ingame help
-	Field title:String
-	Field content:String
+	Field titleKey:String
+	Field contentKey:String
 	Field hideFlag:Int = 0 '1 = hide this, 2 = hide all
 
 	Field showHideOption:Int = True
@@ -160,13 +160,13 @@ Type TIngameHelpWindow
 	Field state:TLowerString
 
 
-	Method Init:TIngameHelpWindow(title:String, content:String, helpGUID:String)
+	Method Init:TIngameHelpWindow(titleKey:String, contentKey:String, helpGUID:String)
 
 		area = New TRectangle.Init(100, 20, 600, 350)
 
 		Self.helpGUID = helpGUID.toLower()
-		Self.content = content
-		Self.title = title
+		Self.contentKey = contentKey
+		Self.titleKey = titleKey
 		state = TLowerString.Create("INGAMEHELP_"+helpGUID)
 
 		Return Self
@@ -217,7 +217,7 @@ Type TIngameHelpWindow
 
 '		modalDialogue.SetOption(GUI_OBJECT_CLICKABLE, FALSE)
 
-		modalDialogue.SetCaptionAndValue(title, "")
+		modalDialogue.SetCaptionAndValue(GetLocale(titleKey), "")
 	'	If modalDialogue.guiCaptionTextBox Then modalDialogue.guiCaptionTextBox.SetFont(.headerFont)
 
 
@@ -228,7 +228,7 @@ Type TIngameHelpWindow
 		guiTextArea.SetFont( GetBitmapFont("default", 14) )
 		guiTextArea.textColor = SColor8.Black
 		guiTextArea.SetWordWrap(True)
-		guiTextArea.SetValue( content )
+		guiTextArea.SetValue( GetLocale(contentKey) )
 		
 		guiTextArea.SetManaged(False)
 


### PR DESCRIPTION
Mit dieser Änderung soll die Unterstützung mehrerer Sprachen für die Spielanleitung vorbereitet werden.

Anstatt den IngameHelp-Fenstern den fertigen Text zu geben, lösen diese die Schlüssel selbst auf. Das ist in jedem Fall besser, da sonst Änderungen in der Spracheinstellung erst nach dem nächsten Spielneustart aktiv werden.

Die aus der Textdatei eingelesene Spielanleitung wird der Sprache als neuer Schlüssel hinzugefügt. Der Code für das Einlesen der Spielanleitungen ist vorbereitet aber noch auskommentiert. Hier muss zunächst noch die Position und das Format für die Anleitungen festgelegt werden.

Für die Screen-spezifische Hilfe habe ich die Hide-Optionen deaktiviert, da sie hier wie bei der Spielanleitung nicht sinnvoll sind.