### PR TITLE
Hide-Option für Kontext-Hilfe

### DIFF
--- a/source/game.misc.ingamehelp.bmx
+++ b/source/game.misc.ingamehelp.bmx
@@ -179,7 +179,7 @@ Type TIngameHelpWindow
 			If IngameHelpWindowCollection.IsDisabledHelpGUID(helpGUID) Then Return False
 
 			'reached display limit?
-			If showLimit > 0 And showLimit < shownTimes Then Return False
+			If showLimit > 0 And showLimit <= shownTimes Then Return False
 		EndIf
 		shownTimes :+ 1
 
@@ -242,6 +242,10 @@ Type TIngameHelpWindow
 	'		checkboxHideThis.textColor = TColor.clBlack.Copy()
 			checkboxHideThis.SetValue( GetLocale("DO_NOT_SHOW_AGAIN") )
 			checkboxHideThis.SetManaged(False)
+			If showHideOption And hideFlag < 1
+				checkboxHideThis.setChecked(True)
+				hideFlag=1
+			EndIf
 			canvas.AddChild(checkboxHideThis)
 
 			checkboxWidth = checkboxHideThis.GetScreenRect().GetW() + 20


### PR DESCRIPTION
Ich war noch nicht zufrieden mit dem Stand der Online-Hilfe. Das Anzeigen der Hide-Option ist zwingend nötig

* sonst erscheint die Hilfe immer wieder
* sonst kann man die automatische Hilfe gar nicht abschalten

Der Spieler muss aber bei jedem Bildschirm wieder den Nicht-Nochmal-Haken setzen. Es ist aber unwahrscheinlich, dass er dieselbe Hilfe immer wieder automatisch sehen will. Daher sollte das Flag beim ersten Anzeigen standardmäßig gesetzt werden.

Beim Rumprobieren (mit Limit) ist mir zudem ein one-off-Fehler aufgefallen. Wenn das Limit auf 1 gesetzt wird, wird die Nachricht dennoch 2x angezeigt (für Anzahl 0 und Anzahl 1).