### PR TITLE
Fix: [Studio] respect max concept count (#299)

### DIFF
--- a/source/game.roomhandler.studio.bmx
+++ b/source/game.roomhandler.studio.bmx
@@ -1080,7 +1080,7 @@ Type RoomHandler_Studio Extends TRoomHandler
 			EndIf
 
 
-			If GetPlayerProgrammeCollection( GetPlayerBase().playerID ).CanCreateProductionConcept(script)
+			If GetPlayerProgrammeCollection( GetPlayerBase().playerID ).CanCreateProductionConcept(script) AND conceptCountMax > conceptCount
 				Local answerText:String
 				If conceptCount > 0
 					answerText = GetRandomLocale("DIALOGUE_STUDIO_ASK_FOR_ANOTHER_SHOPPINGLIST")


### PR DESCRIPTION
(betrifft aktuellen Master-Stand) Bei Shows und Serien mit weniger als 8 Folgen, kann man sich beim Studiomanager immer weiter Einkaufslisten holen. Diese werden dann zwar nicht hinzugefügt (Fehler im Log), aber der Menüpunkt sollte gar nicht erst angeboten werden.

Ich weiß auch nicht ob der Fix der richtige Ansatz ist, oder ob nicht schon CanCreateProductionConcept False zurückliefern sollte, wenn die Einkaufslisen erstellt wurden.

Ein weiteres Problem konnte ich noch nicht beheben. Das Löschen von Einkaufslisten für Serien funktioniert nach dem letzten Umbau. Aber wenn man von Live-Sendungen oder einfachen Filmen die Einkaufsliste in den Papierkorb wirft oder per Rechtsklick löscht, werden sie nicht erfolgreich entfernt. Das Remove/Destroy wird zwar aufgerufen, scheint aber nicht (mehr?) das gewünschte Ergebnis zu liefern. Dieses Problem muss durch Commit 4ceee86 reingekommen sein. Im vorigen Commit funktionierte das Löschen noch.