### PR TITLE
Archivierte Nachrichten DropDown-Überschrift und Abstand

### DIFF
--- a/res/lang/rooms/rooms_de.txt
+++ b/res/lang/rooms/rooms_de.txt
@@ -106,9 +106,10 @@ MESSAGECATEGORY_MONEY               = Geld / Finanzen
 MESSAGECATEGORY_ACHIEVEMENTS        = Erfolge
 MESSAGECATEGORY_AWARDS              = Preise / Sammy
 MESSAGECATEGORY_MISC                = Sonstiges
-MESSAGES_SHOW_ALL                   = alle Nachrichten
-MESSAGES_SHOW_READ                  = nur gelesene
-MESSAGES_SHOW_UNREAD                = nur ungelesene
+MESSAGES_SHOW_HEADING               = Zeige:
+MESSAGES_SHOW_ALL                   = Alle Nachrichten
+MESSAGES_SHOW_READ                  = Nur gelesene
+MESSAGES_SHOW_UNREAD                = Nur ungelesene
 
 BUY_AND_SELL        = Kaufen und Verkaufen
 AND_STATISTICS      = und Statistiken

--- a/res/lang/rooms/rooms_en.txt
+++ b/res/lang/rooms/rooms_en.txt
@@ -106,9 +106,10 @@ MESSAGECATEGORY_MONEY               = Money / Finances
 MESSAGECATEGORY_ACHIEVEMENTS        = Achievements
 MESSAGECATEGORY_AWARDS              = Awards / Sammy
 MESSAGECATEGORY_MISC                = Misc
-MESSAGES_SHOW_ALL                   = all messages
-MESSAGES_SHOW_READ                  = only read
-MESSAGES_SHOW_UNREAD                = only unread
+MESSAGES_SHOW_HEADING               = Show:
+MESSAGES_SHOW_ALL                   = All messages
+MESSAGES_SHOW_READ                  = Only read
+MESSAGES_SHOW_UNREAD                = Only unread
 
 BUY_AND_SELL        = Buy and sell
 AND_STATISTICS      = and statistics

--- a/res/lang/rooms/rooms_es.txt
+++ b/res/lang/rooms/rooms_es.txt
@@ -106,6 +106,7 @@ ROOM_THERE_IS_ALREADY_SOMEONE_IN_THE_ROOM = Ya hay alguien dentro.
 #MESSAGECATEGORY_ACHIEVEMENTS        = 
 #MESSAGECATEGORY_AWARDS              = 
 #MESSAGECATEGORY_MISC                = 
+#MESSAGES_SHOW_HEADING               = 
 #MESSAGES_SHOW_ALL                   = 
 #MESSAGES_SHOW_READ                  = 
 #MESSAGES_SHOW_UNREAD                = 

--- a/res/lang/rooms/rooms_fr.txt
+++ b/res/lang/rooms/rooms_fr.txt
@@ -106,6 +106,7 @@ ROOM_THERE_IS_ALREADY_SOMEONE_IN_THE_ROOM = il ya déjà quelqu'un ici !
 #MESSAGECATEGORY_ACHIEVEMENTS        = 
 #MESSAGECATEGORY_AWARDS              = 
 #MESSAGECATEGORY_MISC                = 
+#MESSAGES_SHOW_HEADING               = 
 #MESSAGES_SHOW_ALL                   = 
 #MESSAGES_SHOW_READ                  = 
 #MESSAGES_SHOW_UNREAD                = 

--- a/res/lang/rooms/rooms_pt-br.txt
+++ b/res/lang/rooms/rooms_pt-br.txt
@@ -106,6 +106,7 @@ DIALOGUE_SUPERMARKET_GOODBYE3          = Hora de bater perna. Até mais.
 #MESSAGECATEGORY_ACHIEVEMENTS        = 
 #MESSAGECATEGORY_AWARDS              = 
 #MESSAGECATEGORY_MISC                = 
+#MESSAGES_SHOW_HEADING               = 
 #MESSAGES_SHOW_ALL                   = 
 #MESSAGES_SHOW_READ                  = 
 #MESSAGES_SHOW_UNREAD                = 

--- a/res/lang/rooms/rooms_tr.txt
+++ b/res/lang/rooms/rooms_tr.txt
@@ -106,6 +106,7 @@ ROOM_THERE_IS_ALREADY_SOMEONE_IN_THE_ROOM = Odada şu anda birileri var...
 #MESSAGECATEGORY_ACHIEVEMENTS        = 
 #MESSAGECATEGORY_AWARDS              = 
 #MESSAGECATEGORY_MISC                = 
+#MESSAGES_SHOW_HEADING               = 
 #MESSAGES_SHOW_ALL                   = 
 #MESSAGES_SHOW_READ                  = 
 #MESSAGES_SHOW_UNREAD                = 

--- a/source/game.screen.archivedmessages.bmx
+++ b/source/game.screen.archivedmessages.bmx
@@ -297,7 +297,7 @@ Type TScreenHandler_OfficeArchivedMessages extends TScreenHandler
 
 
 		'=== CATEGORY SELECTION ===
-		listH = (TVTMessageCategory.count+1) * 20 + 5 + 35
+		listH = (TVTMessageCategory.count+1) * 20 + 5 + 70
 		outer.Init(40, 25 + titleH, 180, 50)
 		contentX = skin.GetContentX(outer.GetX())
 		contentY = skin.GetContentY(outer.GetY())
@@ -325,6 +325,7 @@ Type TScreenHandler_OfficeArchivedMessages extends TScreenHandler
 		Next
 		skin.RenderBorder(outer.GetIntX(), outer.GetIntY(), outer.GetIntW(), outer.GetIntH())
 
+		GetBitmapFont("default", 13, BOLDFONT).DrawSimple(GetLocale("MESSAGES_SHOW_HEADING"), contentX + 12, outer.GetH()-25, colorCategoryDefault)
 		if not showModeSelect
 			showModeSelect = New TGUIDropDown.Create(New TVec2D.Init(outer.GetX() + 12, outer.GetH()-5 ), New TVec2D.Init(147,-1), "", 128, "office_archivedmessages")
 			showModeSelect.SetListContentHeight(60)


### PR DESCRIPTION
Ich habe eine Überschrift hinzugefügt und den Abstand erhöht. Die Großschreibung im Code zu machen, finde ich an dieser Stelle nicht so sinnvoll. Der Key wird nur hier verwendet. Die Lokalisierung kann also schon mit der richtigen Schreibung erfolgen.
Wenn es Dir wichtig ist, kann ich das aber auch noch ändern.