### PR TITLE
Studio: Dialog maximale Anzahl auch bei Filmen

### DIFF
--- a/source/game.roomhandler.studio.bmx
+++ b/source/game.roomhandler.studio.bmx
@@ -995,7 +995,7 @@ Type RoomHandler_Studio Extends TRoomHandler
 					EndIf
 				EndIf
 
-				If Not GetPlayerProgrammeCollection( GetPlayerBase().playerID ).CanCreateProductionConcept(script)
+				If Not GetPlayerProgrammeCollection( GetPlayerBase().playerID ).CanCreateProductionConcept(script) AND conceptCountMax > GameRules.maxProductionConceptsPerScript
 					text :+"~n~n"
 					text :+ GetRandomLocale("DIALOGUE_STUDIO_SHOPPING_LIST_LIMIT_REACHED")
 				EndIf


### PR DESCRIPTION
Der LIMIT_REACHED-Text wird auch angezeigt, wenn es weniger als 8 Einkaufslisten geben kann.
Aktuell wird für die Anzeige des Texts nur CanCreateProductionConcept herangezogen (da darin auch das GameRule-Limit geprüft wird). Allerdings können bei Filmen und Serien mit weniger als 8 Folgen auch einfach schon alle Einkaufslisen geholt worden sein - ohne das Limit zu erreichen. In diesem Fall ist der Text verwirrend.