### PR TITLE
Editieren der Titel für Live-Produktionen

### DIFF
--- a/source/game.roomhandler.studio.bmx
+++ b/source/game.roomhandler.studio.bmx
@@ -762,6 +762,7 @@ Type RoomHandler_Studio Extends TRoomHandler
 			If conceptCount > 1
 				'use title of the script to avoid reading in the custom title
 				pc.SetCustomTitle( pc.script.GetTitle() + " - #" + conceptCount)
+				pc.SetCustomDescription (pc.script.GetDescription())
 			EndIf
 		EndIf
 

--- a/source/game.screen.supermarket.production.bmx
+++ b/source/game.screen.supermarket.production.bmx
@@ -1794,8 +1794,8 @@ Type TGUIProductionEditTextsModalWindow Extends TGUIProductionModalWindow
 				inputSubTitle.SetValue(concept.script.GetTitle())
 				inputSubDescription.SetValue(concept.script.GetDescription())
 			Else
-				inputTitle.SetValue(concept.script.GetTitle())
-				inputDescription.SetValue(concept.script.GetDescription())
+				inputTitle.SetValue(concept.GetTitle())
+				inputDescription.SetValue(concept.GetDescription())
 			EndIf
 		EndIf
 	End Method


### PR DESCRIPTION
Beim Erstellen des Konzepts wird nicht nur der Custom-Titel mit hinzugefügter laufender Nummer gesettz, sondern auch die CustomDescription. Beim Öffnen des Fensters für das Editieren werden die Daten nicht aus dem Skript sondern aus dem Konzept direkt verwendet.

Durch den Custom-Titel ist es ohnehin nicht möglich, den Namen für alle Folgen gleichzeitig umzusetzen (wenn man sich schon alle Einkaufslisten geholt hat). Da ist das analoge Setzen der Beschreibung nur konsequent.

Wenn man Titel und Beschreibung für alle Produktionen ändern will, holt man zunächst nur eine Einkaufsliste, ändert dort Titel und Beschreibung und holt anschließend die restlichen Einkaufslisten. In diesem Fall wurden die Custom-Texte nämlich nicht gesetzt und die Daten werden für die Folgelisten aus dem (genänderten) Skript übernommen.

Closes #238