### PR TITLE
Studiodialog "Starte alle" für Liveproduktionen

### DIFF
--- a/source/game.roomhandler.studio.bmx
+++ b/source/game.roomhandler.studio.bmx
@@ -849,7 +849,7 @@ Type RoomHandler_Studio Extends TRoomHandler
 				conceptCountMax = script.GetSubScriptCount() - producedConceptCount
 			Else
 				conceptCountMax = script.CanGetProducedCount()
-				print "conceptCountMax = " + conceptCountMax  +"  productionLimit=" + script.productionLimit + "  usedInProductionsCount="+script.usedInProductionsCount
+				'print "conceptCountMax = " + conceptCountMax  +"  productionLimit=" + script.productionLimit + "  usedInProductionsCount="+script.usedInProductionsCount
 			EndIf
 		EndIf
 
@@ -1021,7 +1021,7 @@ Type RoomHandler_Studio Extends TRoomHandler
 					EndIf
 				Else
 					If script.IsLive()
-						answerText = GetRandomLocale("DIALOGUE_STUDIO_START_ALL_X_POSSIBLE_PREPRODUCTIONS").Replace("%X%", produceableConcepts)
+						answerText = GetRandomLocale("DIALOGUE_STUDIO_START_ALL_X_POSSIBLE_PREPRODUCTIONS").Replace("%X%", produceableConceptCount)
 					Else
 						texts[0].AddAnswer(TDialogueAnswer.Create( GetRandomLocale("DIALOGUE_STUDIO_START_NEXT_EPISODE"), -2, Null, onClickStartProduction, New TData.Add("script", firstProducibleScript)))
 						answerText = GetRandomLocale("DIALOGUE_STUDIO_START_ALL_X_POSSIBLE_PRODUCTIONS").Replace("%X%", produceableConcepts)


### PR DESCRIPTION
Bei mehreren Live-Produktionen (Morning-Show) ist der customProductions-String "-1, -1, -1, -1", da es keine Folgennummern gibt. Daher sollte in diesem Fall einfach die Anzahl der Vorproduktionen angezeigt werden.

Edit: Hinweis - Für Live-Produktionen mit mehreren Folgen ist auch das Editieren des Titels noch etwas verwirrend. Name und Beschreibung werden nur für eine Folge übernommen. Wenn man dann aber bei der zweiten den Editier-Button anklickt, steht schon der geänderte Titel drin. (Beispiel moringshow mit 4 Folgen)