### PR TITLE
Kosten für Vertragsauflösung

### DIFF
--- a/source/game.screen.stationmap.bmx
+++ b/source/game.screen.stationmap.bmx
@@ -645,6 +645,7 @@ Type TGameGUIAntennaPanel Extends TGameGUIBasicStationmapPanel
 		'=== BOXES ===
 		If TScreenHandler_StationMap.actionMode <> TScreenHandler_StationMap.MODE_NONE
 			Local price:String = "", reach:String = "", reachChange:String = "", runningCost:String =""
+			Local sellingHasCost:Int = False
 			Local headerText:String
 			Local subHeaderText:String
 			Local canAfford:Int = True
@@ -659,7 +660,12 @@ Type TGameGUIAntennaPanel Extends TGameGUIBasicStationmapPanel
 						subHeaderText = GetWorldTime().GetFormattedGameDate(selectedStation.built)
 						reach = TFunctions.convertValue(selectedStation.GetReach(), 2)
 						reachChange = MathHelper.DottedValue( -1 * selectedStation.GetExclusiveReach() )
-						price = TFunctions.convertValue(selectedStation.GetSellPrice(), 2, 0)
+						Local sellPrice:Int = selectedStation.GetSellPrice()
+						If sellPrice < 0
+							SellingHasCost=True
+							sellPrice=-sellPrice
+						EndIf
+						price = TFunctions.convertValue(sellPrice, 2, 0)
 						If selectedStation.HasFlag(TVTStationFlag.NO_RUNNING_COSTS)
 							runningCost = "-/-"
 						Else
@@ -727,7 +733,11 @@ Type TGameGUIAntennaPanel Extends TGameGUIBasicStationmapPanel
 			currentY :+ boxH
 			skin.RenderBox(contentX + 5, currentY, halfW-5, -1, runningCost, "moneyRepetitions", "neutral", skin.fontNormal, ALIGN_RIGHT_CENTER)
 			If TScreenHandler_StationMap.actionMode = GetSellActionMode()
-				skin.RenderBox(contentX + 5 + halfW-5 + 4, currentY, halfW+5, -1, price, "money", "neutral", skin.fontBold, ALIGN_RIGHT_CENTER)
+				If sellingHasCost
+					skin.RenderBox(contentX + 5 + halfW-5 + 4, currentY, halfW+5, -1, price, "money", "neutral", skin.fontBold, ALIGN_RIGHT_CENTER,"bad")
+				Else
+					skin.RenderBox(contentX + 5 + halfW-5 + 4, currentY, halfW+5, -1, price, "money", "neutral", skin.fontBold, ALIGN_RIGHT_CENTER)
+				EndIf
 			Else
 				'fetch financial state of room owner (not player - so take care
 				'if the player is allowed to do this)

--- a/source/game.stationmap.bmx
+++ b/source/game.stationmap.bmx
@@ -2685,11 +2685,13 @@ Type TStationBase Extends TOwnedGameObject {_exposeToLua="selected"}
 
 
 	Method GetSellPrice:Int() {_exposeToLua}
-		'price is multiplied by an age factor of 0.75-0.95
-		Local factor:Float = Max(0.75, 0.95 - Float(GetAge())/1.0)
-		If owner Then Return Int(GetPrice() * factor / 10000) * 10000
+		'price decreasing with age
+		'TODO negative price in red
+		Local offer:Int = Int((0.8 - 0.1 * GetAge()) * GetPrice())
+		'waste removal costs
+		Local minPrice:Int = -GetPrice()/2
 
-		Return Int( GetPrice() * factor / 10000) * 10000
+		return Max(offer, minPrice)
 	End Method
 
 

--- a/source/game.stationmap.bmx
+++ b/source/game.stationmap.bmx
@@ -2686,7 +2686,6 @@ Type TStationBase Extends TOwnedGameObject {_exposeToLua="selected"}
 
 	Method GetSellPrice:Int() {_exposeToLua}
 		'price decreasing with age
-		'TODO negative price in red
 		Local offer:Int = Int((0.8 - 0.1 * GetAge()) * GetPrice())
 		'waste removal costs
 		Local minPrice:Int = -GetPrice()/2

--- a/source/game.stationmap.bmx
+++ b/source/game.stationmap.bmx
@@ -3681,14 +3681,9 @@ Type TStationCableNetworkUplink extends TStationBase {_exposeToLua="selected"}
 
 		local expense:int
 		'pay the provider for cancelingearlier
-		expense = (1.0 - GetSubscriptionProgress())^2 * (GetRunningCosts() - maintenanceCosts)
-
-		local income:int
-		'hardware could be sold
-		Local factor:Float = Max(0.75, 0.95 - Float(GetAge())/1.0)
-		income = hardwareCosts * factor
-
-		return income - expense
+		expense = (1.0 - GetSubscriptionProgress())^2 *3* GetRunningCosts()
+		
+		return -expense
 	End Method
 
 
@@ -4082,14 +4077,9 @@ Type TStationSatelliteUplink extends TStationBase {_exposeToLua="selected"}
 
 		local expense:int
 		'pay the provider for cancelingearlier
-		expense = (1.0 - GetSubscriptionProgress())^2 * (GetRunningCosts() - maintenanceCosts)
+		expense = (1.0 - GetSubscriptionProgress())^2 *3* GetRunningCosts()
 
-		local income:int
-		'hardware could be sold
-		Local factor:Float = Max(0.75, 0.95 - Float(GetAge())/1.0)
-		income = hardwareCosts * factor
-
-		return income - expense
+		return -expense
 	End Method
 
 


### PR DESCRIPTION
Ansatz für #300. Für Verträge wird angenommen, dass die Mietkosten ggf. nötige Hardware enthalten, d.h. bei einer vorzeitigen Vertragsaufläsung kann es keine Erträge geben. Je nach Restlaufzeit ist eine Strafgebühr zu zahlen.

Für Antennen sinkt der Verkaufswert ebenfalls je nach Alter. In keinem Fall erhält man den gesamten Kaufbetrag zurück. Zunächst ist der Verkaufspreis positiv (Materialrestwert/Weiterverwendung potentiell möglich). Ist die Antenne aber zu alt können Verschrottungskosten anfallen.

Langfristig könnten die Parameter vom Schwierigkeitsgrad abhängen. Die aktuellen Parameter sind Diskussionsgrundlage, die Commits sollten vor einem Merge noch zusammengefasst werden.