### PR TITLE
Fix: [Stationmap] satellite contract duration

### DIFF
--- a/source/game.stationmap.bmx
+++ b/source/game.stationmap.bmx
@@ -5660,11 +5660,13 @@ Type TStationMap_Satellite extends TStationMap_BroadcastProvider {_exposeToLua="
 
 	'override
 	Method GetDefaultSubscribedChannelDuration:Int()
-		if deathTime <= 0 then return Super.GetDefaultSubscribedChannelDuration()
+		local defaultDuration:int = Super.GetDefaultSubscribedChannelDuration()
+		if deathTime <= 0 then return defaultDuration
 		'days are rounded down, so they always are lower than the real life time
 		local daysToDeath:int = (deathTime - GetWorldTime().GetTimeGone()) / TWorldTime.DAYLENGTH
-
-		return Min(Super.GetDefaultSubscribedChannelDuration(), daysToDeath * TWorldTime.DAYLENGTH)
+		local durationToDeath:int = daysToDeath * TWorldTime.DAYLENGTH
+		if durationToDeath < 0 then durationToDeath = defaultDuration
+		return Min(defaultDuration, durationToDeath)
 	End Method
 
 


### PR DESCRIPTION
Das Produkt aus Anzahl der Tage bis zum Tod und Tageslänge kann durch einen Überlauf negtiv werden, was zu einer negativen Vertragslaufzeig geführt hätte.
Mit der Änderung wird zumindest das verhindert.
Noch besser wäre möglicherweise die Standardvertragslaufzeit in Tagen mit der Anzahl der Tage bis zum Tod zu vergleichen (bei mehreren Überläufen könnte trotz vieler Tage bis zum Tod ein sehr kleine positive Dauer rauskommen)...

Um den Fehler zu sehen, muss man nur bei Spielstart zur Karte gehen und sich die Vertragslaufzeiten der Satelliten anschauen. Bei mir ist fast immer einer dabei, der initial eine negative Vertragslaufzeit anzeigt - eigentlich sollten da immer 12 Tage stehen.