### PR TITLE
Filmagentur: Verboten-Cursor falls nicht verkäuflich

### DIFF
--- a/source/game.roomhandler.movieagency.bmx
+++ b/source/game.roomhandler.movieagency.bmx
@@ -1194,6 +1194,8 @@ endrem
 		If hoveredGuiProgrammeLicence
 			if hoveredGuiProgrammeLicence.IsDragged()
 				GetGameBase().SetCursor(TGameBase.CURSOR_HOLD)
+			elseif not hoveredGuiProgrammeLicence.licence.IsTradeable()
+				GetGameBase().SetCursor(TGameBase.CURSOR_PICK_VERTICAL, TGameBase.CURSOR_EXTRA_FORBIDDEN)
 			elseif hoveredGuiProgrammeLicence.licence.owner = GetPlayerBase().playerID or GetPlayerBase().getFinance().canAfford(hoveredGuiProgrammeLicence.licence.getPriceForPlayer( GetPlayerBase().playerID ))
 				GetGameBase().SetCursor(TGameBase.CURSOR_PICK_VERTICAL)
 			else


### PR DESCRIPTION
Ein unverkäufliches Programm (selbstproduzierte Live-Show) sollte den Verboten-Marker bekommen.
Aktuell kann das Element durch das Veto schon nicht aus dem Koffer genommen werden. Mit dieser Änderung wird noch der Cursor entsprechend angepasst.