### PR TITLE
Tooltip für "halbe" Türen

### DIFF
--- a/source/game.room.roomdoor.bmx
+++ b/source/game.room.roomdoor.bmx
@@ -201,8 +201,14 @@ Type TRoomDoor extends TRoomDoorBase  {_exposeToLua="selected"}
 
 		If tooltip AND tooltip.enabled
 			if tooltip.Update()
-				tooltip.area.position.SetY(GetScreenRect().GetY() - area.GetH() - tooltip.GetHeight())
-				tooltip.area.position.SetX(GetScreenRect().GetX() + area.GetW()/2 - tooltip.GetWidth()/2)
+				'not enough space for the tooltip above the door
+				If tooltip.GetHeight()-10 > GetScreenRect().GetY() - area.GetH()
+					tooltip.area.position.SetY(GetScreenRect().GetY())
+					tooltip.area.position.SetX(GetScreenRect().GetX() - tooltip.GetWidth())
+				Else
+					tooltip.area.position.SetY(GetScreenRect().GetY() - area.GetH() - tooltip.GetHeight())
+					tooltip.area.position.SetX(GetScreenRect().GetX() + area.GetW()/2 - tooltip.GetWidth()/2)
+				EndIf
 			else
 				'delete old tooltips
 				tooltip = null


### PR DESCRIPTION
Mit dieser Änderung werden die Tooltips für Türen, die nicht ganz zu sehen sind unten links an der Tür angezeigt.

Es hat mich schon in MadTV geärgert, dass ich eine halb sichtbare Tür oben anklicken kann, aber nicht den Tooltip sehen kann. Besonders ärgerlich ist das, wenn man ein Studio hat, das man nur halb sieht. Um zu prüfen, ob es blockiert ist, muss man hinfahren. So könnte man einfach den Tooltip prüfen.