### PR TITLE
Tooltips/Lokalisierung Senderkarte

### DIFF
--- a/res/lang/stations/stations_en.txt
+++ b/res/lang/stations/stations_en.txt
@@ -122,8 +122,8 @@ UNSELLABLE       = unsellable
 
 CONSTRUCTION_TIME                   = Construction Time
 UNDER_CONSTRUCTION                  = Under Construction
-READY_AT_TIME_X                     = Ready at %ACTIVATIONTIME%
-READY_AT_DAY_X                      = Ready at %ACTIVATIONTIME%
+READY_AT_TIME_X                     = Ready at %TIME%
+READY_AT_DAY_X                      = Ready at %TIME%
 X_UNDER_CONSTRUCTION                = %X% under construction
 NEW_STATION_WILL_BE_READY_AT_TIME_X = New station will be ready at %TIME%.
 NEW_STATION_WILL_BE_READY_AT_DAY_X  = New station will be ready at %TIME%.

--- a/res/lang/stations/stations_fr.txt
+++ b/res/lang/stations/stations_fr.txt
@@ -122,8 +122,8 @@ UNSELLABLE       = invendable
 
 CONSTRUCTION_TIME                   = Construction Time
 UNDER_CONSTRUCTION                  = en Construction
-READY_AT_TIME_X                     = Pret à %ACTIVATIONTIME%
-READY_AT_DAY_X                      = Ready at %ACTIVATIONTIME%
+READY_AT_TIME_X                     = Pret à %TIME%
+#READY_AT_DAY_X                      = Ready at %TIME% 
 #X_UNDER_CONSTRUCTION                = 
-NEW_STATION_WILL_BE_READY_AT_TIME_X = New station will be ready at %TIME%
-NEW_STATION_WILL_BE_READY_AT_DAY_X  = New station will be ready at %TIME%
+#NEW_STATION_WILL_BE_READY_AT_TIME_X = New station will be ready at %TIME%
+#NEW_STATION_WILL_BE_READY_AT_DAY_X  = New station will be ready at %TIME%

--- a/res/lang/stations/stations_pt-br.txt
+++ b/res/lang/stations/stations_pt-br.txt
@@ -122,8 +122,8 @@ UNSELLABLE       = Impossível vender
 
 CONSTRUCTION_TIME                   = Tempo de construção
 UNDER_CONSTRUCTION                  = Em Construção
-READY_AT_TIME_X                     = Pronto às %ACTIVATIONTIME%
-READY_AT_DAY_X                      = Pronto em %ACTIVATIONTIME%
+READY_AT_TIME_X                     = Pronto às %TIME%
+READY_AT_DAY_X                      = Pronto em %TIME%
 #X_UNDER_CONSTRUCTION                = 
 NEW_STATION_WILL_BE_READY_AT_TIME_X = A nova estação ficará pronta às %TIME%.
 NEW_STATION_WILL_BE_READY_AT_DAY_X  = A nova estação ficará pronta em %TIME%.

--- a/source/game.screen.stationmap.bmx
+++ b/source/game.screen.stationmap.bmx
@@ -2361,7 +2361,7 @@ Type TScreenHandler_StationMap
 			guiInfoButton.SetTooltip( New TGUITooltipBase.Initialize(GetLocale("SHOW_MAP_DETAILS"), GetLocale("CLICK_TO_SHOW_ADVANCED_MAP_INFORMATION"), New TRectangle.Init(0,0,-1,-1)) )
 			guiInfoButton.GetTooltip()._minContentDim = New TVec2D.Init(120,-1)
 			guiInfoButton.GetTooltip()._maxContentDim = New TVec2D.Init(150,-1)
-			guiInfoButton.GetTooltip().SetOrientationPreset("BOTTOM", 10)
+			guiInfoButton.GetTooltip().SetOrientationPreset("LEFT", 10)
 
 			For Local i:Int = 0 Until guiFilterButtons.length
 				guiFilterButtons[i] = New TGUICheckBox.Create(New TVec2D.Init(695 + i*23, 30 ), New TVec2D.Init(20, 20), String(i + 1), "STATIONMAP")
@@ -2377,7 +2377,7 @@ Type TScreenHandler_StationMap
 				guiFilterbuttons[i].SetTooltip( New TGUITooltipBase.Initialize("", GetLocale("TOGGLE_DISPLAY_OF_STATIONTYPE").Replace("%STATIONTYPE%", GetLocale(TVTStationType.GetAsString(i+1)+"S")), New TRectangle.Init(0,60,-1,-1)) )
 				guiFilterbuttons[i].GetTooltip()._minContentDim = New TVec2D.Init(80,-1)
 				guiFilterbuttons[i].GetTooltip()._maxContentDim = New TVec2D.Init(150,-1)
-				guiFilterbuttons[i].GetTooltip().SetOrientationPreset("BOTTOM", 5)
+				guiFilterbuttons[i].GetTooltip().SetOrientationPreset("LEFT", 5)
 			Next
 
 
@@ -2389,7 +2389,7 @@ Type TScreenHandler_StationMap
 				guiShowStations[i].SetTooltip( New TGUITooltipBase.Initialize("", GetLocale("TOGGLE_DISPLAY_OF_PLAYER_X").Replace("%X%", i+1), New TRectangle.Init(0,60,-1,-1)) )
 				guiShowStations[i].GetTooltip()._minContentDim = New TVec2D.Init(80,-1)
 				guiShowStations[i].GetTooltip()._maxContentDim = New TVec2D.Init(120,-1)
-				guiShowStations[i].GetTooltip().SetOrientationPreset("BOTTOM", 5)
+				guiShowStations[i].GetTooltip().SetOrientationPreset("LEFT", 5)
 			Next
 
 			satelliteSelectionFrame = New TSatelliteSelectionFrame


### PR DESCRIPTION
Für die Auswahlknöpfe war der Tooltip unter dem nun größeren Mauszeiger. Verschiebung nach Links wie im Programmplaner.
Die ACTIVATIONTIME-Variable für die Fertigstellungs-Anzeige in der Karte konnte nicht aufgelöst werden. TIME wie in der deutschen Variante.