### PR TITLE
Karte - auch Preis bei bestehender Anbindung verstecken

### DIFF
--- a/source/game.stationmap.bmx
+++ b/source/game.stationmap.bmx
@@ -3047,11 +3047,12 @@ Type TStationBase Extends TOwnedGameObject {_exposeToLua="selected"}
 		Local cantGetSectionPermissionReason:Int = 1
 		Local cantGetProviderPermissionReason:Int = 1
 		Local isNextReachLevelProbable:Int = False
-		Local showPriceInformation:Int = True
+		Local showPriceInformation:Int = False
 
 		if not HasFlag(TVTStationFlag.PAID)
 			cantGetProviderPermissionReason = CanSubscribeToProvider(1)
 			isNextReachLevelProbable = NextReachLevelProbable(owner, GetExclusiveReach())
+			showPriceInformation = True
 
 			if section And section.NeedsBroadcastPermission(owner, stationType)
 				showPermissionPriceText = not section.HasBroadcastPermission(owner, stationType)


### PR DESCRIPTION
Ein Änderungsvorschlag noch: auch der Preis sollte bei einer schon bestehenden Kabelanbindung versteckt werden. Insb. wenn nicht genug Geld da ist, sieht es sonst so aus, als könne man es sich nicht leisten.

Closes #247