### PR TITLE
Hilfe - nur noch komplettes Deaktivieren

### DIFF
--- a/source/game.ingameinterface.bmx
+++ b/source/game.ingameinterface.bmx
@@ -568,7 +568,7 @@ Type TInGameInterface
 				MenuToolTip.Hover()
 				If MouseManager.IsClicked(1)
 					'force show manual
-					IngameHelpWindowCollection.ShowByHelpGUID("GameManual", True)
+					IngameHelpWindowCollection.openHelpWindow()
 
 					'handled left click
 					MouseManager.SetClickHandled(1)

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -1308,15 +1308,7 @@ endrem
 
 				'show ingame manual
 				If KeyManager.IsHit(KEY_F1) ' and not KeyManager.IsDown(KEY_RSHIFT)
-					Local screen:String = ScreenCollection.GetCurrentScreen().GetName()
-					If IngameHelpWindowCollection.Get(screen)
-						IngameHelpWindowCollection.ShowByHelpGUID(screen , True)
-					Else
-						IngameHelpWindowCollection.ShowByHelpGUID("GameManual", True)
-					EndIf
-					'avoid that this window gets replaced by another one
-					'until it is "closed"
-					IngameHelpWindowCollection.LockCurrent()
+					IngameHelpWindowCollection.openHelpWindow()
 				EndIf
 
 				If KeyManager.Ishit(Key_F6) Then GetSoundManager().PlayMusicPlaylist("default")
@@ -1496,13 +1488,7 @@ endrem
 
 		'Hilfe
 		If KeyManager.IsHit(KEY_F1)
-			Local screen:String = ScreenCollection.GetCurrentScreen().GetName()
-			If IngameHelpWindowCollection.Get(screen)
-				IngameHelpWindowCollection.ShowByHelpGUID(screen , True)
-			Else
-				IngameHelpWindowCollection.ShowByHelpGUID("GameManual", True)
-			EndIf
-			IngameHelpWindowCollection.LockCurrent()
+			IngameHelpWindowCollection.openHelpWindow()
 		EndIf
 	End Function
 
@@ -6581,6 +6567,7 @@ Function InitializeHelp()
 		If HasLocale(helpTextKeyText)
 '			Print "Hilfetext gefunden fuer ~q"+helpTextKeyText+"~q -> "+screen.GetName()
 			Local screenHelpWindow:TIngameHelpWindow=New TIngameHelpWindow.Init(helpTextKeyTitle, helpTextKeyText, screen.GetName())
+			screenHelpWindow.showLimit = 1
 			IngameHelpWindowCollection.Add( screenHelpWindow )
 		EndIf
 	Next


### PR DESCRIPTION
Vereinfachung der automatischen Hilfe. Jede Hilfeseite wird nur noch einmal (pro gestartetem Spiel) angezeigt, außer der Spieler deaktiviert die Hinweise durch einmaliges Setzen des "nicht mehr anzeigen"-Hakens. Falls gesetzt wird diese Option auch persistert, so dass beim Laden eines Spielstands die Hilfetexte nicht wieder angezeigt werden.
Wenn die Option wieder deaktiviert wird, werden Hilfeseiten auch wieder (einmalig) angezeigt.

PR zunächst zum Review, falls die Persistenzproblematik für entfallene Arrays noch behoben wird.

Closes #241 
