### PR TITLE
database cleanup

### DIFF
--- a/res/database/Default/database.xml
+++ b/res/database/Default/database.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tvgdb>
+<tvtdb>
 	<version value="3" />
-</tvgdb>
+</tvtdb>

--- a/res/database/Default/database_achievements.xml
+++ b/res/database/Default/database_achievements.xml
@@ -205,7 +205,7 @@
 						<de>Erhöhe das Sendegebiet auf über 5 Millionen Einwohner.</de>
 						<en>Increase the broadcast area to more than 5 million inhabitants.</en>
 					</text>
-					<data type="reachBroadcastArea" minReachAbsolute="5000000" checkMinute="5" />
+					<data type="reachBroadcastArea" minReachAbsolute="5000000" />
 				</task>
 			</tasks>
 			<rewards>

--- a/res/database/Default/database_ads.xml
+++ b/res/database/Default/database_ads.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tvgdb>
+<tvtdb>
 	<version value="3" />
 	<allads>
 		<ad id="01b8c1c8-f3b3-4353-92fb-e24f5c7dc5b4">
@@ -197,7 +197,8 @@ You will really have to chew.</en>
 				<en>Action game figures of your favorite politicians. For a short time Birne and Genschman for the price of one.</en>
 			</description>
 			<conditions min_audience="28.6564" min_image="12" target_group="16" pro_pressure_groups="0" contra_pressure_groups="0"/>
-			<data quality="18" repetitions="1" duration="3" profit="165" penalty="260" infomercial_profit="25" fix_infomercial_profit="1" year_range_from="1982" year_range_to="1989"/>
+			<data quality="18" repetitions="1" duration="3" profit="165" penalty="260" infomercial_profit="25" fix_infomercial_profit="1" />
+			<availability year_range_from="1982" year_range_to="1989" />
 		</ad>
 		<ad id="PoliPlayw02">
 			<title>
@@ -208,7 +209,8 @@ You will really have to chew.</en>
 				<en>Action game figures of your favorite politicians. For a short time "Blooming landscapes"-Helmut and "Red Socks"-Gregor for the price of one.</en>
 			</description>
 			<conditions min_audience="28.6564" min_image="12" target_group="16" pro_pressure_groups="0" contra_pressure_groups="0"/>
-			<data quality="18" repetitions="1" duration="3" profit="165" penalty="260" infomercial_profit="25" fix_infomercial_profit="1" year_range_from="1990" year_range_to="1997"/>
+			<data quality="18" repetitions="1" duration="3" profit="165" penalty="260" infomercial_profit="25" fix_infomercial_profit="1" />
+			<availability year_range_from="1990" year_range_to="1997" />
 		</ad>
 		<ad id="PoliPlayw03">
 			<title>
@@ -219,7 +221,8 @@ You will really have to chew.</en>
 				<en>Action game figures of your favorite politicians. For a short time "Get me a bottle of beer" -Gerhard and "Cleaning Squad"-Joschka for the price of one.</en>
 			</description>
 			<conditions min_audience="28.6564" min_image="12" target_group="16" pro_pressure_groups="0" contra_pressure_groups="0"/>
-			<data quality="18" repetitions="1" duration="3" profit="165" penalty="260" infomercial_profit="25" fix_infomercial_profit="1" year_range_from="1998" year_range_to="2004"/>
+			<data quality="18" repetitions="1" duration="3" profit="165" penalty="260" infomercial_profit="25" fix_infomercial_profit="1" />
+			<availability year_range_from="1998" year_range_to="2004" />
 		</ad>
 		<ad id="42b4aa37-1274-4da2-9d72-4e203720eeb6">
 			<title>
@@ -230,7 +233,8 @@ You will really have to chew.</en>
 				<en>Action game figures of your favorite politician. For short time Action-Murkel and Chaoz-Ruszler for the price of one.</en>
 			</description>
 			<conditions min_audience="28.6564" min_image="12" target_group="16" pro_pressure_groups="0" contra_pressure_groups="0"/>
-			<data quality="18" repetitions="1" duration="3" profit="165" penalty="260" infomercial_profit="25" fix_infomercial_profit="1" year_range_from="2005" year_range_to="2017"/>
+			<data quality="18" repetitions="1" duration="3" profit="165" penalty="260" infomercial_profit="25" fix_infomercial_profit="1" />
+			<availability year_range_from="2005" year_range_to="2017" />
 		</ad>
 		<ad id="44af9e71-7c61-4531-b125-181948cd791a">
 			<title>
@@ -560,7 +564,8 @@ But only with Relocation Rudolph!</en>
 				<en>Surfing the web in the garden! WiFi cable up to 200m.</en>
 			</description>
 			<conditions min_audience="6.77" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0"/>
-			<data quality="10" repetitions="2" duration="2" profit="407" penalty="625" year_range_from="1998" year_range_to="0" infomercial_profit="41" fix_infomercial_profit="1"/>
+			<data quality="10" repetitions="2" duration="2" profit="407" penalty="625" infomercial_profit="41" fix_infomercial_profit="1"/>
+			<availability year_range_from="1998" />
 		</ad>
 		<ad id="a401f20f-8832-45df-a274-2599fd8d0afb">
 			<title>
@@ -899,7 +904,8 @@ Special week: no bottle deposit.</en>
 				<en>Computer scrap beginning at 50 pfennig per kilo. Now also offering modern B/W monitors.</en>
 			</description>
 			<conditions min_audience="4.1671" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0"/>
-			<data quality="12" repetitions="7" duration="3" profit="581" penalty="746" year_range_from="0" year_range_to="2002" infomercial_profit="40" fix_infomercial_profit="1"/>
+			<data quality="12" repetitions="7" duration="3" profit="581" penalty="746" infomercial_profit="40" fix_infomercial_profit="1"/>
+			<availability year_range_to="2002" />
 		</ad>
 		<ad id="d8ee3597-56e1-4117-909a-bde9da3f9f9e">
 			<title>
@@ -910,7 +916,8 @@ Special week: no bottle deposit.</en>
 				<en>Computer scrap beginning at 50 eurocent per kilo. Now also offering modern CRT screens.</en>
 			</description>
 			<conditions min_audience="4.1671" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0"/>
-			<data quality="14" repetitions="7" duration="3" profit="581" penalty="746" year_range_from="2003" year_range_to="0" infomercial_profit="40" fix_infomercial_profit="1"/>
+			<data quality="14" repetitions="7" duration="3" profit="581" penalty="746"infomercial_profit="40" fix_infomercial_profit="1"/>
+			<availability year_range_from="2003" />
 		</ad>
 		<ad id="da699c1f-4117-4fc6-b365-a3a7608105ab">
 			<title>
@@ -1109,7 +1116,8 @@ I feel good with Lemur</en>
 				<en>Get our  jazzy covers for your mobile phone. Well and truly over for drunken grayish blue. Now also available for all models of Sumens.</en>
 			</description>
 			<conditions min_audience="1.8225" min_image="18" target_group="2" allowed_programme_type="0" pro_pressure_groups="0" contra_pressure_groups="0"/>
-			<data infomercial="1" quality="20" repetitions="4" duration="4" profit="900" penalty="1274" year_range_from="1998" year_range_to="2003" infomercial_profit="50" fix_infomercial_profit="1"/>
+			<data infomercial="1" quality="20" repetitions="4" duration="4" profit="900" penalty="1274" infomercial_profit="50" fix_infomercial_profit="1"/>
+			<availability year_range_from="1998" year_range_to="2003" />
 		</ad>
 		<ad id="ronny-ad-Kaschaemm" creator="5578" created_by="Ronny">
 			<title>
@@ -1145,7 +1153,8 @@ I feel good with Lemur</en>
 				<en>Crazy beats by Israelic superstar DJ Meshugge. All 3 hits on one Album.</en>
 			</description>
 			<conditions min_audience="1.8225" min_image="18" target_group="2" allowed_programme_type="0" pro_pressure_groups="0" contra_pressure_groups="0"/>
-			<data infomercial="1" quality="18" repetitions="4" duration="4" profit="900" penalty="1474" year_range_from="1992" year_range_to="1995" infomercial_profit="50" fix_infomercial_profit="1"/>
+			<data infomercial="1" quality="18" repetitions="4" duration="4" profit="900" penalty="1474" infomercial_profit="50" fix_infomercial_profit="1"/>
+			<availability year_range_from="1992" year_range_to="1995" />
 		</ad>
 		<ad id="ronny-ad-Senner-Kaes" creator="5578" created_by="Ronny">
 			<title>
@@ -1181,7 +1190,8 @@ I feel good with Lemur</en>
 				<en>We sell nothing but nodding dogs. But this at competitive prices. New in the stores: the dwarf dachshund in the scale 1:1.</en>
 			</description>
 			<conditions min_audience="6.2511" min_image="0" target_group="0" allowed_programme_type="0" pro_pressure_groups="0" contra_pressure_groups="0"/>
-			<data infomercial="1" quality="19" repetitions="4" duration="3" profit="475" penalty="669" year_range_from="1973" year_range_to="1988" infomercial_profit="55" fix_infomercial_profit="1"/>
+			<data infomercial="1" quality="19" repetitions="4" duration="3" profit="475" penalty="669" infomercial_profit="55" fix_infomercial_profit="1"/>
+			<availability year_range_from="1973" year_range_to="1988" />
 		</ad>
 		<ad id="ronny-ad-Wackeldackel">
 			<title>
@@ -1193,7 +1203,8 @@ I feel good with Lemur</en>
 				<en>We, again, sell nothing but nodding dogs. But this at competitive prices. New in the stores: the dwarf dachshund in the scale 1:1.</en>
 			</description>
 			<conditions min_audience="6.2511" min_image="0" target_group="0" allowed_programme_type="0" pro_pressure_groups="0" contra_pressure_groups="0"/>
-			<data infomercial="1" quality="17" repetitions="4" duration="3" profit="475" penalty="669" year_range_from="1997" year_range_to="2008" infomercial_profit="50" fix_infomercial_profit="1"/>
+			<data infomercial="1" quality="17" repetitions="4" duration="3" profit="475" penalty="669" infomercial_profit="50" fix_infomercial_profit="1"/>
+			<availability year_range_from="1997" year_range_to="2008" />
 		</ad>
 		<ad id="ronny-ad-allhits-01" creator="5578" created_by="Ronny">
 			<title>
@@ -1205,7 +1216,8 @@ I feel good with Lemur</en>
 				<en>Your music sampler! All hits of the last 3 days on one brimful filled 90 minutes audio cassette. In stereo!</en>
 			</description>
 			<conditions min_audience="2.08" min_image="12" target_group="2"/>
-			<data infomercial="1" quality="20" repetitions="4" duration="3" profit="815" penalty="1220" year_range_from="1985" year_range_to="1986" fix_infomercial_profit="1"/>
+			<data infomercial="1" quality="20" repetitions="4" duration="3" profit="815" penalty="1220" fix_infomercial_profit="1"/>
+			<availability year_range_from="1985" year_range_to="1986" />
 		</ad>
 		<ad id="ronny-ad-allhits-02" creator="5578" created_by="Ronny">
 			<title>
@@ -1217,7 +1229,8 @@ I feel good with Lemur</en>
 				<en>"All Hits 2" is back again!! 40 mega hits on one double MC. Only now with poster ready to get painted!</en>
 			</description>
 			<conditions min_audience="2.083" min_image="4" target_group="3"/>
-			<data infomercial="1" quality="22" repetitions="7" duration="4" profit="815" penalty="1150" year_range_from="1987" year_range_to="1988" fix_infomercial_profit="1"/>
+			<data infomercial="1" quality="22" repetitions="7" duration="4" profit="815" penalty="1150" fix_infomercial_profit="1"/>
+			<availability year_range_from="1987" year_range_to="1988" />
 		</ad>
 		<ad id="ronny-ad-allhits-03" creator="5578" created_by="Ronny">
 			<title>
@@ -1229,7 +1242,8 @@ I feel good with Lemur</en>
 				<en>Not one cassette, not two or three! Unbelieveable 4 music cassettes got filled with hits of the last 5 years. Your walkman never will play other music!</en>
 			</description>
 			<conditions min_audience="2.083" min_image="7" target_group="2"/>
-			<data infomercial="1" quality="18" repetitions="4" duration="3" profit="815" penalty="1100" year_range_from="1988" year_range_to="1990" fix_infomercial_profit="1"/>
+			<data infomercial="1" quality="18" repetitions="4" duration="3" profit="815" penalty="1100" fix_infomercial_profit="1"/>
+			<availability year_range_from="1988" year_range_to="1990" />
 		</ad>
 		<ad id="ronny-ad-arthritis-01" creator="5578" created_by="Ronny">
 			<title>
@@ -1314,7 +1328,8 @@ Brucey - harsh fragrance for male experts.</en>
 				<en>The hit chewy candy from Hawaii. Never before sugar tasted that tro-tro-tropical.</en>
 			</description>
 			<conditions min_audience="2.6" min_image="18" target_group="1"/>
-			<data quality="15" repetitions="4" duration="2" profit="770" penalty="1167" fix_infomercial_profit="1" year_range_to="1999"/>
+			<data quality="15" repetitions="4" duration="2" profit="770" penalty="1167" fix_infomercial_profit="1" />
+			<availability year_range_to="1999" />
 		</ad>
 		<ad id="ronny-ad-kalua-02" creator="5578" created_by="Ronny">
 			<title>
@@ -1325,7 +1340,8 @@ Brucey - harsh fragrance for male experts.</en>
 				<en>The Hawaiian chewy candy now with a brand new and trendy taste. Candied chicken claws create this fascinating seasoning.</en>
 			</description>
 			<conditions min_audience="2.6041" min_image="18" target_group="1"/>
-			<data quality="20" repetitions="4" duration="2" profit="770" penalty="1082" fix_infomercial_profit="1" year_range_from="2000"/>
+			<data quality="20" repetitions="4" duration="2" profit="770" penalty="1082" fix_infomercial_profit="1" />
+			<availability year_range_from="2000" />
 		</ad>
 		<ad id="ronny-ad-kambalott-01" creator="5578" created_by="Ronny">
 			<title>
@@ -1395,7 +1411,8 @@ Brucey - harsh fragrance for male experts.</en>
 				<en>Eastern Germanys hop, and the bottles from Western Germany created this fascinating beer. Tasty beer for fathers of all countries.</en>
 			</description>
 			<conditions min_audience="9.3772" min_image="12" target_group="256"/>
-			<data infomercial="1" quality="25" repetitions="3" duration="4" profit="377" penalty="500" year_range_from="1990" year_range_to="1993" infomercial_profit="85" fix_infomercial_profit="1"/>
+			<data infomercial="1" quality="25" repetitions="3" duration="4" profit="377" penalty="500" infomercial_profit="85" fix_infomercial_profit="1"/>
+			<availability year_range_from="1990" year_range_to="1993" />
 		</ad>
 		<ad id="ronny-ad-sanitaxi-01" creator="5578" created_by="Ronny">
 			<title>
@@ -1467,7 +1484,8 @@ Available in any well-stocked drugstore.</en>
 				<en>We are looking for a new earth. Take care and thanks for the fish. Your dolphins.</en>
 			</description>
 			<conditions min_audience="46.89" min_image="0" target_group="0" allowed_programme_type="0" prohibited_programme_type="0" pro_pressure_groups="0" contra_pressure_groups="0"/>
-			<data infomercial="1" quality="15" repetitions="1" duration="7" profit="170" penalty="453" year_range_from="1999" year_range_to="2000" infomercial_profit="50" fix_infomercial_profit="1"/>
+			<data infomercial="1" quality="15" repetitions="1" duration="7" profit="170" penalty="453" infomercial_profit="50" fix_infomercial_profit="1"/>
+			<availability year_range_from="1999" year_range_to="2000" />
 		</ad>
 		<ad id="sjaele-ad-Bio-Tube" creator="7430" created_by="Sjaele">
 			<title>
@@ -1478,7 +1496,7 @@ Available in any well-stocked drugstore.</en>
 				<en>A tube full to the brim with organic whool-food. Tastes like mom's food, does not crumble and is sooo healthy! Ideal for long gaming sessions.</en>
 			</description>
 			<conditions min_audience="1.3015" min_image="12" target_group="2" allowed_programme_type="0" pro_pressure_groups="0" contra_pressure_groups="0"/>
-			<data infomercial="1" quality="25" repetitions="3" duration="2" profit="1132" penalty="1900" year_range_from="0" year_range_to="0" infomercial_profit="50" fix_infomercial_profit="1"/>
+			<data infomercial="1" quality="25" repetitions="3" duration="2" profit="1132" penalty="1900" infomercial_profit="50" fix_infomercial_profit="1"/>
 		</ad>
 		<ad id="sjaele-ad-Macht-nischt" creator="7430" created_by="Sjaele">
 			<title>
@@ -1490,7 +1508,8 @@ Available in any well-stocked drugstore.</en>
 				<en>The big excuse book. Excuses for every occasion from kindergarten to your own funeral. Never be at a complete loss again.</en>
 			</description>
 			<conditions min_audience="2.86" min_image="0" target_group="0" allowed_programme_type="0" pro_pressure_groups="0" contra_pressure_groups="0"/>
-			<data infomercial="1" quality="20" repetitions="7" duration="4" profit="718" penalty="1277" year_range_from="0" year_range_to="1998" infomercial_profit="105" fix_infomercial_profit="1"/>
+			<data infomercial="1" quality="20" repetitions="7" duration="4" profit="718" penalty="1277" infomercial_profit="105" fix_infomercial_profit="1"/>
+			<availability year_range_to="1998" />
 		</ad>
 		<ad id="sjaele-ad-Macht-nischt2" creator="7430" created_by="Sjaele">
 			<title>
@@ -1502,7 +1521,8 @@ Available in any well-stocked drugstore.</en>
 				<en>The online shop. Excuses for every occasion from kindergarten to your own funeral. Never be at a complete loss again.</en>
 			</description>
 			<conditions min_audience="2.86" min_image="0" target_group="0" allowed_programme_type="0" pro_pressure_groups="0" contra_pressure_groups="0"/>
-			<data infomercial="1" quality="25" repetitions="7" duration="4" profit="718" penalty="1277" year_range_from="1999" year_range_to="0" infomercial_profit="100" fix_infomercial_profit="1"/>
+			<data infomercial="1" quality="25" repetitions="7" duration="4" profit="718" penalty="1277" infomercial_profit="100" fix_infomercial_profit="1"/>
+			<availability year_range_from="1999" />
 		</ad>
 		<ad id="sjaele-ad-Ratz-Fatz" creator="7430" created_by="Sjaele">
 			<title>
@@ -1514,7 +1534,7 @@ Available in any well-stocked drugstore.</en>
 				<en>Your missus is no longer worth a straw? Call the Hassle Frazzle divorce hotline. We provide reasons, occasions, attorneys and guarantee for not-guilty verdicts!</en>
 			</description>
 			<conditions min_audience="11.4612" min_image="4" target_group="128" allowed_programme_type="0" pro_pressure_groups="0" contra_pressure_groups="0"/>
-			<data infomercial="1" quality="15" repetitions="3" duration="3" profit="322" penalty="504" year_range_from="0" year_range_to="0" infomercial_profit="50" fix_infomercial_profit="1"/>
+			<data infomercial="1" quality="15" repetitions="3" duration="3" profit="322" penalty="504" infomercial_profit="50" fix_infomercial_profit="1"/>
 		</ad>
 		<ad id="sjaele-ad-Umrechner02" creator="7430" created_by="Sjaele">
 			<title>
@@ -1526,7 +1546,8 @@ Available in any well-stocked drugstore.</en>
 				<en>The manual for converting East German mark (DDM) to Deutsche Mark (DEM)! For those who want to know exactly. Because everything used to be better. And cheaper?</en>
 			</description>
 			<conditions min_audience="6.2511" min_image="0" target_group="0" allowed_programme_type="0" pro_pressure_groups="0" contra_pressure_groups="0"/>
-			<data infomercial="1" quality="25" repetitions="1" duration="2" profit="400" penalty="697" year_range_from="1990" year_range_to="2002" infomercial_profit="50" fix_infomercial_profit="1"/>
+			<data infomercial="1" quality="25" repetitions="1" duration="2" profit="400" penalty="697" infomercial_profit="50" fix_infomercial_profit="1"/>
+			<availability year_range_from="1990" year_range_to="2002" />
 		</ad>
 		<ad id="sjaele-ad-Umrechner" creator="7430" created_by="Sjaele">
 			<title>
@@ -1538,7 +1559,8 @@ Available in any well-stocked drugstore.</en>
 				<en>The website for converting Euro (EUR) to Deutsche Mark (DEM). For those who want tok know exactly. Because everything used to be better.</en>
 			</description>
 			<conditions min_audience="6.2511" min_image="0" target_group="0" allowed_programme_type="0" pro_pressure_groups="0" contra_pressure_groups="0"/>
-			<data infomercial="1" quality="25" repetitions="1" duration="2" profit="400" penalty="697" year_range_from="2003" year_range_to="0" infomercial_profit="50" fix_infomercial_profit="1"/>
+			<data infomercial="1" quality="25" repetitions="1" duration="2" profit="400" penalty="697" infomercial_profit="50" fix_infomercial_profit="1"/>
+			<availability year_range_from="2003" />
 		</ad>
 		<ad id="speedminister-ad-Beisele" creator="8605" created_by="SpeedMinister">
 			<title>
@@ -1667,7 +1689,8 @@ Available in any well-stocked drugstore.</en>
 				<en>A touch of genious: our double bock beer is now also free of alcohol! Oans, zwoa, droa, g'suffa!</en>
 			</description>
 			<conditions min_audience="4.1617" min_image="40" target_group="0"/>
-			<data infomercial="1" quality="22" repetitions="5" duration="2" profit="580" penalty="932" infomercial_profit="76" fix_infomercial_profit="1" year_range_from="2006"/>
+			<data infomercial="1" quality="22" repetitions="5" duration="2" profit="580" penalty="932" infomercial_profit="76" fix_infomercial_profit="1" />
+			<availability year_range_from="2006" />
 		</ad>
 		<ad id="speedminister-ad-Hopfengurgler2" creator="8605" created_by="SpeedMinister">
 			<title>
@@ -1679,7 +1702,8 @@ Available in any well-stocked drugstore.</en>
 				<en>Genuine: Pilsner, export and wheat bear now also available as suppository! Handy in a 40s party pack! That drags! Oans, zwoa, droa, ziags!</en>
 			</description>
 			<conditions min_audience="4.17" min_image="0" target_group="0"/>
-			<data infomercial="1" quality="15" repetitions="5" duration="4" profit="568" penalty="450" fix_infomercial_profit="1" year_range_to="2005"/>
+			<data infomercial="1" quality="15" repetitions="5" duration="4" profit="568" penalty="450" fix_infomercial_profit="1" />
+			<availability year_range_to="2005" />
 		</ad>
 		<ad id="speedminister-ad-Hummeldoof" creator="8605" created_by="SpeedMinister">
 			<title>
@@ -2141,7 +2165,8 @@ Available in any well-stocked drugstore.</en>
 				<en>Wedding? Company event? Family celebration? Car breakdown! Removal! Donkeys to rent and to buy! Donkey24!</en>
 			</description>
 			<conditions min_audience="0.78" min_image="0"/>
-			<data infomercial="1" quality="18" repetitions="4" duration="3" profit="1400" penalty="1915" fix_infomercial_profit="1" year_range_to="1999" />
+			<data infomercial="1" quality="18" repetitions="4" duration="3" profit="1400" penalty="1915" fix_infomercial_profit="1" />
+			<availability year_range_to="1999" />
 		</ad>
 		<ad id="speedminister-ad-esel24-01" creator="8605" created_by="SpeedMinister">
 			<title>
@@ -2153,7 +2178,8 @@ Available in any well-stocked drugstore.</en>
 				<en>Wedding? Company event? Family celebration? Car breakdown! Removal! Donkeys to rent and to buy! Donkey24.come!</en>
 			</description>
 			<conditions min_audience="0.78" min_image="0"/>
-			<data infomercial="1" quality="15" repetitions="4" duration="3" profit="1400" penalty="1915" fix_infomercial_profit="1" year_range_from="2000"/>
+			<data infomercial="1" quality="15" repetitions="4" duration="3" profit="1400" penalty="1915" fix_infomercial_profit="1" />
+			<availability year_range_from="2000" />
 		</ad>
 		<ad id="speedminister-ad-four4down-01" creator="8605" created_by="SpeedMinister">
 			<title>
@@ -2461,7 +2487,8 @@ Available in any well-stocked drugstore.</en>
 				<en>Valvoa the truck for the woman. 460 PS only 350.000 Euro, on request also in pink.</en>
 			</description>
 			<conditions min_audience="20.84" min_image="4" target_group="128"/>
-			<data infomercial="1" quality="15" repetitions="2" duration="5" profit="210" penalty="359" infomercial_profit="47" fix_infomercial_profit="1" year_range_from="2002" year_range_to="-1"/>
+			<data infomercial="1" quality="15" repetitions="2" duration="5" profit="210" penalty="359" infomercial_profit="47" fix_infomercial_profit="1" />
+			<availability year_range_from="2002" />
 		</ad>
 		<ad id="speedminister-ad-valvoa-02" creator="8605" created_by="SpeedMinister">
 			<title>
@@ -2472,7 +2499,8 @@ Available in any well-stocked drugstore.</en>
 				<en>Valvoa the truck for the woman. 460 PS only 700.000 DEM, on request also in pink.</en>
 			</description>
 			<conditions min_audience="20.84" min_image="4" target_group="128"/>
-			<data infomercial="1" quality="15" repetitions="2" duration="5" profit="210" penalty="359" infomercial_profit="47" fix_infomercial_profit="1" year_range_from="-1" year_range_to="2001"/>
+			<data infomercial="1" quality="15" repetitions="2" duration="5" profit="210" penalty="359" infomercial_profit="47" fix_infomercial_profit="1" />
+			<availability year_range_to="2001" />
 		</ad>
 
 
@@ -2511,4 +2539,4 @@ Available in any well-stocked drugstore.</en>
 			<data quality="45" repetitions="3" duration="0" profit="2500" penalty="790" infomercial_profit="300" fix_infomercial_profit="1" available="0" type="1" />
 		</ad>
 	</allads>
-</tvgdb>
+</tvtdb>

--- a/res/database/Default/database_news.xml
+++ b/res/database/Default/database_news.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tvgdb>
+<tvtdb>
 	<version value="3" />
 	<allnews>
 		<news id="6b1065dd-36d5-4b4b-9904-1a8b7fd1d9c1" thread_id="0328d075-c155-43c9-b0c1-e130eb972f38" type="0" creator="">
@@ -2848,4 +2848,4 @@ Demonstrations are expected again this year.</en>
 			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 	</allnews>
-</tvgdb>
+</tvtdb>

--- a/res/database/Default/database_news.xml
+++ b/res/database/Default/database_news.xml
@@ -15,7 +15,7 @@
 				<effect trigger="happen" type="triggernews" news="7c2911a9-c9b4-40d1-b4f6-02fb0025358a" />
 			</effects>
 			<data genre="0" price="1.0" quality="58" />
-			<conditions year_range_from="2001" year_range_to="2009" />
+			<availability year_range_from="2001" year_range_to="2009" />
 		</news>
 		<news id="0b597995-f993-4124-aa24-950e2e8aa68a" thread_id="0328d075-c155-43c9-b0c1-e130eb972f38" type="2" creator="">
 			<title>
@@ -30,7 +30,7 @@
 				<effect trigger="happen" type="triggernews" news="e60afa58-04ad-437d-9da7-460d149d3fee" />
 			</effects>
 			<data genre="0" price="1.0" quality="58" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="52a3c289-8be8-4410-9dda-b9cff4eb6f34" thread_id="0328d075-c155-43c9-b0c1-e130eb972f38" type="2" creator="">
 			<title>
@@ -45,7 +45,7 @@
 				<effect trigger="happen" type="triggernews" news="10a0fd7d-0c75-4de8-925c-9095a724c12f" />
 			</effects>
 			<data genre="0" price="1.0" quality="49" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="bbc324f4-32b7-4e3f-a91f-5f6b6e958200" thread_id="0328d075-c155-43c9-b0c1-e130eb972f38" type="2" creator="">
 			<title>
@@ -60,7 +60,7 @@
 				<effect trigger="happen" type="triggernews" news="52a3c289-8be8-4410-9dda-b9cff4eb6f34" />
 			</effects>
 			<data genre="0" price="1.0" quality="39" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="10a0fd7d-0c75-4de8-925c-9095a724c12f" thread_id="0328d075-c155-43c9-b0c1-e130eb972f38" type="2" creator="">
 			<title>
@@ -75,7 +75,7 @@
 				<effect trigger="happen" type="triggernews" news="4649173b-2c51-417e-b661-509f21d0112c" />
 			</effects>
 			<data genre="0" price="1.0" quality="49" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="2b808db1-96cf-46ab-b912-f172fdf60b69" thread_id="0328d075-c155-43c9-b0c1-e130eb972f38" type="2" creator="">
 			<title>
@@ -88,7 +88,7 @@
 			</description>
 			<effects />
 			<data genre="0" price="1.0" quality="68" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="75e966f2-929d-479d-b24a-9ef2fcbf529c" thread_id="0328d075-c155-43c9-b0c1-e130eb972f38" type="2" creator="">
 			<title>
@@ -103,7 +103,7 @@
 				<effect trigger="happen" type="triggernews" news="f822fef6-ae57-4831-9c81-cc7001a19ba8" />
 			</effects>
 			<data genre="0" price="1.0" quality="49" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="689218a0-412c-4afb-9901-fd77f62c484f" thread_id="0328d075-c155-43c9-b0c1-e130eb972f38" type="2" creator="">
 			<title>
@@ -118,7 +118,7 @@
 				<effect trigger="happen" type="triggernews" news="75e966f2-929d-479d-b24a-9ef2fcbf529c" />
 			</effects>
 			<data genre="0" price="1.0" quality="39" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="f822fef6-ae57-4831-9c81-cc7001a19ba8" thread_id="0328d075-c155-43c9-b0c1-e130eb972f38" type="2" creator="">
 			<title>
@@ -133,7 +133,7 @@
 				<effect trigger="happen" type="triggernews" news="bbc324f4-32b7-4e3f-a91f-5f6b6e958200" />
 			</effects>
 			<data genre="0" price="1.0" quality="39" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="59077885-90a6-4827-84ce-68ac57aaa622" thread_id="0328d075-c155-43c9-b0c1-e130eb972f38" type="2" creator="">
 			<title>
@@ -148,7 +148,7 @@
 				<effect trigger="happen" type="triggernews" news="0b597995-f993-4124-aa24-950e2e8aa68a" />
 			</effects>
 			<data genre="0" price="1.0" quality="58" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="4649173b-2c51-417e-b661-509f21d0112c" thread_id="0328d075-c155-43c9-b0c1-e130eb972f38" type="2" creator="">
 			<title>
@@ -163,7 +163,7 @@
 				<effect trigger="happen" type="triggernews" news="59077885-90a6-4827-84ce-68ac57aaa622" />
 			</effects>
 			<data genre="0" price="1.0" quality="68" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="7c2911a9-c9b4-40d1-b4f6-02fb0025358a" thread_id="0328d075-c155-43c9-b0c1-e130eb972f38" type="2" creator="">
 			<title>
@@ -178,7 +178,7 @@
 				<effect trigger="happen" type="triggernews" news="689218a0-412c-4afb-9901-fd77f62c484f" />
 			</effects>
 			<data genre="0" price="1.0" quality="49" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="e60afa58-04ad-437d-9da7-460d149d3fee" thread_id="0328d075-c155-43c9-b0c1-e130eb972f38" type="2" creator="">
 			<title>
@@ -193,7 +193,7 @@
 				<effect trigger="happen" type="triggernews" news="073fb966-3ac6-42e2-9fda-e86740008573" />
 			</effects>
 			<data genre="0" price="1.0" quality="58" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="073fb966-3ac6-42e2-9fda-e86740008573" thread_id="0328d075-c155-43c9-b0c1-e130eb972f38" type="2" creator="">
 			<title>
@@ -208,7 +208,7 @@
 				<effect trigger="happen" type="triggernews" news="2b808db1-96cf-46ab-b912-f172fdf60b69" />
 			</effects>
 			<data genre="0" price="1.0" quality="58" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="5d4cd7b3-5932-4c8a-8563-4045be7e38da" thread_id="05662ace-7867-418c-a9c3-10fa8c1face8" type="0" creator="">
 			<title>
@@ -223,7 +223,7 @@
 				<effect trigger="happen" type="triggernews" news="44ec3ab6-aaef-4b52-a441-a192481f3b74" />
 			</effects>
 			<data genre="4" price="1.0" quality="38" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="b5a5d23a-aa80-4505-ad9d-a71ea63247c9" thread_id="05662ace-7867-418c-a9c3-10fa8c1face8" type="2" creator="">
 			<title>
@@ -238,7 +238,7 @@
 				<effect trigger="happen" type="triggernews" news="8661ce67-edd4-4d30-885b-5374d39f37c3" />
 			</effects>
 			<data genre="4" price="1.0" quality="43" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="8661ce67-edd4-4d30-885b-5374d39f37c3" thread_id="05662ace-7867-418c-a9c3-10fa8c1face8" type="2" creator="">
 			<title>
@@ -253,7 +253,7 @@
 				<effect trigger="happen" type="triggernews" news="3a75a2f5-c859-40df-ad2a-be5e6fd4567b" />
 			</effects>
 			<data genre="4" price="1.0" quality="41" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="44ec3ab6-aaef-4b52-a441-a192481f3b74" thread_id="05662ace-7867-418c-a9c3-10fa8c1face8" type="2" creator="">
 			<title>
@@ -268,7 +268,7 @@
 				<effect trigger="happen" type="triggernews" news="b5a5d23a-aa80-4505-ad9d-a71ea63247c9" />
 			</effects>
 			<data genre="4" price="1.0" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="3a75a2f5-c859-40df-ad2a-be5e6fd4567b" thread_id="05662ace-7867-418c-a9c3-10fa8c1face8" type="2" creator="">
 			<title>
@@ -283,7 +283,7 @@
 				<effect trigger="happen" type="triggernews" news="a4d64044-2db5-422d-9533-53677d8c4540" />
 			</effects>
 			<data genre="4" price="1.0" quality="49" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="a4d64044-2db5-422d-9533-53677d8c4540" thread_id="05662ace-7867-418c-a9c3-10fa8c1face8" type="2" creator="">
 			<title>
@@ -296,7 +296,7 @@
 			</description>
 			<effects />
 			<data genre="4" price="1.0" quality="48" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="7859dc7a-a913-459e-bddc-4f963ac70868" thread_id="08b4660d-4f7f-4aca-b03d-edfe271fb7e4" type="0" creator="">
 			<title>
@@ -311,7 +311,7 @@
 				<effect trigger="happen" type="triggernews" news="cad649a3-26ec-4b13-b00b-7b2a7937bdd2" />
 			</effects>
 			<data genre="4" price="1.30" quality="88" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="cad649a3-26ec-4b13-b00b-7b2a7937bdd2" thread_id="08b4660d-4f7f-4aca-b03d-edfe271fb7e4" type="2" creator="">
 			<title>
@@ -326,7 +326,7 @@
 				<effect trigger="happen" type="triggernews" news="64f1f8ab-d036-428a-b9fd-1543dbf319f1" />
 			</effects>
 			<data genre="4" price="1.20" quality="78" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="a3bbd916-2520-4a31-8f3e-3380950230da" thread_id="08b4660d-4f7f-4aca-b03d-edfe271fb7e4" type="2" creator="">
 			<title>
@@ -341,7 +341,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="4" price="1.4" quality="52" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="10976403-9968-4c3e-95c6-362c3f760944" thread_id="08b4660d-4f7f-4aca-b03d-edfe271fb7e4" type="2" creator="">
 			<title>
@@ -356,7 +356,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="a3bbd916-2520-4a31-8f3e-3380950230da" />
 			</effects>
 			<data genre="4" price="0.7" quality="67" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="64f1f8ab-d036-428a-b9fd-1543dbf319f1" thread_id="08b4660d-4f7f-4aca-b03d-edfe271fb7e4" type="2" creator="">
 			<title>
@@ -371,7 +371,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="10976403-9968-4c3e-95c6-362c3f760944" />
 			</effects>
 			<data genre="4" price="1.20" quality="73" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="d79c8cd7-e9b7-444c-93a8-12a983f402f3" thread_id="097948d0-cb97-4739-92fd-f66d55cd6290" type="0" creator="">
 			<title>
@@ -384,7 +384,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="4" price="1.0" quality="19" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="91881279-bf29-49bd-9a0b-c98c36f8ceaa" thread_id="0acccc29-1ef7-4613-8f78-1c0ad3b601e5" type="0" creator="">
 			<title>
@@ -399,7 +399,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="7d63161c-7937-4cce-95c6-2c82529c06ac" />
 			</effects>
 			<data genre="1" price="0.8" quality="23" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="7d63161c-7937-4cce-95c6-2c82529c06ac" thread_id="0acccc29-1ef7-4613-8f78-1c0ad3b601e5" type="2" creator="">
 			<title>
@@ -414,7 +414,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="296f6aca-a031-4f2f-b6a5-2317abadbb40" />
 			</effects>
 			<data genre="1" price="0.8" quality="13" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="296f6aca-a031-4f2f-b6a5-2317abadbb40" thread_id="0acccc29-1ef7-4613-8f78-1c0ad3b601e5" type="2" creator="">
 			<title>
@@ -429,7 +429,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="ec53534e-da72-4cbe-ab00-f2f4e3005ed1" />
 			</effects>
 			<data genre="1" price="0.8" quality="19" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="ec53534e-da72-4cbe-ab00-f2f4e3005ed1" thread_id="0acccc29-1ef7-4613-8f78-1c0ad3b601e5" type="2" creator="">
 			<title>
@@ -442,7 +442,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="1" price="0.8" quality="21" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="6bba8dff-b5da-40b1-9db8-0e3cc655c14b" thread_id="0f4bf47b-dd51-4c3e-8d44-47ed0908ae37" type="0" creator="">
 			<title>
@@ -457,7 +457,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="24c635b8-7a9c-4faf-9b72-b24f7b193afa" />
 			</effects>
 			<data genre="0" price="0.7" quality="49" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="85e5385e-eb33-4bee-8697-0e1b145e1ce3" thread_id="0f4bf47b-dd51-4c3e-8d44-47ed0908ae37" type="2" creator="">
 			<title>
@@ -470,7 +470,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="0" price="0.5" quality="51" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="22925a92-8d65-4515-9f99-676d56c1d74b" thread_id="0f4bf47b-dd51-4c3e-8d44-47ed0908ae37" type="2" creator="">
 			<title>
@@ -485,7 +485,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="b468ddac-247c-465d-9693-a7ab81b08fb1" />
 			</effects>
 			<data genre="0" price="1.0" quality="39" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="24c635b8-7a9c-4faf-9b72-b24f7b193afa" thread_id="0f4bf47b-dd51-4c3e-8d44-47ed0908ae37" type="2" creator="">
 			<title>
@@ -500,7 +500,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="22925a92-8d65-4515-9f99-676d56c1d74b" />
 			</effects>
 			<data genre="0" price="1.0" quality="58" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="b468ddac-247c-465d-9693-a7ab81b08fb1" thread_id="0f4bf47b-dd51-4c3e-8d44-47ed0908ae37" type="2" creator="">
 			<title>
@@ -515,7 +515,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="85e5385e-eb33-4bee-8697-0e1b145e1ce3" />
 			</effects>
 			<data genre="0" price="1.0" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 
 		<news id="1b15ca2e-e303-4863-9173-137eff033d7c_chemnitz" thread_id="1e6aa012-4bb1-44f3-82ea-c2d70f05b5f8" type="0" creator="">
@@ -532,7 +532,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="8906094a-6ee5-4054-9e8c-9eea78ea8950" time="2,2,2,16,23"/>
 			</effects>
 			<data genre="4" price="1.0" quality="39" />
-			<conditions year_range_from="1990" year_range_to="-1" />
+			<availability year_range_from="1990" year_range_to="-1" />
 		</news>
 		<news id="777c94c2-49a6-4e72-ad02-06c33f7350bc_chemnitz" thread_id="1e6aa012-4bb1-44f3-82ea-c2d70f05b5f8" type="2" creator="">
 			<title>
@@ -548,7 +548,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="f0ff4741-d46a-4cb9-97f7-4dca6b21ad03_chemnitz_euro" time="1,8,20" />
 			</effects>
 			<data genre="4" price="1.0" quality="29" />
-			<conditions year_range_from="1990" year_range_to="-1" />
+			<availability year_range_from="1990" year_range_to="-1" />
 		</news>
 		<news id="8906094a-6ee5-4054-9e8c-9eea78ea8950" thread_id="1e6aa012-4bb1-44f3-82ea-c2d70f05b5f8" type="2" creator="">
 			<title>
@@ -560,7 +560,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<en>According to a letter claiming responsibility, the animal rights activists of the group "ZORRO" are responsible for the elopement of the rhinoceros.</en>
 			</description>
 			<data genre="4" price="1.0" quality="25" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="f0ff4741-d46a-4cb9-97f7-4dca6b21ad03_chemnitz" thread_id="1e6aa012-4bb1-44f3-82ea-c2d70f05b5f8" type="2" creator="">
 			<title>
@@ -575,7 +575,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="7f17bb0b-b424-4177-8d3e-0ef9ec0f5485_chemnitz" time="2,1,1,4,12" />
 			</effects>
 			<data genre="4" price="1.0" quality="35" />
-			<conditions year_range_from="1990" year_range_to="2001" />
+			<availability year_range_from="1990" year_range_to="2001" />
 		</news>
 		<news id="f0ff4741-d46a-4cb9-97f7-4dca6b21ad03_chemnitz_euro" thread_id="1e6aa012-4bb1-44f3-82ea-c2d70f05b5f8" type="2" creator="">
 			<title>
@@ -590,7 +590,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="7f17bb0b-b424-4177-8d3e-0ef9ec0f5485_chemnitz" time="2,1,1,4,12" />
 			</effects>
 			<data genre="4" price="1.0" quality="35" />
-			<conditions year_range_from="2002" year_range_to="-1" />
+			<availability year_range_from="2002" year_range_to="-1" />
 		</news>
 		<news id="7f17bb0b-b424-4177-8d3e-0ef9ec0f5485_chemnitz" thread_id="1e6aa012-4bb1-44f3-82ea-c2d70f05b5f8" type="2" creator="">
 			<title>
@@ -605,7 +605,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="a4f30290-dc9f-49e0-ad44-727e00e44693" time="2,1,1,16,23" />
 			</effects>
 			<data genre="4" price="1.0" quality="26" />
-			<conditions year_range_from="1990" year_range_to="-1" />
+			<availability year_range_from="1990" year_range_to="-1" />
 		</news>
 		<news id="a4f30290-dc9f-49e0-ad44-727e00e44693" thread_id="1e6aa012-4bb1-44f3-82ea-c2d70f05b5f8" type="2" creator="">
 			<title>
@@ -618,7 +618,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="4" price="1.0" quality="23" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<!-- karl-marx-stadt-variant -->
 		<news id="1b15ca2e-e303-4863-9173-137eff033d7c_karlmarxstadt" thread_id="1e6aa012-4bb1-44f3-82ea-c2d70f05b5f8" type="0" creator="">
@@ -636,7 +636,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="8906094a-6ee5-4054-9e8c-9eea78ea8950" time="2,2,2,16,23"/>
 			</effects>
 			<data genre="4" price="1.0" quality="39" />
-			<conditions year_range_from="-1" year_range_to="1989" />
+			<availability year_range_from="-1" year_range_to="1989" />
 		</news>
 		<news id="777c94c2-49a6-4e72-ad02-06c33f7350bc_karlmarxstadt" thread_id="1e6aa012-4bb1-44f3-82ea-c2d70f05b5f8" type="2" creator="">
 			<title>
@@ -652,7 +652,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="f0ff4741-d46a-4cb9-97f7-4dca6b21ad03_karlmarxstadt" time="1,8,20" />
 			</effects>
 			<data genre="4" price="1.0" quality="29" />
-			<conditions year_range_from="-1" year_range_to="1989" />
+			<availability year_range_from="-1" year_range_to="1989" />
 		</news>
 		<news id="f0ff4741-d46a-4cb9-97f7-4dca6b21ad03_karlmarxstadt" thread_id="1e6aa012-4bb1-44f3-82ea-c2d70f05b5f8" type="2" creator="">
 			<title>
@@ -668,7 +668,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="7f17bb0b-b424-4177-8d3e-0ef9ec0f5485_chemnitz" time="2,1,1,4,12" />
 			</effects>
 			<data genre="4" price="1.0" quality="35" />
-			<conditions year_range_from="-1" year_range_to="1989" />
+			<availability year_range_from="-1" year_range_to="1989" />
 		</news>
 		<news id="7f17bb0b-b424-4177-8d3e-0ef9ec0f5485_karlmarxstadt" thread_id="1e6aa012-4bb1-44f3-82ea-c2d70f05b5f8" type="2" creator="">
 			<title>
@@ -683,7 +683,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="a4f30290-dc9f-49e0-ad44-727e00e44693" time="2,1,1,16,23" />
 			</effects>
 			<data genre="4" price="1.0" quality="26" />
-			<conditions year_range_from="-1" year_range_to="1989" />
+			<availability year_range_from="-1" year_range_to="1989" />
 		</news>
 
 		<news id="b8a64acb-74e0-4786-9810-2c6531b3bcd3" thread_id="1f0fcab5-6a25-435b-912e-8f95d2b63c15" type="0" creator="">
@@ -699,7 +699,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="5af0af95-84b8-4018-96e6-9e25e93a2687" time="2,1,2,9,16" />
 			</effects>
 			<data genre="0" price="0.5" quality="58" />
-			<conditions year_range_from="2003" year_range_to="-1" />
+			<availability year_range_from="2003" year_range_to="-1" />
 		</news>
 		<news id="5af0af95-84b8-4018-96e6-9e25e93a2687" thread_id="1f0fcab5-6a25-435b-912e-8f95d2b63c15" type="2" creator="">
 			<title>
@@ -714,7 +714,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="d39a88bf-fa64-40f9-936e-0d15d355f26b" time="2,1,1,8,17" />
 			</effects>
 			<data genre="0" price="0.7" quality="64" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="d39a88bf-fa64-40f9-936e-0d15d355f26b" thread_id="1f0fcab5-6a25-435b-912e-8f95d2b63c15" type="2" creator="">
 			<title>
@@ -727,7 +727,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="0" price="0.7" quality="61" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 
 		<news id="2f64517a-f2d6-4720-a195-6a35cc6e72c6" thread_id="1f721fc7-32d1-4c82-8f05-6a20393dba8e" type="0" creator="">
@@ -743,7 +743,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="1135edbe-daf4-4ed7-8817-b352b9ee7442" time="1,8,12" />
 			</effects>
 			<data genre="3" price="1.0" quality="19" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="2f64517a-f2d6-4720-a195-6a35cc6e72c6_1" thread_id="1f721fc7-32d1-4c82-8f05-6a20393dba8e" type="0" creator="">
 			<title>
@@ -758,7 +758,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="1135edbe-daf4-4ed7-8817-b352b9ee7442" time="1,8,12" />
 			</effects>
 			<data genre="3" price="1.0" quality="19" />
-			<conditions year_range_from="-1" year_range_to="1981" />
+			<availability year_range_from="-1" year_range_to="1981" />
 		</news>
 		<news id="2f64517a-f2d6-4720-a195-6a35cc6e72c6_2" thread_id="1f721fc7-32d1-4c82-8f05-6a20393dba8e" type="0" creator="">
 			<title>
@@ -773,7 +773,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="1135edbe-daf4-4ed7-8817-b352b9ee7442" time="1,8,12" />
 			</effects>
 			<data genre="3" price="1.0" quality="19" />
-			<conditions year_range_from="1982" year_range_to="1991" />
+			<availability year_range_from="1982" year_range_to="1991" />
 		</news>
 		<news id="2f64517a-f2d6-4720-a195-6a35cc6e72c6_3" thread_id="1f721fc7-32d1-4c82-8f05-6a20393dba8e" type="0" creator="">
 			<title>
@@ -788,7 +788,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="1135edbe-daf4-4ed7-8817-b352b9ee7442" time="1,8,12" />
 			</effects>
 			<data genre="3" price="1.0" quality="19" />
-			<conditions year_range_from="1992" year_range_to="2002" />
+			<availability year_range_from="1992" year_range_to="2002" />
 		</news>
 		<news id="1135edbe-daf4-4ed7-8817-b352b9ee7442" thread_id="1f721fc7-32d1-4c82-8f05-6a20393dba8e" type="2" creator="">
 			<title>
@@ -803,7 +803,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="5345cee0-138e-4531-a239-71015a8ca909" time="2,1,1,8,11" />
 			</effects>
 			<data genre="3" price="1.0" quality="49" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="5345cee0-138e-4531-a239-71015a8ca909" thread_id="1f721fc7-32d1-4c82-8f05-6a20393dba8e" type="2" creator="">
 			<title>
@@ -818,7 +818,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="d3ca7812-9b3e-41e5-852c-e4f4ef045a06" time="2,2,3,8,18" />
 			</effects>
 			<data genre="0" price="1.0" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="d3ca7812-9b3e-41e5-852c-e4f4ef045a06" thread_id="1f721fc7-32d1-4c82-8f05-6a20393dba8e" type="2" creator="">
 			<title>
@@ -833,7 +833,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="d3ca7812-9b3e-41e5-852c-e4f4ef045aff-2" time="2,1,1,9,17" />
 			</effects>
 			<data genre="0" price="1.0" quality="35" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="d3ca7812-9b3e-41e5-852c-e4f4ef045aff-2" thread_id="1f721fc7-32d1-4c82-8f05-6a20393dba8e" type="2" creator="">
 			<title>
@@ -848,7 +848,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="d3ca7812-9b3e-41e5-852c-e4f4ef045aff-3" time="1,9,15" />
 			</effects>
 			<data genre="0" price="1.0" quality="30" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="d3ca7812-9b3e-41e5-852c-e4f4ef045aff-3" thread_id="1f721fc7-32d1-4c82-8f05-6a20393dba8e" type="2" creator="">
 			<title>
@@ -863,7 +863,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="d3ca7812-9b3e-41e5-852c-e4f4ef045aff-4" time="2,1,1,8,12" />
 			</effects>
 			<data genre="0" price="1.0" quality="38" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="d3ca7812-9b3e-41e5-852c-e4f4ef045aff-4" thread_id="1f721fc7-32d1-4c82-8f05-6a20393dba8e" type="2" creator="">
 			<title>
@@ -878,7 +878,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="d3ca7812-9b3e-41e5-852c-e4f4ef045aff-5" time="1,6,11" />
 			</effects>
 			<data genre="0" price="1.0" quality="28" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="d3ca7812-9b3e-41e5-852c-e4f4ef045aff-5" thread_id="1f721fc7-32d1-4c82-8f05-6a20393dba8e" type="2" creator="">
 			<title>
@@ -891,7 +891,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="0" price="1.0" quality="51" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 
 		<news id="32617459-a2eb-412a-87c9-0411314c0694" thread_id="24f462b9-bac5-499e-ae2d-780f225872b1" type="0" creator="">
@@ -905,7 +905,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="0" price="1.0" quality="68" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="a8356756-4d49-42db-9b36-b91da8a0539f" thread_id="2c8a146f-9700-4ad0-ae4a-9328f7c00912" type="0" creator="">
 			<title>
@@ -918,7 +918,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="2" price="1.0" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="094806da-5113-4b57-b09a-c0639ebc20f9" thread_id="3af0567a-bc40-43f0-94c1-f2e1cefb2238" type="0" creator="">
 			<title>
@@ -933,7 +933,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="d4b58f67-56ed-4c7b-a524-3c641187c348" />
 			</effects>
 			<data genre="0" price="1.0" quality="28" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="bf0ee1be-3dc3-4581-8614-fff5253d6330" thread_id="3af0567a-bc40-43f0-94c1-f2e1cefb2238" type="2" creator="">
 			<title>
@@ -948,7 +948,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="17528858-a7e0-4b6d-a515-d245e40ce87c" />
 			</effects>
 			<data genre="0" price="1.0" quality="39" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="23fc5b0e-d3d8-4049-970b-236966ec8da5" thread_id="3af0567a-bc40-43f0-94c1-f2e1cefb2238" type="2" creator="">
 			<title>
@@ -961,7 +961,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="0" price="1.0" quality="39" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="17528858-a7e0-4b6d-a515-d245e40ce87c" thread_id="3af0567a-bc40-43f0-94c1-f2e1cefb2238" type="2" creator="">
 			<title>
@@ -976,7 +976,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="23fc5b0e-d3d8-4049-970b-236966ec8da5" />
 			</effects>
 			<data genre="0" price="0.5" quality="42" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="79b75334-0bec-4061-a029-890601f10b5e" thread_id="3af0567a-bc40-43f0-94c1-f2e1cefb2238" type="2" creator="">
 			<title>
@@ -991,7 +991,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="bf0ee1be-3dc3-4581-8614-fff5253d6330" />
 			</effects>
 			<data genre="0" price="1.0" quality="58" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="d4b58f67-56ed-4c7b-a524-3c641187c348" thread_id="3af0567a-bc40-43f0-94c1-f2e1cefb2238" type="2" creator="">
 			<title>
@@ -1006,7 +1006,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="79b75334-0bec-4061-a029-890601f10b5e" />
 			</effects>
 			<data genre="0" price="1.0" quality="28" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="53d11d51-473e-499d-91dc-5cd59fb7cf34" thread_id="4234e2b1-3938-40df-8855-8f730cdd1d01" type="0" creator="">
 			<title>
@@ -1019,7 +1019,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="0" price="1.0" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="679a06d6-ade8-40fa-9770-eb3c31ef75ec" thread_id="49165cd6-34e3-4d00-8afd-f6eb3ae808ef" type="0" creator="">
 			<title>
@@ -1032,7 +1032,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="4" price="1.0" quality="15" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="b6b215f8-17de-44f0-b3f5-a23e06794705" thread_id="4ea94528-27be-4366-9f5b-80e6893a3e9b" type="0" creator="">
 			<title>
@@ -1045,7 +1045,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="4" price="1.0" quality="9" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="6b9c5dc4-d2ca-4f09-9eb7-794765ccd584" thread_id="4edc7a2f-4387-43f8-be1c-5119d4a4fa29" type="0" creator="">
 			<title>
@@ -1060,7 +1060,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="8bc34c83-4fc3-4aab-afa6-f67fa479902c" />
 			</effects>
 			<data genre="3" price="0.7" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="8bc34c83-4fc3-4aab-afa6-f67fa479902c" thread_id="4edc7a2f-4387-43f8-be1c-5119d4a4fa29" type="2" creator="">
 			<title>
@@ -1075,7 +1075,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="71ffceeb-a304-4d09-80bd-69fe8e672eab" />
 			</effects>
 			<data genre="3" price="1.0" quality="39" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="71ffceeb-a304-4d09-80bd-69fe8e672eab" thread_id="4edc7a2f-4387-43f8-be1c-5119d4a4fa29" type="2" creator="">
 			<title>
@@ -1090,7 +1090,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="b06abbd3-94a3-4ebc-8635-9c4beb24195f" />
 			</effects>
 			<data genre="3" price="0.7" quality="39" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="b06abbd3-94a3-4ebc-8635-9c4beb24195f" thread_id="4edc7a2f-4387-43f8-be1c-5119d4a4fa29" type="2" creator="">
 			<title>
@@ -1103,7 +1103,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="3" price="1.0" quality="39" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="5f897c83-8355-4cbc-9478-5bdd8281adb9" thread_id="5695db52-4ad0-4dfa-9e23-192cb9c12146" type="0" creator="">
 			<title>
@@ -1116,7 +1116,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="2" price="0.7" quality="25" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="9d57694b-1419-4bb8-bac9-bb092c383e83" thread_id="5bbbce34-01a6-43f9-b882-eceb5ffd7884" type="0" creator="">
 			<title>
@@ -1129,7 +1129,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="4" price="1.0" quality="39" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="67f49f75-14d8-495d-83cf-f36ba136bb9c" thread_id="5c46bb57-f494-4986-ac5a-76061dae1399" type="0" creator="">
 			<title>
@@ -1142,7 +1142,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="0" price="1.0" quality="9" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="2c217224-62fd-4583-b457-1c69c813aff6" thread_id="5d832597-6cdc-4bfe-9213-0a82cd45b130" type="0" creator="">
 			<title>
@@ -1160,7 +1160,7 @@ Her normal body size is expected to be reached in a week.</en>
 				/>
 			</effects>
 			<data genre="2" price="0.7" quality="23" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="e250f180-310d-4639-bdd4-229b818f3a92-a" thread_id="5d832597-6cdc-4bfe-9213-0a82cd45b130" type="2" creator="">
 			<title>
@@ -1173,7 +1173,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="2" price="1.05" quality="18" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="e250f180-310d-4639-bdd4-229b818f3a92-b" thread_id="5d832597-6cdc-4bfe-9213-0a82cd45b130" type="2" creator="">
 			<title>
@@ -1186,7 +1186,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="2" price="1.05" quality="39" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="d28c5997-c17c-4b68-9289-773617b62e58" thread_id="60185c09-38ec-4c44-a884-ed76b8bca258" type="0" creator="">
 			<title>
@@ -1199,7 +1199,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="1" price="1.0" quality="23" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="b2719e00-bd4c-42dd-8398-35cf359009b0" thread_id="646312c1-7980-47ca-8d77-0e0e07a5ba67" type="0" creator="">
 			<title>
@@ -1214,7 +1214,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="0dd305ab-89ef-4961-8a6b-5e67e809d309" />
 			</effects>
 			<data genre="3" price="1.0" quality="49" />
-			<conditions year_range_from="1992" year_range_to="-1" />
+			<availability year_range_from="1992" year_range_to="-1" />
 		</news>
 		<news id="b2719e00-bd4c-42dd-8398-35cf359009b0_2" thread_id="646312c1-7980-47ca-8d77-0e0e07a5ba67" type="0" creator="">
 			<title>
@@ -1229,7 +1229,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="0dd305ab-89ef-4961-8a6b-5e67e809d309" />
 			</effects>
 			<data genre="3" price="1.0" quality="49" />
-			<conditions year_range_from="-1" year_range_to="1991" />
+			<availability year_range_from="-1" year_range_to="1991" />
 		</news>
 		<news id="0dd305ab-89ef-4961-8a6b-5e67e809d309" thread_id="646312c1-7980-47ca-8d77-0e0e07a5ba67" type="2" creator="">
 			<title>
@@ -1244,7 +1244,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="44977907-8f02-4023-a42b-c109b8837a86" />
 			</effects>
 			<data genre="3" price="1.0" quality="39" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="44977907-8f02-4023-a42b-c109b8837a86" thread_id="646312c1-7980-47ca-8d77-0e0e07a5ba67" type="2" creator="">
 			<title>
@@ -1259,7 +1259,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="7c626ce4-5ae7-45d7-9909-6c2b42ce18e3" />
 			</effects>
 			<data genre="3" price="1.0" quality="39" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="7c626ce4-5ae7-45d7-9909-6c2b42ce18e3" thread_id="646312c1-7980-47ca-8d77-0e0e07a5ba67" type="2" creator="">
 			<title>
@@ -1274,7 +1274,7 @@ Her normal body size is expected to be reached in a week.</en>
 				<effect trigger="happen" type="triggernews" news="2195e517-be06-4729-8508-824119e5d4aa" />
 			</effects>
 			<data genre="3" price="1.0" quality="39" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="2195e517-be06-4729-8508-824119e5d4aa" thread_id="646312c1-7980-47ca-8d77-0e0e07a5ba67" type="2" creator="">
 			<title>
@@ -1287,7 +1287,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="0" price="1.0" quality="49" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="e534c0e3-0f37-4e37-92f1-7c2796168572" thread_id="67c8a17b-d314-4016-bf94-2c2b079912af" type="0" creator="">
 			<title>
@@ -1300,7 +1300,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="2" price="1.0" quality="19" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="ff604bfe-8d59-4ec4-bf45-46d67f81bf82" thread_id="7677c54c-f01e-48c6-b2e5-3fbdbc94fad1" type="0" creator="">
 			<title>
@@ -1313,7 +1313,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="3" price="1.0" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="df3f342a-6bb2-4445-9f77-2765d51a8187" thread_id="769c4c90-9ddc-4c72-8ad7-1850f0c95109" type="0" creator="">
 			<title>
@@ -1326,7 +1326,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="3" price="1.0" quality="39" />
-			<conditions year_range_from="1995" year_range_to="-1" />
+			<availability year_range_from="1995" year_range_to="-1" />
 		</news>
 		<news id="df3f342a-6bb2-4445-9f77-2765d51a8187_2" thread_id="769c4c90-9ddc-4c72-8ad7-1850f0c95109" type="0" creator="">
 			<title>
@@ -1339,7 +1339,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="3" price="1.0" quality="39" />
-			<conditions year_range_from="-1" year_range_to="1994" />
+			<availability year_range_from="-1" year_range_to="1994" />
 		</news>
 		<news id="bc2475d4-e45d-484d-9095-16e2c06bea72" thread_id="7c62ccae-017a-4db9-872f-dfc75ddd4b4c" type="0" creator="">
 			<title>
@@ -1352,7 +1352,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="1" price="0.7" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="d5835942-1658-4140-9272-2450165344de" thread_id="81ef8cbc-3208-4786-aa0d-6d6f824e79ca" type="0" creator="">
 			<title>
@@ -1365,7 +1365,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="3" price="1.0" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="68923a81-fdf8-4416-a85b-c943850b9b9a" thread_id="8539de3d-c301-4376-9763-2e0f1f2a6d9f" type="0" creator="">
 			<title>
@@ -1378,7 +1378,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="0" price="0.7" quality="25" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="c465e880-20cb-4c42-bdb0-76950380eb02" thread_id="89d538a2-9f45-4d55-b672-49de6ebaaebd" type="0" creator="">
 			<title>
@@ -1391,7 +1391,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="5" price="1.0" quality="58" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="27a9048d-2066-404a-8a8e-aceb1ad6d84a" thread_id="8e1eca41-5270-4fc1-99a6-c2404809e276" type="0" creator="">
 			<title>
@@ -1404,7 +1404,7 @@ Her normal body size is expected to be reached in a week.</en>
 			</description>
 			<effects />
 			<data genre="1" price="0.7" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="bd674ac6-d8be-4b53-8023-185adfeaf90c" thread_id="8e65fd80-587e-4c17-a12f-09e368dca29e" type="0" creator="">
 			<title>
@@ -1419,7 +1419,7 @@ A NASA pot set will also be raffled off.</en>
 			</description>
 			<effects />
 			<data genre="1" price="1.0" quality="14" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="22e00cc1-288d-4405-815b-51da1e25f6e5" thread_id="902e3964-abe0-41cd-8f80-18a09e7e4aea" type="0" creator="">
 			<title>
@@ -1432,7 +1432,7 @@ A NASA pot set will also be raffled off.</en>
 			</description>
 			<effects />
 			<data genre="0" price="0.7" quality="62" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="f82cdc27-72a8-4007-94ce-8b94c15eeb7d" thread_id="903482a4-19ea-41d4-9c1c-08edd2b35961" type="0" creator="">
 			<title>
@@ -1445,7 +1445,7 @@ A NASA pot set will also be raffled off.</en>
 			</description>
 			<effects />
 			<data genre="4" price="1.0" quality="45" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="1a4d7fd8-855a-47e4-871a-dc72eb4680ba" thread_id="94e573ec-1350-405c-b2f6-8684958e6e8b" type="0" creator="">
 			<title>
@@ -1462,7 +1462,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="441f0aa3-0412-4236-991c-ddae48f2b62a" time="2,1,1,9,17" />
 			</effects>
 			<data genre="0" price="0.7" quality="23" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="441f0aa3-0412-4236-991c-ddae48f2b62a" thread_id="94e573ec-1350-405c-b2f6-8684958e6e8b" type="2" creator="">
 			<title>
@@ -1477,7 +1477,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="fb43d1ce-61b8-4625-8385-520b8f0d282c" time="2,1,1,4,13" />
 			</effects>
 			<data genre="0" price="1.0" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="fb43d1ce-61b8-4625-8385-520b8f0d282c" thread_id="94e573ec-1350-405c-b2f6-8684958e6e8b" type="2" creator="">
 			<title>
@@ -1492,7 +1492,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="7949493e-c6e0-4b59-a06c-044ddbf66dd0" time="2,1,1,0,13" />
 			</effects>
 			<data genre="0" price="0.7" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="7949493e-c6e0-4b59-a06c-044ddbf66dd0" thread_id="94e573ec-1350-405c-b2f6-8684958e6e8b" type="2" creator="">
 			<title>
@@ -1507,7 +1507,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="d86c9008-6752-4358-b545-2d09e23bf24a" time="1,2,6" />
 			</effects>
 			<data genre="0" price="1.0" quality="23" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="d86c9008-6752-4358-b545-2d09e23bf24a" thread_id="94e573ec-1350-405c-b2f6-8684958e6e8b" type="2" creator="">
 			<title>
@@ -1520,7 +1520,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="0" price="1.0" quality="39" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 
 		<news id="de78d446-a89c-4281-b018-a2c6f8975211" thread_id="9707f767-9129-46ea-84d2-a4870897fdfb" type="0" creator="">
@@ -1536,7 +1536,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="2899a642-b0dc-4285-98e0-10835eb911fc" time="2,1,3,6,18" />
 			</effects>
 			<data genre="4" price="1.0" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="2899a642-b0dc-4285-98e0-10835eb911fc" thread_id="9707f767-9129-46ea-84d2-a4870897fdfb" type="2" creator="">
 			<title>
@@ -1551,7 +1551,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="2dd29a642-a0dc-f275-32ef-16815eb34ff" time="2,1,3,6,18" />
 			</effects>
 			<data genre="4" price="1.0" quality="49" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="2dd29a642-a0dc-f275-32ef-16815eb34ff" thread_id="9707f767-9129-46ea-84d2-a4870897fdfb" type="2" creator="">
 			<title>
@@ -1564,7 +1564,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="4" price="0.7" quality="39" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 
 		<news id="newsevent-unknown-preyts-ep1" thread_id="newsevent-unknown-preyts" type="0" creator="">
@@ -1580,7 +1580,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="newsevent-unknown-preyts-ep2" time="2,1,2,6,18" />
 			</effects>
 			<data genre="2" price="1.0" quality="30" />
-			<conditions year_range_from="2004" year_range_to="2005" />
+			<availability year_range_from="2004" year_range_to="2005" />
 		</news>
 		<news id="newsevent-unknown-preyts-ep2" thread_id="newsevent-unknown-preyts" type="2" creator="">
 			<title>
@@ -1595,7 +1595,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="newsevent-unknown-preyts-ep3" time="1,6,12" />
 			</effects>
 			<data genre="2" price="1.0" quality="25" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="newsevent-unknown-preyts-ep3" thread_id="newsevent-unknown-preyts" type="2" creator="">
 			<title>
@@ -1610,7 +1610,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="newsevent-unknown-preyts-ep4" time="2,2,3,8,21" />
 			</effects>
 			<data genre="2" price="1.0" quality="35" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="newsevent-unknown-preyts-ep4" thread_id="newsevent-unknown-preyts" type="2" creator="">
 			<title>
@@ -1625,7 +1625,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="newsevent-unknown-preyts-ep2" time="2,1,1,7,11" />
 			</effects>
 			<data genre="2" price="1.0" quality="25" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="newsevent-unknown-preyts-ep5" thread_id="newsevent-unknown-preyts" type="2" creator="">
 			<title>
@@ -1638,7 +1638,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="2" price="1.0" quality="30" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 
 		<news id="53769295-e71f-4cbc-a127-3e3cfb70b394" thread_id="a3e86722-1b9a-4cf4-991f-a7da7d16872b" type="0" creator="">
@@ -1652,7 +1652,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="4" price="0.7" quality="58" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="db23af24-bf5c-42d3-8567-fa7b2c1a4e3f" thread_id="a5ba32a7-cedc-463d-9cf9-fb628c7a7fb1" type="0" creator="">
 			<title>
@@ -1664,7 +1664,7 @@ Demonstrations are expected again this year.</en>
 				<en>Last night the Mona Lisa was stolen from the Louvre in Paris. A night watchman noticed this when he wanted to clean the frame.</en>
 			</description>
 			<data genre="5" price="1.0" quality="49" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="3756602f-ddcc-4e7c-9ebc-4c1a3259d8c2" thread_id="a6ec2fd9-ff73-4f4b-829b-01f331dc6f92" type="0" creator="">
 			<title>
@@ -1677,7 +1677,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="4" price="1.0" quality="9" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="ba7b3713-d66c-4777-b0d4-1195bcef9850" thread_id="a8c65186-08a7-4099-b303-994272ffc9c6" type="0" creator="">
 			<title>
@@ -1692,7 +1692,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="920616c0-05b7-4078-a253-d070e58b7b98" time="2,1,1,7-9" />
 			</effects>
 			<data genre="4" price="1.0" quality="58" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="920616c0-05b7-4078-a253-d070e58b7b98" thread_id="a8c65186-08a7-4099-b303-994272ffc9c6" type="2" creator="">
 			<title>
@@ -1705,7 +1705,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="4" price="1.0" quality="49" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="6134da01-d7d0-48dc-94d5-fbe43bd4dda6" thread_id="aebe2cd0-0c5e-4d38-9cca-b2ab634ee4f6" type="0" creator="">
 			<title>
@@ -1718,7 +1718,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="3" price="1.0" quality="33" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="ab0b9817-e9af-41f1-a5f1-5c83a4c974ea" thread_id="b22b0ecb-78f4-4bfa-a3dd-19cf475d994c" type="0" creator="">
 			<title>
@@ -1731,7 +1731,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="4" price="0.7" quality="39" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="053b3454-01b7-4e55-9aaa-06e03dd67e12" thread_id="b2b0eae0-e095-4d99-ac01-cb1ff6c98f5c" type="0" creator="">
 			<title>
@@ -1744,7 +1744,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="2" price="0.7" quality="40" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="d824c05e-00fc-4d4f-a1cd-40a8e7a42085" thread_id="b504e69a-721b-4c1c-838c-fdbd8684dd45" type="0" creator="">
 			<title>
@@ -1757,7 +1757,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="0" price="0.5" quality="58" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="6898a824-d53c-483b-a9c1-80a22129893b" thread_id="b54104bd-758d-4b1b-88e5-77a4816c6754" type="0" creator="">
 			<title>
@@ -1770,7 +1770,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="0" price="0.5" quality="39" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="9e4efc53-e374-4260-9bf6-e3265f6df566" thread_id="b7c32373-4781-4523-97ec-8398933fc8c3" type="0" creator="">
 			<title>
@@ -1785,7 +1785,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="a5bba03c-67ff-4070-ad92-e1e663cf33a4" />
 			</effects>
 			<data genre="4" price="1.0" quality="39" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="a5bba03c-67ff-4070-ad92-e1e663cf33a4" thread_id="b7c32373-4781-4523-97ec-8398933fc8c3" type="2" creator="">
 			<title>
@@ -1800,7 +1800,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="5f7ea775-4031-4cf8-8bc0-83c9b0aca07d" />
 			</effects>
 			<data genre="4" price="1.0" quality="27" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="5f7ea775-4031-4cf8-8bc0-83c9b0aca07d" thread_id="b7c32373-4781-4523-97ec-8398933fc8c3" type="2" creator="">
 			<title>
@@ -1813,7 +1813,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="4" price="1.0" quality="26" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="83ba96bc-4560-4ac0-9929-329eb7f68751" thread_id="b900820c-cc68-4ef8-a021-58b56c7414be" type="0" creator="">
 			<title>
@@ -1826,7 +1826,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="3" price="0.7" quality="72" />
-			<conditions year_range_from="1986" year_range_to="1998" />
+			<availability year_range_from="1986" year_range_to="1998" />
 		</news>
 		<news id="83ba96bc-4560-4ac0-9929-329eb7f68751_2" thread_id="b900820c-cc68-4ef8-a021-58b56c7414be" type="0" creator="">
 			<title>
@@ -1839,7 +1839,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="3" price="0.7" quality="72" />
-			<conditions year_range_from="1999" year_range_to="-1" />
+			<availability year_range_from="1999" year_range_to="-1" />
 		</news>
 		<news id="d2b527a3-3181-4cbc-baa2-7bd4c7503a74_1" thread_id="baadc4ea-796b-44a2-b4cb-d333f01516ea_1" type="0" creator="">
 			<title>
@@ -1854,7 +1854,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="9c1f0f27-72d6-4bbd-b271-939ab31c3010_1" />
 			</effects>
 			<data genre="4" price="1.0" quality="19" />
-			<conditions year_range_from="-1" year_range_to="2001" />
+			<availability year_range_from="-1" year_range_to="2001" />
 		</news>
 		<news id="9c1f0f27-72d6-4bbd-b271-939ab31c3010_1" thread_id="baadc4ea-796b-44a2-b4cb-d333f01516ea_1" type="2" creator="">
 			<title>
@@ -1867,7 +1867,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="4" price="1.0" quality="19" />
-			<conditions year_range_from="-1" year_range_to="2001" />
+			<availability year_range_from="-1" year_range_to="2001" />
 		</news>
 		<news id="d2b527a3-3181-4cbc-baa2-7bd4c7503a74_2" thread_id="baadc4ea-796b-44a2-b4cb-d333f01516ea_2" type="0" creator="">
 			<title>
@@ -1882,7 +1882,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="9c1f0f27-72d6-4bbd-b271-939ab31c3010_2" />
 			</effects>
 			<data genre="4" price="1.0" quality="19" />
-			<conditions year_range_from="2002" year_range_to="-1" />
+			<availability year_range_from="2002" year_range_to="-1" />
 		</news>
 		<news id="9c1f0f27-72d6-4bbd-b271-939ab31c3010_2" thread_id="baadc4ea-796b-44a2-b4cb-d333f01516ea_2" type="2" creator="">
 			<title>
@@ -1895,7 +1895,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="4" price="1.0" quality="19" />
-			<conditions year_range_from="2002" year_range_to="-1" />
+			<availability year_range_from="2002" year_range_to="-1" />
 		</news>
 		<news id="4177ebd7-888e-4df0-97bd-c74109e81616" thread_id="bae6336f-1755-4619-96b8-9b66f9ff6c7a" type="0" creator="">
 			<title>
@@ -1908,7 +1908,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="0" price="0.7" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="2420ee19-a1a3-41fc-97a0-60c77715324a" thread_id="bb84934b-e89e-45ca-88ad-565ad8151996" type="0" creator="">
 			<title>
@@ -1921,7 +1921,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="4" price="1.0" quality="14" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 
 		<news id="34977b2a-b976-48f8-8254-001ebe2263f1" thread_id="c6a7d19b-eab1-4fc4-87eb-c9b4291e6778" type="0" creator="">
@@ -1938,7 +1938,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="cee19a85-bbf4-4d2b-9239-cca90d8d76ad" time="3,5,9,15"  />
 			</effects>
 			<data genre="0" price="1.0" quality="38" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="cee19a85-bbf4-4d2b-9239-cca90d8d76ad" thread_id="c6a7d19b-eab1-4fc4-87eb-c9b4291e6778" type="2" creator="">
 			<title>
@@ -1954,7 +1954,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="34edc95f-49f3-4131-bc39-8ed5cfc293b1" time="2,1,1,19,21" />
 			</effects>
 			<data genre="0" price="0.5" quality="49" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="661a9905-912e-4801-ad63-73b9ead7fd78" thread_id="c6a7d19b-eab1-4fc4-87eb-c9b4291e6778" type="2" creator="">
 			<title>
@@ -1966,7 +1966,7 @@ Demonstrations are expected again this year.</en>
 				<en>Initial projections have shown that voter turnout has never been so low. The polls won't fill up in the afternoon.</en>
 			</description>
 			<data genre="0" price="0.5" quality="68" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="34edc95f-49f3-4131-bc39-8ed5cfc293b1" thread_id="c6a7d19b-eab1-4fc4-87eb-c9b4291e6778" type="2" creator="">
 			<title>
@@ -1981,7 +1981,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="9c5ec87d-9056-46ca-a38b-58ce5dddf2eb" time="2,1,1,8,17" />
 			</effects>
 			<data genre="0" price="0.5" quality="78" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="9c5ec87d-9056-46ca-a38b-58ce5dddf2eb" thread_id="c6a7d19b-eab1-4fc4-87eb-c9b4291e6778" type="2" creator="">
 			<title>
@@ -1996,7 +1996,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="c3848e4a-6629-4481-b036-7aa9abad6e92"  time="2,2,3,9,17" />
 			</effects>
 			<data genre="0" price="1.0" quality="49" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="c3848e4a-6629-4481-b036-7aa9abad6e92" thread_id="c6a7d19b-eab1-4fc4-87eb-c9b4291e6778" type="2" creator="">
 			<title>
@@ -2011,7 +2011,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="1b87d798-85de-486d-a683-25c11db8c929" time="2,1,1,8,17"  />
 			</effects>
 			<data genre="0" price="1.0" quality="58" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="1b87d798-85de-486d-a683-25c11db8c929" thread_id="c6a7d19b-eab1-4fc4-87eb-c9b4291e6778" type="2" creator="">
 			<title>
@@ -2024,7 +2024,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="0" price="0.5" quality="88" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 
 		<news id="99fe6727-f9ea-4a1d-89b5-928a655b1695" thread_id="c82d429c-fa85-4771-b661-7181b4607c9f" type="0" creator="">
@@ -2040,7 +2040,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="f9a45fff-1546-ffa8-aa8a6ddb4880ad7f3" />
 			</effects>
 			<data genre="4" price="1.0" quality="88" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="f9a45fff-1546-ffa8-aa8a6ddb4880ad7f3" thread_id="c82d429c-fa85-4771-b661-7181b4607c9f" type="2" creator="">
 			<title>
@@ -2055,7 +2055,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="d8e0085f-2835-48e3-b0a8-4ab489f277f2" />
 			</effects>
 			<data genre="4" price="1.0" quality="78" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="d8e0085f-2835-48e3-b0a8-4ab489f277f2" thread_id="c82d429c-fa85-4771-b661-7181b4607c9f" type="2" creator="">
 			<title>
@@ -2070,7 +2070,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="3b01bf6c-1551-4fc7-b196-d129cce1f7a5" />
 			</effects>
 			<data genre="4" price="1.0" quality="58" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="3b01bf6c-1551-4fc7-b196-d129cce1f7a5" thread_id="c82d429c-fa85-4771-b661-7181b4607c9f" type="2" creator="">
 			<title>
@@ -2085,7 +2085,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="64897c07-0f8a-4f2e-ae52-e09ec7295066" />
 			</effects>
 			<data genre="4" price="1.0" quality="58" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="64897c07-0f8a-4f2e-ae52-e09ec7295066" thread_id="c82d429c-fa85-4771-b661-7181b4607c9f" type="2" creator="">
 			<title>
@@ -2100,7 +2100,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="e023198f-1705-46b7-aee4-ce17880e65b3" />
 			</effects>
 			<data genre="4" price="1.0" quality="39" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="e023198f-1705-46b7-aee4-ce17880e65b3" thread_id="c82d429c-fa85-4771-b661-7181b4607c9f" type="2" creator="">
 			<title>
@@ -2115,7 +2115,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="1aad1ce7-966c-4d3b-a6d1-1a0ece958440" />
 			</effects>
 			<data genre="4" price="1.0" quality="88" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="1aad1ce7-966c-4d3b-a6d1-1a0ece958440" thread_id="c82d429c-fa85-4771-b661-7181b4607c9f" type="2" creator="">
 			<title>
@@ -2130,7 +2130,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="fd620ae0-8d62-4243-83f2-b36b024d3594" />
 			</effects>
 			<data genre="4" price="1.0" quality="58" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="fd620ae0-8d62-4243-83f2-b36b024d3594" thread_id="c82d429c-fa85-4771-b661-7181b4607c9f" type="2" creator="">
 			<title>
@@ -2145,7 +2145,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="565d023d-7826-47c9-a9cd-bb36ed847c73" />
 			</effects>
 			<data genre="4" price="1.0" quality="68" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="565d023d-7826-47c9-a9cd-bb36ed847c73" thread_id="c82d429c-fa85-4771-b661-7181b4607c9f" type="2" creator="">
 			<title>
@@ -2160,7 +2160,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="aa493fff-2456-ffa3-fa4a-a7bc4e7cc5a3" />
 			</effects>
 			<data genre="4" price="1.0" quality="88" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="aa493fff-2456-ffa3-fa4a-a7bc4e7cc5a3" thread_id="c82d429c-fa85-4771-b661-7181b4607c9f" type="2" creator="">
 			<title>
@@ -2172,7 +2172,7 @@ Demonstrations are expected again this year.</en>
 				<en>After the San Francisco earthquake the clean-up work is finished. The earthquake killed a total of 3971 people.</en>
 			</description>
 			<data genre="4" price="1.0" quality="73" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 
 		<news id="64d0b36d-2dda-4ab5-af7f-e9087c35e1ea" thread_id="ccb647c9-025f-4a00-876b-0b95ea303d7c" type="0" creator="">
@@ -2186,7 +2186,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="4" price="1.0" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="dfd40ed6-dbae-4c7a-9128-8d2befb589f0" thread_id="d259cc83-9c13-438c-a990-1076d6892e60" type="0" creator="">
 			<title>
@@ -2201,7 +2201,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="0e8af79d-2b80-4802-884e-bcaa3b70ed22" />
 			</effects>
 			<data genre="3" price="1.0" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="0e8af79d-2b80-4802-884e-bcaa3b70ed22" thread_id="d259cc83-9c13-438c-a990-1076d6892e60" type="2" creator="">
 			<title>
@@ -2216,7 +2216,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="f6890750-2d10-44cd-822c-52e09bcc431c" />
 			</effects>
 			<data genre="3" price="1.0" quality="19" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="f6890750-2d10-44cd-822c-52e09bcc431c" thread_id="d259cc83-9c13-438c-a990-1076d6892e60" type="2" creator="">
 			<title>
@@ -2231,7 +2231,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="de5a8f0e-3445-432d-987d-56d998d173b6" />
 			</effects>
 			<data genre="3" price="1.0" quality="19" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="de5a8f0e-3445-432d-987d-56d998d173b6" thread_id="d259cc83-9c13-438c-a990-1076d6892e60" type="2" creator="">
 			<title>
@@ -2246,7 +2246,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="a8aab24e-fbaa-4fa0-b815-5b4b3a6aca35" />
 			</effects>
 			<data genre="3" price="1.0" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="a8aab24e-fbaa-4fa0-b815-5b4b3a6aca35" thread_id="d259cc83-9c13-438c-a990-1076d6892e60" type="2" creator="">
 			<title>
@@ -2259,7 +2259,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="3" price="1.0" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="11dc4748-f11f-45b6-9a4e-b2dfa6b8abfd" thread_id="d33d8133-e1a8-4660-a1c8-fc2272fb8448" type="0" creator="">
 			<title>
@@ -2272,7 +2272,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="4" price="1.1" quality="12" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="a6ac4b6c-83a0-433a-9336-c7256b6e3165" thread_id="d4c54bd0-cecf-4f40-bb10-7cda64543f3d" type="0" creator="">
 			<title>
@@ -2285,7 +2285,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="3" price="1.0" quality="39" />
-			<conditions year_range_from="1993" year_range_to="-1" />
+			<availability year_range_from="1993" year_range_to="-1" />
 		</news>
 		<news id="a6ac4b6c-83a0-433a-9336-c7256b6e3165_2" thread_id="d4c54bd0-cecf-4f40-bb10-7cda64543f3d" type="0" creator="">
 			<title>
@@ -2298,7 +2298,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="3" price="1.0" quality="39" />
-			<conditions year_range_from="1982" year_range_to="1992" />
+			<availability year_range_from="1982" year_range_to="1992" />
 		</news>
 		<news id="a008bb9e-8e06-4b59-84ff-5bd46f3bc1d2" thread_id="d89029e7-9fa4-43d0-9f59-9704c818e63e" type="0" creator="">
 			<title>
@@ -2313,7 +2313,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="571543da-edcb-48c5-866d-e978491be0b9" time="2,1,1,7-15" />
 			</effects>
 			<data genre="2" price="1.0" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="571543da-edcb-48c5-866d-e978491be0b9" thread_id="d89029e7-9fa4-43d0-9f59-9704c818e63e" type="2" creator="">
 			<title>
@@ -2329,7 +2329,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="ef0b1006-b2ce-41b9-a783-1b556124df40"  time="1,8,13" />
 			</effects>
 			<data genre="2" price="1.0" quality="39" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="ef0b1006-b2ce-41b9-a783-1b556124df40" thread_id="d89029e7-9fa4-43d0-9f59-9704c818e63e" type="2" creator="">
 			<title>
@@ -2344,7 +2344,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="a4138dc1-9369-4735-9377-64a569cde6dc" time="2,1,1,12,18" />
 			</effects>
 			<data genre="2" price="1.0" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="a4138dc1-9369-4735-9377-64a569cde6dc" thread_id="d89029e7-9fa4-43d0-9f59-9704c818e63e" type="2" creator="">
 			<title>
@@ -2359,7 +2359,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="e2ec64a7-fc37-4a07-b567-1f7761821df7" time="2,1,2,8,20" />
 			</effects>
 			<data genre="2" price="1.0" quality="49" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="e2ec64a7-fc37-4a07-b567-1f7761821df7" thread_id="d89029e7-9fa4-43d0-9f59-9704c818e63e" type="2" creator="">
 			<title>
@@ -2371,7 +2371,7 @@ Demonstrations are expected again this year.</en>
 				<en>Michel Bollock will switch to Real next season for €75 million. Hochness rubs his hands: "For the money we get 2 new Bollocks."</en>
 			</description>
 			<data genre="2" price="1.0" quality="19" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 
 		<news id="3a5e6a8d-a0ee-4175-ba92-a5bada7cf291" thread_id="d8ca951a-2240-488a-8913-ddb5b75c8add" type="0" creator="">
@@ -2387,7 +2387,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="f67941dc-54a1-428f-b3c0-c58d7877aa85" time="2,2,4,5,17" />
 			</effects>
 			<data genre="1" price="1.0" quality="20" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="f67941dc-54a1-428f-b3c0-c58d7877aa85" thread_id="d8ca951a-2240-488a-8913-ddb5b75c8add" type="2" creator="">
 			<title>
@@ -2402,7 +2402,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="b0dca345-b75e-4d34-97c1-9467339cdbb0" time="2,1,1,3,22" />
 			</effects>
 			<data genre="1" price="1.0" quality="18" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="b0dca345-b75e-4d34-97c1-9467339cdbb0" thread_id="d8ca951a-2240-488a-8913-ddb5b75c8add" type="2" creator="">
 			<title>
@@ -2417,7 +2417,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="89857ce2-b83a-4f36-97da-5a780db79d03" time="2,1,2,9,17"  />
 			</effects>
 			<data genre="1" price="1.0" quality="19" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="89857ce2-b83a-4f36-97da-5a780db79d03" thread_id="d8ca951a-2240-488a-8913-ddb5b75c8add" type="2" creator="">
 			<title>
@@ -2432,7 +2432,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="af1d00d5-19bd-4135-8e66-46263735f688"  time="2,1,1,5,22" />
 			</effects>
 			<data genre="1" price="1.0" quality="19" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="af1d00d5-19bd-4135-8e66-46263735f688" thread_id="d8ca951a-2240-488a-8913-ddb5b75c8add" type="2" creator="">
 			<title>
@@ -2447,7 +2447,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="91a7a88b-b4ff-47b3-b709-6e98d6232cbb" time="1,8,19" />
 			</effects>
 			<data genre="1" price="1.0" quality="13" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="91a7a88b-b4ff-47b3-b709-6e98d6232cbb" thread_id="d8ca951a-2240-488a-8913-ddb5b75c8add" type="2" creator="">
 			<title>
@@ -2462,7 +2462,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="a0104185-2bc8-4b05-90e1-383418c8d66d" time="2,1,3,5,23" />
 			</effects>
 			<data genre="1" price="1.0" quality="11" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="a0104185-2bc8-4b05-90e1-383418c8d66d" thread_id="d8ca951a-2240-488a-8913-ddb5b75c8add" type="2" creator="">
 			<title>
@@ -2477,7 +2477,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="7fed1494-c4fb-44b1-842f-c6caf08ce376" time="2,1,1,9,13"  />
 			</effects>
 			<data genre="1" price="1.0" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="7fed1494-c4fb-44b1-842f-c6caf08ce376" thread_id="d8ca951a-2240-488a-8913-ddb5b75c8add" type="2" creator="">
 			<title>
@@ -2490,7 +2490,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="1" price="1.0" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 
 		<news id="fded6521-4bc8-400a-8b97-0749573812d1" thread_id="dcb76d49-9b99-41f1-9020-54d3f1f22ff7" type="0" creator="">
@@ -2503,7 +2503,7 @@ Demonstrations are expected again this year.</en>
 				<en>Since so many terrorists get lost in attacks on Duban, they should now be equipped with GPS. This rumor was found on the Internet.</en>
 			</description>
 			<data genre="0" price="1.0" quality="21" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="05cb2eba-bad9-424c-920e-5d2772497069" thread_id="de6fcb92-7b35-4a6a-9daf-7d5904d622fa" type="0" creator="">
 			<title>
@@ -2518,7 +2518,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="94c8810c-b24b-44f2-a88a-3fb3d49fac22" />
 			</effects>
 			<data genre="0" price="0.7" quality="38" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="94c8810c-b24b-44f2-a88a-3fb3d49fac22" thread_id="de6fcb92-7b35-4a6a-9daf-7d5904d622fa" type="2" creator="">
 			<title>
@@ -2531,7 +2531,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="0" price="0.7" quality="48" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 
 		<news id="e730d750-5b8f-4f10-a7c5-86936521de82" thread_id="e6be4f49-d79e-4096-97ff-2cef4795a10b" type="0" creator="">
@@ -2547,7 +2547,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="b368f82c-392c-47d5-b494-f8bfe9029c25" />
 			</effects>
 			<data genre="4" price="1.0" quality="58" />
-			<conditions year_range_from="1996" year_range_to="-1" />
+			<availability year_range_from="1996" year_range_to="-1" />
 		</news>
 		<news id="b368f82c-392c-47d5-b494-f8bfe9029c25" thread_id="e6be4f49-d79e-4096-97ff-2cef4795a10b" type="2" creator="">
 			<title>
@@ -2562,7 +2562,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="0edca939-dbee-41f9-a1bf-8bec9b7718fb" />
 			</effects>
 			<data genre="4" price="1.0" quality="48" />
-			<conditions year_range_from="1996" year_range_to="-1" />
+			<availability year_range_from="1996" year_range_to="-1" />
 		</news>
 		<news id="0edca939-dbee-41f9-a1bf-8bec9b7718fb" thread_id="e6be4f49-d79e-4096-97ff-2cef4795a10b" type="2" creator="">
 			<title>
@@ -2577,7 +2577,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="ff1f0a05-040c-4930-a314-12784ce12177" />
 			</effects>
 			<data genre="4" price="1.0" quality="29" />
-			<conditions year_range_from="1996" year_range_to="-1" />
+			<availability year_range_from="1996" year_range_to="-1" />
 		</news>
 		<news id="ff1f0a05-040c-4930-a314-12784ce12177" thread_id="e6be4f49-d79e-4096-97ff-2cef4795a10b" type="2" creator="">
 			<title>
@@ -2590,7 +2590,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="4" price="0.7" quality="48" />
-			<conditions year_range_from="1996" year_range_to="-1" />
+			<availability year_range_from="1996" year_range_to="-1" />
 		</news>
 
 		<news id="e730d750-5b8f-4f10-a7c5-86936521de82_2" thread_id="e6be4f49-d79e-4096-97ff-2cef4795a10b_2" type="0" creator="">
@@ -2606,7 +2606,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="b368f82c-392c-47d5-b494-f8bfe9029c25_2" />
 			</effects>
 			<data genre="4" price="1.0" quality="58" />
-			<conditions year_range_from="1996" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="1995" />
 		</news>
 		<news id="b368f82c-392c-47d5-b494-f8bfe9029c25_2" thread_id="e6be4f49-d79e-4096-97ff-2cef4795a10b_2" type="2" creator="">
 			<title>
@@ -2621,7 +2621,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="0edca939-dbee-41f9-a1bf-8bec9b7718fb_2" />
 			</effects>
 			<data genre="4" price="1.0" quality="48" />
-			<conditions year_range_from="-1" year_range_to="1995" />
+			<availability year_range_from="-1" year_range_to="1995" />
 		</news>
 		<news id="0edca939-dbee-41f9-a1bf-8bec9b7718fb_2" thread_id="e6be4f49-d79e-4096-97ff-2cef4795a10b_2" type="2" creator="">
 			<title>
@@ -2636,7 +2636,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="ff1f0a05-040c-4930-a314-12784ce12177_2" />
 			</effects>
 			<data genre="4" price="1.0" quality="29" />
-			<conditions year_range_from="-1" year_range_to="1995" />
+			<availability year_range_from="-1" year_range_to="1995" />
 		</news>
 		<news id="ff1f0a05-040c-4930-a314-12784ce12177_2" thread_id="e6be4f49-d79e-4096-97ff-2cef4795a10b_2" type="2" creator="">
 			<title>
@@ -2649,7 +2649,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="4" price="0.7" quality="48" />
-			<conditions year_range_from="-1" year_range_to="1995" />
+			<availability year_range_from="-1" year_range_to="1995" />
 		</news>
 
 		<news id="d9aa67c1-5aa3-4519-9cc2-ef8e1a769ae5" thread_id="e7afb16c-023e-47d8-a23c-8f45efa02854" type="0" creator="">
@@ -2663,7 +2663,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="3" price="1.0" quality="21" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="bc7adf97-1b60-4745-99b3-f18604837103" thread_id="f0228a97-bf9b-4d35-9723-9dcbbbc99b1b" type="0" creator="">
 			<title>
@@ -2678,7 +2678,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="00f05239-8ab5-41c3-b6d5-de1b86491511" time="2,2,3,8,23" />
 			</effects>
 			<data genre="1" price="1.0" quality="34" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="00f05239-8ab5-41c3-b6d5-de1b86491511" thread_id="f0228a97-bf9b-4d35-9723-9dcbbbc99b1b" type="2" creator="">
 			<title>
@@ -2693,7 +2693,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="214c6e1b-b643-465d-8f7c-e40bae941dbc" time="2,1,2,8,23" />
 			</effects>
 			<data genre="1" price="1.0" quality="27" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="214c6e1b-b643-465d-8f7c-e40bae941dbc" thread_id="f0228a97-bf9b-4d35-9723-9dcbbbc99b1b" type="2" creator="">
 			<title>
@@ -2708,7 +2708,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="c0bcc0b2-0a77-4615-8070-7c044af5b9f9"  time="2,1,2,8,23"/>
 			</effects>
 			<data genre="1" price="1.0" quality="23" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="c0bcc0b2-0a77-4615-8070-7c044af5b9f9" thread_id="f0228a97-bf9b-4d35-9723-9dcbbbc99b1b" type="2" creator="">
 			<title>
@@ -2721,7 +2721,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="1" price="1.0" quality="19" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 
 		<news id="906a95a1-45c2-403c-b204-2b3f55a6bdad" thread_id="f23be612-26ee-48f8-ad1e-17e310af7997" type="0" creator="">
@@ -2737,7 +2737,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="fb74b1bd-a603-4eaa-ae64-9b549dd96903" />
 			</effects>
 			<data genre="0" price="0.7" quality="78" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="fb74b1bd-a603-4eaa-ae64-9b549dd96903" thread_id="f23be612-26ee-48f8-ad1e-17e310af7997" type="2" creator="">
 			<title>
@@ -2752,7 +2752,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="935ffed6-639e-4bb1-80a1-607cc4665772" />
 			</effects>
 			<data genre="0" price="1.20" quality="75" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="935ffed6-639e-4bb1-80a1-607cc4665772" thread_id="f23be612-26ee-48f8-ad1e-17e310af7997" type="2" creator="">
 			<title>
@@ -2767,7 +2767,7 @@ Demonstrations are expected again this year.</en>
 				<effect trigger="happen" type="triggernews" news="896c6fc0-4eb8-4363-ba30-c9742b91713c" />
 			</effects>
 			<data genre="0" price="0.7" quality="71" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="896c6fc0-4eb8-4363-ba30-c9742b91713c" thread_id="f23be612-26ee-48f8-ad1e-17e310af7997" type="2" creator="">
 			<title>
@@ -2780,7 +2780,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="0" price="1.0" quality="70" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="213666dc-f4d5-496c-8e1f-8761827cb7b1" thread_id="f4c775ab-ab54-4ef3-93e7-109e3a7035ee" type="0" creator="">
 			<title>
@@ -2793,7 +2793,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="4" price="1.0" quality="19" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="bb461721-455c-4b8b-b45f-1465c7700644" thread_id="f5f7219e-7144-49de-adc0-19a32c81642c" type="0" creator="">
 			<title>
@@ -2806,7 +2806,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="1" price="1.0" quality="32" />
-			<conditions year_range_from="1998" year_range_to="2005" />
+			<availability year_range_from="1998" year_range_to="2005" />
 		</news>
 		<news id="f9188a93-fa5d-4062-badb-6dba0d25f2ec" thread_id="fc0cbc46-ddf2-470a-95f7-b4329fc7004b" type="0" creator="">
 			<title>
@@ -2819,7 +2819,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="1" price="1.0" quality="29" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="69190830-8d76-432b-8217-ddcc685d0466" thread_id="fdf31ef7-053f-41b2-9ac2-e92b4f23da48" type="0" creator="">
 			<title>
@@ -2832,7 +2832,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="1" price="1.0" quality="35" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 		<news id="182fc068-6f07-45be-bc60-5637ce50f6e4" thread_id="ffb5a2fd-d41c-4f8b-a3ec-546762485d47" type="0" creator="">
 			<title>
@@ -2845,7 +2845,7 @@ Demonstrations are expected again this year.</en>
 			</description>
 			<effects />
 			<data genre="2" price="1.0" quality="39" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 	</allnews>
 </tvgdb>

--- a/res/database/Default/database_people.xml
+++ b/res/database/Default/database_people.xml
@@ -251,7 +251,7 @@
 			<nick_name></nick_name>
             <first_name_original>Tom</first_name_original>
             <last_name_original>Cruise</last_name_original>
-            <details job="2" gender="1" birthday="1962-07-03" deathday="" country="US" />
+            <details job="2" gender="1" birthday="1962-07-03" deathday="" country="USA" />
 		</person>
 		<person id="6b53e3ec-0d66-4131-84ec-a48b9bbe3b77" tmdb_id="0" imdb_id="nm0000361" creator="">
 			<first_name>Brain</first_name>
@@ -325,7 +325,7 @@
 			<nick_name></nick_name>
             <first_name_original>River</first_name_original>
             <last_name_original>Phoenix</last_name_original>
-            <details job="2" gender="1" birthday="1970-08-23" deathday="1993-10-31" country="US" />
+            <details job="2" gender="1" birthday="1970-08-23" deathday="1993-10-31" country="USA" />
 			<data popularity="20" affinity="0" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="0" topgenre="0" />
 		</person>
 		<person id="a80152d6-43dc-4f9c-a562-a5dbf821bc1f" tmdb_id="0" imdb_id="nm0000020" creator="">
@@ -802,7 +802,7 @@
 			<nick_name></nick_name>
             <first_name_original>Liam</first_name_original>
             <last_name_original>Neeson</last_name_original>
-            <details job="2" gender="1" birthday="1952-06-07" deathday="" country="IE" />
+            <details job="2" gender="1" birthday="1952-06-07" deathday="" country="IRL" />
 			<data popularity="20" affinity="0" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="0" topgenre="0" />
 		</person>
 		<person id="61b52966-3363-4fb3-a8d1-61a5555a0961" tmdb_id="0" imdb_id="nm0000559" creator="">
@@ -1277,7 +1277,7 @@
             <nick_name></nick_name>
             <first_name_original>Michael</first_name_original>
             <last_name_original>Caine</last_name_original>
-            <details job="2" gender="1" birthday="1933-03-14" deathday="" country="UK" />
+            <details job="2" gender="1" birthday="1933-03-14" deathday="" country="GB" />
         </person>
         <person id="0bc5cf6c-b76f-4feb-bfda-ae838f61b317" tmdb_id="" imdb_id="nm0001099" creator="8782" created_by="DerFronck">
             <first_name>Jay</first_name>
@@ -1285,7 +1285,7 @@
             <nick_name></nick_name>
             <first_name_original>Jeff</first_name_original>
             <last_name_original>Daniels</last_name_original>
-            <details job="2" gender="1" birthday="1955-02-19" deathday="" country="US" />
+            <details job="2" gender="1" birthday="1955-02-19" deathday="" country="USA" />
         </person>
 
 
@@ -1296,7 +1296,7 @@
             <nick_name></nick_name>
             <first_name_original>Noomi</first_name_original>
             <last_name_original>Rapace</last_name_original>
-            <details job="2" gender="2" birthday="1979-12-28" deathday="" country="SE" />
+            <details job="2" gender="2" birthday="1979-12-28" deathday="" country="S" />
         </person>
         <person id="DF-Celebreties-Kristin_Wiig" tmdb_id="" imdb_id="nm1325419" creator="8782" created_by="DerFronck">
             <first_name>Kirsten</first_name>
@@ -1304,7 +1304,7 @@
             <nick_name></nick_name>
             <first_name_original>Kristin</first_name_original>
             <last_name_original>Wiig</last_name_original>
-            <details job="2" gender="2" birthday="1973-08-22" deathday="" country="US" />
+            <details job="2" gender="2" birthday="1973-08-22" deathday="" country="USA" />
         </person>
         <person id="DF-Celebreties-Charlize_Theron" tmdb_id="" imdb_id="nm0000234" creator="8782" created_by="DerFronck">
             <first_name>Karli</first_name>
@@ -1320,7 +1320,7 @@
             <nick_name></nick_name>
             <first_name_original>Emilia</first_name_original>
             <last_name_original>Clarke</last_name_original>
-            <details job="2" gender="2" birthday="1986-10-23" deathday="" country="UK" />
+            <details job="2" gender="2" birthday="1986-10-23" deathday="" country="GB" />
         </person>
         <person id="DF-Celebreties-Katie_Holmes" tmdb_id="" imdb_id="nm0005017" creator="8782" created_by="DerFronck">
             <first_name>Cathy</first_name>
@@ -1328,7 +1328,7 @@
             <nick_name></nick_name>
             <first_name_original>Katie</first_name_original>
             <last_name_original>Holmes</last_name_original>
-            <details job="2" gender="2" birthday="1974-01-30" deathday="" country="US" />
+            <details job="2" gender="2" birthday="1974-01-30" deathday="" country="USA" />
         </person>
         <person id="DF-Celebreties-Jessica_Chastain" tmdb_id="" imdb_id="nm1567113" creator="8782" created_by="DerFronck">
             <first_name>Jessica</first_name>
@@ -1336,7 +1336,7 @@
             <nick_name></nick_name>
             <first_name_original>Jessica</first_name_original>
             <last_name_original>Chastain</last_name_original>
-            <details job="2" gender="2" birthday="1977-03-24" deathday="" country="US" />
+            <details job="2" gender="2" birthday="1977-03-24" deathday="" country="USA" />
         </person>
         <person id="DF-Celebreties-Lena_Headey" tmdb_id="" imdb_id="nm0372176" creator="8782" created_by="DerFronck">
             <first_name>Lenora</first_name>
@@ -1352,7 +1352,7 @@
             <nick_name></nick_name>
             <first_name_original>Sophie</first_name_original>
             <last_name_original>Turner</last_name_original>
-            <details job="2" gender="2" birthday="1996-02-21" deathday="" country="UK" />
+            <details job="2" gender="2" birthday="1996-02-21" deathday="" country="GB" />
         </person>
         <person id="DF-Celebreties-Peter_Dinklage" tmdb_id="" imdb_id="nm0227759" creator="8782" created_by="DerFronck">
             <first_name>Petr</first_name>
@@ -1360,7 +1360,7 @@
             <nick_name></nick_name>
             <first_name_original>Peter</first_name_original>
             <last_name_original>Dinklage</last_name_original>
-            <details job="2" gender="1" birthday="1969-06-11" deathday="" country="US" />
+            <details job="2" gender="1" birthday="1969-06-11" deathday="" country="USA" />
         </person>
         <person id="DF-Celebreties-Kit_Harrington" tmdb_id="" imdb_id="nm3229685" creator="8782" created_by="DerFronck">
             <first_name>Kitt</first_name>
@@ -1368,7 +1368,7 @@
             <nick_name></nick_name>
             <first_name_original>Kit</first_name_original>
             <last_name_original>Harington</last_name_original>
-            <details job="2" gender="1" birthday="1986-12-26" deathday="" country="UK" />
+            <details job="2" gender="1" birthday="1986-12-26" deathday="" country="GB" />
         </person>
         <person id="DF-Celebreties-Nikolaj_Coster-Waldau" tmdb_id="" imdb_id="nm0182666" creator="8782" created_by="DerFronck">
             <first_name>Nikolaus</first_name>
@@ -1384,7 +1384,7 @@
             <nick_name></nick_name>
             <first_name_original>Sean</first_name_original>
             <last_name_original>Bean</last_name_original>
-            <details job="2" gender="1" birthday="1959-04-17" deathday="" country="UK" />
+            <details job="2" gender="1" birthday="1959-04-17" deathday="" country="GB" />
         </person>
         <person id="DF-Celebreties-Aiden_Gillen" tmdb_id="" imdb_id="nm0318821" creator="8782" created_by="DerFronck">
             <first_name>Ey'Dan</first_name>
@@ -1392,7 +1392,7 @@
             <nick_name></nick_name>
             <first_name_original>Aidan</first_name_original>
             <last_name_original>Gillen</last_name_original>
-            <details job="2" gender="1" birthday="1968-04-24" deathday="" country="IE" />
+            <details job="2" gender="1" birthday="1968-04-24" deathday="" country="IRL" />
         </person>
         <person id="DF-Celebreties-Iain_Glenn" tmdb_id="" imdb_id="nm0322513" creator="8782" created_by="DerFronck">
             <first_name>Jearn</first_name>
@@ -1400,7 +1400,7 @@
             <nick_name></nick_name>
             <first_name_original>Iain</first_name_original>
             <last_name_original>Glenn</last_name_original>
-            <details job="2" gender="1" birthday="1968-04-24" deathday="" country="UK" />
+            <details job="2" gender="1" birthday="1968-04-24" deathday="" country="GB" />
         </person>
         <person id="DF-Celebreties-Michael_Fassbender" tmdb_id="" imdb_id="nm1055413" creator="8782" created_by="DerFronck">
             <first_name>Mike</first_name>
@@ -1408,7 +1408,7 @@
             <nick_name></nick_name>
             <first_name_original>Michael</first_name_original>
             <last_name_original>Fassbender</last_name_original>
-            <details job="2" gender="1" birthday="1970-04-02" deathday="" country="DE" />
+            <details job="2" gender="1" birthday="1970-04-02" deathday="" country="D" />
         </person>
         <person id="DF-Celebreties-Idris_Elba" tmdb_id="" imdb_id="nm0252961" creator="8782" created_by="DerFronck">
             <first_name>Eidris</first_name>
@@ -1416,7 +1416,7 @@
             <nick_name></nick_name>
             <first_name_original>Idris</first_name_original>
             <last_name_original>Elba</last_name_original>
-            <details job="2" gender="1" birthday="1972-09-06" deathday="" country="UK" />
+            <details job="2" gender="1" birthday="1972-09-06" deathday="" country="GB" />
         </person>
         <person id="DF-Celebreties-Christian_Bale" tmdb_id="" imdb_id="nm0000288" creator="8782" created_by="DerFronck">
             <first_name>Christian</first_name>
@@ -1424,7 +1424,7 @@
             <nick_name></nick_name>
             <first_name_original>Christian</first_name_original>
             <last_name_original>Bale</last_name_original>
-            <details job="2" gender="1" birthday="1974-01-30" deathday="" country="UK" />
+            <details job="2" gender="1" birthday="1974-01-30" deathday="" country="GB" />
             <data popularity="10" affinity="0" fame="0" scandalizing="10" price_mod="1" power="25" humor="0" charisma="21" appearance="21" topgenre="0" />
         </person>
         <person id="DF-Celebreties-Matt_Damon" tmdb_id="" imdb_id="nm0000354" creator="8782" created_by="DerFronck">
@@ -1433,7 +1433,7 @@
             <nick_name></nick_name>
             <first_name_original>Matt</first_name_original>
             <last_name_original>Damon</last_name_original>
-            <details job="2" gender="1" birthday="1970-10-08" deathday="" country="US" />
+            <details job="2" gender="1" birthday="1970-10-08" deathday="" country="USA" />
         </person>
         <person id="DF-Celebreties-Wil_Wheaton" tmdb_id="" imdb_id="nm0000696" creator="8782" created_by="DerFronck">
             <first_name>Will</first_name>
@@ -1441,7 +1441,7 @@
             <nick_name></nick_name>
             <first_name_original>Wil</first_name_original>
             <last_name_original>Wheaton</last_name_original>
-            <details job="2" gender="1" birthday="1972-07-29" deathday="" country="US" />
+            <details job="2" gender="1" birthday="1972-07-29" deathday="" country="USA" />
         </person>
         <person id="DF-Celebreties-Corey_Feldman" tmdb_id="" imdb_id="nm0000397" creator="8782" created_by="DerFronck">
             <first_name>Corey</first_name>
@@ -1449,7 +1449,7 @@
             <nick_name></nick_name>
             <first_name_original>Corey</first_name_original>
             <last_name_original>Feldman</last_name_original>
-            <details job="2" gender="1" birthday="1971-07-16" deathday="" country="US" />
+            <details job="2" gender="1" birthday="1971-07-16" deathday="" country="USA" />
         </person>
         <person id="DF-Celebreties-Jerry_O'Connell" tmdb_id="" imdb_id="nm0005278" creator="8782" created_by="DerFronck">
             <first_name>Cherry</first_name>
@@ -1457,7 +1457,7 @@
             <nick_name></nick_name>
             <first_name_original>Jerry</first_name_original>
             <last_name_original>O'Connell</last_name_original>
-            <details job="2" gender="1" birthday="1974-02-17" deathday="" country="US" />
+            <details job="2" gender="1" birthday="1974-02-17" deathday="" country="USA" />
         </person>
         <person id="DF-Celebreties-David_Benioff" tmdb_id="" imdb_id="nm1125275" creator="8782" created_by="DerFronck">
             <first_name>Dave</first_name>
@@ -1465,7 +1465,7 @@
             <nick_name></nick_name>
             <first_name_original>David</first_name_original>
             <last_name_original>Benioff</last_name_original>
-            <details job="1" gender="1" birthday="1970-09-25" deathday="" country="US" />
+            <details job="1" gender="1" birthday="1970-09-25" deathday="" country="USA" />
         </person>
         <person id="DF-Celebreties-D.B._Weiss" tmdb_id="" imdb_id="nm1888967" creator="8782" created_by="DerFronck">
             <first_name>Dee Bee</first_name>
@@ -1473,7 +1473,7 @@
             <nick_name></nick_name>
             <first_name_original>D.B.</first_name_original>
             <last_name_original>Weiss</last_name_original>
-            <details job="1" gender="1" birthday="1971-04-23" deathday="" country="US" />
+            <details job="1" gender="1" birthday="1971-04-23" deathday="" country="USA" />
         </person>
 
 
@@ -1484,7 +1484,7 @@
 			<nick_name></nick_name>
 			<first_name_original>Andrew</first_name_original>
 			<last_name_original>Lincoln</last_name_original>
-			<details job="2" gender="1" birthday="1973-09-14" deathday="" country="UK" />
+			<details job="2" gender="1" birthday="1973-09-14" deathday="" country="GB" />
 		</person>
 
 		<person id="DF-Celebreties-Norman_Reedus" tmdb_id="" imdb_id="nm0005342" creator="8782" created_by="DerFronck">
@@ -1493,7 +1493,7 @@
 			<nick_name></nick_name>
 			<first_name_original>Norman</first_name_original>
 			<last_name_original>Reedus</last_name_original>
-			<details job="2" gender="1" birthday="1969-01-06" deathday="" country="US" />
+			<details job="2" gender="1" birthday="1969-01-06" deathday="" country="USA" />
 		</person>
 
 		<person id="DF-Celebreties-Steven_Yeun" tmdb_id="" imdb_id="nm3081796" creator="8782" created_by="DerFronck">
@@ -1502,7 +1502,7 @@
 			<nick_name></nick_name>
 			<first_name_original>Steven</first_name_original>
 			<last_name_original>Yeun</last_name_original>
-			<details job="2" gender="1" birthday="1983-12-21" deathday="" country="KR" />
+			<details job="2" gender="1" birthday="1983-12-21" deathday="" country="ROK" />
 		</person>
 
 		<person id="DF-Celebreties-Chandler_Riggs" tmdb_id="" imdb_id="nm3385128" creator="8782" created_by="DerFronck">
@@ -1511,7 +1511,7 @@
 			<nick_name></nick_name>
 			<first_name_original>Chandler</first_name_original>
 			<last_name_original>Riggs</last_name_original>
-			<details job="2" gender="1" birthday="1999-06-27" deathday="" country="US" />
+			<details job="2" gender="1" birthday="1999-06-27" deathday="" country="USA" />
 		</person>
 
 
@@ -1521,7 +1521,7 @@
 			<nick_name></nick_name>
 			<first_name_original>Lauren</first_name_original>
 			<last_name_original>Cohan</last_name_original>
-			<details job="2" gender="2" birthday="1982-01-07" deathday="" country="US" />
+			<details job="2" gender="2" birthday="1982-01-07" deathday="" country="USA" />
 		</person>
 
 		<person id="DF-Celebreties-Melissa_McBride" tmdb_id="" imdb_id="nm0564350" creator="8782" created_by="DerFronck">
@@ -1530,7 +1530,7 @@
 			<nick_name></nick_name>
 			<first_name_original>Melissa</first_name_original>
 			<last_name_original>McBride</last_name_original>
-			<details job="2" gender="2" birthday="1965-05-23" deathday="" country="US" />
+			<details job="2" gender="2" birthday="1965-05-23" deathday="" country="USA" />
 			<data popularity="10" affinity="0" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="0" topgenre="0" />
 		</person>
 
@@ -1540,7 +1540,7 @@
 			<nick_name></nick_name>
 			<first_name_original>Frank</first_name_original>
 			<last_name_original>Darabont</last_name_original>
-			<details job="1" gender="1" birthday="1959-01-28" deathday="" country="FR" />
+			<details job="1" gender="1" birthday="1959-01-28" deathday="" country="F" />
 		</person>
 
 
@@ -1767,7 +1767,7 @@
 			<last_name>Moldman</last_name>
 			<first_name_original>Gary</first_name_original>
 			<last_name_original>Oldman</last_name_original>
-			<details job="2" gender="1"  birthday="1958-03-21" deathday="" country="UK" />
+			<details job="2" gender="1"  birthday="1958-03-21" deathday="" country="GB" />
 			<data popularity="30" affinity="50" fame="40" scandalizing="10" price_mod="0" power="25" humor="9" charisma="45" appearance="42" topgenre="0" />
 		</person>
 		<person id="TheRob-celebritypeople-WimBlurry" tmdb_id="0" imdb_id="nm0000347" creator="8751" created_by="TheRob">
@@ -1776,7 +1776,7 @@
 			<last_name>Blurry</last_name>
 			<first_name_original>Tim</first_name_original>
 			<last_name_original>Curry</last_name_original>
-			<details job="2" gender="1"  birthday="1946-04-19" deathday="" country="UK" />
+			<details job="2" gender="1"  birthday="1946-04-19" deathday="" country="GB" />
 			<data popularity="30" affinity="40" fame="30" scandalizing="25" price_mod="0" power="0" humor="9" charisma="21" appearance="42" topgenre="0" />
 		</person>
 		<person id="TheRob-celebritypeople-WeatLove" tmdb_id="0" imdb_id="nm0001533" creator="8751" created_by="TheRob">
@@ -1821,7 +1821,7 @@
 			<last_name>Barloff</last_name>
 			<first_name_original>Boris</first_name_original>
 			<last_name_original>Karloff</last_name_original>
-			<details job="2" gender="1"  birthday="1887-11-23" deathday="1969-02-02" country="UK" />
+			<details job="2" gender="1"  birthday="1887-11-23" deathday="1969-02-02" country="GB" />
 			<data popularity="40" affinity="40" fame="50" scandalizing="0" price_mod="0" power="25" humor="23" charisma="53" appearance="52" topgenre="12" />
 		</person>
 	  	<person id="TheRob-celebritypeople-WalterRattnau" tmdb_id="0" imdb_id="nm0000527" creator="8751" created_by="TheRob">
@@ -1857,7 +1857,7 @@
 			<last_name>Charkowski</last_name>
 			<first_name_original>Andrei</first_name_original>
 			<last_name_original>Tarkovsky</last_name_original>
-			<details job="2" gender="1"  birthday="1932-04-04" deathday="1986-12-29" country="UdSSR" />
+			<details job="2" gender="1"  birthday="1932-04-04" deathday="1986-12-29" country="SU" />
 			<data popularity="20" affinity="40" fame="20" scandalizing="0" price_mod="0" power="42" humor="0" charisma="34" appearance="42" topgenre="7" />
 		</person>
 	 	<person id="TheRob-celebritypeople-SilvyMelbourne" tmdb_id="0" imdb_id="nm0796662" creator="8751" created_by="TheRob">
@@ -1888,7 +1888,7 @@
 			<last_name>Hencs</last_name>
 			<first_name_original>Tom</first_name_original>
 			<last_name_original>Hanks</last_name_original>
-			<details job="2" gender="1" birthday="1956-07-09" deathday="" country="US" />
+			<details job="2" gender="1" birthday="1956-07-09" deathday="" country="USA" />
 			<data popularity="10" affinity="10" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="0" topgenre="0" />
 		</person>
 		<!-- Thomas Oberlies Regie und Schauspieler von Kurzfilmen (und Dr. der Mathematik) kenn ich noch aus meinem Studium -->
@@ -1906,7 +1906,7 @@
 			<last_name>Norrisshey</last_name>
 			<first_name_original>Neil</first_name_original>
 			<last_name_original>Morrissey</last_name_original>
-			<details job="2" gender="1"  birthday="1962-07-04" deathday="" country="UK" />
+			<details job="2" gender="1"  birthday="1962-07-04" deathday="" country="GB" />
 			<data popularity="10" affinity="10" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="0" topgenre="0" />
 		</person>
 
@@ -1958,7 +1958,7 @@
 		<person id="ronny-programmeperson-bennyjameson" fictional="1" creator="5578" created_by="Ronny">
 			<first_name>Benny</first_name>
 			<last_name>Jameson</last_name>
-			<details job="12" gender="1"  birthday="1962" deathday="2040" country="CA" />
+			<details job="12" gender="1"  birthday="1962" deathday="2040" country="CDN" />
 			<data popularity="10" affinity="40" fame="0" scandalizing="0" price_mod="1" power="30" humor="48" charisma="20" appearance="90" topgenre="9" />
 		</person>
 		<person id="ronny-programmeperson-freddyjbush" fictional="1" creator="5578" created_by="Ronny">
@@ -1971,7 +1971,7 @@
 			<first_name>Pipé-Laho</first_name>
 			<last_name>Rashin</last_name>
 			<nick_name>Pipé-Laho</nick_name>
-			<details job="16" gender="2" birthday="" deathday="" country="CAN/RI" fictional="1" />
+			<details job="16" gender="2" birthday="" deathday="" country="CDN" fictional="1" />
 			<data popularity="60" affinity="40" fame="40" scandalizing="40" price_mod="1.1" power="15" humor="25" charisma="30" appearance="80" topgenre="102" />
 		</person>
 	</celebritypeople>

--- a/res/database/Default/database_people.xml
+++ b/res/database/Default/database_people.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tvgdb>
+<tvtdb>
 	<version value="3"  />
 	<celebritypeople>
 		<person id="88ba23dc-d4f1-4c77-9ddf-8dbf4a4ce3b2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
@@ -3001,4 +3001,4 @@
 	</insignificantpeople>
 
 	<exportOptions onlyFakes="true" onlyCustom="false" dataStructure="FakeData" />
-</tvgdb>
+</tvtdb>

--- a/res/database/Default/database_people.xml
+++ b/res/database/Default/database_people.xml
@@ -19,8 +19,7 @@
 			<first_name>Patty</first_name>
 			<last_name>Glansen</last_name>
 			<nick_name></nick_name>
-			<images face_code="2:2:2:#EDA657:-1:-1:1:-1:7#C808A8:6:2:-1:3:3:7:13#581410:-1:-1" />
-			<details job="2" gender="2" birthday="1961" deathday="" country="D" fictional="1" />
+			<details job="2" gender="2" birthday="1961" deathday="" country="D" fictional="1" face_code="2:2:2:#EDA657:-1:-1:1:-1:7#C808A8:6:2:-1:3:3:7:13#581410:-1:-1" />
 			<data popularity="20" affinity="50" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="0" topgenre="0" />
 		</person>
 		<person id="1cac5a80-97dc-46f6-8c34-761c4fe43db5" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
@@ -167,8 +166,8 @@
 			<first_name>Betty</first_name>
 			<last_name>Botterblom</last_name>
 			<nick_name></nick_name>
-			<details job="136" gender="2" birthday="" deathday="" country="USA" fictional="1" />
-			<data popularity="20" affinity="0" fame="50" scandalizing="0" price_mod="1" power="10" humor="45" charisma="35" appearance="95" topgenre="6" face_code="2:2:3:#FCBA9F:-1:-1:0:-1:9#48A96E:6:5:-1:0:5:0:9#FFD11C:-1:-1" />
+			<details job="136" gender="2" birthday="" deathday="" country="USA" fictional="1" face_code="2:2:3:#FCBA9F:-1:-1:0:-1:9#48A96E:6:5:-1:0:5:0:9#FFD11C:-1:-1" />
+			<data popularity="20" affinity="0" fame="50" scandalizing="0" price_mod="1" power="10" humor="45" charisma="35" appearance="95" topgenre="6" />
 		</person>
 		<person id="79c081cb-755e-41b8-bd50-11f00e6b1382" tmdb_id="0" imdb_id="nm0108523" creator="">
 			<first_name>Pierre</first_name>
@@ -1286,7 +1285,6 @@
             <nick_name></nick_name>
             <first_name_original>Jeff</first_name_original>
             <last_name_original>Daniels</last_name_original>
-            <images />
             <details job="2" gender="1" birthday="1955-02-19" deathday="" country="US" />
         </person>
 
@@ -1314,7 +1312,6 @@
             <nick_name></nick_name>
             <first_name_original>Charlize</first_name_original>
             <last_name_original>Theron</last_name_original>
-            <images />
             <details job="2" gender="2" birthday="1977-08-07" deathday="" country="ZA" />
         </person>
         <person id="DF-Celebreties-Emilia_Clarke" tmdb_id="" imdb_id="nm3592338" creator="8782" created_by="DerFronck">
@@ -1323,7 +1320,6 @@
             <nick_name></nick_name>
             <first_name_original>Emilia</first_name_original>
             <last_name_original>Clarke</last_name_original>
-            <images />
             <details job="2" gender="2" birthday="1986-10-23" deathday="" country="UK" />
         </person>
         <person id="DF-Celebreties-Katie_Holmes" tmdb_id="" imdb_id="nm0005017" creator="8782" created_by="DerFronck">
@@ -1332,7 +1328,6 @@
             <nick_name></nick_name>
             <first_name_original>Katie</first_name_original>
             <last_name_original>Holmes</last_name_original>
-            <images />
             <details job="2" gender="2" birthday="1974-01-30" deathday="" country="US" />
         </person>
         <person id="DF-Celebreties-Jessica_Chastain" tmdb_id="" imdb_id="nm1567113" creator="8782" created_by="DerFronck">
@@ -1341,7 +1336,6 @@
             <nick_name></nick_name>
             <first_name_original>Jessica</first_name_original>
             <last_name_original>Chastain</last_name_original>
-            <images />
             <details job="2" gender="2" birthday="1977-03-24" deathday="" country="US" />
         </person>
         <person id="DF-Celebreties-Lena_Headey" tmdb_id="" imdb_id="nm0372176" creator="8782" created_by="DerFronck">
@@ -1350,7 +1344,6 @@
             <nick_name></nick_name>
             <first_name_original>Lena</first_name_original>
             <last_name_original>Headey</last_name_original>
-            <images />
             <details job="2" gender="2" birthday="1973-10-03" deathday="" country="BM" />
         </person>
         <person id="DF-Celebreties-Sophie_Turner" tmdb_id="" imdb_id="nm3849842" creator="8782" created_by="DerFronck">
@@ -1359,7 +1352,6 @@
             <nick_name></nick_name>
             <first_name_original>Sophie</first_name_original>
             <last_name_original>Turner</last_name_original>
-            <images />
             <details job="2" gender="2" birthday="1996-02-21" deathday="" country="UK" />
         </person>
         <person id="DF-Celebreties-Peter_Dinklage" tmdb_id="" imdb_id="nm0227759" creator="8782" created_by="DerFronck">
@@ -1368,7 +1360,6 @@
             <nick_name></nick_name>
             <first_name_original>Peter</first_name_original>
             <last_name_original>Dinklage</last_name_original>
-            <images />
             <details job="2" gender="1" birthday="1969-06-11" deathday="" country="US" />
         </person>
         <person id="DF-Celebreties-Kit_Harrington" tmdb_id="" imdb_id="nm3229685" creator="8782" created_by="DerFronck">
@@ -1377,7 +1368,6 @@
             <nick_name></nick_name>
             <first_name_original>Kit</first_name_original>
             <last_name_original>Harington</last_name_original>
-            <images />
             <details job="2" gender="1" birthday="1986-12-26" deathday="" country="UK" />
         </person>
         <person id="DF-Celebreties-Nikolaj_Coster-Waldau" tmdb_id="" imdb_id="nm0182666" creator="8782" created_by="DerFronck">
@@ -1386,7 +1376,6 @@
             <nick_name></nick_name>
             <first_name_original>Nikolaj</first_name_original>
             <last_name_original>Coster-Waldau</last_name_original>
-            <images />
             <details job="2" gender="1" birthday="1970-07-27" deathday="" country="DK" />
         </person>
         <person id="DF-Celebreties-Sean_Bean" tmdb_id="" imdb_id="nm0000293" creator="8782" created_by="DerFronck">
@@ -1395,7 +1384,6 @@
             <nick_name></nick_name>
             <first_name_original>Sean</first_name_original>
             <last_name_original>Bean</last_name_original>
-            <images />
             <details job="2" gender="1" birthday="1959-04-17" deathday="" country="UK" />
         </person>
         <person id="DF-Celebreties-Aiden_Gillen" tmdb_id="" imdb_id="nm0318821" creator="8782" created_by="DerFronck">
@@ -1404,7 +1392,6 @@
             <nick_name></nick_name>
             <first_name_original>Aidan</first_name_original>
             <last_name_original>Gillen</last_name_original>
-            <images />
             <details job="2" gender="1" birthday="1968-04-24" deathday="" country="IE" />
         </person>
         <person id="DF-Celebreties-Iain_Glenn" tmdb_id="" imdb_id="nm0322513" creator="8782" created_by="DerFronck">
@@ -1413,7 +1400,6 @@
             <nick_name></nick_name>
             <first_name_original>Iain</first_name_original>
             <last_name_original>Glenn</last_name_original>
-            <images />
             <details job="2" gender="1" birthday="1968-04-24" deathday="" country="UK" />
         </person>
         <person id="DF-Celebreties-Michael_Fassbender" tmdb_id="" imdb_id="nm1055413" creator="8782" created_by="DerFronck">
@@ -1422,7 +1408,6 @@
             <nick_name></nick_name>
             <first_name_original>Michael</first_name_original>
             <last_name_original>Fassbender</last_name_original>
-            <images />
             <details job="2" gender="1" birthday="1970-04-02" deathday="" country="DE" />
         </person>
         <person id="DF-Celebreties-Idris_Elba" tmdb_id="" imdb_id="nm0252961" creator="8782" created_by="DerFronck">
@@ -1431,7 +1416,6 @@
             <nick_name></nick_name>
             <first_name_original>Idris</first_name_original>
             <last_name_original>Elba</last_name_original>
-            <images />
             <details job="2" gender="1" birthday="1972-09-06" deathday="" country="UK" />
         </person>
         <person id="DF-Celebreties-Christian_Bale" tmdb_id="" imdb_id="nm0000288" creator="8782" created_by="DerFronck">
@@ -1440,7 +1424,6 @@
             <nick_name></nick_name>
             <first_name_original>Christian</first_name_original>
             <last_name_original>Bale</last_name_original>
-            <images />
             <details job="2" gender="1" birthday="1974-01-30" deathday="" country="UK" />
             <data popularity="10" affinity="0" fame="0" scandalizing="10" price_mod="1" power="25" humor="0" charisma="21" appearance="21" topgenre="0" />
         </person>
@@ -1450,7 +1433,6 @@
             <nick_name></nick_name>
             <first_name_original>Matt</first_name_original>
             <last_name_original>Damon</last_name_original>
-            <images />
             <details job="2" gender="1" birthday="1970-10-08" deathday="" country="US" />
         </person>
         <person id="DF-Celebreties-Wil_Wheaton" tmdb_id="" imdb_id="nm0000696" creator="8782" created_by="DerFronck">
@@ -1459,7 +1441,6 @@
             <nick_name></nick_name>
             <first_name_original>Wil</first_name_original>
             <last_name_original>Wheaton</last_name_original>
-            <images />
             <details job="2" gender="1" birthday="1972-07-29" deathday="" country="US" />
         </person>
         <person id="DF-Celebreties-Corey_Feldman" tmdb_id="" imdb_id="nm0000397" creator="8782" created_by="DerFronck">
@@ -1468,7 +1449,6 @@
             <nick_name></nick_name>
             <first_name_original>Corey</first_name_original>
             <last_name_original>Feldman</last_name_original>
-            <images />
             <details job="2" gender="1" birthday="1971-07-16" deathday="" country="US" />
         </person>
         <person id="DF-Celebreties-Jerry_O'Connell" tmdb_id="" imdb_id="nm0005278" creator="8782" created_by="DerFronck">
@@ -1477,7 +1457,6 @@
             <nick_name></nick_name>
             <first_name_original>Jerry</first_name_original>
             <last_name_original>O'Connell</last_name_original>
-            <images />
             <details job="2" gender="1" birthday="1974-02-17" deathday="" country="US" />
         </person>
         <person id="DF-Celebreties-David_Benioff" tmdb_id="" imdb_id="nm1125275" creator="8782" created_by="DerFronck">
@@ -1486,7 +1465,6 @@
             <nick_name></nick_name>
             <first_name_original>David</first_name_original>
             <last_name_original>Benioff</last_name_original>
-            <images />
             <details job="1" gender="1" birthday="1970-09-25" deathday="" country="US" />
         </person>
         <person id="DF-Celebreties-D.B._Weiss" tmdb_id="" imdb_id="nm1888967" creator="8782" created_by="DerFronck">
@@ -1495,7 +1473,6 @@
             <nick_name></nick_name>
             <first_name_original>D.B.</first_name_original>
             <last_name_original>Weiss</last_name_original>
-            <images />
             <details job="1" gender="1" birthday="1971-04-23" deathday="" country="US" />
         </person>
 

--- a/res/database/Default/database_programmes.xml
+++ b/res/database/Default/database_programmes.xml
@@ -441,7 +441,7 @@ Klassiker mit [1|Full].</de>
 				<member index="3" function="2">0c774ab3-9301-4759-a3e1-40520dc9e7b9</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="B" year="1997" distribution="1" maingenre="6" subgenre="" flags="4" blocks="2" price_mod="1" />
+			<data country="BE" year="1997" distribution="1" maingenre="6" subgenre="" flags="4" blocks="2" price_mod="1" />
 			<ratings critics="9" speed="4" outcome="0" />
 		</programme>
 		<programme id="eed42954-967a-4150-bb4c-ebc6392e2f99" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120601" creator="">
@@ -1150,7 +1150,7 @@ Horror vom Feinsten</de>
 				<en></en>
 			</description>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="BEL" year="2011" distribution="2" maingenre="0" subgenre="" flags="128" blocks="2" price_mod="0.85" />
+			<data country="BE" year="2011" distribution="2" maingenre="0" subgenre="" flags="128" blocks="2" price_mod="0.85" />
 			<ratings critics="7" speed="10" outcome="0" />
 		</programme>
 		<programme id="d9bd6851-b70d-4130-8f79-230e2df0a910" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0104779" creator="">
@@ -2113,7 +2113,7 @@ Packender und bis in die Nebenrollen gut besetzter Militärthriller</de>
 				<en></en>
 			</description>
 			<staff>
-				<member index="1" function="2">common-amateur-actors</member>
+				<member index="0" function="2">common-amateur-actors</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
 			<data country="GB" year="1995" distribution="2" maingenre="6" subgenre="" flags="4" blocks="1" price_mod="1" />
@@ -2910,7 +2910,7 @@ Hervorragend inszenierter Gangster-Film</de>
 				<member index="4" function="2">42b56d65-244f-4a70-bc35-22e1fd7709f0</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="VRC" year="2003" distribution="1" maingenre="2" subgenre="" flags="0" blocks="2" price_mod="1" />
+			<data country="CN" year="2003" distribution="1" maingenre="2" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="56" speed="32" outcome="47" />
 		</programme>
 		<programme id="487e524e-09d2-4294-b552-4f361cd26651" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0212985" creator="">
@@ -3284,7 +3284,7 @@ Monumentaler Meilenstein</de>
 				<member index="0" function="1">fa5cf4fe-7704-4eab-808b-5ea8f3935c6d</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="POL" year="2001" distribution="1" maingenre="0" subgenre="" flags="16" blocks="3" price_mod="0.50" />
+			<data country="PL" year="2001" distribution="1" maingenre="0" subgenre="" flags="16" blocks="3" price_mod="0.50" />
 			<ratings critics="5" speed="2" outcome="8" />
 		</programme>
 		<programme id="8fb1588d-27c3-4daf-9bf9-9fd338e08010" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0104431" creator="">
@@ -3724,7 +3724,7 @@ Nach dem Roman von Agatha Kissme.</de>
 				<member index="2" function="2">c3494dd5-506b-46d1-97bd-12182ffa88da</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="US" year="2006" distribution="1" maingenre="17" subgenre="" flags="16" blocks="3" price_mod="1.7" />
+			<data country="USA" year="2006" distribution="1" maingenre="17" subgenre="" flags="16" blocks="3" price_mod="1.7" />
 			<ratings critics="94" speed="80" outcome="89" />
 		</programme>
 		<programme id="bddb797f-53cd-4d15-bb96-bb4b148203b2" product="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
@@ -4787,7 +4787,7 @@ Fast in zeitdeckendem Erzähltempo beschreibt Zinnemanns Klassiker das Schicksal
 				<member index="2" function="2">edb89eb9-1592-41cb-83b6-81eeecfacfd3</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="MO" year="2000" distribution="1" maingenre="6" subgenre="" flags="4" blocks="1" price_mod="1" />
+			<data country="RM" year="2000" distribution="1" maingenre="6" subgenre="" flags="4" blocks="1" price_mod="1" />
 			<ratings critics="47" speed="9" outcome="4" />
 		</programme>
 		<programme id="74b34ac0-150b-494a-aaa8-285f42bad55a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0093894" creator="">
@@ -6096,7 +6096,7 @@ Von den Kritikern lange Zeit verkannt</de>
 				<member index="1" function="2">bedfa8be-aaff-457d-b549-893c3a784c9b</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="AT" year="2001" distribution="2" maingenre="6" subgenre="" flags="4" blocks="2" price_mod="0.90" />
+			<data country="A" year="2001" distribution="2" maingenre="6" subgenre="" flags="4" blocks="2" price_mod="0.90" />
 			<ratings critics="52" speed="1" outcome="0" />
 		</programme>
 		<programme id="855fdb66-87d3-4fb6-8be0-56517c969d32" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0048802" creator="">
@@ -6859,7 +6859,7 @@ Tragische Liebesgeschichte</de>
 				<member index="5" function="2">92513641-1a42-4313-931b-26561ca3fab7</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="CAN" year="1994" distribution="2" maingenre="16" subgenre="2" flags="0" blocks="1" price_mod="0.67" />
+			<data country="CDN" year="1994" distribution="2" maingenre="16" subgenre="2" flags="0" blocks="1" price_mod="0.67" />
 			<ratings critics="4" speed="70" outcome="28" />
 			<children>
 				<programme id="10700e05-245c-49fe-a317-ba9ff97c83f3" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="">
@@ -7511,7 +7511,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 				<member index="1" function="2">396f8bfa-a414-4a25-85c7-4e05c687f6a0</member>
 			</staff>
 			<groups target_groups="3" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="AUT" distribution="2" maingenre="6" subgenre="" flags="4" blocks="2" price_mod="0.85" />
+			<data country="A" distribution="2" maingenre="6" subgenre="" flags="4" blocks="2" price_mod="0.85" />
 			<releaseTime year_relative="-1" year_relative_min="2006" year_relative_max="2008" />
 			<ratings critics="35" speed="7" outcome="0" />
 			<children>
@@ -8361,7 +8361,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 				<member index="0" function="1">Ronny-person-director-TomasPetran</member>
 			</staff>
 			<groups target_groups="1" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="CSSR" year="1973" distribution="2" maingenre="9" subgenre="5" flags="2" blocks="1" price_mod="1.00" />
+			<data country="CS" year="1973" distribution="2" maingenre="9" subgenre="5" flags="2" blocks="1" price_mod="1.00" />
 			<ratings critics="47" speed="29" outcome="0" />
 			<children>
 				<programme id="therob-programme-speiuebelunddubrovnik-ep201" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
@@ -8710,7 +8710,7 @@ Die legendäre Verfilmung des deutschen Literaturklassikers mit [1|Full] und [2|
 				<member index="4" function="2">TheRob-TowerTV-ArchieRemedy</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="UK" year="1962" distribution="1" maingenre="1" subgenre="" flags="0" blocks="4" price_mod="1.00" />
+			<data country="GB" year="1962" distribution="1" maingenre="1" subgenre="" flags="0" blocks="4" price_mod="1.00" />
 			<ratings critics="86" speed="53" outcome="53" />
 		</programme>
 
@@ -8905,7 +8905,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 				<member index="0" function="1">TheRob-TowerTV-JosefVolkk</member>
 			</staff>
 			<groups target_groups="1" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="HUN" year="1969" distribution="2" maingenre="3" subgenre="" flags="0" blocks="1" price_mod="1.00" />
+			<data country="H" year="1969" distribution="2" maingenre="3" subgenre="" flags="0" blocks="1" price_mod="1.00" />
 			<ratings critics="27" speed="36" outcome="0" />
 			<children>
 				<programme id="therob-programme-KaltkabelindieZukunft-ep201" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751/7430" created_by="Sjaele/TheRob">
@@ -9752,7 +9752,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="3" function="2">TheRob-TowerTV-BallerinaRatyavina</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="UdSSR" year="1962" distribution="1" maingenre="7" subgenre="2" flags="0" blocks="2" price_mod="1.00" />
+			<data country="SU" year="1962" distribution="1" maingenre="7" subgenre="2" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="77" speed="29" outcome="72" />
 		</programme>
 
@@ -9777,7 +9777,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="3" function="2">TheRob-TowerTV-SerenaParkawskiya</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="UdSSR" year="1966" distribution="1" maingenre="11" subgenre="7" flags="0" blocks="4" price_mod="1.00" />
+			<data country="SU" year="1966" distribution="1" maingenre="11" subgenre="7" flags="0" blocks="4" price_mod="1.00" />
 			<ratings critics="81" speed="22" outcome="63" />
 		</programme>
 
@@ -9801,7 +9801,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="2" function="2">TheRob-TowerTV-IlljitschSafrauski</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="UdSSR" year="1961" distribution="1" maingenre="7" subgenre="" flags="0" blocks="1" price_mod="1.00" />
+			<data country="SU" year="1961" distribution="1" maingenre="7" subgenre="" flags="0" blocks="1" price_mod="1.00" />
 			<ratings critics="93" speed="26" outcome="22" />
 		</programme>
 
@@ -9826,7 +9826,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="3" function="2">TheRob-TowerTV-NikiGringoff</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="UdSSR" year="1972" distribution="1" maingenre="16" subgenre="14" flags="0" blocks="3" price_mod="1.00" />
+			<data country="SU" year="1972" distribution="1" maingenre="16" subgenre="14" flags="0" blocks="3" price_mod="1.00" />
 			<ratings critics="84" speed="36" outcome="83" />
 		</programme>
 
@@ -9851,7 +9851,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="3" function="2">TheRob-TowerTV-NikiGringoff</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="UdSSR" year="1975" distribution="1" maingenre="7" subgenre="" flags="0" blocks="2" price_mod="1.00" />
+			<data country="SU" year="1975" distribution="1" maingenre="7" subgenre="" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="73" speed="36" outcome="43" />
 		</programme>
 
@@ -9900,7 +9900,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="2" function="2">TheRob-TowerTV-ErlandoJoschkason</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="SUE" year="1986" distribution="1" maingenre="16" subgenre="7" flags="0" blocks="3" price_mod="1.00" />
+			<data country="CH" year="1986" distribution="1" maingenre="16" subgenre="7" flags="0" blocks="3" price_mod="1.00" />
 			<ratings critics="86" speed="26" outcome="71" />
 		</programme>
 
@@ -9949,7 +9949,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="2" function="2">1c0582ef-99fd-4403-b743-a767a8f44bf5</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="UK" year="1958" distribution="1" maingenre="7" subgenre="15" flags="0" blocks="3" price_mod="1.00" />
+			<data country="GB" year="1958" distribution="1" maingenre="7" subgenre="15" flags="0" blocks="3" price_mod="1.00" />
 			<ratings critics="47" speed="36" outcome="49" />
 		</programme>
 
@@ -9974,7 +9974,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="3" function="2">1c0582ef-99fd-4403-b743-a767a8f44bf5</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="UK" year="1954" distribution="1" maingenre="15" subgenre="5" flags="0" blocks="2" price_mod="1.00" />
+			<data country="GB" year="1954" distribution="1" maingenre="15" subgenre="5" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="77" speed="58" outcome="72" />
 		</programme>
 
@@ -10489,7 +10489,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="2" function="2">TheRob-TowerTV-LouDerFume</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="FR" year="1968" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="1.00" />
+			<data country="F" year="1968" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="53" speed="58" outcome="51" />
 		</programme>
 
@@ -10905,7 +10905,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="3" function="2">TheRob-TowerTV-EddiePMobison</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="IT" year="1967" distribution="0" maingenre="5" subgenre="4" flags="0" blocks="2" price_mod="1.00" />
+			<data country="I" year="1967" distribution="0" maingenre="5" subgenre="4" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="47" speed="59" outcome="41" />
 		</programme>
 

--- a/res/database/Default/database_programmes.xml
+++ b/res/database/Default/database_programmes.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tvgdb>
+<tvtdb>
 	<version value="3" />
 	<allprogrammes>
-		<programme id="3bd76bd9-3cb7-4a9d-8e57-815b1ea7c2f0" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0048545" rt_id="0" creator="">
+		<programme id="3bd76bd9-3cb7-4a9d-8e57-815b1ea7c2f0" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0048545" creator="">
 			<title>
 				<de>...sie waren sich der Konsequenzen nicht bewusst</de>
 				<en></en>
@@ -25,7 +25,7 @@
 			<data country="USA" year="1955" distribution="1" maingenre="15" subgenre="" flags="0" blocks="2" price_mod="0.90" />
 			<ratings critics="56" speed="32" outcome="75" />
 		</programme>
-		<programme id="54084557-4497-48d5-8e3a-6a6c987ebb26" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0114746" rt_id="0" creator="">
+		<programme id="54084557-4497-48d5-8e3a-6a6c987ebb26" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0114746" creator="">
 			<title>
 				<de>11 Donkeys</de>
 				<en></en>
@@ -48,7 +48,7 @@
 			<data country="USA" year="1995" distribution="1" maingenre="16" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="42" speed="28" outcome="51" />
 		</programme>
-		<programme id="7bb9393b-0102-41d3-8237-8a10d9442845" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0074084" rt_id="0" creator="">
+		<programme id="7bb9393b-0102-41d3-8237-8a10d9442845" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0074084" creator="">
 			<title>
 				<de>1899 (Achtzehnhundertneunundneunzig)</de>
 				<en></en>
@@ -71,7 +71,7 @@
 			<data country="I" year="1976" distribution="1" maingenre="13" subgenre="" flags="8" blocks="5" price_mod="1" />
 			<ratings critics="80" speed="42" outcome="61" />
 		</programme>
-		<programme id="e011ef37-2adb-4ba1-95bb-81b088c1ccd8" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0062622" rt_id="0" creator="">
+		<programme id="e011ef37-2adb-4ba1-95bb-81b088c1ccd8" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0062622" creator="">
 			<title>
 				<de>2002: Bredouille im All</de>
 				<en></en>
@@ -96,7 +96,7 @@ Ein symphonischer Science-Fiction-Trip</de>
 			<data country="GB" year="1968" distribution="1" maingenre="16" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="89" speed="14" outcome="65" />
 		</programme>
-		<programme id="1003a969-6d96-4f0f-94ce-954c0f5ad502" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0289043" rt_id="0" creator="">
+		<programme id="1003a969-6d96-4f0f-94ce-954c0f5ad502" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0289043" creator="">
 			<title>
 				<de>27 Tage verpasst</de>
 				<en></en>
@@ -120,7 +120,7 @@ Ein symphonischer Science-Fiction-Trip</de>
 			<data country="GB" year="2002" distribution="1" maingenre="12" subgenre="" flags="64" blocks="2" price_mod="1" />
 			<ratings critics="18" speed="37" outcome="47" />
 		</programme>
-		<programme id="5e00ef4a-d016-4548-b7f4-12ab87293b93" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0091635" rt_id="0" creator="">
+		<programme id="5e00ef4a-d016-4548-b7f4-12ab87293b93" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0091635" creator="">
 			<title>
 				<de>59 1/2 Tage</de>
 				<en></en>
@@ -141,7 +141,7 @@ Ein symphonischer Science-Fiction-Trip</de>
 			<data country="USA" year="1986" distribution="1" maingenre="8" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="18" speed="42" outcome="61" />
 		</programme>
-		<programme id="5c4c567b-dda6-4d7e-b90a-82d254f6d5a8" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0119576" rt_id="0" creator="">
+		<programme id="5c4c567b-dda6-4d7e-b90a-82d254f6d5a8" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0119576" creator="">
 			<title>
 				<de>59 1/2 Tage in Paris</de>
 				<en></en>
@@ -163,7 +163,7 @@ Aber diesmal schauen ihm erheblich weniger Voyeure dabei zu.</de>
 			<data country="USA" year="1997" distribution="1" maingenre="8" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="9" speed="23" outcome="32" />
 		</programme>
-		<programme id="a6112791-74c2-4f8a-9906-d36aea7111d5" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0119471" rt_id="0" creator="">
+		<programme id="a6112791-74c2-4f8a-9906-d36aea7111d5" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0119471" creator="">
 			<title>
 				<de>A.K. - Das kleine Arschlochkind</de>
 				<en></en>
@@ -183,7 +183,7 @@ Bescheidene Witzverkettungen nach den Comics von Waldi Meirs</de>
 			<data country="D" year="1997" distribution="1" maingenre="3" subgenre="" flags="2" blocks="2" price_mod="1.33" />
 			<ratings critics="4" speed="32" outcome="32" />
 		</programme>
-		<programme id="a21b8f61-59a1-4924-8881-8fece978b63d" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0133152" rt_id="0" creator="">
+		<programme id="a21b8f61-59a1-4924-8881-8fece978b63d" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0133152" creator="">
 			<title>
 				<de>Affenerde</de>
 				<en></en>
@@ -207,7 +207,7 @@ Starke Kostüme, insgesamt aber leider schwaches Remake</de>
 			<data country="USA" year="2001" distribution="1" maingenre="16" subgenre="" flags="0" blocks="3" price_mod="1.33" />
 			<ratings critics="32" speed="32" outcome="42" />
 		</programme>
-		<programme id="10905777-b8b5-49d7-a10e-5d364c8b254a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0105690" rt_id="0" creator="">
+		<programme id="10905777-b8b5-49d7-a10e-5d364c8b254a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0105690" creator="">
 			<title>
 				<de>Alarmstufe: Seeehr Dringend!</de>
 				<en></en>
@@ -231,7 +231,7 @@ Starke Kostüme, insgesamt aber leider schwaches Remake</de>
 			<data country="USA" year="1992" distribution="1" maingenre="2" subgenre="" flags="0" blocks="2" price_mod="0.97" />
 			<ratings critics="29" speed="65" outcome="60" />
 		</programme>
-		<programme id="82833c29-2958-4715-8363-6a9af3455284" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0057380" rt_id="0" creator="">
+		<programme id="82833c29-2958-4715-8363-6a9af3455284" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0057380" creator="">
 			<title>
 				<de>Alte Schmetterfaust</de>
 				<en></en>
@@ -253,7 +253,7 @@ Starke Kostüme, insgesamt aber leider schwaches Remake</de>
 			<data country="D" year="1964" distribution="1" maingenre="18" subgenre="" flags="0" blocks="3" price_mod="0.90" />
 			<ratings critics="51" speed="51" outcome="42" />
 		</programme>
-		<programme id="e3c4000f-917c-402a-8423-355c2fc29c7b" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0216216" rt_id="0" creator="">
+		<programme id="e3c4000f-917c-402a-8423-355c2fc29c7b" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0216216" creator="">
 			<title>
 				<de>Am sechsten Tag erschuf...</de>
 				<en></en>
@@ -275,7 +275,7 @@ Starke Kostüme, insgesamt aber leider schwaches Remake</de>
 			<data country="USA" year="2000" distribution="1" maingenre="16" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="28" speed="51" outcome="32" />
 		</programme>
-		<programme id="57cfeca1-a06b-402d-8d9d-80a4ab84976a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120586" rt_id="0" creator="">
+		<programme id="57cfeca1-a06b-402d-8d9d-80a4ab84976a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120586" creator="">
 			<title>
 				<de>Amerikanische Nazis</de>
 				<en></en>
@@ -296,7 +296,7 @@ Starke Kostüme, insgesamt aber leider schwaches Remake</de>
 			<data country="USA" year="1998" distribution="1" maingenre="2" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="51" speed="56" outcome="56" />
 		</programme>
-		<programme id="631f722f-b5dc-4663-bd81-5e9b1231c84e" product="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="631f722f-b5dc-4663-bd81-5e9b1231c84e" product="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>An Asian Spooky Story</de>
 				<en></en>
@@ -316,7 +316,7 @@ Raffinierter phantastischer Film.</de>
 			<data country="HK" year="1987" distribution="1" maingenre="15" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="51" speed="28" outcome="37" />
 		</programme>
-		<programme id="ff731f85-f535-4f77-89e6-a15a79e4ec4e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0042332" rt_id="0" creator="">
+		<programme id="ff731f85-f535-4f77-89e6-a15a79e4ec4e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0042332" creator="">
 			<title>
 				<de>Aschenputtel</de>
 				<en></en>
@@ -335,7 +335,7 @@ Raffinierter phantastischer Film.</de>
 			<data country="USA" year="1950" distribution="1" maingenre="3" subgenre="" flags="2" blocks="2" price_mod="1.7" />
 			<ratings critics="37" speed="42" outcome="65" />
 		</programme>
-		<programme id="de8e89b1-a05b-45b8-814f-4103464ec84f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0043265" rt_id="0" creator="">
+		<programme id="de8e89b1-a05b-45b8-814f-4103464ec84f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0043265" creator="">
 			<title>
 				<de>Asian Queen</de>
 				<en></en>
@@ -360,7 +360,7 @@ Klassiker mit [1|Full].</de>
 			<data country="USA" year="1951" distribution="1" maingenre="15" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="65" speed="51" outcome="61" />
 		</programme>
-		<programme id="22530967-81d9-4117-9f3d-086ae3ce959d" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0033022" rt_id="0" creator="">
+		<programme id="22530967-81d9-4117-9f3d-086ae3ce959d" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0033022" creator="">
 			<title>
 				<de>[1|Last] &amp; [2|Last] - Auf hohem Meere</de>
 				<en></en>
@@ -382,7 +382,7 @@ Klassiker mit [1|Full].</de>
 			<data country="USA" year="1940" distribution="1" maingenre="5" subgenre="" flags="0" blocks="1" price_mod="1" />
 			<ratings critics="32" speed="56" outcome="56" />
 		</programme>
-		<programme id="62b1d458-7d93-4c3f-ac85-656edd87f21b" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0024601" rt_id="0" creator="">
+		<programme id="62b1d458-7d93-4c3f-ac85-656edd87f21b" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0024601" creator="">
 			<title>
 				<de>[1|Last] &amp; [2|Last] - Kinder der Wüste</de>
 				<en></en>
@@ -406,7 +406,7 @@ Klassiker mit [1|Full].</de>
 			<data country="USA" year="1933" distribution="1" maingenre="5" subgenre="" flags="0" blocks="1" price_mod="0.67" />
 			<ratings critics="32" speed="61" outcome="51" />
 		</programme>
-		<programme id="6afd31a8-8f3b-408c-a59b-7a68a9c8ab9f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0034492" rt_id="0" creator="">
+		<programme id="6afd31a8-8f3b-408c-a59b-7a68a9c8ab9f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0034492" creator="">
 			<title>
 				<de>Bambey</de>
 				<en></en>
@@ -425,7 +425,7 @@ Klassiker mit [1|Full].</de>
 			<data country="USA" year="1942" distribution="1" maingenre="3" subgenre="" flags="2" blocks="1" price_mod="1.7" />
 			<ratings critics="61" speed="47" outcome="84" />
 		</programme>
-		<programme id="9bec0952-e3a8-48fc-82e9-d96e2809e746" product="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="9bec0952-e3a8-48fc-82e9-d96e2809e746" product="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Beer, Bier, Pivo</de>
 				<en></en>
@@ -444,7 +444,7 @@ Klassiker mit [1|Full].</de>
 			<data country="B" year="1997" distribution="1" maingenre="6" subgenre="" flags="4" blocks="2" price_mod="1" />
 			<ratings critics="9" speed="4" outcome="0" />
 		</programme>
-		<programme id="eed42954-967a-4150-bb4c-ebc6392e2f99" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120601" rt_id="0" creator="">
+		<programme id="eed42954-967a-4150-bb4c-ebc6392e2f99" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120601" creator="">
 			<title>
 				<de>Being [3|Full]</de>
 				<en></en>
@@ -468,7 +468,7 @@ Absolut abgedrehte Komödie und fulminantes Debüt von [0|Full].</de>
 			<data country="USA" year="1999" distribution="1" maingenre="5" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="56" speed="47" outcome="42" />
 		</programme>
-		<programme id="e751a77b-43a4-4b63-88d6-7e1ac6768603" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0100405" rt_id="0" creator="">
+		<programme id="e751a77b-43a4-4b63-88d6-7e1ac6768603" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0100405" creator="">
 			<title>
 				<de>Betty - a Woman</de>
 				<en></en>
@@ -492,7 +492,7 @@ Eine Liebe gegen jede Vernunft und Verhaltensregel, dafür umso romantischer - d
 			<data country="USA" year="1990" distribution="1" maingenre="15" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="37" speed="42" outcome="80" />
 		</programme>
-		<programme id="f51954ef-5d8a-4ca0-9936-fca27da79267" product="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="f51954ef-5d8a-4ca0-9936-fca27da79267" product="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Biedermeier - (K)eine Zeit zum Feiern</de>
 				<en></en>
@@ -509,7 +509,7 @@ Eine Liebe gegen jede Vernunft und Verhaltensregel, dafür umso romantischer - d
 			<data country="D" year="1992" distribution="2" maingenre="6" subgenre="" flags="4" blocks="1" price_mod="0.90" />
 			<ratings critics="14" speed="23" outcome="0" />
 		</programme>
-		<programme id="6cdf8bd4-aa54-469f-a77b-4cc486e83bab" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0183649" rt_id="0" creator="">
+		<programme id="6cdf8bd4-aa54-469f-a77b-4cc486e83bab" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0183649" creator="">
 			<title>
 				<de>Bleib ja am Hörer!</de>
 				<en></en>
@@ -533,7 +533,7 @@ Hochspannung auf originelle Weise</de>
 			<data country="USA" year="2002" distribution="1" maingenre="2" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="47" speed="65" outcome="61" />
 		</programme>
-		<programme id="1214b6aa-0565-41f9-9315-5cac131e0577" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0118749" rt_id="0" creator="">
+		<programme id="1214b6aa-0565-41f9-9315-5cac131e0577" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0118749" creator="">
 			<title>
 				<de>Boogie-Woogie-Träume</de>
 				<en></en>
@@ -558,7 +558,7 @@ Hochspannung auf originelle Weise</de>
 			<data country="USA" year="1997" distribution="1" maingenre="8" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="23" speed="37" outcome="37" />
 		</programme>
-		<programme id="9fb84901-fc52-4203-b983-15a8b20239aa" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0087829" rt_id="0" creator="">
+		<programme id="9fb84901-fc52-4203-b983-15a8b20239aa" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0087829" creator="">
 			<title>
 				<de>Brenzliges Business</de>
 				<en></en>
@@ -581,7 +581,7 @@ Hochspannung auf originelle Weise</de>
 			<data country="USA" year="1984" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="0.90" />
 			<ratings critics="32" speed="56" outcome="32" />
 		</programme>
-		<programme id="9559311d-06a6-44e1-b016-6f2a22fce65a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0054698" rt_id="0" creator="">
+		<programme id="9559311d-06a6-44e1-b016-6f2a22fce65a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0054698" creator="">
 			<title>
 				<de>Brunch bei Stephanie</de>
 				<en></en>
@@ -606,7 +606,7 @@ Hochspannung auf originelle Weise</de>
 			<data country="USA" year="1961" distribution="1" maingenre="15" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="28" speed="28" outcome="56" />
 		</programme>
-		<programme id="5dc5e4aa-07c2-48ad-8e1a-789418f712f8" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0169547" rt_id="0" creator="">
+		<programme id="5dc5e4aa-07c2-48ad-8e1a-789418f712f8" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0169547" creator="">
 			<title>
 				<de>Canadian Chick</de>
 				<en></en>
@@ -632,7 +632,7 @@ Großartig besetzt mit [1|Full]</de>
 			<data country="USA" year="1999" distribution="1" maingenre="15" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="56" speed="28" outcome="61" />
 		</programme>
-		<programme id="a5d599a4-fc9a-4c06-84ab-86008658e849" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0163651" rt_id="0" creator="">
+		<programme id="a5d599a4-fc9a-4c06-84ab-86008658e849" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0163651" creator="">
 			<title>
 				<de>Canadian Fry</de>
 				<en></en>
@@ -658,7 +658,7 @@ Größtenteils geschmacklose, aber urkomische Witze.</de>
 			<data country="USA" year="1999" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="4" speed="56" outcome="61" />
 		</programme>
-		<programme id="028911ea-63a1-40bb-8dbd-c7d75afac0ec" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0328828" rt_id="0" creator="">
+		<programme id="028911ea-63a1-40bb-8dbd-c7d75afac0ec" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0328828" creator="">
 			<title>
 				<de>Canadian Fry - Wedding Party</de>
 				<en></en>
@@ -683,7 +683,7 @@ Deutlich weniger erfolgreich als die Vorgänger</de>
 			<data country="USA" year="2003" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="0" speed="56" outcome="23" />
 		</programme>
-		<programme id="a405db78-5899-4702-bfd2-6368bc00416e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0252866" rt_id="0" creator="">
+		<programme id="a405db78-5899-4702-bfd2-6368bc00416e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0252866" creator="">
 			<title>
 				<de>Canadian Fry 2</de>
 				<en></en>
@@ -708,7 +708,7 @@ Trotzdem komisch</de>
 			<data country="USA" year="2001" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="1.33" />
 			<ratings critics="0" speed="65" outcome="56" />
 		</programme>
-		<programme id="19862239-af53-4d4a-a40f-cea991e70671" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0208092" rt_id="0" creator="">
+		<programme id="19862239-af53-4d4a-a40f-cea991e70671" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0208092" creator="">
 			<title>
 				<de>Catch - Kühe und Rubine</de>
 				<en></en>
@@ -733,7 +733,7 @@ Auf der ganzen Linie durchgeknallter Streifen</de>
 			<data country="GB" year="2000" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="42" speed="65" outcome="61" />
 		</programme>
-		<programme id="870dd29c-9f53-4581-8d62-8b62522aebc3" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0086567" rt_id="0" creator="">
+		<programme id="870dd29c-9f53-4581-8d62-8b62522aebc3" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0086567" creator="">
 			<title>
 				<de>Computerkrieg</de>
 				<en></en>
@@ -758,7 +758,7 @@ Auf der ganzen Linie durchgeknallter Streifen</de>
 			<data country="USA" year="1983" distribution="1" maingenre="2" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="14" speed="23" outcome="23" />
 		</programme>
-		<programme id="bb1900be-2c33-4d24-ad7d-878976ea816a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0112442" rt_id="0" creator="">
+		<programme id="bb1900be-2c33-4d24-ad7d-878976ea816a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0112442" creator="">
 			<title>
 				<de>Coole Typen - Really Bad Boys</de>
 				<en></en>
@@ -782,7 +782,7 @@ Auf der ganzen Linie durchgeknallter Streifen</de>
 			<data country="USA" year="1995" distribution="1" maingenre="2" subgenre="" flags="64" blocks="3" price_mod="1" />
 			<ratings critics="18" speed="65" outcome="61" />
 		</programme>
-		<programme id="b70b3d64-252e-4df2-ab80-7a8d8ab5eeba" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0172156" rt_id="0" creator="">
+		<programme id="b70b3d64-252e-4df2-ab80-7a8d8ab5eeba" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0172156" creator="">
 			<title>
 				<de>Coole Typen II</de>
 				<en></en>
@@ -806,7 +806,7 @@ Primitiv</de>
 			<data country="USA" year="2003" distribution="1" maingenre="2" subgenre="" flags="64" blocks="3" price_mod="1.33" />
 			<ratings critics="23" speed="56" outcome="51" />
 		</programme>
-		<programme id="989481a2-4862-4296-a9a7-9e583bf4fb3c" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0087843" rt_id="0" creator="">
+		<programme id="989481a2-4862-4296-a9a7-9e583bf4fb3c" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0087843" creator="">
 			<title>
 				<de>Da war mal in Amerika</de>
 				<en></en>
@@ -832,7 +832,7 @@ Freigabe von FSK 18 auf FSK 16 heruntergestuft</de>
 			<data country="USA" year="1982" distribution="1" maingenre="13" subgenre="" flags="8" blocks="5" price_mod="1" />
 			<ratings critics="84" speed="32" outcome="80" />
 		</programme>
-		<programme id="64f9566f-1602-4267-bd51-b292175e3d33" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0056869" rt_id="0" creator="">
+		<programme id="64f9566f-1602-4267-bd51-b292175e3d33" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0056869" creator="">
 			<title>
 				<de>Das Geflügel</de>
 				<en></en>
@@ -857,7 +857,7 @@ Einer der späteren [0|Last]s</de>
 			<data country="USA" year="1963" distribution="1" maingenre="12" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="61" speed="32" outcome="70" />
 		</programme>
-		<programme id="714fb2c8-81e0-44d3-92fe-3dac9ee579eb" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0110216" rt_id="0" creator="">
+		<programme id="714fb2c8-81e0-44d3-92fe-3dac9ee579eb" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0110216" creator="">
 			<title>
 				<de>Das Männerbaby</de>
 				<en></en>
@@ -881,7 +881,7 @@ Einer der späteren [0|Last]s</de>
 			<data country="USA" year="1994" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="1.33" />
 			<ratings critics="4" speed="32" outcome="23" />
 		</programme>
-		<programme id="3d32e7f9-5414-4886-a80a-90a2b474f1e8" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120749" rt_id="0" creator="">
+		<programme id="3d32e7f9-5414-4886-a80a-90a2b474f1e8" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120749" creator="">
 			<title>
 				<de>Das Plumbium-Rätsel</de>
 				<en></en>
@@ -902,7 +902,7 @@ Einer der späteren [0|Last]s</de>
 			<data country="USA" year="1998" distribution="1" maingenre="2" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="42" speed="61" outcome="42" />
 		</programme>
-		<programme id="1625bab2-e066-4dfb-b070-dd64dffadc42" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0103772" rt_id="0" creator="">
+		<programme id="1625bab2-e066-4dfb-b070-dd64dffadc42" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0103772" creator="">
 			<title>
 				<de>Das Tier in mir</de>
 				<en></en>
@@ -926,7 +926,7 @@ Zerreißender Erotik-Thriller von [0|Full]</de>
 			<data country="USA" year="1992" distribution="1" maingenre="8" subgenre="" flags="0" blocks="3" price_mod="1.33" />
 			<ratings critics="51" speed="61" outcome="75" />
 		</programme>
-		<programme id="3ee39744-362a-4930-a791-0e928fbb8225" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0079116" rt_id="0" creator="">
+		<programme id="3ee39744-362a-4930-a791-0e928fbb8225" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0079116" creator="">
 			<title>
 				<de>Dem Alcatraz entkommen</de>
 				<en></en>
@@ -949,7 +949,7 @@ Nach einer wahren Begebenheit</de>
 			<data country="USA" year="1979" distribution="1" maingenre="13" subgenre="" flags="8" blocks="2" price_mod="0.90" />
 			<ratings critics="70" speed="42" outcome="56" />
 		</programme>
-		<programme id="031e9089-2f07-444f-a2fd-cb34139e6dcf" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0396171" rt_id="0" creator="">
+		<programme id="031e9089-2f07-444f-a2fd-cb34139e6dcf" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0396171" creator="">
 			<title>
 				<de>Deodorant - Des Mörders Erzählung</de>
 				<en></en>
@@ -973,7 +973,7 @@ Nach einer wahren Begebenheit</de>
 			<data country="D/F" year="2006" distribution="1" maingenre="15" subgenre="" flags="0" blocks="3" price_mod="1.33" />
 			<ratings critics="56" speed="37" outcome="51" />
 		</programme>
-		<programme id="80cf65fb-c25d-4f03-accf-802b00b15c59" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0073195" rt_id="0" creator="">
+		<programme id="80cf65fb-c25d-4f03-accf-802b00b15c59" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0073195" creator="">
 			<title>
 				<de>Der Albinohai</de>
 				<en></en>
@@ -995,7 +995,7 @@ Nach einer wahren Begebenheit</de>
 			<data country="USA" year="1974" distribution="1" maingenre="12" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="42" speed="65" outcome="75" />
 		</programme>
-		<programme id="f9b74ad8-0f5c-4271-aee2-e486155da966" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0110148" rt_id="0" creator="">
+		<programme id="f9b74ad8-0f5c-4271-aee2-e486155da966" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0110148" creator="">
 			<title>
 				<de>Der befragte Vampir</de>
 				<en></en>
@@ -1019,7 +1019,7 @@ Nach einer wahren Begebenheit</de>
 			<data country="USA" year="1994" distribution="1" maingenre="12" subgenre="" flags="0" blocks="3" price_mod="0.90" />
 			<ratings critics="23" speed="42" outcome="42" />
 		</programme>
-		<programme id="e81e6ca9-ee3a-4553-a2b2-0543e026de43" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0041959" rt_id="0" creator="">
+		<programme id="e81e6ca9-ee3a-4553-a2b2-0543e026de43" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0041959" creator="">
 			<title>
 				<de>Der Dritte im Bunde</de>
 				<en></en>
@@ -1044,7 +1044,7 @@ Einzigartig durch die Walzermusik und das Nachkriegswien</de>
 			<data country="GB" year="1949" distribution="1" maingenre="17" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="84" speed="42" outcome="75" />
 		</programme>
-		<programme id="74d0e69d-31bc-49b0-878a-d2663e0e27ed" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0083866" rt_id="0" creator="">
+		<programme id="74d0e69d-31bc-49b0-878a-d2663e0e27ed" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0083866" creator="">
 			<title>
 				<de>Der Extraterrestrische</de>
 				<en></en>
@@ -1067,7 +1067,7 @@ Einzigartig durch die Walzermusik und das Nachkriegswien</de>
 			<data country="USA" year="1982" distribution="1" maingenre="16" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="47" speed="47" outcome="75" />
 		</programme>
-		<programme id="8ef29506-1756-400d-8f9c-30b9d64cd7a4" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0051200" rt_id="0" creator="">
+		<programme id="8ef29506-1756-400d-8f9c-30b9d64cd7a4" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0051200" creator="">
 			<title>
 				<de>Der Gasthof im Spechtswald</de>
 				<en></en>
@@ -1091,7 +1091,7 @@ Einzigartig durch die Walzermusik und das Nachkriegswien</de>
 			<data country="D" year="1957" distribution="1" maingenre="202" subgenre="" flags="0" blocks="2" price_mod="0.90" />
 			<ratings critics="42" speed="32" outcome="47" />
 		</programme>
-		<programme id="04fc2288-b422-4fa6-b42e-aa91b922345f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0070047" rt_id="0" creator="">
+		<programme id="04fc2288-b422-4fa6-b42e-aa91b922345f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0070047" creator="">
 			<title>
 				<de>Der Geister-Austreiber</de>
 				<en></en>
@@ -1116,7 +1116,7 @@ Horror vom Feinsten</de>
 			<data country="USA" year="1973" distribution="1" maingenre="12" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="28" speed="42" outcome="65" />
 		</programme>
-		<programme id="92fcebf8-48f9-4217-b64a-e170093e1ace" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0118715" rt_id="0" creator="">
+		<programme id="92fcebf8-48f9-4217-b64a-e170093e1ace" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0118715" creator="">
 			<title>
 				<de>Der Große Glubowski</de>
 				<en></en>
@@ -1140,7 +1140,7 @@ Horror vom Feinsten</de>
 			<data country="USA" year="1998" distribution="1" maingenre="5" subgenre="" flags="0" blocks="3" price_mod="1.7" />
 			<ratings critics="0" speed="14" outcome="56" />
 		</programme>
-		<programme id="53406dc9-1e66-4f79-aa24-67a2ed4c7441" product="3" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="53406dc9-1e66-4f79-aa24-67a2ed4c7441" product="3" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Der Hammer fällt LIVE</de>
 				<en></en>
@@ -1153,7 +1153,7 @@ Horror vom Feinsten</de>
 			<data country="BEL" year="2011" distribution="2" maingenre="0" subgenre="" flags="128" blocks="2" price_mod="0.85" />
 			<ratings critics="7" speed="10" outcome="0" />
 		</programme>
-		<programme id="d9bd6851-b70d-4130-8f79-230e2df0a910" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0104779" rt_id="0" creator="">
+		<programme id="d9bd6851-b70d-4130-8f79-230e2df0a910" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0104779" creator="">
 			<title>
 				<de>Der herbe Erdtrabant</de>
 				<en></en>
@@ -1177,7 +1177,7 @@ Horror vom Feinsten</de>
 			<data country="GB" year="1992" distribution="1" maingenre="8" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="51" speed="37" outcome="42" />
 		</programme>
-		<programme id="b8b36ceb-b26e-4ecd-92be-e77376c1ce1b" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0082096" rt_id="0" creator="">
+		<programme id="b8b36ceb-b26e-4ecd-92be-e77376c1ce1b" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0082096" creator="">
 			<title>
 				<de>Der Kahn</de>
 				<en></en>
@@ -1199,7 +1199,7 @@ Horror vom Feinsten</de>
 			<data country="D" year="1981" distribution="1" maingenre="2" subgenre="" flags="0" blocks="3" price_mod="0.90" />
 			<ratings critics="65" speed="32" outcome="75" />
 		</programme>
-		<programme id="82cb8476-90f7-4cf5-b1ed-5f4dbbf25707" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0107426" rt_id="0" creator="">
+		<programme id="82cb8476-90f7-4cf5-b1ed-5f4dbbf25707" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0107426" creator="">
 			<title>
 				<de>Der kleine Buddhist</de>
 				<en></en>
@@ -1223,7 +1223,7 @@ Horror vom Feinsten</de>
 			<data country="GB" year="1993" distribution="1" maingenre="13" subgenre="" flags="8" blocks="3" price_mod="1.33" />
 			<ratings critics="56" speed="28" outcome="42" />
 		</programme>
-		<programme id="7cd945b8-ce70-4d08-bbce-f7ccb81885e5" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0107362" rt_id="0" creator="">
+		<programme id="7cd945b8-ce70-4d08-bbce-f7ccb81885e5" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0107362" creator="">
 			<title>
 				<de>Der letzte Kinoheld</de>
 				<en></en>
@@ -1246,7 +1246,7 @@ Horror vom Feinsten</de>
 			<data country="USA" year="1993" distribution="1" maingenre="2" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="18" speed="37" outcome="42" />
 		</programme>
-		<programme id="ab9601a1-966e-4091-80bf-a5a8d80d97fb" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0102266" rt_id="0" creator="">
+		<programme id="ab9601a1-966e-4091-80bf-a5a8d80d97fb" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0102266" creator="">
 			<title>
 				<de>Der letzte Scout - Nicht Sterben</de>
 				<en></en>
@@ -1271,7 +1271,7 @@ Horror vom Feinsten</de>
 			<data country="USA" year="1991" distribution="1" maingenre="2" subgenre="" flags="64" blocks="2" price_mod="0.67" />
 			<ratings critics="23" speed="80" outcome="65" />
 		</programme>
-		<programme id="34207d9d-34a6-46a3-9071-075aa3e42895" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0325710" rt_id="0" creator="">
+		<programme id="34207d9d-34a6-46a3-9071-075aa3e42895" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0325710" creator="">
 			<title>
 				<de>Der letzte Tai-Chi-Kämpfer</de>
 				<en></en>
@@ -1298,7 +1298,7 @@ Berührende, einigermaßen glaubwürdige Geschichte und eingängige Musik von Ha
 			<data country="USA" year="2003" distribution="1" maingenre="13" subgenre="" flags="8" blocks="3" price_mod="1" />
 			<ratings critics="65" speed="42" outcome="61" />
 		</programme>
-		<programme id="fc0bf277-6d13-48ea-8829-f5f0e1ac72e1" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0099348" rt_id="0" creator="">
+		<programme id="fc0bf277-6d13-48ea-8829-f5f0e1ac72e1" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0099348" creator="">
 			<title>
 				<de>Der mit den Wölfen schunkelt</de>
 				<en></en>
@@ -1323,7 +1323,7 @@ Sehenswertes Regie-Debüt von [0|Full]</de>
 			<data country="USA" year="1990" distribution="1" maingenre="18" subgenre="" flags="0" blocks="4" price_mod="0.90" />
 			<ratings critics="70" speed="42" outcome="75" />
 		</programme>
-		<programme id="0c046c5c-2b35-43b9-92d6-750b712a1c2e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0081163" rt_id="0" creator="">
+		<programme id="0c046c5c-2b35-43b9-92d6-750b712a1c2e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0081163" creator="">
 			<title>
 				<de>Der Spiegelmord</de>
 				<en></en>
@@ -1348,7 +1348,7 @@ Namhafte Schauspieler, aber das Konzept kann nicht überzeugen.</de>
 			<data country="GB" year="1980" distribution="1" maingenre="17" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="28" speed="23" outcome="32" />
 		</programme>
-		<programme id="596591ce-2274-47e4-b989-86adaa05dee5" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0075314" rt_id="0" creator="">
+		<programme id="596591ce-2274-47e4-b989-86adaa05dee5" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0075314" creator="">
 			<title>
 				<de>Der Taxifahrer</de>
 				<en></en>
@@ -1373,7 +1373,7 @@ Nachvollziehbar und verstörend, grandios inszeniert von [0|Full].</de>
 			<data country="USA" year="1976" distribution="1" maingenre="2" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="75" speed="51" outcome="75" />
 		</programme>
-		<programme id="53adcff5-1ea0-4167-8cb0-8487566f21ff" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120660" rt_id="0" creator="">
+		<programme id="53adcff5-1ea0-4167-8cb0-8487566f21ff" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120660" creator="">
 			<title>
 				<de>Der Top-Staatsfeind</de>
 				<en></en>
@@ -1396,7 +1396,7 @@ Nachvollziehbar und verstörend, grandios inszeniert von [0|Full].</de>
 			<data country="USA" year="1998" distribution="1" maingenre="2" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="51" speed="28" outcome="42" />
 		</programme>
-		<programme id="0bd87de4-b2ca-4c2b-822c-4c18967d1a29" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0167404" rt_id="0" creator="">
+		<programme id="0bd87de4-b2ca-4c2b-822c-4c18967d1a29" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0167404" creator="">
 			<title>
 				<de>Der übernatürliche Sinn</de>
 				<en></en>
@@ -1418,7 +1418,7 @@ Nachvollziehbar und verstörend, grandios inszeniert von [0|Full].</de>
 			<data country="USA" year="1999" distribution="1" maingenre="17" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="51" speed="42" outcome="56" />
 		</programme>
-		<programme id="18283e98-98db-4864-88f2-6093d8f2265a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120611" rt_id="0" creator="">
+		<programme id="18283e98-98db-4864-88f2-6093d8f2265a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120611" creator="">
 			<title>
 				<de>Der Vampirjäger</de>
 				<en></en>
@@ -1442,7 +1442,7 @@ Blutiges Spektakel für Genre-Fans und Schwachköpfe</de>
 			<data country="USA" year="1998" distribution="1" maingenre="2" subgenre="" flags="64" blocks="3" price_mod="1" />
 			<ratings critics="4" speed="51" outcome="51" />
 		</programme>
-		<programme id="a48d3913-b963-465c-b41d-cfa55046f6da" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0187738" rt_id="0" creator="">
+		<programme id="a48d3913-b963-465c-b41d-cfa55046f6da" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0187738" creator="">
 			<title>
 				<de>Der Vampirjäger 2</de>
 				<en></en>
@@ -1466,7 +1466,7 @@ Erfolgreiche Forsetzung des Schreckens</de>
 			<data country="USA" year="2002" distribution="1" maingenre="2" subgenre="" flags="64" blocks="2" price_mod="1" />
 			<ratings critics="0" speed="65" outcome="56" />
 		</programme>
-		<programme id="88593448-151d-4928-88af-19507cbbbbb1" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0049293" rt_id="0" creator="">
+		<programme id="88593448-151d-4928-88af-19507cbbbbb1" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0049293" creator="">
 			<title>
 				<de>Der Wachmann von Korpenigg</de>
 				<en></en>
@@ -1490,7 +1490,7 @@ Erfolgreiche Forsetzung des Schreckens</de>
 			<data country="D" year="1956" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="51" speed="47" outcome="51" />
 		</programme>
-		<programme id="d4ece8b7-8766-4d05-a2cd-979ffc938d37" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0305224" rt_id="0" creator="">
+		<programme id="d4ece8b7-8766-4d05-a2cd-979ffc938d37" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0305224" creator="">
 			<title>
 				<de>Der Wut-Psychiater</de>
 				<en></en>
@@ -1513,7 +1513,7 @@ Erfolgreiche Forsetzung des Schreckens</de>
 			<data country="USA" year="2003" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="1.33" />
 			<ratings critics="23" speed="56" outcome="42" />
 		</programme>
-		<programme id="bcb305d5-678b-4c8b-b34d-6de0e484dc7f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0088247" rt_id="0" creator="">
+		<programme id="bcb305d5-678b-4c8b-b34d-6de0e484dc7f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0088247" creator="">
 			<title>
 				<de>Determinator</de>
 				<en></en>
@@ -1538,7 +1538,7 @@ Erfolgreiche Forsetzung des Schreckens</de>
 			<data country="USA" year="1984" distribution="1" maingenre="2" subgenre="" flags="64" blocks="2" price_mod="0.67" />
 			<ratings critics="23" speed="80" outcome="80" />
 		</programme>
-		<programme id="f84d636c-49fc-40e2-89fd-7927d1237dcb" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0083169" rt_id="0" creator="">
+		<programme id="f84d636c-49fc-40e2-89fd-7927d1237dcb" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0083169" creator="">
 			<title>
 				<de>Die Adretten vom Junker Bill</de>
 				<en></en>
@@ -1562,7 +1562,7 @@ Erfolgreiche Forsetzung des Schreckens</de>
 			<data country="USA" year="1981" distribution="1" maingenre="15" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="61" speed="56" outcome="18" />
 		</programme>
-		<programme id="a11e062a-10ce-4005-b8d5-5c6a23ef8ccc" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0106918" rt_id="0" creator="">
+		<programme id="a11e062a-10ce-4005-b8d5-5c6a23ef8ccc" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0106918" creator="">
 			<title>
 				<de>Die Aktiengesellschaft</de>
 				<en></en>
@@ -1585,7 +1585,7 @@ Erfolgreiche Forsetzung des Schreckens</de>
 			<data country="USA" year="1993" distribution="1" maingenre="17" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="61" speed="14" outcome="42" />
 		</programme>
-		<programme id="00fd4fd6-3f9e-4231-b808-ec396f90a65d" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0050212" rt_id="0" creator="">
+		<programme id="00fd4fd6-3f9e-4231-b808-ec396f90a65d" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0050212" creator="">
 			<title>
 				<de>Die Brücke beim Kai</de>
 				<en></en>
@@ -1610,7 +1610,7 @@ Klassiker von [0|Full]</de>
 			<data country="GB" year="1957" distribution="1" maingenre="13" subgenre="" flags="8" blocks="3" price_mod="0.67" />
 			<ratings critics="65" speed="51" outcome="51" />
 		</programme>
-		<programme id="35190c1d-aa55-4e84-967f-72a374e84dcf" product="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="35190c1d-aa55-4e84-967f-72a374e84dcf" product="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Die Demoskopie des Menschen</de>
 				<en></en>
@@ -1627,7 +1627,7 @@ Klassiker von [0|Full]</de>
 			<data country="D" year="1996" distribution="2" maingenre="6" subgenre="" flags="4" blocks="2" price_mod="0.67" />
 			<ratings critics="42" speed="23" outcome="4" />
 		</programme>
-		<programme id="5d6c6f27-c8a6-402a-80d0-216c814abbc6" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0061852" rt_id="0" creator="">
+		<programme id="5d6c6f27-c8a6-402a-80d0-216c814abbc6" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0061852" creator="">
 			<title>
 				<de>Die Dschungelgeschichte</de>
 				<en></en>
@@ -1647,7 +1647,7 @@ Walt Mouseworks Meisterwerk</de>
 			<data country="USA" year="1967" distribution="1" maingenre="3" subgenre="" flags="2" blocks="2" price_mod="1.7" />
 			<ratings critics="51" speed="65" outcome="70" />
 		</programme>
-		<programme id="e7b9499a-6398-4ad4-b389-73ca0b8072ac" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0233142" rt_id="0" creator="">
+		<programme id="e7b9499a-6398-4ad4-b389-73ca0b8072ac" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0233142" creator="">
 			<title>
 				<de>Die Elvis-Bande in Las Vegas</de>
 				<en></en>
@@ -1673,7 +1673,7 @@ Bunte Action mit [1|Full]</de>
 			<data country="USA" year="2001" distribution="1" maingenre="2" subgenre="" flags="64" blocks="3" price_mod="1" />
 			<ratings critics="28" speed="75" outcome="37" />
 		</programme>
-		<programme id="cb37aafc-916a-47bf-9e2e-3d1908f2ab33" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0060390" rt_id="0" creator="">
+		<programme id="cb37aafc-916a-47bf-9e2e-3d1908f2ab33" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0060390" creator="">
 			<title>
 				<de>Die Fahreinheit 401</de>
 				<en></en>
@@ -1697,7 +1697,7 @@ Bunte Action mit [1|Full]</de>
 			<data country="GB" year="1966" distribution="1" maingenre="16" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="80" speed="37" outcome="32" />
 		</programme>
-		<programme id="2fcf1b3e-701c-434d-acf3-c34c94227e7d" product="3" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="2fcf1b3e-701c-434d-acf3-c34c94227e7d" product="3" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Die große Verarsche-Show</de>
 				<en></en>
@@ -1710,7 +1710,7 @@ Bunte Action mit [1|Full]</de>
 			<data country="D" year="2000" distribution="2" maingenre="0" subgenre="" flags="128" blocks="2" price_mod="0.9" />
 			<ratings critics="7" speed="11" outcome="8" />
 		</programme>
-		<programme id="33739403-cb16-4dfc-b9da-42658c40f261" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0138447" rt_id="0" creator="">
+		<programme id="33739403-cb16-4dfc-b9da-42658c40f261" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0138447" creator="">
 			<title>
 				<de>Die Helfer: Feuersbrunst in Manhattan</de>
 				<en></en>
@@ -1735,7 +1735,7 @@ Anrührender Film, geplant als TV-Serie - es blieb beim Piloten.</de>
 			<data country="USA" year="1997" distribution="1" maingenre="17" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="56" speed="42" outcome="23" />
 		</programme>
-		<programme id="d3bc0aa1-7eac-4235-aec8-d9e26337db36" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0119396" rt_id="0" creator="">
+		<programme id="d3bc0aa1-7eac-4235-aec8-d9e26337db36" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0119396" creator="">
 			<title>
 				<de>Die Raubstewardess</de>
 				<en></en>
@@ -1760,7 +1760,7 @@ Anrührender Film, geplant als TV-Serie - es blieb beim Piloten.</de>
 			<data country="USA" year="1997" distribution="1" maingenre="2" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="51" speed="51" outcome="56" />
 		</programme>
-		<programme id="b18cdbe1-185b-4037-b337-7fea68dc70f5" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0162661" rt_id="0" creator="">
+		<programme id="b18cdbe1-185b-4037-b337-7fea68dc70f5" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0162661" creator="">
 			<title>
 				<de>Die schläfrige Kehle</de>
 				<en></en>
@@ -1784,7 +1784,7 @@ Anrührender Film, geplant als TV-Serie - es blieb beim Piloten.</de>
 			<data country="USA" year="1999" distribution="1" maingenre="12" subgenre="" flags="0" blocks="2" price_mod="1.33" />
 			<ratings critics="23" speed="32" outcome="51" />
 		</programme>
-		<programme id="8bd2c897-f72c-4e51-901f-e594db17de02" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0047396" rt_id="0" creator="">
+		<programme id="8bd2c897-f72c-4e51-901f-e594db17de02" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0047396" creator="">
 			<title>
 				<de>Die Sicht zum Hinterhof</de>
 				<en></en>
@@ -1809,7 +1809,7 @@ Anrührender Film, geplant als TV-Serie - es blieb beim Piloten.</de>
 			<data country="USA" year="1954" distribution="1" maingenre="17" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="75" speed="51" outcome="84" />
 		</programme>
-		<programme id="a1d45a76-b16f-43b0-aa9d-7fe8778be885" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0065718" rt_id="0" creator="">
+		<programme id="a1d45a76-b16f-43b0-aa9d-7fe8778be885" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0065718" creator="">
 			<title>
 				<de>Die Streichholzhammerbowle</de>
 				<en></en>
@@ -1833,7 +1833,7 @@ Keine leichte Aufgabe für [1|Full]</de>
 			<data country="D" year="1970" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="32" speed="51" outcome="28" />
 		</programme>
-		<programme id="c714764b-adf6-423d-9d6e-c8c8aa92aa0e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0036818" rt_id="0" creator="">
+		<programme id="c714764b-adf6-423d-9d6e-c8c8aa92aa0e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0036818" creator="">
 			<title>
 				<de>Die Streichholzhammerbowle</de>
 				<en></en>
@@ -1858,7 +1858,7 @@ Bestechender Klassiker mit [1|Full]</de>
 			<data country="D" year="1944" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="89" speed="65" outcome="65" />
 		</programme>
-		<programme id="8a018228-cd6a-49eb-88fb-ade85d730cea" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0053604" rt_id="0" creator="">
+		<programme id="8a018228-cd6a-49eb-88fb-ade85d730cea" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0053604" creator="">
 			<title>
 				<de>Die Wohnung</de>
 				<en></en>
@@ -1883,7 +1883,7 @@ Exzellente Besetzung und Regie</de>
 			<data country="USA" year="1960" distribution="1" maingenre="5" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="70" speed="37" outcome="70" />
 		</programme>
-		<programme id="8a6ddb70-3404-49f9-ab27-631ea11505fd" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0117951" rt_id="0" creator="">
+		<programme id="8a6ddb70-3404-49f9-ab27-631ea11505fd" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0117951" creator="">
 			<title>
 				<de>Die Zugspanner</de>
 				<en></en>
@@ -1908,7 +1908,7 @@ Exzellente Besetzung und Regie</de>
 			<data country="GB" year="1996" distribution="1" maingenre="15" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="56" speed="51" outcome="56" />
 		</programme>
-		<programme id="24062b9f-0ec7-4b65-b4ce-23c751ed5951" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0089755" rt_id="0" creator="">
+		<programme id="24062b9f-0ec7-4b65-b4ce-23c751ed5951" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0089755" creator="">
 			<title>
 				<de>Diesseits von Namibia</de>
 				<en></en>
@@ -1930,7 +1930,7 @@ Exzellente Besetzung und Regie</de>
 			<data country="USA" year="1985" distribution="1" maingenre="15" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="70" speed="28" outcome="61" />
 		</programme>
-		<programme id="125d9ff5-f476-465c-a7cc-30d5a1678681" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0059113" rt_id="0" creator="">
+		<programme id="125d9ff5-f476-465c-a7cc-30d5a1678681" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0059113" creator="">
 			<title>
 				<de>Doktor Schiefwagen</de>
 				<en></en>
@@ -1954,7 +1954,7 @@ Exzellente Besetzung und Regie</de>
 			<data country="USA" year="1965" distribution="1" maingenre="13" subgenre="" flags="8" blocks="4" price_mod="0.67" />
 			<ratings critics="61" speed="23" outcome="47" />
 		</programme>
-		<programme id="46509f82-bcc6-4a3e-88b7-a5029e22f0f5" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0057012" rt_id="0" creator="">
+		<programme id="46509f82-bcc6-4a3e-88b7-a5029e22f0f5" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0057012" creator="">
 			<title>
 				<de>Dr. Merkwürdig...</de>
 				<en></en>
@@ -1979,7 +1979,7 @@ Schwarzer Humor, gute Musik und [1|Full] in drei verschiedenen Rollen.</de>
 			<data country="GB" year="1964" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="0.90" />
 			<ratings critics="61" speed="42" outcome="65" />
 		</programme>
-		<programme id="923d3ef3-db6c-48c5-afba-16f95f211a72" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0048014" rt_id="0" creator="">
+		<programme id="923d3ef3-db6c-48c5-afba-16f95f211a72" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0048014" creator="">
 			<title>
 				<de>Drei Kerle im Eis</de>
 				<en></en>
@@ -2002,7 +2002,7 @@ Hochkarätige Komödie von 1955</de>
 			<data country="A" year="1955" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="47" speed="42" outcome="42" />
 		</programme>
-		<programme id="6fb0c54f-a4d6-4cf2-b022-b88044267a99" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0054826" rt_id="0" creator="">
+		<programme id="6fb0c54f-a4d6-4cf2-b022-b88044267a99" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0054826" creator="">
 			<title>
 				<de>Drei Kerle in einem Ruderboot</de>
 				<en></en>
@@ -2025,7 +2025,7 @@ Das Trio [1|Last], [2|Last], [3|Last] sorgt für den riesigen Spaß des Films</d
 			<data country="D" year="1961" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="0.90" />
 			<ratings critics="47" speed="65" outcome="51" />
 		</programme>
-		<programme id="7edc06e5-0205-4b63-8ff8-ec86bfdbfbf1" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0105583" rt_id="0" creator="">
+		<programme id="7edc06e5-0205-4b63-8ff8-ec86bfdbfbf1" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0105583" creator="">
 			<title>
 				<de>Durch die Augen des Killers</de>
 				<en></en>
@@ -2052,7 +2052,7 @@ Schockierender Thriller mit [1|Full]
 			<data country="USA" year="1992" distribution="1" maingenre="17" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="61" speed="61" outcome="42" />
 		</programme>
-		<programme id="15adba17-620f-45e5-bc37-80f7b1e65c3b" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0059139" rt_id="0" creator="">
+		<programme id="15adba17-620f-45e5-bc37-80f7b1e65c3b" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0059139" creator="">
 			<title>
 				<de>Durchs wilde Tadschikistan</de>
 				<en></en>
@@ -2077,7 +2077,7 @@ Spannendes Abenteuer nach Karl Meier</de>
 			<data country="D" year="1965" distribution="1" maingenre="2" subgenre="" flags="0" blocks="2" price_mod="0.90" />
 			<ratings critics="56" speed="70" outcome="51" />
 		</programme>
-		<programme id="5d7e43a1-5e60-41ac-9fd8-365798d3c86a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0104257" rt_id="0" creator="">
+		<programme id="5d7e43a1-5e60-41ac-9fd8-365798d3c86a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0104257" creator="">
 			<title>
 				<de>Ehre in Frage gestellt</de>
 				<en></en>
@@ -2103,7 +2103,7 @@ Packender und bis in die Nebenrollen gut besetzter Militärthriller</de>
 			<data country="USA" year="1992" distribution="1" maingenre="17" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="65" speed="61" outcome="61" />
 		</programme>
-		<programme id="4ce1c133-6062-4ad4-b925-729007157db9" product="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="4ce1c133-6062-4ad4-b925-729007157db9" product="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Ein Ei zum Frühstück?</de>
 				<en></en>
@@ -2119,7 +2119,7 @@ Packender und bis in die Nebenrollen gut besetzter Militärthriller</de>
 			<data country="GB" year="1995" distribution="2" maingenre="6" subgenre="" flags="4" blocks="1" price_mod="1" />
 			<ratings critics="28" speed="51" outcome="18" />
 		</programme>
-		<programme id="2f8b9df3-8a71-433d-a2b0-855a5ee9ca31" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0074937" rt_id="0" creator="">
+		<programme id="2f8b9df3-8a71-433d-a2b0-855a5ee9ca31" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0074937" creator="">
 			<title>
 				<de>Ein Toter zum Nachtisch</de>
 				<en></en>
@@ -2145,7 +2145,7 @@ Urkomisches Gagfeuerwerk</de>
 			<data country="USA" year="1976" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="61" speed="70" outcome="61" />
 		</programme>
-		<programme id="e61018ba-b0db-439c-a852-a54a66fde481" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0088323" rt_id="0" creator="">
+		<programme id="e61018ba-b0db-439c-a852-a54a66fde481" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0088323" creator="">
 			<title>
 				<de>Eine nimmerendende Erzählung</de>
 				<en></en>
@@ -2168,7 +2168,7 @@ Liebevoll erzählt, nettes Kostüm für den Glücksdrachen Fuchur</de>
 			<data country="D" year="1984" distribution="1" maingenre="10" subgenre="" flags="0" blocks="2" price_mod="0.90" />
 			<ratings critics="37" speed="37" outcome="56" />
 		</programme>
-		<programme id="999d5c89-5676-4715-a3e1-64811ee31f2f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0266308" rt_id="0" creator="">
+		<programme id="999d5c89-5676-4715-a3e1-64811ee31f2f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0266308" creator="">
 			<title>
 				<de>Elitekampf</de>
 				<en></en>
@@ -2193,7 +2193,7 @@ Ultrabrutal, doch nicht allzu weit hergeholt</de>
 			<data country="J" year="2000" distribution="1" maingenre="2" subgenre="" flags="64" blocks="2" price_mod="1" />
 			<ratings critics="61" speed="70" outcome="56" />
 		</programme>
-		<programme id="9fb0fb72-79d3-4ceb-9846-dac8d1eb4265" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0078748" rt_id="0" creator="">
+		<programme id="9fb0fb72-79d3-4ceb-9846-dac8d1eb4265" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0078748" creator="">
 			<title>
 				<de>Extraterrestrial - Das schreckliche Wesen aus dem All</de>
 				<en></en>
@@ -2216,7 +2216,7 @@ Ultrabrutal, doch nicht allzu weit hergeholt</de>
 			<data country="GB" year="1979" distribution="1" maingenre="16" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="18" speed="37" outcome="65" />
 		</programme>
-		<programme id="61cb5e94-7496-4a47-9637-e97fd2b9dd17" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0118583" rt_id="0" creator="">
+		<programme id="61cb5e94-7496-4a47-9637-e97fd2b9dd17" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0118583" creator="">
 			<title>
 				<de>Extraterrestrial - Die Reinkarnation</de>
 				<en></en>
@@ -2237,7 +2237,7 @@ Ultrabrutal, doch nicht allzu weit hergeholt</de>
 			<data country="USA" year="1997" distribution="1" maingenre="16" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="9" speed="42" outcome="28" />
 		</programme>
-		<programme id="820cc04c-ed37-4b1d-8e8a-67672dd65deb" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0090605" rt_id="0" creator="">
+		<programme id="820cc04c-ed37-4b1d-8e8a-67672dd65deb" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0090605" creator="">
 			<title>
 				<de>Extraterrestrial - Sie sind zurück</de>
 				<en></en>
@@ -2259,7 +2259,7 @@ Ultrabrutal, doch nicht allzu weit hergeholt</de>
 			<data country="USA" year="1986" distribution="1" maingenre="16" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="28" speed="32" outcome="70" />
 		</programme>
-		<programme id="00b3c3f7-2395-4a80-b1a4-d3bf427282bb" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0103644" rt_id="0" creator="">
+		<programme id="00b3c3f7-2395-4a80-b1a4-d3bf427282bb" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0103644" creator="">
 			<title>
 				<de>Extraterrestrial 3</de>
 				<en></en>
@@ -2280,7 +2280,7 @@ Ultrabrutal, doch nicht allzu weit hergeholt</de>
 			<data country="USA" year="1992" distribution="1" maingenre="16" subgenre="" flags="0" blocks="2" price_mod="1.33" />
 			<ratings critics="9" speed="32" outcome="37" />
 		</programme>
-		<programme id="23a4dc1f-8ad0-49c7-9051-7c9132bd69c5" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0370263" rt_id="0" creator="">
+		<programme id="23a4dc1f-8ad0-49c7-9051-7c9132bd69c5" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0370263" creator="">
 			<title>
 				<de>Extraterrestrials gegen Jäger</de>
 				<en></en>
@@ -2304,7 +2304,7 @@ Aus einem solchen Zusammentreffen hätte man wohl mehr machen können.</de>
 			<data country="USA" year="2004" distribution="1" maingenre="16" subgenre="" flags="0" blocks="2" price_mod="1.33" />
 			<ratings critics="9" speed="37" outcome="37" />
 		</programme>
-		<programme id="125041ff-a99e-4c03-bb10-a10fa9e8ecc9" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0079945" rt_id="0" creator="">
+		<programme id="125041ff-a99e-4c03-bb10-a10fa9e8ecc9" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0079945" creator="">
 			<title>
 				<de>Far Track - Der Film</de>
 				<en></en>
@@ -2326,7 +2326,7 @@ Aus einem solchen Zusammentreffen hätte man wohl mehr machen können.</de>
 			<data country="USA" year="1979" distribution="1" maingenre="16" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="37" speed="18" outcome="47" />
 		</programme>
-		<programme id="f5054637-6fba-4e4b-bdf4-ea0c8defb3e7" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0084726" rt_id="0" creator="">
+		<programme id="f5054637-6fba-4e4b-bdf4-ea0c8defb3e7" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0084726" creator="">
 			<title>
 				<de>Far Track II - Das Korn des Hahns</de>
 				<en></en>
@@ -2348,7 +2348,7 @@ Aus einem solchen Zusammentreffen hätte man wohl mehr machen können.</de>
 			<data country="USA" year="1982" distribution="1" maingenre="16" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="42" speed="37" outcome="51" />
 		</programme>
-		<programme id="0010031b-3b3a-41e1-bcde-6743a429f158" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0088170" rt_id="0" creator="">
+		<programme id="0010031b-3b3a-41e1-bcde-6743a429f158" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0088170" creator="">
 			<title>
 				<de>Far Track III - Die Suche nach Mr. Scook</de>
 				<en></en>
@@ -2370,7 +2370,7 @@ Aus einem solchen Zusammentreffen hätte man wohl mehr machen können.</de>
 			<data country="USA" year="1984" distribution="1" maingenre="16" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="56" speed="56" outcome="51" />
 		</programme>
-		<programme id="0fb8f985-0d9d-48c1-8e5a-f38912e556c5" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0092007" rt_id="0" creator="">
+		<programme id="0fb8f985-0d9d-48c1-8e5a-f38912e556c5" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0092007" creator="">
 			<title>
 				<de>Far Track IV - Zurück ins Präsens</de>
 				<en></en>
@@ -2392,7 +2392,7 @@ Aus einem solchen Zusammentreffen hätte man wohl mehr machen können.</de>
 			<data country="USA" year="1986" distribution="1" maingenre="16" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="37" speed="37" outcome="47" />
 		</programme>
-		<programme id="79eb1bd2-5c5b-4a77-bf14-e9d3a6496bf0" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0117731" rt_id="0" creator="">
+		<programme id="79eb1bd2-5c5b-4a77-bf14-e9d3a6496bf0" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0117731" creator="">
 			<title>
 				<de>Far Track VIII - Das erste Treffen</de>
 				<en></en>
@@ -2417,7 +2417,7 @@ Aus einem solchen Zusammentreffen hätte man wohl mehr machen können.</de>
 			<data country="USA" year="1996" distribution="1" maingenre="16" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="56" speed="80" outcome="65" />
 		</programme>
-		<programme id="ad487fa2-2103-4540-b138-7cbd19b429d5" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0098382" rt_id="0" creator="">
+		<programme id="ad487fa2-2103-4540-b138-7cbd19b429d5" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0098382" creator="">
 			<title>
 				<de>Far Track V - Der Rand des Weltalls</de>
 				<en></en>
@@ -2439,7 +2439,7 @@ Aus einem solchen Zusammentreffen hätte man wohl mehr machen können.</de>
 			<data country="USA" year="1989" distribution="1" maingenre="16" subgenre="" flags="0" blocks="2" price_mod="1.33" />
 			<ratings critics="28" speed="18" outcome="42" />
 		</programme>
-		<programme id="199e7a34-6dc7-4551-af24-50c9f455428a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0102975" rt_id="0" creator="">
+		<programme id="199e7a34-6dc7-4551-af24-50c9f455428a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0102975" creator="">
 			<title>
 				<de>Far Track VI - Unbekanntes Territorium</de>
 				<en></en>
@@ -2461,7 +2461,7 @@ Aus einem solchen Zusammentreffen hätte man wohl mehr machen können.</de>
 			<data country="USA" year="1991" distribution="1" maingenre="16" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="42" speed="37" outcome="51" />
 		</programme>
-		<programme id="8566103d-6318-4ec7-9e19-d81f305fd8f7" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0111280" rt_id="0" creator="">
+		<programme id="8566103d-6318-4ec7-9e19-d81f305fd8f7" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0111280" creator="">
 			<title>
 				<de>Far Track VII - Generationsmeeting</de>
 				<en></en>
@@ -2485,7 +2485,7 @@ Aus einem solchen Zusammentreffen hätte man wohl mehr machen können.</de>
 			<data country="USA" year="1994" distribution="1" maingenre="16" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="37" speed="37" outcome="61" />
 		</programme>
-		<programme id="649352b6-2b36-47d0-8f85-d0992bba662f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0253754" rt_id="0" creator="">
+		<programme id="649352b6-2b36-47d0-8f85-d0992bba662f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0253754" creator="">
 			<title>
 				<de>Far Track X - Nimmersatt</de>
 				<en></en>
@@ -2510,7 +2510,7 @@ Aus einem solchen Zusammentreffen hätte man wohl mehr machen können.</de>
 			<data country="USA" year="2002" distribution="1" maingenre="16" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="14" speed="80" outcome="37" />
 		</programme>
-		<programme id="6273b893-99bf-4234-a312-a7a2d00845ec" product="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="6273b893-99bf-4234-a312-a7a2d00845ec" product="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Faszination Plusquamperfekt</de>
 				<en></en>
@@ -2527,7 +2527,7 @@ Aus einem solchen Zusammentreffen hätte man wohl mehr machen können.</de>
 			<data country="D" year="1989" distribution="2" maingenre="6" subgenre="" flags="4" blocks="2" price_mod="1" />
 			<ratings critics="35" speed="0" outcome="10" />
 		</programme>
-		<programme id="89720b04-7bef-487c-84d6-a906f243a4a9" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0233469" rt_id="0" creator="">
+		<programme id="89720b04-7bef-487c-84d6-a906f243a4a9" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0233469" creator="">
 			<title>
 				<de>Fatal Damage - Zeit der Rache</de>
 				<en></en>
@@ -2551,7 +2551,7 @@ Aus einem solchen Zusammentreffen hätte man wohl mehr machen können.</de>
 			<data country="USA" year="2002" distribution="1" maingenre="2" subgenre="" flags="0" blocks="2" price_mod="1.33" />
 			<ratings critics="9" speed="18" outcome="37" />
 		</programme>
-		<programme id="02067514-42c5-4c74-b255-bf582c8ecd8e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0091042" rt_id="0" creator="">
+		<programme id="02067514-42c5-4c74-b255-bf582c8ecd8e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0091042" creator="">
 			<title>
 				<de>Ferris nimmt sich Ferien</de>
 				<en></en>
@@ -2575,7 +2575,7 @@ Aus einem solchen Zusammentreffen hätte man wohl mehr machen können.</de>
 			<data country="USA" year="1986" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="0.90" />
 			<ratings critics="23" speed="28" outcome="28" />
 		</programme>
-		<programme id="afb3ad66-31ec-4353-9356-81d2a1cd9f87" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0098439" rt_id="0" creator="">
+		<programme id="afb3ad66-31ec-4353-9356-81d2a1cd9f87" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0098439" creator="">
 			<title>
 				<de>Flamenco &amp; Buck</de>
 				<en></en>
@@ -2599,7 +2599,7 @@ Rasante Action mit Starbesetzung</de>
 			<data country="USA" year="1989" distribution="1" maingenre="2" subgenre="" flags="64" blocks="2" price_mod="0.67" />
 			<ratings critics="18" speed="80" outcome="47" />
 		</programme>
-		<programme id="1a02b18a-b596-4c8d-8c50-2a4fb3f1037d" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0096895" rt_id="0" creator="">
+		<programme id="1a02b18a-b596-4c8d-8c50-2a4fb3f1037d" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0096895" creator="">
 			<title>
 				<de>Flederflügel</de>
 				<en></en>
@@ -2623,7 +2623,7 @@ Die finstere Fledermaus als Pionier der Realverfilmungswelle</de>
 			<data country="USA" year="1989" distribution="1" maingenre="10" subgenre="" flags="0" blocks="3" price_mod="0.90" />
 			<ratings critics="32" speed="61" outcome="61" />
 		</programme>
-		<programme id="9f23a668-5294-483c-92c2-5b775d23e233" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0118883" rt_id="0" creator="">
+		<programme id="9f23a668-5294-483c-92c2-5b775d23e233" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0118883" creator="">
 			<title>
 				<de>Fleischers Wahn</de>
 				<en></en>
@@ -2645,7 +2645,7 @@ Die finstere Fledermaus als Pionier der Realverfilmungswelle</de>
 			<data country="USA" year="1997" distribution="1" maingenre="2" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="37" speed="47" outcome="37" />
 		</programme>
-		<programme id="205e8a66-4211-4f84-81c2-6c97726f2e31" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0092099" rt_id="0" creator="">
+		<programme id="205e8a66-4211-4f84-81c2-6c97726f2e31" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0092099" creator="">
 			<title>
 				<de>Flop Wummen - Sie fürchten keine Schwiegermutter</de>
 				<en></en>
@@ -2672,7 +2672,7 @@ Mit „Flop Wummen“ gelang [1|Full] der internationale Durchbruch.</de>
 			<data country="USA" year="1986" distribution="1" maingenre="2" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="32" speed="51" outcome="70" />
 		</programme>
-		<programme id="1fb76245-bc71-40cb-ae77-a7d299a13d91" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0325980" rt_id="0" creator="">
+		<programme id="1fb76245-bc71-40cb-ae77-a7d299a13d91" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0325980" creator="">
 			<title>
 				<de>Fluch der Südsee</de>
 				<en></en>
@@ -2696,7 +2696,7 @@ Mit „Flop Wummen“ gelang [1|Full] der internationale Durchbruch.</de>
 			<data country="USA" year="2003" distribution="1" maingenre="2" subgenre="" flags="0" blocks="3" price_mod="1.7" />
 			<ratings critics="9" speed="9" outcome="70" />
 		</programme>
-		<programme id="4843087d-7f56-48b5-afa8-49860b91e82c" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0100802" rt_id="0" creator="">
+		<programme id="4843087d-7f56-48b5-afa8-49860b91e82c" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0100802" creator="">
 			<title>
 				<de>Fremde Erinnerung - Agent ohne Wissen</de>
 				<en></en>
@@ -2720,7 +2720,7 @@ Mit „Flop Wummen“ gelang [1|Full] der internationale Durchbruch.</de>
 			<data country="USA" year="1990" distribution="1" maingenre="16" subgenre="" flags="64" blocks="2" price_mod="1" />
 			<ratings critics="32" speed="75" outcome="75" />
 		</programme>
-		<programme id="34e68b2c-33c0-4f5d-89bf-2664a704ebe2" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0116367" rt_id="0" creator="">
+		<programme id="34e68b2c-33c0-4f5d-89bf-2664a704ebe2" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0116367" creator="">
 			<title>
 				<de>From Lust Spilling Lawn</de>
 				<en></en>
@@ -2746,7 +2746,7 @@ Zweite Hälfte: Splatter</de>
 			<data country="USA" year="1996" distribution="1" maingenre="12" subgenre="" flags="64" blocks="2" price_mod="1" />
 			<ratings critics="23" speed="84" outcome="61" />
 		</programme>
-		<programme id="3a6fad6c-b608-4018-bf5f-086f96e70969" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0268380" rt_id="0" creator="">
+		<programme id="3a6fad6c-b608-4018-bf5f-086f96e70969" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0268380" creator="">
 			<title>
 				<de>Frostbeulen-Zeit</de>
 				<en></en>
@@ -2767,7 +2767,7 @@ Erfrischender Spaß</de>
 			<data country="USA" year="2002" distribution="1" maingenre="3" subgenre="" flags="2" blocks="2" price_mod="1" />
 			<ratings critics="37" speed="70" outcome="65" />
 		</programme>
-		<programme id="881e1b80-3ef3-4092-8c60-ca8dbd03da64" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0059578" rt_id="0" creator="">
+		<programme id="881e1b80-3ef3-4092-8c60-ca8dbd03da64" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0059578" creator="">
 			<title>
 				<de>Für ein paar Euros zuviel</de>
 				<en></en>
@@ -2791,7 +2791,7 @@ Musik: Ennio MurrIchOchne</de>
 			<data country="I" year="1965" distribution="1" maingenre="18" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="61" speed="70" outcome="70" />
 		</programme>
-		<programme id="a9e1994f-afa9-4820-884a-83e36fb3eb85" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0081505" rt_id="0" creator="">
+		<programme id="a9e1994f-afa9-4820-884a-83e36fb3eb85" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0081505" creator="">
 			<title>
 				<de>Gleaming</de>
 				<en></en>
@@ -2816,7 +2816,7 @@ Schaurige Atmosphäre, packende Bilder und [1|Full] in Höchstform</de>
 			<data country="GB" year="1980" distribution="1" maingenre="12" subgenre="" flags="0" blocks="3" price_mod="0.90" />
 			<ratings critics="61" speed="61" outcome="75" />
 		</programme>
-		<programme id="b1b81bcb-ed45-4814-b8ec-bdea9028e6e1" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0099685" rt_id="0" creator="">
+		<programme id="b1b81bcb-ed45-4814-b8ec-bdea9028e6e1" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0099685" creator="">
 			<title>
 				<de>GreatFellows - Drei Mafia-Jahrzehnte</de>
 				<en></en>
@@ -2841,7 +2841,7 @@ Hervorragend inszenierter Gangster-Film</de>
 			<data country="USA" year="1990" distribution="1" maingenre="17" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="70" speed="80" outcome="70" />
 		</programme>
-		<programme id="0310e263-7de7-4d2a-8095-019c1edf3148" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120885" rt_id="0" creator="">
+		<programme id="0310e263-7de7-4d2a-8095-019c1edf3148" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120885" creator="">
 			<title>
 				<de>Hack the Fog - Wenn die Pfote mit dem Köter wedelt</de>
 				<en></en>
@@ -2865,7 +2865,7 @@ Hervorragend inszenierter Gangster-Film</de>
 			<data country="USA" year="1997" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="56" speed="32" outcome="32" />
 		</programme>
-		<programme id="f7c56e3e-38c9-4e86-a0fd-87cf0aec53a8" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0110912" rt_id="0" creator="">
+		<programme id="f7c56e3e-38c9-4e86-a0fd-87cf0aec53a8" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0110912" creator="">
 			<title>
 				<de>Halb-Fiction</de>
 				<en></en>
@@ -2890,7 +2890,7 @@ Hervorragend inszenierter Gangster-Film</de>
 			<data country="USA" year="1994" distribution="1" maingenre="2" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="37" speed="75" outcome="84" />
 		</programme>
-		<programme id="d6e17f77-d520-4bcc-9553-f4f5d5f46b4a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0299977" rt_id="0" creator="">
+		<programme id="d6e17f77-d520-4bcc-9553-f4f5d5f46b4a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0299977" creator="">
 			<title>
 				<de>Halbgott</de>
 				<en></en>
@@ -2913,7 +2913,7 @@ Hervorragend inszenierter Gangster-Film</de>
 			<data country="VRC" year="2003" distribution="1" maingenre="2" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="56" speed="32" outcome="47" />
 		</programme>
-		<programme id="487e524e-09d2-4294-b552-4f361cd26651" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0212985" rt_id="0" creator="">
+		<programme id="487e524e-09d2-4294-b552-4f361cd26651" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0212985" creator="">
 			<title>
 				<de>Hannie's Ball</de>
 				<en></en>
@@ -2937,7 +2937,7 @@ Judy Foerster wollte den Part der Clarice Starling nicht erneut übernehmen</de>
 			<data country="USA" year="2001" distribution="1" maingenre="17" subgenre="" flags="64" blocks="3" price_mod="1.33" />
 			<ratings critics="42" speed="70" outcome="70" />
 		</programme>
-		<programme id="ea821c8d-c22d-4c51-8613-871b5df4791e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0118880" rt_id="0" creator="">
+		<programme id="ea821c8d-c22d-4c51-8613-871b5df4791e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0118880" creator="">
 			<title>
 				<de>Hawk Air</de>
 				<en></en>
@@ -2962,7 +2962,7 @@ Judy Foerster wollte den Part der Clarice Starling nicht erneut übernehmen</de>
 			<data country="USA" year="1997" distribution="1" maingenre="2" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="23" speed="61" outcome="37" />
 		</programme>
-		<programme id="3d3e29a0-3b50-466f-b89d-65c83183aa5f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0117665" rt_id="0" creator="">
+		<programme id="3d3e29a0-3b50-466f-b89d-65c83183aa5f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0117665" creator="">
 			<title>
 				<de>Hells Kitchen</de>
 				<en></en>
@@ -2987,7 +2987,7 @@ Emotionsgeladen und überwältigend</de>
 			<data country="USA" year="1996" distribution="1" maingenre="2" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="61" speed="65" outcome="65" />
 		</programme>
-		<programme id="263a2fb5-0137-4829-81a8-1d5a74c38d4c" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0166924" rt_id="0" creator="">
+		<programme id="263a2fb5-0137-4829-81a8-1d5a74c38d4c" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0166924" creator="">
 			<title>
 				<de>Holland-DriveIn - Straße der Dunkelheit</de>
 				<en></en>
@@ -3012,7 +3012,7 @@ Emotionsgeladen und überwältigend</de>
 			<data country="USA" year="2001" distribution="1" maingenre="17" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="65" speed="51" outcome="61" />
 		</programme>
-		<programme id="af470310-3220-47bb-8d88-cb548973b46f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0116040" rt_id="0" creator="">
+		<programme id="af470310-3220-47bb-8d88-cb548973b46f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0116040" creator="">
 			<title>
 				<de>Im Tunnel begraben</de>
 				<en></en>
@@ -3035,7 +3035,7 @@ Emotionsgeladen und überwältigend</de>
 			<data country="USA" year="1996" distribution="1" maingenre="2" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="28" speed="32" outcome="37" />
 		</programme>
-		<programme id="856d513e-8ce9-483d-b2bf-035a27c65321" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0180748" rt_id="0" creator="">
+		<programme id="856d513e-8ce9-483d-b2bf-035a27c65321" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0180748" creator="">
 			<title>
 				<de>In Asien essen sie Katzen</de>
 				<en></en>
@@ -3059,7 +3059,7 @@ Emotionsgeladen und überwältigend</de>
 			<data country="DK" year="1999" distribution="1" maingenre="5" subgenre="" flags="64" blocks="2" price_mod="1.33" />
 			<ratings critics="14" speed="75" outcome="42" />
 		</programme>
-		<programme id="6f6b1f1e-0f7d-4ef2-9513-17fbe1148926" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0087469" rt_id="0" creator="">
+		<programme id="6f6b1f1e-0f7d-4ef2-9513-17fbe1148926" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0087469" creator="">
 			<title>
 				<de>Indianer James und der Krempel des Todes</de>
 				<en></en>
@@ -3081,7 +3081,7 @@ Abenteuer-Action in bewährter Manier</de>
 			<data country="USA" year="1984" distribution="1" maingenre="1" subgenre="2" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="37" speed="75" outcome="70" />
 		</programme>
-		<programme id="fc3d089c-61fe-4647-a1d9-e1e6756f0405" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0097576" rt_id="0" creator="">
+		<programme id="fc3d089c-61fe-4647-a1d9-e1e6756f0405" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0097576" creator="">
 			<title>
 				<de>Indianer James und die letzten Kreuzritter</de>
 				<en></en>
@@ -3107,7 +3107,7 @@ Stupide: die Deutschenverunglimpfungsversuche</de>
 			<data country="USA" year="1989" distribution="1" maingenre="1" subgenre="2" flags="0" blocks="3" price_mod="1.33" />
 			<ratings critics="32" speed="89" outcome="75" />
 		</programme>
-		<programme id="76d7c991-7375-4cd1-9426-e7aa686a0349" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0082971" rt_id="0" creator="">
+		<programme id="76d7c991-7375-4cd1-9426-e7aa686a0349" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0082971" creator="">
 			<title>
 				<de>Indianer James: Der verschollene Schatz</de>
 				<en></en>
@@ -3131,7 +3131,7 @@ Ein Millionenpublikum begleitet ihn noch heute dabei</de>
 			<data country="USA" year="1981" distribution="1" maingenre="1" subgenre="2" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="47" speed="80" outcome="80" />
 		</programme>
-		<programme id="fe0a9b63-9871-4b9c-90c1-2c8068c89847" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0104231" rt_id="0" creator="">
+		<programme id="fe0a9b63-9871-4b9c-90c1-2c8068c89847" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0104231" creator="">
 			<title>
 				<de>Irgendwo, ganz weit weg</de>
 				<en></en>
@@ -3155,7 +3155,7 @@ Durchschnittliche Fernsehkost, der ein ausgeklügeltes Drehbuch fehlt</de>
 			<data country="USA" year="1992" distribution="1" maingenre="15" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="28" speed="32" outcome="23" />
 		</programme>
-		<programme id="354f60b9-89ac-4f01-b13e-49429f09f087" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0093773" rt_id="0" creator="">
+		<programme id="354f60b9-89ac-4f01-b13e-49429f09f087" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0093773" creator="">
 			<title>
 				<de>Jäger aus dem All</de>
 				<en></en>
@@ -3179,7 +3179,7 @@ Durchschnittliche Fernsehkost, der ein ausgeklügeltes Drehbuch fehlt</de>
 			<data country="USA" year="1987" distribution="1" maingenre="2" subgenre="16" flags="64" blocks="2" price_mod="0.67" />
 			<ratings critics="18" speed="61" outcome="65" />
 		</programme>
-		<programme id="fbc0bd08-3076-46dc-a966-dc1fdfcd461e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0100403" rt_id="0" creator="">
+		<programme id="fbc0bd08-3076-46dc-a966-dc1fdfcd461e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0100403" creator="">
 			<title>
 				<de>Jäger aus dem All 2</de>
 				<en></en>
@@ -3205,7 +3205,7 @@ Weniger erfolgreiche Fortsetzung des Action-Hits</de>
 			<data country="USA" year="1990" distribution="1" maingenre="2" subgenre="16" flags="64" blocks="2" price_mod="0.90" />
 			<ratings critics="4" speed="65" outcome="37" />
 		</programme>
-		<programme id="4e3545dc-1760-4649-8a99-e219cdd5159e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0052618" rt_id="0" creator="">
+		<programme id="4e3545dc-1760-4649-8a99-e219cdd5159e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0052618" creator="">
 			<title>
 				<de>Judah Judah Ben Hur</de>
 				<en></en>
@@ -3231,7 +3231,7 @@ Monumentaler Meilenstein</de>
 			<data country="USA" year="1959" distribution="1" maingenre="13" subgenre="2" flags="0" blocks="5" price_mod="0.90" />
 			<ratings critics="65" speed="61" outcome="70" />
 		</programme>
-		<programme id="8df86321-0fcd-4903-b9e9-2b67e0eaafea" product="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="8df86321-0fcd-4903-b9e9-2b67e0eaafea" product="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Kakiemon-Porzellanmanufakturen in Japan</de>
 				<en></en>
@@ -3247,7 +3247,7 @@ Monumentaler Meilenstein</de>
 			<data country="D" year="1992" distribution="2" maingenre="6" subgenre="" flags="4" blocks="1" price_mod="1.10" />
 			<ratings critics="47" speed="5" outcome="15" />
 		</programme>
-		<programme id="cedc8a53-202f-4b47-bcd3-b87b25add3d7" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0099810" rt_id="0" creator="">
+		<programme id="cedc8a53-202f-4b47-bcd3-b87b25add3d7" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0099810" creator="">
 			<title>
 				<de>Kalter Krieg im tiefen Ozean</de>
 				<en></en>
@@ -3271,7 +3271,7 @@ Monumentaler Meilenstein</de>
 			<data country="USA" year="1990" distribution="1" maingenre="2" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="56" speed="51" outcome="51" />
 		</programme>
-		<programme id="c2f960af-16fa-45f8-8b3a-1a17d4d9f3cf" product="7" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="c2f960af-16fa-45f8-8b3a-1a17d4d9f3cf" product="7" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Kaminfeuer</de>
 				<en></en>
@@ -3287,7 +3287,7 @@ Monumentaler Meilenstein</de>
 			<data country="POL" year="2001" distribution="1" maingenre="0" subgenre="" flags="16" blocks="3" price_mod="0.50" />
 			<ratings critics="5" speed="2" outcome="8" />
 		</programme>
-		<programme id="8fb1588d-27c3-4daf-9bf9-9fd338e08010" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0104431" rt_id="0" creator="">
+		<programme id="8fb1588d-27c3-4daf-9bf9-9fd338e08010" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0104431" creator="">
 			<title>
 				<de>Kentin - Allein in Big Apple</de>
 				<en></en>
@@ -3310,7 +3310,7 @@ Ein neuer Aufguß - sicherlich, aber immer noch klasse</de>
 			<data country="USA" year="1992" distribution="1" maingenre="5" subgenre="9" flags="0" blocks="2" price_mod="1.33" />
 			<ratings critics="32" speed="42" outcome="51" />
 		</programme>
-		<programme id="2102ca88-99a1-4e94-aa3c-331148a7531e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0099785" rt_id="0" creator="">
+		<programme id="2102ca88-99a1-4e94-aa3c-331148a7531e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0099785" creator="">
 			<title>
 				<de>Kentin - Im Haus ohne Eltern</de>
 				<en></en>
@@ -3333,7 +3333,7 @@ Origineller Spaß</de>
 			<data country="USA" year="1990" distribution="1" maingenre="5" subgenre="9" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="42" speed="56" outcome="61" />
 		</programme>
-		<programme id="17ee639a-dd1e-42dc-bc0d-a13b8cfa2893" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0107614" rt_id="0" creator="">
+		<programme id="17ee639a-dd1e-42dc-bc0d-a13b8cfa2893" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0107614" creator="">
 			<title>
 				<de>Kindermädchen mit Stoppeln</de>
 				<en></en>
@@ -3356,7 +3356,7 @@ Unterhaltsamer Familienspaß</de>
 			<data country="USA" year="1993" distribution="1" maingenre="5" subgenre="9" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="37" speed="47" outcome="42" />
 		</programme>
-		<programme id="40ecbbda-de25-4132-a873-0d6ac8ff58da" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0096842" rt_id="0" creator="">
+		<programme id="40ecbbda-de25-4132-a873-0d6ac8ff58da" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0096842" creator="">
 			<title>
 				<de>Klasterix - Die Hinkelsteinmission</de>
 				<en></en>
@@ -3375,7 +3375,7 @@ Unterhaltsamer Familienspaß</de>
 			<data country="F" year="1989" distribution="1" maingenre="3" subgenre="" flags="2" blocks="2" price_mod="0.67" />
 			<ratings critics="37" speed="56" outcome="37" />
 		</programme>
-		<programme id="fdbd1c3b-a074-4e94-9734-193ac8165ab5" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0088748" rt_id="0" creator="">
+		<programme id="fdbd1c3b-a074-4e94-9734-193ac8165ab5" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0088748" creator="">
 			<title>
 				<de>Klasterix - Sieg über den Cäsaren</de>
 				<en></en>
@@ -3395,7 +3395,7 @@ Frei nach Flaszini und Oberzo</de>
 			<data country="F" year="1985" distribution="1" maingenre="3" subgenre="" flags="2" blocks="2" price_mod="0.67" />
 			<ratings critics="37" speed="37" outcome="37" />
 		</programme>
-		<programme id="f829eff5-e453-4631-9e9a-33831949d208" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0109162" rt_id="0" creator="">
+		<programme id="f829eff5-e453-4631-9e9a-33831949d208" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0109162" creator="">
 			<title>
 				<de>Klasterix auf dem neuen Kontinent</de>
 				<en></en>
@@ -3414,7 +3414,7 @@ Frei nach Flaszini und Oberzo</de>
 			<data country="D" year="1994" distribution="1" maingenre="3" subgenre="" flags="2" blocks="2" price_mod="1.33" />
 			<ratings critics="32" speed="47" outcome="56" />
 		</programme>
-		<programme id="6f1fb397-aeb6-4de4-899b-d8c34504d9c4" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0061369" rt_id="0" creator="">
+		<programme id="6f1fb397-aeb6-4de4-899b-d8c34504d9c4" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0061369" creator="">
 			<title>
 				<de>Klasterix der Gallier</de>
 				<en></en>
@@ -3434,7 +3434,7 @@ Verfilmung des Comics von Flaszini und Oberzo</de>
 			<data country="F" year="1967" distribution="1" maingenre="3" subgenre="" flags="2" blocks="2" price_mod="1" />
 			<ratings critics="37" speed="23" outcome="47" />
 		</programme>
-		<programme id="0814f68e-89a8-4e54-9b71-962735128df1" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0072901" rt_id="0" creator="">
+		<programme id="0814f68e-89a8-4e54-9b71-962735128df1" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0072901" creator="">
 			<title>
 				<de>Klasterix triumphiert in Rom</de>
 				<en></en>
@@ -3453,7 +3453,7 @@ Verfilmung des Comics von Flaszini und Oberzo</de>
 			<data country="F" year="1976" distribution="1" maingenre="3" subgenre="" flags="2" blocks="2" price_mod="0.67" />
 			<ratings critics="37" speed="51" outcome="56" />
 		</programme>
-		<programme id="3daeb4bf-8a17-447f-b194-a1987e1652fc" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0062687" rt_id="0" creator="">
+		<programme id="3daeb4bf-8a17-447f-b194-a1987e1652fc" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0062687" creator="">
 			<title>
 				<de>Klasterix und Kleopatra</de>
 				<en></en>
@@ -3473,7 +3473,7 @@ Regie-Debüt für [0|Full]</de>
 			<data country="F" year="1968" distribution="1" maingenre="3" subgenre="" flags="2" blocks="2" price_mod="0.67" />
 			<ratings critics="47" speed="47" outcome="56" />
 		</programme>
-		<programme id="c0debc50-3963-4e88-a66d-a45f76f9fa6c" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0371552" rt_id="0" creator="">
+		<programme id="c0debc50-3963-4e88-a66d-a45f76f9fa6c" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0371552" creator="">
 			<title>
 				<de>Klasterix und die Nordmänner</de>
 				<en></en>
@@ -3493,7 +3493,7 @@ Ging im WM-Jahr unter</de>
 			<data country="F" year="2006" distribution="1" maingenre="3" subgenre="" flags="2" blocks="2" price_mod="0.67" />
 			<ratings critics="42" speed="56" outcome="28" />
 		</programme>
-		<programme id="e14c3026-b946-4f5b-9986-a41aa03a9bd4" product="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="e14c3026-b946-4f5b-9986-a41aa03a9bd4" product="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Klimax Kulturgeschichte: Eine weibliche Erörterung</de>
 				<en></en>
@@ -3510,7 +3510,7 @@ Ging im WM-Jahr unter</de>
 			<data country="D" year="1990" distribution="2" maingenre="6" subgenre="" flags="4" blocks="5" price_mod="1.33" />
 			<ratings critics="75" speed="15" outcome="10" />
 		</programme>
-		<programme id="17de5244-71c7-4407-8b54-f6f49eb1719f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0053472" rt_id="0" creator="">
+		<programme id="17de5244-71c7-4407-8b54-f6f49eb1719f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0053472" creator="">
 			<title>
 				<de>Knappe Luft</de>
 				<en></en>
@@ -3532,7 +3532,7 @@ Ein außerordentlicher Kunstfilm und ein Juwel in jeder Filmsammlung</de>
 			<data country="F" year="1960" distribution="1" maingenre="15" subgenre="4" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="80" speed="51" outcome="75" />
 		</programme>
-		<programme id="6dc4a96c-96a6-4470-bff6-8b7e9d8d20a1" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0094651" rt_id="0" creator="">
+		<programme id="6dc4a96c-96a6-4470-bff6-8b7e9d8d20a1" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0094651" creator="">
 			<title>
 				<de>Krachtenjagd in Amsterdam</de>
 				<en></en>
@@ -3556,7 +3556,7 @@ Atmosphärisch dichter Thriller aus Holland</de>
 			<data country="NL" year="1987" distribution="1" maingenre="17" subgenre="4" flags="0" blocks="2" price_mod="0.90" />
 			<ratings critics="47" speed="42" outcome="37" />
 		</programme>
-		<programme id="c187ad46-15a6-47a7-b183-7a9e8c54ca56" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0104498" rt_id="0" creator="">
+		<programme id="c187ad46-15a6-47a7-b183-7a9e8c54ca56" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0104498" creator="">
 			<title>
 				<de>Kreisch wenn Du es schaffst</de>
 				<en></en>
@@ -3580,7 +3580,7 @@ Atmosphärisch dichter Thriller aus Holland</de>
 			<data country="USA" year="1992" distribution="1" maingenre="17" subgenre="2" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="61" speed="51" outcome="37" />
 		</programme>
-		<programme id="0a1f784a-44d3-4bd0-9045-14e4fc7c1535" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0090555" rt_id="0" creator="">
+		<programme id="0a1f784a-44d3-4bd0-9045-14e4fc7c1535" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0090555" creator="">
 			<title>
 				<de>Kroko-Skip - Ein Krokodil zum Knutschen</de>
 				<en></en>
@@ -3603,7 +3603,7 @@ Kinohit 1986</de>
 			<data country="AUS" year="1986" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="32" speed="32" outcome="51" />
 		</programme>
-		<programme id="77e95ae0-1d5f-4109-9f45-704d0a82b55e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0078346" rt_id="0" creator="">
+		<programme id="77e95ae0-1d5f-4109-9f45-704d0a82b55e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0078346" creator="">
 			<title>
 				<de>Kryptons Superheld</de>
 				<en></en>
@@ -3626,7 +3626,7 @@ Kinohit 1986</de>
 			<data country="GB" year="1978" distribution="1" maingenre="16" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="28" speed="61" outcome="61" />
 		</programme>
-		<programme id="42761763-4125-4a66-8227-40027caab44a" product="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="42761763-4125-4a66-8227-40027caab44a" product="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Kultur Heute</de>
 				<en></en>
@@ -3643,7 +3643,7 @@ Kinohit 1986</de>
 			<data country="D" year="1985" distribution="1" maingenre="6" subgenre="" flags="4" blocks="1" price_mod="1" />
 			<ratings critics="100" speed="39" outcome="0" />
 		</programme>
-		<programme id="4fe2dff2-039d-4747-b37a-7f79010b9997" product="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="4fe2dff2-039d-4747-b37a-7f79010b9997" product="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Kunst am Arsch der Welt</de>
 				<en></en>
@@ -3660,7 +3660,7 @@ Kinohit 1986</de>
 			<data country="D" year="1983" distribution="2" maingenre="6" subgenre="" flags="4" blocks="1" price_mod="0.13" />
 			<ratings critics="54" speed="15" outcome="10" />
 		</programme>
-		<programme id="cb16cf80-5fcd-4cfb-8f9c-fbbde94768d0" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0046732" rt_id="0" creator="">
+		<programme id="cb16cf80-5fcd-4cfb-8f9c-fbbde94768d0" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0046732" creator="">
 			<title>
 				<de>Kurz nach Mitternacht auf der Reeperbahn</de>
 				<en></en>
@@ -3686,7 +3686,7 @@ auf der Reeperbahn nachts um kurz nach Mitternacht.</de>
 			<data country="D" year="1954" distribution="1" maingenre="5" subgenre="" flags="8" blocks="2" price_mod="1" />
 			<ratings critics="37" speed="32" outcome="47" />
 		</programme>
-		<programme id="c1fd4525-d074-48eb-85e5-844da77d40ea" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0055205" rt_id="0" creator="">
+		<programme id="c1fd4525-d074-48eb-85e5-844da77d40ea" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0055205" creator="">
 			<title>
 				<de>Kurz vor Fünf 'gen Paddington</de>
 				<en></en>
@@ -3709,7 +3709,7 @@ Nach dem Roman von Agatha Kissme.</de>
 			<data country="GB" year="1961" distribution="1" maingenre="4" subgenre="" flags="8" blocks="2" price_mod="0.90" />
 			<ratings critics="56" speed="42" outcome="56" />
 		</programme>
-		<programme id="c4348eef-2678-486b-a07c-ce00dc4fed91" product="5" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="c4348eef-2678-486b-a07c-ce00dc4fed91" product="5" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Landung auf dem Mars</de>
 				<en></en>
@@ -3727,7 +3727,7 @@ Nach dem Roman von Agatha Kissme.</de>
 			<data country="US" year="2006" distribution="1" maingenre="17" subgenre="" flags="16" blocks="3" price_mod="1.7" />
 			<ratings critics="94" speed="80" outcome="89" />
 		</programme>
-		<programme id="bddb797f-53cd-4d15-bb96-bb4b148203b2" product="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="bddb797f-53cd-4d15-bb96-bb4b148203b2" product="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Lolcat: Da lacht die Katz'!</de>
 				<en></en>
@@ -3743,7 +3743,7 @@ Nach dem Roman von Agatha Kissme.</de>
 			<data country="USA" year="2007" distribution="1" maingenre="6" subgenre="" flags="4" blocks="1" price_mod="0.07" />
 			<ratings critics="13" speed="23" outcome="9" />
 		</programme>
-		<programme id="4c8d0a86-edf7-4cd2-b18f-16fb66d5fd2b" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0110419" rt_id="0" creator="">
+		<programme id="4c8d0a86-edf7-4cd2-b18f-16fb66d5fd2b" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0110419" creator="">
 			<title>
 				<de>MacGeifer - Jäger des Atlantisschatzes</de>
 				<en></en>
@@ -3764,7 +3764,7 @@ Nach dem Ende der Serie drehte R. D. Handerson noch zwei TV-Filme als Angus MacG
 			<data country="USA" year="1994" distribution="1" maingenre="1" subgenre="2" flags="0" blocks="2" price_mod="0.90" />
 			<ratings critics="51" speed="65" outcome="61" />
 		</programme>
-		<programme id="a82f5075-b41b-43ff-9301-ece663dac159" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0110420" rt_id="0" creator="">
+		<programme id="a82f5075-b41b-43ff-9301-ece663dac159" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0110420" creator="">
 			<title>
 				<de>MacGeifer - Sackgasse Hölle</de>
 				<en></en>
@@ -3784,7 +3784,7 @@ Nach dem Ende der Serie drehte R. D. Handerson noch zwei TV-Filme als Angus MacG
 			<data country="USA" year="1994" distribution="1" maingenre="2" subgenre="" flags="0" blocks="2" price_mod="0.90" />
 			<ratings critics="47" speed="75" outcome="61" />
 		</programme>
-		<programme id="65c5515b-cc7c-4910-acca-ffa0cebd405f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0181689" rt_id="0" creator="">
+		<programme id="65c5515b-cc7c-4910-acca-ffa0cebd405f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0181689" creator="">
 			<title>
 				<de>Majoranreport</de>
 				<en></en>
@@ -3808,7 +3808,7 @@ Nach dem Ende der Serie drehte R. D. Handerson noch zwei TV-Filme als Angus MacG
 			<data country="USA" year="2002" distribution="1" maingenre="16" subgenre="2" flags="0" blocks="3" price_mod="1.33" />
 			<ratings critics="32" speed="56" outcome="56" />
 		</programme>
-		<programme id="6a9105ff-c5ba-496c-b099-7ec5fb4aa465" product="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="6a9105ff-c5ba-496c-b099-7ec5fb4aa465" product="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Mal rückwärts!</de>
 				<en></en>
@@ -3827,7 +3827,7 @@ Nach dem Ende der Serie drehte R. D. Handerson noch zwei TV-Filme als Angus MacG
 			<data country="NL" year="2001" distribution="2" maingenre="6" subgenre="" flags="4" blocks="1" price_mod="1" />
 			<ratings critics="32" speed="18" outcome="12" />
 		</programme>
-		<programme id="96167e15-a67b-4894-8f07-dcd4cb29a01f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0083944" rt_id="0" creator="">
+		<programme id="96167e15-a67b-4894-8f07-dcd4cb29a01f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0083944" creator="">
 			<title>
 				<de>Mambo</de>
 				<en></en>
@@ -3852,7 +3852,7 @@ Gut gemachte Action am laufenden Band</de>
 			<data country="USA" year="1982" distribution="1" maingenre="2" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="9" speed="80" outcome="75" />
 		</programme>
-		<programme id="877ff6f8-06ae-425f-af02-914a7c1d7921" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0053172" rt_id="0" creator="">
+		<programme id="877ff6f8-06ae-425f-af02-914a7c1d7921" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0053172" creator="">
 			<title>
 				<de>Matratzenwispern</de>
 				<en></en>
@@ -3873,7 +3873,7 @@ Gut gemachte Action am laufenden Band</de>
 			<data country="USA" year="1959" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="0.90" />
 			<ratings critics="23" speed="61" outcome="51" />
 		</programme>
-		<programme id="d8d9ff73-d8d2-4a65-9149-d5e6b48bf1af" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0472043" rt_id="0" creator="">
+		<programme id="d8d9ff73-d8d2-4a65-9149-d5e6b48bf1af" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0472043" creator="">
 			<title>
 				<de>Meal Gibtsschons Maya</de>
 				<en></en>
@@ -3896,7 +3896,7 @@ Schockierende Bilder, was bei [0|Full] allerdings kaum mehr verwundert.</de>
 			<data country="USA" year="2006" distribution="1" maingenre="2" subgenre="11" flags="64" blocks="3" price_mod="1.33" />
 			<ratings critics="61" speed="84" outcome="56" />
 		</programme>
-		<programme id="9e07aa7c-5bb2-426a-86dc-f17dcafb53ca" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0072705" rt_id="0" creator="">
+		<programme id="9e07aa7c-5bb2-426a-86dc-f17dcafb53ca" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0072705" creator="">
 			<title>
 				<de>Meilenweit 'gen Westen</de>
 				<en></en>
@@ -3919,7 +3919,7 @@ Schockierende Bilder, was bei [0|Full] allerdings kaum mehr verwundert.</de>
 			<data country="USA" year="1975" distribution="1" maingenre="18" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="28" speed="28" outcome="32" />
 		</programme>
-		<programme id="dc799d3a-fd8f-42eb-a864-c3ecddb2d33d" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120737" rt_id="0" creator="">
+		<programme id="dc799d3a-fd8f-42eb-a864-c3ecddb2d33d" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120737" creator="">
 			<title>
 				<de>Meister Der Dinge: Die Kumpels</de>
 				<en></en>
@@ -3944,7 +3944,7 @@ Schockierende Bilder, was bei [0|Full] allerdings kaum mehr verwundert.</de>
 			<data country="USA" year="2001" distribution="1" maingenre="10" subgenre="13" flags="0" blocks="4" price_mod="1.7" />
 			<ratings critics="32" speed="32" outcome="75" />
 		</programme>
-		<programme id="0a54e57d-ff0b-4099-a2e6-e2a889fd63b4" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0167260" rt_id="0" creator="">
+		<programme id="0a54e57d-ff0b-4099-a2e6-e2a889fd63b4" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0167260" creator="">
 			<title>
 				<de>Meister Der Dinge: Die Rückkehr des Oberhauptes</de>
 				<en></en>
@@ -3970,7 +3970,7 @@ Gilt als Krönung der Trilogie</de>
 			<data country="USA" year="2003" distribution="1" maingenre="10" subgenre="13" flags="0" blocks="4" price_mod="1.7" />
 			<ratings critics="42" speed="70" outcome="80" />
 		</programme>
-		<programme id="c5a32c8c-24ff-44ef-b0f4-d09b678a4f4d" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0167261" rt_id="0" creator="">
+		<programme id="c5a32c8c-24ff-44ef-b0f4-d09b678a4f4d" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0167261" creator="">
 			<title>
 				<de>Meister Der Dinge: Die Zwei Dinger</de>
 				<en></en>
@@ -3995,7 +3995,7 @@ Gilt als Krönung der Trilogie</de>
 			<data country="USA" year="2002" distribution="1" maingenre="10" subgenre="13" flags="0" blocks="4" price_mod="1.33" />
 			<ratings critics="37" speed="65" outcome="80" />
 		</programme>
-		<programme id="f3264ebf-f0fa-401c-b067-ee58784bc16c" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0146675" rt_id="0" creator="">
+		<programme id="f3264ebf-f0fa-401c-b067-ee58784bc16c" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0146675" creator="">
 			<title>
 				<de>Millenium Day - Die letzte Nacht vorm Chaos</de>
 				<en></en>
@@ -4018,7 +4018,7 @@ Gilt als Krönung der Trilogie</de>
 			<data country="USA" year="1999" distribution="1" maingenre="2" subgenre="" flags="0" blocks="3" price_mod="1.33" />
 			<ratings critics="9" speed="61" outcome="32" />
 		</programme>
-		<programme id="c1bc4a1c-4f63-435c-bdbe-27ebfaec0b31" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0117060" rt_id="0" creator="">
+		<programme id="c1bc4a1c-4f63-435c-bdbe-27ebfaec0b31" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0117060" creator="">
 			<title>
 				<de>Mission: Vertrackt</de>
 				<en></en>
@@ -4043,7 +4043,7 @@ Gilt als Krönung der Trilogie</de>
 			<data country="USA" year="1996" distribution="1" maingenre="2" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="56" speed="70" outcome="75" />
 		</programme>
-		<programme id="607ab0bd-7350-41fd-bfbb-515a35d02ad7" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120755" rt_id="0" creator="">
+		<programme id="607ab0bd-7350-41fd-bfbb-515a35d02ad7" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120755" creator="">
 			<title>
 				<de>Mission: Vertrackt 2</de>
 				<en></en>
@@ -4068,7 +4068,7 @@ Gilt als Krönung der Trilogie</de>
 			<data country="USA" year="2000" distribution="1" maingenre="2" subgenre="" flags="0" blocks="3" price_mod="1.33" />
 			<ratings critics="28" speed="75" outcome="56" />
 		</programme>
-		<programme id="ffb69a86-8d02-430e-aa6b-bdb8c8098d32" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0077413" rt_id="0" creator="">
+		<programme id="ffb69a86-8d02-430e-aa6b-bdb8c8098d32" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0077413" creator="">
 			<title>
 				<de>Mord am Nil</de>
 				<en></en>
@@ -4093,7 +4093,7 @@ Gut besetzter Krimi nach Agatha Kissme</de>
 			<data country="GB" year="1978" distribution="1" maingenre="4" subgenre="" flags="8" blocks="3" price_mod="1" />
 			<ratings critics="61" speed="61" outcome="56" />
 		</programme>
-		<programme id="4a8b7373-2f02-4d66-b717-5cfded60c312" product="5" licence_type="1" tmdb_id="0" imdb_id="tt0086879" rt_id="0" creator="">
+		<programme id="4a8b7373-2f02-4d66-b717-5cfded60c312" product="5" licence_type="1" tmdb_id="0" imdb_id="tt0086879" creator="">
 			<title>
 				<de>Mozart</de>
 				<en></en>
@@ -4118,7 +4118,7 @@ Grandiose Oper von [0|Full]</de>
 			<data country="USA" year="1984" distribution="1" maingenre="202" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="61" speed="61" outcome="65" />
 		</programme>
-		<programme id="7e389c3b-ead3-441f-8e51-0298a5190f5a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0075268" rt_id="0" creator="">
+		<programme id="7e389c3b-ead3-441f-8e51-0298a5190f5a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0075268" creator="">
 			<title>
 				<de>Mr. Galaxie</de>
 				<en></en>
@@ -4142,7 +4142,7 @@ Viel Muckis, wenig Grips</de>
 			<data country="USA" year="1976" distribution="1" maingenre="5" subgenre="7" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="4" speed="28" outcome="28" />
 		</programme>
-		<programme id="ba2469e0-86fe-4212-87f3-b024feeeff9b" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0066999" rt_id="0" creator="">
+		<programme id="ba2469e0-86fe-4212-87f3-b024feeeff9b" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0066999" creator="">
 			<title>
 				<de>Muddy Harry</de>
 				<en></en>
@@ -4165,7 +4165,7 @@ Dank rauher Methoden und seiner .44 Magnum wurde Muddy Harry zum Publikumsliebli
 			<data country="USA" year="1971" distribution="1" maingenre="2" subgenre="4" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="51" speed="70" outcome="65" />
 		</programme>
-		<programme id="b3281aba-d3ec-40c0-86b7-3b7147367c2d" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0070355" rt_id="0" creator="">
+		<programme id="b3281aba-d3ec-40c0-86b7-3b7147367c2d" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0070355" creator="">
 			<title>
 				<de>Muddy Harry 2 - Katamaran</de>
 				<en></en>
@@ -4185,7 +4185,7 @@ Dank rauher Methoden und seiner .44 Magnum wurde Muddy Harry zum Publikumsliebli
 			<data country="USA" year="1973" distribution="1" maingenre="2" subgenre="4" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="47" speed="75" outcome="61" />
 		</programme>
-		<programme id="d246c1c9-335e-43b4-9ce2-ef843960525f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0074483" rt_id="0" creator="">
+		<programme id="d246c1c9-335e-43b4-9ce2-ef843960525f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0074483" creator="">
 			<title>
 				<de>Muddy Harry 3 - Ohne Erbarmen</de>
 				<en></en>
@@ -4208,7 +4208,7 @@ Dank rauher Methoden und seiner .44 Magnum wurde Muddy Harry zum Publikumsliebli
 			<data country="USA" year="1976" distribution="1" maingenre="2" subgenre="4" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="32" speed="56" outcome="47" />
 		</programme>
-		<programme id="21bd1171-e56f-4492-87ae-bd873a9e8911" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0086383" rt_id="0" creator="">
+		<programme id="21bd1171-e56f-4492-87ae-bd873a9e8911" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0086383" creator="">
 			<title>
 				<de>Muddy Harry 4 - Muddy Harry will be back</de>
 				<en></en>
@@ -4228,7 +4228,7 @@ Dank rauher Methoden und seiner .44 Magnum wurde Muddy Harry zum Publikumsliebli
 			<data country="USA" year="1983" distribution="1" maingenre="2" subgenre="4" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="37" speed="51" outcome="51" />
 		</programme>
-		<programme id="d585abdf-ba12-4e04-a224-f3797a9c62fe" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0094963" rt_id="0" creator="">
+		<programme id="d585abdf-ba12-4e04-a224-f3797a9c62fe" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0094963" creator="">
 			<title>
 				<de>Muddy Harry 5 - Endkampf</de>
 				<en></en>
@@ -4250,7 +4250,7 @@ Dank rauher Methoden und seiner .44 Magnum wurde Muddy Harry zum Publikumsliebli
 			<data country="USA" year="1988" distribution="1" maingenre="2" subgenre="4" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="28" speed="28" outcome="37" />
 		</programme>
-		<programme id="07252cce-a3cb-4672-b089-65c5e7fc1a20" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0053855" rt_id="0" creator="">
+		<programme id="07252cce-a3cb-4672-b089-65c5e7fc1a20" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0053855" creator="">
 			<title>
 				<de>Netter Gott trifft Halunke</de>
 				<en></en>
@@ -4274,7 +4274,7 @@ Köstlicher Spaß mit [1|Full]</de>
 			<data country="D" year="1960" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="61" speed="61" outcome="37" />
 		</programme>
-		<programme id="0e3286f9-f2fb-4f6f-bdb9-03326d28c899" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0110357" rt_id="0" creator="">
+		<programme id="0e3286f9-f2fb-4f6f-bdb9-03326d28c899" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0110357" creator="">
 			<title>
 				<de>Obermotz der Löwen</de>
 				<en></en>
@@ -4295,7 +4295,7 @@ Mouseworks oscarprämiertes Meisterwerk</de>
 			<data country="USA" year="1994" distribution="1" maingenre="3" subgenre="" flags="2" blocks="2" price_mod="1.7" />
 			<ratings critics="47" speed="61" outcome="80" />
 		</programme>
-		<programme id="227054c8-7275-4c5a-9532-a25a3c848741" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0185937" rt_id="0" creator="">
+		<programme id="227054c8-7275-4c5a-9532-a25a3c848741" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0185937" creator="">
 			<title>
 				<de>Osthexen-Projekt</de>
 				<en></en>
@@ -4319,7 +4319,7 @@ Mouseworks oscarprämiertes Meisterwerk</de>
 			<data country="USA" year="1999" distribution="1" maingenre="12" subgenre="" flags="0" blocks="2" price_mod="1.7" />
 			<ratings critics="37" speed="0" outcome="37" />
 		</programme>
-		<programme id="311e4c32-ae6f-40d2-80b6-d93883d54398" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0175880" rt_id="0" creator="">
+		<programme id="311e4c32-ae6f-40d2-80b6-d93883d54398" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0175880" creator="">
 			<title>
 				<de>Packnulia</de>
 				<en></en>
@@ -4344,7 +4344,7 @@ Oscar-Nominierung für [1|Last] (Bester Nebendarsteller)</de>
 			<data country="USA" year="1999" distribution="1" maingenre="15" subgenre="7" flags="0" blocks="4" price_mod="1" />
 			<ratings critics="61" speed="32" outcome="61" />
 		</programme>
-		<programme id="9f7eba49-21d8-4539-9f7f-5792f5ceef11" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0099052" rt_id="0" creator="">
+		<programme id="9f7eba49-21d8-4539-9f7f-5792f5ceef11" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0099052" creator="">
 			<title>
 				<de>Panic Spiders</de>
 				<en></en>
@@ -4366,7 +4366,7 @@ Oscar-Nominierung für [1|Last] (Bester Nebendarsteller)</de>
 			<data country="USA" year="1990" distribution="1" maingenre="12" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="18" speed="37" outcome="47" />
 		</programme>
-		<programme id="87bd84bd-cdac-4dae-be9a-7812ce1cf93b" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0051152" rt_id="0" creator="">
+		<programme id="87bd84bd-cdac-4dae-be9a-7812ce1cf93b" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0051152" creator="">
 			<title>
 				<de>Papa dagegen umso mehr</de>
 				<en></en>
@@ -4390,7 +4390,7 @@ Oscar-Nominierung für [1|Last] (Bester Nebendarsteller)</de>
 			<data country="D" year="1957" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="47" speed="37" outcome="42" />
 		</programme>
-		<programme id="e7d131ab-68fc-4872-b9f6-9a860a4fb543" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0309698" rt_id="0" creator="">
+		<programme id="e7d131ab-68fc-4872-b9f6-9a860a4fb543" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0309698" creator="">
 			<title>
 				<de>Persönlichkeit</de>
 				<en></en>
@@ -4414,7 +4414,7 @@ Oscar-Nominierung für [1|Last] (Bester Nebendarsteller)</de>
 			<data country="USA" year="2003" distribution="1" maingenre="17" subgenre="12" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="56" speed="56" outcome="42" />
 		</programme>
-		<programme id="3600090e-4757-437d-a9bf-8fd5b8895c4b" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0090756" rt_id="0" creator="">
+		<programme id="3600090e-4757-437d-a9bf-8fd5b8895c4b" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0090756" creator="">
 			<title>
 				<de>Pink Silk</de>
 				<en></en>
@@ -4439,7 +4439,7 @@ Abgrundtief düster, beängstigend und atemberaubend - Kultfilm der 80er</de>
 			<data country="USA" year="1986" distribution="1" maingenre="17" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="70" speed="37" outcome="61" />
 		</programme>
-		<programme id="d26578e7-bdce-4a6f-86a9-f9ae24d05345" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0087928" rt_id="0" creator="">
+		<programme id="d26578e7-bdce-4a6f-86a9-f9ae24d05345" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0087928" creator="">
 			<title>
 				<de>Polizeikadetten ...zu dumm für andere Jobs</de>
 				<en></en>
@@ -4462,7 +4462,7 @@ Abgrundtief düster, beängstigend und atemberaubend - Kultfilm der 80er</de>
 			<data country="USA" year="1984" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="14" speed="56" outcome="47" />
 		</programme>
-		<programme id="886779ae-39a2-4fe3-b1e4-259220e2cea3" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0089822" rt_id="0" creator="">
+		<programme id="886779ae-39a2-4fe3-b1e4-259220e2cea3" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0089822" creator="">
 			<title>
 				<de>Polizeikadetten 2 - Jetzt geht's los</de>
 				<en></en>
@@ -4485,7 +4485,7 @@ Abgrundtief düster, beängstigend und atemberaubend - Kultfilm der 80er</de>
 			<data country="USA" year="1985" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="14" speed="42" outcome="28" />
 		</programme>
-		<programme id="6200aa46-d74e-419f-a474-63c4cba3b622" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0091777" rt_id="0" creator="">
+		<programme id="6200aa46-d74e-419f-a474-63c4cba3b622" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0091777" creator="">
 			<title>
 				<de>Polizeikadetten 3 - Ohne Bremse</de>
 				<en></en>
@@ -4508,7 +4508,7 @@ Abgrundtief düster, beängstigend und atemberaubend - Kultfilm der 80er</de>
 			<data country="USA" year="1986" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="14" speed="42" outcome="23" />
 		</programme>
-		<programme id="a8c67b89-a481-4144-bcf8-09873132192f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0093756" rt_id="0" creator="">
+		<programme id="a8c67b89-a481-4144-bcf8-09873132192f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0093756" creator="">
 			<title>
 				<de>Polizeikadetten 4 - nun geht's rund</de>
 				<en></en>
@@ -4531,7 +4531,7 @@ Abgrundtief düster, beängstigend und atemberaubend - Kultfilm der 80er</de>
 			<data country="USA" year="1987" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="14" speed="51" outcome="23" />
 		</programme>
-		<programme id="5202c7ac-0440-4588-81c4-92fa3352e1bf" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0095882" rt_id="0" creator="">
+		<programme id="5202c7ac-0440-4588-81c4-92fa3352e1bf" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0095882" creator="">
 			<title>
 				<de>Polizeikadetten 5 - Mission: Miami Beach</de>
 				<en></en>
@@ -4555,7 +4555,7 @@ Abgrundtief düster, beängstigend und atemberaubend - Kultfilm der 80er</de>
 			<data country="USA" year="1988" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="1.33" />
 			<ratings critics="9" speed="51" outcome="14" />
 		</programme>
-		<programme id="bb60fe78-9fce-40e0-a733-d6151214be22" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0098105" rt_id="0" creator="">
+		<programme id="bb60fe78-9fce-40e0-a733-d6151214be22" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0098105" creator="">
 			<title>
 				<de>Polizeikadetten 6 - Keine Gegenwehr</de>
 				<en></en>
@@ -4578,7 +4578,7 @@ Abgrundtief düster, beängstigend und atemberaubend - Kultfilm der 80er</de>
 			<data country="USA" year="1989" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="1.33" />
 			<ratings critics="4" speed="37" outcome="18" />
 		</programme>
-		<programme id="cd38cf17-85c6-4591-9a06-67ea59a7820c" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0110857" rt_id="0" creator="">
+		<programme id="cd38cf17-85c6-4591-9a06-67ea59a7820c" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0110857" creator="">
 			<title>
 				<de>Polizeikadetten 7 - Der Moskauauftrag</de>
 				<en></en>
@@ -4602,7 +4602,7 @@ Abgrundtief düster, beängstigend und atemberaubend - Kultfilm der 80er</de>
 			<data country="USA" year="1994" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="4" speed="28" outcome="14" />
 		</programme>
-		<programme id="d438f363-6240-4679-9eda-8cd5da00760c" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0080661" rt_id="0" creator="">
+		<programme id="d438f363-6240-4679-9eda-8cd5da00760c" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0080661" creator="">
 			<title>
 				<de>Pressed to Chill</de>
 				<en></en>
@@ -4628,7 +4628,7 @@ Abgrundtief düster, beängstigend und atemberaubend - Kultfilm der 80er</de>
 			<data country="USA" year="1980" distribution="1" maingenre="17" subgenre="" flags="64" blocks="2" price_mod="0.67" />
 			<ratings critics="65" speed="42" outcome="61" />
 		</programme>
-		<programme id="b9c6190d-a9f6-4a94-8092-4a1266b43b62" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0054215" rt_id="0" creator="">
+		<programme id="b9c6190d-a9f6-4a94-8092-4a1266b43b62" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0054215" creator="">
 			<title>
 				<de>Psychopathpath</de>
 				<en></en>
@@ -4655,7 +4655,7 @@ Klassiker von [0|Full]</de>
 			<data country="USA" year="1960" distribution="1" maingenre="17" subgenre="" flags="0" blocks="2" price_mod="0.90" />
 			<ratings critics="70" speed="56" outcome="80" />
 		</programme>
-		<programme id="022e3fe7-001e-41ef-8696-89d3ab78dcf1" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0044706" rt_id="0" creator="">
+		<programme id="022e3fe7-001e-41ef-8696-89d3ab78dcf1" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0044706" creator="">
 			<title>
 				<de>Pünktlich zum Mittag</de>
 				<en></en>
@@ -4679,7 +4679,7 @@ Fast in zeitdeckendem Erzähltempo beschreibt Zinnemanns Klassiker das Schicksal
 			<data country="USA" year="1952" distribution="1" maingenre="18" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="61" speed="9" outcome="75" />
 		</programme>
-		<programme id="7d34bc7d-91af-47bb-a943-09d8c571a4da" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0074486" rt_id="0" creator="">
+		<programme id="7d34bc7d-91af-47bb-a943-09d8c571a4da" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0074486" creator="">
 			<title>
 				<de>Radiergummikopf</de>
 				<en></en>
@@ -4702,7 +4702,7 @@ Fast in zeitdeckendem Erzähltempo beschreibt Zinnemanns Klassiker das Schicksal
 			<data country="USA" year="1977" distribution="1" maingenre="12" subgenre="" flags="64" blocks="2" price_mod="0.67" />
 			<ratings critics="56" speed="42" outcome="51" />
 		</programme>
-		<programme id="e02b25cf-0485-4f74-b243-5f1a62351b43" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0116213" rt_id="0" creator="">
+		<programme id="e02b25cf-0485-4f74-b243-5f1a62351b43" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0116213" creator="">
 			<title>
 				<de>Railgun</de>
 				<en></en>
@@ -4725,7 +4725,7 @@ Fast in zeitdeckendem Erzähltempo beschreibt Zinnemanns Klassiker das Schicksal
 			<data country="USA" year="1996" distribution="1" maingenre="2" subgenre="16" flags="0" blocks="2" price_mod="1.33" />
 			<ratings critics="14" speed="75" outcome="42" />
 		</programme>
-		<programme id="3fb3dccb-06da-451f-9b04-4bf1abc2a5fd" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120201" rt_id="0" creator="">
+		<programme id="3fb3dccb-06da-451f-9b04-4bf1abc2a5fd" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120201" creator="">
 			<title>
 				<de>Raumschiffkadetten</de>
 				<en></en>
@@ -4750,7 +4750,7 @@ Fast in zeitdeckendem Erzähltempo beschreibt Zinnemanns Klassiker das Schicksal
 			<data country="USA" year="1997" distribution="1" maingenre="16" subgenre="2" flags="64" blocks="3" price_mod="0.67" />
 			<ratings critics="28" speed="89" outcome="65" />
 		</programme>
-		<programme id="6be0ac19-6120-4270-9fba-ed89c71424ab" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0077215" rt_id="0" creator="">
+		<programme id="6be0ac19-6120-4270-9fba-ed89c71424ab" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0077215" creator="">
 			<title>
 				<de>Raumschiff Galaktikus</de>
 				<en></en>
@@ -4772,7 +4772,7 @@ Fast in zeitdeckendem Erzähltempo beschreibt Zinnemanns Klassiker das Schicksal
 			<data country="USA" year="1978" distribution="1" maingenre="16" subgenre="2" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="23" speed="37" outcome="37" />
 		</programme>
-		<programme id="5eb4277b-41be-4b51-b639-5c8ec17cdb0a" product="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="5eb4277b-41be-4b51-b639-5c8ec17cdb0a" product="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Reiseziel Molwanien</de>
 				<en></en>
@@ -4790,7 +4790,7 @@ Fast in zeitdeckendem Erzähltempo beschreibt Zinnemanns Klassiker das Schicksal
 			<data country="MO" year="2000" distribution="1" maingenre="6" subgenre="" flags="4" blocks="1" price_mod="1" />
 			<ratings critics="47" speed="9" outcome="4" />
 		</programme>
-		<programme id="74b34ac0-150b-494a-aaa8-285f42bad55a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0093894" rt_id="0" creator="">
+		<programme id="74b34ac0-150b-494a-aaa8-285f42bad55a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0093894" creator="">
 			<title>
 				<de>Renn um Dein Leben - mit Todesgarantie</de>
 				<en></en>
@@ -4812,7 +4812,7 @@ Fast in zeitdeckendem Erzähltempo beschreibt Zinnemanns Klassiker das Schicksal
 			<data country="USA" year="1987" distribution="1" maingenre="2" subgenre="16" flags="64" blocks="2" price_mod="0.90" />
 			<ratings critics="28" speed="75" outcome="65" />
 		</programme>
-		<programme id="e33e9b8c-3869-4cab-978b-904c4a7a423f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0105236" rt_id="0" creator="">
+		<programme id="e33e9b8c-3869-4cab-978b-904c4a7a423f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0105236" creator="">
 			<title>
 				<de>Reservoir Cocks - Wilde Hühner</de>
 				<en></en>
@@ -4836,7 +4836,7 @@ Fast in zeitdeckendem Erzähltempo beschreibt Zinnemanns Klassiker das Schicksal
 			<data country="USA" year="1992" distribution="1" maingenre="2" subgenre="" flags="64" blocks="2" price_mod="1.33" />
 			<ratings critics="51" speed="70" outcome="56" />
 		</programme>
-		<programme id="dc98f98f-81c3-48aa-b921-4404ef1a1f19" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0085549" rt_id="0" creator="">
+		<programme id="dc98f98f-81c3-48aa-b921-4404ef1a1f19" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0085549" creator="">
 			<title>
 				<de>Rhythmus des Tanzes</de>
 				<en></en>
@@ -4857,7 +4857,7 @@ Oscar für den Titelsong "Rhythmus des Tanzes... What a Feeling"</de>
 			<data country="USA" year="1983" distribution="1" maingenre="15" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="51" speed="37" outcome="47" />
 		</programme>
-		<programme id="faeda8ec-0111-4afd-b193-22aafe618a48" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0113492" rt_id="0" creator="">
+		<programme id="faeda8ec-0111-4afd-b193-22aafe618a48" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0113492" creator="">
 			<title>
 				<de>Richter der Zukunft</de>
 				<en></en>
@@ -4881,7 +4881,7 @@ Oscar für den Titelsong "Rhythmus des Tanzes... What a Feeling"</de>
 			<data country="USA" year="1995" distribution="1" maingenre="2" subgenre="16" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="23" speed="56" outcome="37" />
 		</programme>
-		<programme id="d3ee7430-978f-4eda-9c7a-9215aa71efa1" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0110989" rt_id="0" creator="">
+		<programme id="d3ee7430-978f-4eda-9c7a-9215aa71efa1" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0110989" creator="">
 			<title>
 				<de>Rickie Reich</de>
 				<en></en>
@@ -4902,7 +4902,7 @@ Nett</de>
 			<data country="USA" year="1994" distribution="1" maingenre="9" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="28" speed="51" outcome="37" />
 		</programme>
-		<programme id="10b21397-415e-46fe-8a06-6ce961c9f17e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0075148" rt_id="0" creator="">
+		<programme id="10b21397-415e-46fe-8a06-6ce961c9f17e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0075148" creator="">
 			<title>
 				<de>Ricky</de>
 				<en></en>
@@ -4928,7 +4928,7 @@ Nett</de>
 			<data country="USA" year="1976" distribution="1" maingenre="2" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="32" speed="56" outcome="75" />
 		</programme>
-		<programme id="a95b18f9-7ca8-4179-9eae-b1c2b83f1487" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0079817" rt_id="0" creator="">
+		<programme id="a95b18f9-7ca8-4179-9eae-b1c2b83f1487" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0079817" creator="">
 			<title>
 				<de>Ricky II</de>
 				<en></en>
@@ -4953,7 +4953,7 @@ Nett</de>
 			<data country="USA" year="1979" distribution="1" maingenre="2" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="23" speed="51" outcome="51" />
 		</programme>
-		<programme id="3f265739-a215-4564-9fa1-69eb0b7660a3" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0084602" rt_id="0" creator="">
+		<programme id="3f265739-a215-4564-9fa1-69eb0b7660a3" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0084602" creator="">
 			<title>
 				<de>Ricky III - Das Ohr des Geparden</de>
 				<en></en>
@@ -4978,7 +4978,7 @@ Nett</de>
 			<data country="USA" year="1982" distribution="1" maingenre="2" subgenre="" flags="0" blocks="2" price_mod="0.90" />
 			<ratings critics="14" speed="56" outcome="32" />
 		</programme>
-		<programme id="2dd83894-ba84-4c08-a952-48e4d95218e7" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0089927" rt_id="0" creator="">
+		<programme id="2dd83894-ba84-4c08-a952-48e4d95218e7" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0089927" creator="">
 			<title>
 				<de>Ricky IV - Der Milleniumsfight</de>
 				<en></en>
@@ -5002,7 +5002,7 @@ Nett</de>
 			<data country="USA" year="1985" distribution="1" maingenre="2" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="14" speed="51" outcome="23" />
 		</programme>
-		<programme id="8624a0d6-0f8b-45f6-8914-430d396e1e81" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0100507" rt_id="0" creator="">
+		<programme id="8624a0d6-0f8b-45f6-8914-430d396e1e81" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0100507" creator="">
 			<title>
 				<de>Ricky V</de>
 				<en></en>
@@ -5026,7 +5026,7 @@ Nett</de>
 			<data country="USA" year="1990" distribution="1" maingenre="2" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="14" speed="51" outcome="37" />
 		</programme>
-		<programme id="2f89cc69-cf6a-4edf-8cf3-5c401514e4c7" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0093870" rt_id="0" creator="">
+		<programme id="2f89cc69-cf6a-4edf-8cf3-5c401514e4c7" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0093870" creator="">
 			<title>
 				<de>Robota Cup</de>
 				<en></en>
@@ -5054,7 +5054,7 @@ Knallharter Sci-Fi-Actioner von [0|Full]</de>
 			<data country="USA" year="1987" distribution="1" maingenre="16" subgenre="2" flags="64" blocks="2" price_mod="0.67" />
 			<ratings critics="51" speed="89" outcome="70" />
 		</programme>
-		<programme id="3094de00-92d6-4a28-a1a8-878a6f653358" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0100502" rt_id="0" creator="">
+		<programme id="3094de00-92d6-4a28-a1a8-878a6f653358" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0100502" creator="">
 			<title>
 				<de>Robota Cup 2</de>
 				<en></en>
@@ -5081,7 +5081,7 @@ Gute Action, aber mehr auch nicht</de>
 			<data country="USA" year="1990" distribution="1" maingenre="16" subgenre="" flags="64" blocks="2" price_mod="0.67" />
 			<ratings critics="28" speed="80" outcome="42" />
 		</programme>
-		<programme id="b199a6b3-7469-4827-8d09-318719524cd4" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0107978" rt_id="0" creator="">
+		<programme id="b199a6b3-7469-4827-8d09-318719524cd4" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0107978" creator="">
 			<title>
 				<de>Robota Cup 3</de>
 				<en></en>
@@ -5108,7 +5108,7 @@ Gute Action, aber mehr auch nicht</de>
 			<data country="USA" year="1993" distribution="1" maingenre="16" subgenre="2" flags="0" blocks="2" price_mod="1.33" />
 			<ratings critics="4" speed="70" outcome="28" />
 		</programme>
-		<programme id="0bdfc8f8-5113-4eab-8b01-5e0cabad9f00" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0289765" rt_id="0" creator="">
+		<programme id="0bdfc8f8-5113-4eab-8b01-5e0cabad9f00" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0289765" creator="">
 			<title>
 				<de>Rubinroter Waran</de>
 				<en></en>
@@ -5131,7 +5131,7 @@ Gute Action, aber mehr auch nicht</de>
 			<data country="USA" year="2002" distribution="1" maingenre="17" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="70" speed="65" outcome="56" />
 		</programme>
-		<programme id="775d5197-34f9-41e5-944e-5da6e7d92724" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0088763" rt_id="0" creator="">
+		<programme id="775d5197-34f9-41e5-944e-5da6e7d92724" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0088763" creator="">
 			<title>
 				<de>Rückkehr in die Zukunft</de>
 				<en>Return to the Future</en>
@@ -5155,7 +5155,7 @@ Kult aus den 80ern</de>
 			<data country="USA" year="1985" distribution="1" maingenre="16" subgenre="5" flags="0" blocks="2" price_mod="0.90" />
 			<ratings critics="42" speed="61" outcome="61" />
 		</programme>
-		<programme id="6bf27807-bf40-4b58-9070-7812b43d00d6" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0096874" rt_id="0" creator="">
+		<programme id="6bf27807-bf40-4b58-9070-7812b43d00d6" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0096874" creator="">
 			<title>
 				<de>Rückkehr in die Zukunft 2</de>
 				<en>Return to the Future 2</en>
@@ -5178,7 +5178,7 @@ Kult aus den 80ern</de>
 			<data country="USA" year="1989" distribution="1" maingenre="16" subgenre="5" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="32" speed="56" outcome="51" />
 		</programme>
-		<programme id="e1b9455a-5ba0-4b56-942d-5c31828bb9f7" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0099088" rt_id="0" creator="">
+		<programme id="e1b9455a-5ba0-4b56-942d-5c31828bb9f7" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0099088" creator="">
 			<title>
 				<de>Rückkehr in die Zukunft 3</de>
 				<en>Return to the Future 3</en>
@@ -5202,7 +5202,7 @@ Rückkehr in die Zukunft</de>
 			<data country="USA" year="1990" distribution="1" maingenre="16" subgenre="5" flags="0" blocks="2" price_mod="0.90" />
 			<ratings critics="18" speed="37" outcome="51" />
 		</programme>
-		<programme id="820cf425-7453-4bdf-bb5d-7632e9cfb6f8" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0098084" rt_id="0" creator="">
+		<programme id="820cf425-7453-4bdf-bb5d-7632e9cfb6f8" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0098084" creator="">
 			<title>
 				<de>Ruhestätte der Plüschtiere</de>
 				<en></en>
@@ -5227,7 +5227,7 @@ Kult-Horror nach dem Roman von Stephen King</de>
 			<data country="USA" year="1989" distribution="1" maingenre="12" subgenre="" flags="64" blocks="2" price_mod="0.67" />
 			<ratings critics="18" speed="61" outcome="56" />
 		</programme>
-		<programme id="1cead1f7-013f-4fe7-97ee-f1ba074f9328" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0102926" rt_id="0" creator="">
+		<programme id="1cead1f7-013f-4fe7-97ee-f1ba074f9328" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0102926" creator="">
 			<title>
 				<de>Schweigende Hammel</de>
 				<en></en>
@@ -5249,7 +5249,7 @@ Genauso grausam wie genial</de>
 			<data country="USA" year="1991" distribution="1" maingenre="17" subgenre="" flags="0" blocks="3" price_mod="0.90" />
 			<ratings critics="70" speed="70" outcome="84" />
 		</programme>
-		<programme id="4ba8837e-ee51-4c40-8ed4-0217737f17f3" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0114369" rt_id="0" creator="">
+		<programme id="4ba8837e-ee51-4c40-8ed4-0217737f17f3" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0114369" creator="">
 			<title>
 				<de>Sechs und Eins Todsünden</de>
 				<en></en>
@@ -5273,7 +5273,7 @@ Genauso grausam wie genial</de>
 			<data country="USA" year="1995" distribution="1" maingenre="17" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="37" speed="51" outcome="65" />
 		</programme>
-		<programme id="f9cff182-7248-4675-97c9-d5cd9813f4ec" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0033467" rt_id="0" creator="">
+		<programme id="f9cff182-7248-4675-97c9-d5cd9813f4ec" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0033467" creator="">
 			<title>
 				<de>Sie Sietzen Kain</de>
 				<en></en>
@@ -5296,7 +5296,7 @@ Gilt bei vielen Kritikern als bester Film aller Zeiten</de>
 			<data country="USA" year="1941" distribution="1" maingenre="13" subgenre="" flags="8" blocks="3" price_mod="0.67" />
 			<ratings critics="94" speed="32" outcome="61" />
 		</programme>
-		<programme id="3713ab2a-aadb-4e27-831e-6270b176724a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0121210" rt_id="0" creator="">
+		<programme id="3713ab2a-aadb-4e27-831e-6270b176724a" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0121210" creator="">
 			<title>
 				<de>Solo-Abendessen oder der 90. Jahrestag</de>
 				<en></en>
@@ -5320,7 +5320,7 @@ Silvester-Spaß</de>
 			<data country="D" year="1963" distribution="1" maingenre="5" subgenre="" flags="8" blocks="1" price_mod="1" />
 			<ratings critics="37" speed="70" outcome="70" />
 		</programme>
-		<programme id="376ada51-867e-46f1-bb24-e0ee855dc50f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0133952" rt_id="0" creator="">
+		<programme id="376ada51-867e-46f1-bb24-e0ee855dc50f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0133952" creator="">
 			<title>
 				<de>Sonderrechtszustand</de>
 				<en></en>
@@ -5341,7 +5341,7 @@ Silvester-Spaß</de>
 			<data country="USA" year="1998" distribution="1" maingenre="2" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="32" speed="37" outcome="37" />
 		</programme>
-		<programme id="c1ba65e2-12d2-489b-89dd-41ceff24d7e9" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0054331" rt_id="0" creator="">
+		<programme id="c1ba65e2-12d2-489b-89dd-41ceff24d7e9" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0054331" creator="">
 			<title>
 				<de>Spartakus</de>
 				<en></en>
@@ -5367,7 +5367,7 @@ Große Bilder, [0|Last] konnte jedoch nicht nach seinen Vorstellungen arbeiten</
 			<data country="USA" year="1960" distribution="1" maingenre="13" subgenre="2,11" flags="8" blocks="4" price_mod="0.67" />
 			<ratings critics="61" speed="47" outcome="56" />
 		</programme>
-		<programme id="4e080c71-fa02-4639-aa4c-c786c9521993" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0119174" rt_id="0" creator="">
+		<programme id="4e080c71-fa02-4639-aa4c-c786c9521993" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0119174" creator="">
 			<title>
 				<de>Spiel um Leben und Tod</de>
 				<en></en>
@@ -5393,7 +5393,7 @@ Ein typischer [0|Last]</de>
 			<data country="USA" year="1997" distribution="1" maingenre="17" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="56" speed="37" outcome="56" />
 		</programme>
-		<programme id="410d7cd4-cdad-4ae8-a533-dc454fd388de" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0401792" rt_id="0" creator="">
+		<programme id="410d7cd4-cdad-4ae8-a533-dc454fd388de" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0401792" creator="">
 			<title>
 				<de>Stadt der Sünden</de>
 				<en></en>
@@ -5418,7 +5418,7 @@ Ein typischer [0|Last]</de>
 			<data country="USA" year="2005" distribution="1" maingenre="2" subgenre="" flags="64" blocks="3" price_mod="1" />
 			<ratings critics="28" speed="75" outcome="61" />
 		</programme>
-		<programme id="d1ba4308-64dd-4a2c-8e2b-d219671573b6" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0111282" rt_id="0" creator="">
+		<programme id="d1ba4308-64dd-4a2c-8e2b-d219671573b6" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0111282" creator="">
 			<title>
 				<de>Sterngaed</de>
 				<en></en>
@@ -5446,7 +5446,7 @@ Aufwendiges Actionspektakel von Regisseur [0|Full]</de>
 			<data country="USA" year="1994" distribution="1" maingenre="16" subgenre="2" flags="0" blocks="3" price_mod="0.90" />
 			<ratings critics="61" speed="75" outcome="70" />
 		</programme>
-		<programme id="08ada450-5841-4e7e-88c3-5567d14a2fa4" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0100934" rt_id="0" creator="">
+		<programme id="08ada450-5841-4e7e-88c3-5567d14a2fa4" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0100934" creator="">
 			<title>
 				<de>Stürmische Rose</de>
 				<en></en>
@@ -5467,7 +5467,7 @@ Aufwendiges Actionspektakel von Regisseur [0|Full]</de>
 			<data country="USA" year="1990" distribution="1" maingenre="8" subgenre="15" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="18" speed="32" outcome="61" />
 		</programme>
-		<programme id="13cc99a6-4e82-4126-9b75-72f190901a2a" product="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="13cc99a6-4e82-4126-9b75-72f190901a2a" product="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Talk um 10</de>
 				<en></en>
@@ -5484,7 +5484,7 @@ Aufwendiges Actionspektakel von Regisseur [0|Full]</de>
 			<data country="D" year="1990" distribution="2" maingenre="6" subgenre="" flags="4" blocks="1" price_mod="0.90" />
 			<ratings critics="80" speed="4" outcome="4" />
 		</programme>
-		<programme id="69955785-3357-4292-b20b-aba24f0cd98f" product="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="69955785-3357-4292-b20b-aba24f0cd98f" product="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Talk um 10 Spezial</de>
 				<en></en>
@@ -5501,7 +5501,7 @@ Aufwendiges Actionspektakel von Regisseur [0|Full]</de>
 			<data country="D" year="1991" distribution="1" maingenre="6" subgenre="" flags="4" blocks="1" price_mod="0.67" />
 			<ratings critics="70" speed="4" outcome="18" />
 		</programme>
-		<programme id="6cab2c62-39d7-4e0a-b957-191d54fc78f9" product="3" licence_type="1" fictional="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="6cab2c62-39d7-4e0a-b957-191d54fc78f9" product="3" licence_type="1" fictional="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>TED am Morgen</de>
 				<en>TED in the morning</en>
@@ -5517,7 +5517,7 @@ Aufwendiges Actionspektakel von Regisseur [0|Full]</de>
 			<data country="D" year="2001" distribution="1" maingenre="0" subgenre="" flags="128" blocks="1" broadcast_time_slot_start="6" broadcast_time_slot_end="10" price_mod="1.0" />
 			<ratings critics="25" speed="10" outcome="15" />
 		</programme>
-		<programme id="ffdbdca2-7ad9-bbfc-b1a1-af1d24ee7ab5" product="3" licence_type="1" fictional="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="ffdbdca2-7ad9-bbfc-b1a1-af1d24ee7ab5" product="3" licence_type="1" fictional="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>TED am Abend</de>
 				<en>TED in the evening</en>
@@ -5533,7 +5533,7 @@ Aufwendiges Actionspektakel von Regisseur [0|Full]</de>
 			<data country="D" year="2001" distribution="1" maingenre="0" subgenre="" flags="128" blocks="1" broadcast_time_slot_start="17" broadcast_time_slot_end="21" price_mod="1.0" />
 			<ratings critics="25" speed="10" outcome="15" />
 		</programme>
-		<programme id="3a0c9fba-3b1e-49e1-afdf-340e4aa1f913" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0093409" rt_id="0" creator="">
+		<programme id="3a0c9fba-3b1e-49e1-afdf-340e4aa1f913" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0093409" creator="">
 			<title>
 				<de>Tödliche Wummen - Zwei murrende Profis</de>
 				<en></en>
@@ -5556,7 +5556,7 @@ Kultige Action-Komödie voller Spannung und Spaß</de>
 			<data country="USA" year="1987" distribution="1" maingenre="2" subgenre="" flags="64" blocks="2" price_mod="0.67" />
 			<ratings critics="47" speed="80" outcome="75" />
 		</programme>
-		<programme id="34167b6e-abc6-474b-a77f-1d644827e7b2" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0097733" rt_id="0" creator="">
+		<programme id="34167b6e-abc6-474b-a77f-1d644827e7b2" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0097733" creator="">
 			<title>
 				<de>Tödliche Wummen 2 - Knackpunkt Los Angeles</de>
 				<en></en>
@@ -5580,7 +5580,7 @@ Tödliche Wummen 2 steht Teil 1 in nichts nach</de>
 			<data country="USA" year="1989" distribution="1" maingenre="2" subgenre="" flags="64" blocks="3" price_mod="1" />
 			<ratings critics="37" speed="84" outcome="75" />
 		</programme>
-		<programme id="1178f3ef-03d8-48ca-a34d-81f27fe04b47" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0122151" rt_id="0" creator="">
+		<programme id="1178f3ef-03d8-48ca-a34d-81f27fe04b47" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0122151" creator="">
 			<title>
 				<de>Tödliche Wummen 4 - Zwei Bullen klären die Sache</de>
 				<en></en>
@@ -5606,7 +5606,7 @@ Auch das vierte Tödliche-Wummen-Abenteuer ist ein wahres Schmuckstück</de>
 			<data country="USA" year="1998" distribution="1" maingenre="2" subgenre="" flags="64" blocks="3" price_mod="1.33" />
 			<ratings critics="23" speed="80" outcome="51" />
 		</programme>
-		<programme id="182427cb-b6b3-4404-a33d-8a7db18c7288" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120647" rt_id="0" creator="">
+		<programme id="182427cb-b6b3-4404-a33d-8a7db18c7288" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120647" creator="">
 			<title>
 				<de>Tödlicher Einschlag</de>
 				<en></en>
@@ -5629,7 +5629,7 @@ Auch das vierte Tödliche-Wummen-Abenteuer ist ein wahres Schmuckstück</de>
 			<data country="USA" year="1998" distribution="1" maingenre="16" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="56" speed="37" outcome="37" />
 		</programme>
-		<programme id="c4be7d64-35e9-4e56-8e6e-284d642beee6" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0063032" rt_id="0" creator="">
+		<programme id="c4be7d64-35e9-4e56-8e6e-284d642beee6" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0063032" creator="">
 			<title>
 				<de>Tote kleistern seinen Pfad</de>
 				<en></en>
@@ -5654,7 +5654,7 @@ Klassiker von [0|Full]</de>
 			<data country="I" year="1968" distribution="1" maingenre="18" subgenre="" flags="64" blocks="2" price_mod="1" />
 			<ratings critics="61" speed="70" outcome="65" />
 		</programme>
-		<programme id="a81aeb88-402a-45d4-93b2-ded9187ce8a5" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0180093" rt_id="0" creator="">
+		<programme id="a81aeb88-402a-45d4-93b2-ded9187ce8a5" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0180093" creator="">
 			<title>
 				<de>Totenmesse für einen Traum</de>
 				<en></en>
@@ -5678,7 +5678,7 @@ Ohne Frage einer der effektivsten Filme über die Erfahrung der Drogensucht</de>
 			<data country="USA" year="2000" distribution="1" maingenre="2" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="61" speed="51" outcome="56" />
 		</programme>
-		<programme id="ad4e53ca-e000-42f6-b887-4688d073b532" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0111503" rt_id="0" creator="">
+		<programme id="ad4e53ca-e000-42f6-b887-4688d073b532" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0111503" creator="">
 			<title>
 				<de>True Spy - Die Frau des Spiones</de>
 				<en></en>
@@ -5703,7 +5703,7 @@ Spritziger Actioner mit dem Erfolgsduo [0|Last] / [1|Last]</de>
 			<data country="USA" year="1994" distribution="1" maingenre="2" subgenre="" flags="0" blocks="3" price_mod="0.90" />
 			<ratings critics="28" speed="70" outcome="56" />
 		</programme>
-		<programme id="71fbb079-26e6-46f7-a33f-f814881d013e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0060315" rt_id="0" creator="">
+		<programme id="71fbb079-26e6-46f7-a33f-f814881d013e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0060315" creator="">
 			<title>
 				<de>Tschancou</de>
 				<en></en>
@@ -5729,7 +5729,7 @@ Spritziger Actioner mit dem Erfolgsduo [0|Last] / [1|Last]</de>
 			<data country="I" year="1966" distribution="1" maingenre="18" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="47" speed="61" outcome="70" />
 		</programme>
-		<programme id="02d0dfa5-dbcf-40b5-abb4-7e20a58d8efa" product="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="02d0dfa5-dbcf-40b5-abb4-7e20a58d8efa" product="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Tschüssikowski A4</de>
 				<en></en>
@@ -5747,7 +5747,7 @@ Spritziger Actioner mit dem Erfolgsduo [0|Last] / [1|Last]</de>
 			<data country="D" year="2006" distribution="2" maingenre="6" subgenre="" flags="4" blocks="1" price_mod="0.90" />
 			<ratings critics="84" speed="37" outcome="14" />
 		</programme>
-		<programme id="de72f0f4-898a-45af-87a7-c4e57cbbdc9f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0064116" rt_id="0" creator="">
+		<programme id="de72f0f4-898a-45af-87a7-c4e57cbbdc9f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0064116" creator="">
 			<title>
 				<de>Tüdel mir den Song vom Brot</de>
 				<en></en>
@@ -5772,7 +5772,7 @@ Mit der unvergleichlichen Musik Ennio MurrIchOchnes</de>
 			<data country="I" year="1968" distribution="1" maingenre="18" subgenre="" flags="0" blocks="4" price_mod="0.67" />
 			<ratings critics="75" speed="32" outcome="84" />
 		</programme>
-		<programme id="72a81bb1-876f-4caf-9e71-2aee3ea93df7" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0212720" rt_id="0" creator="">
+		<programme id="72a81bb1-876f-4caf-9e71-2aee3ea93df7" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0212720" creator="">
 			<title>
 				<de>U.I. - Unberechenbare Intelligenz</de>
 				<en></en>
@@ -5795,7 +5795,7 @@ Mit der unvergleichlichen Musik Ennio MurrIchOchnes</de>
 			<data country="USA" year="2001" distribution="1" maingenre="16" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="65" speed="37" outcome="56" />
 		</programme>
-		<programme id="1b796621-755a-4f44-8386-aec9716b52d2" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0066921" rt_id="0" creator="">
+		<programme id="1b796621-755a-4f44-8386-aec9716b52d2" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0066921" creator="">
 			<title>
 				<de>Uhrmaschinerie Gelb</de>
 				<en></en>
@@ -5822,7 +5822,7 @@ Die ultimative Filmfarce von [0|Full]</de>
 			<data country="GB" year="1971" distribution="1" maingenre="16" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="84" speed="61" outcome="70" />
 		</programme>
-		<programme id="216d7e50-2893-4a2e-973a-4f55a3ab81b0" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0209144" rt_id="0" creator="">
+		<programme id="216d7e50-2893-4a2e-973a-4f55a3ab81b0" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0209144" creator="">
 			<title>
 				<de>Uno Momento</de>
 				<en></en>
@@ -5846,7 +5846,7 @@ Spannende Story, rückwärts erzählt</de>
 			<data country="USA" year="2000" distribution="1" maingenre="17" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="65" speed="47" outcome="61" />
 		</programme>
-		<programme id="53bcf09f-998b-42e5-a71a-3e667312c48c" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0106977" rt_id="0" creator="">
+		<programme id="53bcf09f-998b-42e5-a71a-3e667312c48c" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0106977" creator="">
 			<title>
 				<de>Unschuldig gejagt</de>
 				<en></en>
@@ -5870,7 +5870,7 @@ Nach der erfolgreichen Serie</de>
 			<data country="USA" year="1993" distribution="1" maingenre="2" subgenre="" flags="0" blocks="3" price_mod="0.90" />
 			<ratings critics="65" speed="70" outcome="61" />
 		</programme>
-		<programme id="7bbd28e8-00ef-4a3d-bf5a-418badcd1048" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0259711" rt_id="0" creator="">
+		<programme id="7bbd28e8-00ef-4a3d-bf5a-418badcd1048" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0259711" creator="">
 			<title>
 				<de>Vanillinhimmel</de>
 				<en></en>
@@ -5895,7 +5895,7 @@ Kühler Thriller mit Schockwirkung</de>
 			<data country="USA" year="2001" distribution="1" maingenre="17" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="51" speed="47" outcome="61" />
 		</programme>
-		<programme id="3bb8a0be-e5f2-43a6-9401-d0f13264d1a3" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0137523" rt_id="0" creator="">
+		<programme id="3bb8a0be-e5f2-43a6-9401-d0f13264d1a3" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0137523" creator="">
 			<title>
 				<de>Veit's Club</de>
 				<en></en>
@@ -5919,7 +5919,7 @@ Aufwühlender Film von [0|Full]</de>
 			<data country="USA" year="1999" distribution="1" maingenre="2" subgenre="" flags="64" blocks="3" price_mod="1" />
 			<ratings critics="65" speed="80" outcome="61" />
 		</programme>
-		<programme id="3e0e1b50-06d7-4fb9-a07e-0f7e4bdb9f97" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120873" rt_id="0" creator="">
+		<programme id="3e0e1b50-06d7-4fb9-a07e-0f7e4bdb9f97" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120873" creator="">
 			<title>
 				<de>Verfolgt, gejagt und atemlos</de>
 				<en></en>
@@ -5942,7 +5942,7 @@ Aufwühlender Film von [0|Full]</de>
 			<data country="USA" year="1998" distribution="1" maingenre="2" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="32" speed="65" outcome="23" />
 		</programme>
-		<programme id="2993a09b-10fb-4c1b-96db-d8f4c9c4b152" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0091693" rt_id="0" creator="">
+		<programme id="2993a09b-10fb-4c1b-96db-d8f4c9c4b152" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0091693" creator="">
 			<title>
 				<de>Verschwundene Helden</de>
 				<en></en>
@@ -5967,7 +5967,7 @@ Bewegender Film mit [1|Full] in seiner ersten Filmhauptrolle</de>
 			<data country="USA" year="1986" distribution="1" maingenre="15" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="65" speed="28" outcome="37" />
 		</programme>
-		<programme id="6d7e006a-1202-4965-bc68-e617e243ba11" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0116705" rt_id="0" creator="">
+		<programme id="6d7e006a-1202-4965-bc68-e617e243ba11" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0116705" creator="">
 			<title>
 				<de>Versprechen sind zu halten</de>
 				<en></en>
@@ -5989,7 +5989,7 @@ Bewegender Film mit [1|Full] in seiner ersten Filmhauptrolle</de>
 			<data country="USA" year="1996" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="14" speed="56" outcome="47" />
 		</programme>
-		<programme id="b04ded66-43a5-4a9c-9f0e-d7073edb4e2f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0052357" rt_id="0" creator="">
+		<programme id="b04ded66-43a5-4a9c-9f0e-d7073edb4e2f" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0052357" creator="">
 			<title>
 				<de>Vertikal - Aus dem Reich von Oben</de>
 				<en></en>
@@ -6015,7 +6015,7 @@ Von den Kritikern lange Zeit verkannt</de>
 			<data country="USA" year="1958" distribution="1" maingenre="12" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="80" speed="42" outcome="56" />
 		</programme>
-		<programme id="7698124b-4994-4a7f-ba5a-88d0b4295dce" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0119488" rt_id="0" creator="">
+		<programme id="7698124b-4994-4a7f-ba5a-88d0b4295dce" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0119488" creator="">
 			<title>
 				<de>Vertrauliches L.A.</de>
 				<en></en>
@@ -6040,7 +6040,7 @@ Von den Kritikern lange Zeit verkannt</de>
 			<data country="USA" year="1997" distribution="1" maingenre="17" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="61" speed="51" outcome="56" />
 		</programme>
-		<programme id="a61e7775-7565-48cd-ab4a-e5faea09d70d" product="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="a61e7775-7565-48cd-ab4a-e5faea09d70d" product="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>VHS im Test</de>
 				<en></en>
@@ -6052,13 +6052,13 @@ Von den Kritikern lange Zeit verkannt</de>
 			<staff>
 				<member index="0" function="1">f14d6ba0-0db5-4a76-a4d3-daba1603e4f6</member>
 				<member index="1" function="2">1994aa3a-23c3-48ce-b20a-d1f021df8c63</member>
-				<member index="1" function="2">2994ff3d-ffc4-f8ce-c25a-e1g0d1df8c64</member>
+				<member index="2" function="2">2994ff3d-ffc4-f8ce-c25a-e1g0d1df8c64</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
 			<data country="D" year="2004" distribution="1" maingenre="6" subgenre="" flags="4" blocks="1" price_mod="1" />
 			<ratings critics="42" speed="47" outcome="0" />
 		</programme>
-		<programme id="893bf116-f3ef-447d-aa20-fa2a97d6ae86" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0265086" rt_id="0" creator="">
+		<programme id="893bf116-f3ef-447d-aa20-fa2a97d6ae86" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0265086" creator="">
 			<title>
 				<de>Vogel am Boden</de>
 				<en></en>
@@ -6082,7 +6082,7 @@ Von den Kritikern lange Zeit verkannt</de>
 			<data country="USA" year="2001" distribution="1" maingenre="2" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="51" speed="51" outcome="61" />
 		</programme>
-		<programme id="862497a5-844d-42cb-a691-c4e3876cd1bc" product="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="862497a5-844d-42cb-a691-c4e3876cd1bc" product="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Wasser-Theremin, Klickphone &amp; Achselgeige: Musikgeschmack im Grenzbereich</de>
 				<en></en>
@@ -6099,7 +6099,7 @@ Von den Kritikern lange Zeit verkannt</de>
 			<data country="AT" year="2001" distribution="2" maingenre="6" subgenre="" flags="4" blocks="2" price_mod="0.90" />
 			<ratings critics="52" speed="1" outcome="0" />
 		</programme>
-		<programme id="855fdb66-87d3-4fb6-8be0-56517c969d32" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0048802" rt_id="0" creator="">
+		<programme id="855fdb66-87d3-4fb6-8be0-56517c969d32" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0048802" creator="">
 			<title>
 				<de>Wenn Papa mit dem Kinde</de>
 				<en></en>
@@ -6120,7 +6120,7 @@ Von den Kritikern lange Zeit verkannt</de>
 			<data country="D" year="1955" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="37" speed="32" outcome="32" />
 		</programme>
-		<programme id="66789ab6-52ba-451c-bb3b-61d2e1000258" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0116830" rt_id="0" creator="">
+		<programme id="66789ab6-52ba-451c-bb3b-61d2e1000258" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0116830" creator="">
 			<title>
 				<de>Wer als Letzter noch steht</de>
 				<en></en>
@@ -6144,7 +6144,7 @@ Neo-Western mit [1|Full]</de>
 			<data country="USA" year="1996" distribution="1" maingenre="18" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="37" speed="42" outcome="51" />
 		</programme>
-		<programme id="e0da07de-d9fc-4426-bcf2-119d344598c8" product="3" licence_type="1" fictional="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="e0da07de-d9fc-4426-bcf2-119d344598c8" product="3" licence_type="1" fictional="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Wer wird Pleitegeier?</de>
 				<en></en>
@@ -6163,7 +6163,7 @@ Spannende Unterhaltung und knifflige Fragen.</de>
 			<data country="D" year="1999" distribution="2" maingenre="100" subgenre="" flags="0" blocks="1" price_mod="1.33" />
 			<ratings critics="28" speed="75" outcome="61" />
 		</programme>
-		<programme id="610d076a-29fa-4e92-a7f2-190ff066fd8e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0266543" rt_id="0" creator="">
+		<programme id="610d076a-29fa-4e92-a7f2-190ff066fd8e" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0266543" creator="">
 			<title>
 				<de>Wo ist Neymo?</de>
 				<en></en>
@@ -6184,7 +6184,7 @@ Erstaunlich erfolgreich, wahrscheinlich weil Pionier des Animationsfilms</de>
 			<data country="USA" year="2003" distribution="1" maingenre="3" subgenre="9" flags="2" blocks="2" price_mod="1.33" />
 			<ratings critics="56" speed="56" outcome="47" />
 		</programme>
-		<programme id="d2bc9371-e904-4f8e-8140-f24e7eb49ef9" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120591" rt_id="0" creator="">
+		<programme id="d2bc9371-e904-4f8e-8140-f24e7eb49ef9" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0120591" creator="">
 			<title>
 				<de>World Crisis - the end is neigh!</de>
 				<en></en>
@@ -6209,7 +6209,7 @@ Erstaunlich erfolgreich, wahrscheinlich weil Pionier des Animationsfilms</de>
 			<data country="USA" year="1998" distribution="1" maingenre="16" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="37" speed="51" outcome="56" />
 		</programme>
-		<programme id="dae4ffcd-f576-4d5a-8930-0713c0ba77a8" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0023943" rt_id="0" creator="">
+		<programme id="dae4ffcd-f576-4d5a-8930-0713c0ba77a8" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0023943" creator="">
 			<title>
 				<de>Wra Diabulo</de>
 				<en></en>
@@ -6235,7 +6235,7 @@ Vielleicht der beste [1|Last] &amp; [2|Last] nach der gleichnamigen Oper von Aub
 			<data country="USA" year="1933" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="0.90" />
 			<ratings critics="56" speed="80" outcome="75" />
 		</programme>
-		<programme id="bc016a6c-3db2-44c3-b106-a934989e7f3d" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0058150" rt_id="0" creator="">
+		<programme id="bc016a6c-3db2-44c3-b106-a934989e7f3d" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0058150" creator="">
 			<title>
 				<de>Yams Pond 005 - Bronzedaumen</de>
 				<en></en>
@@ -6260,7 +6260,7 @@ Gilt allgemein als bester Pond</de>
 			<data country="GB" year="1964" distribution="1" maingenre="17" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="42" speed="75" outcome="80" />
 		</programme>
-		<programme id="0665a5b5-ec94-4127-a1a6-83d6b3a6af66" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0071807" rt_id="0" creator="">
+		<programme id="0665a5b5-ec94-4127-a1a6-83d6b3a6af66" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0071807" creator="">
 			<title>
 				<de>Yams Pond 005 - Der Kerl mit der Silberknarre</de>
 				<en></en>
@@ -6285,7 +6285,7 @@ Sehr gelungener Yams Pond</de>
 			<data country="GB" year="1974" distribution="1" maingenre="17" subgenre="" flags="0" blocks="3" price_mod="0.90" />
 			<ratings critics="32" speed="70" outcome="70" />
 		</programme>
-		<programme id="fb3edb42-f11e-48d6-98bd-50a0e4bec8d8" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0059800" rt_id="0" creator="">
+		<programme id="fb3edb42-f11e-48d6-98bd-50a0e4bec8d8" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0059800" creator="">
 			<title>
 				<de>Yams Pond 005 - Eiskugel</de>
 				<en></en>
@@ -6309,7 +6309,7 @@ Sehr gelungener Yams Pond</de>
 			<data country="GB" year="1965" distribution="1" maingenre="17" subgenre="" flags="0" blocks="3" price_mod="0.90" />
 			<ratings critics="28" speed="65" outcome="80" />
 		</programme>
-		<programme id="649e905d-8df1-4776-8ce5-0216ed4acc71" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0070328" rt_id="0" creator="">
+		<programme id="649e905d-8df1-4776-8ce5-0216ed4acc71" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0070328" creator="">
 			<title>
 				<de>Yams Pond 005 - Entscheidung über Leben und Tod</de>
 				<en></en>
@@ -6334,7 +6334,7 @@ Sehr gelungener Yams Pond</de>
 			<data country="GB" year="1973" distribution="1" maingenre="17" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="18" speed="65" outcome="70" />
 		</programme>
-		<programme id="d35a1a79-8564-40c5-863f-a45a3b590149" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0062512" rt_id="0" creator="">
+		<programme id="d35a1a79-8564-40c5-863f-a45a3b590149" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0062512" creator="">
 			<title>
 				<de>Yams Pond 005 - Keiner lebt zweimal</de>
 				<en></en>
@@ -6358,7 +6358,7 @@ Sehr gelungener Yams Pond</de>
 			<data country="GB" year="1967" distribution="1" maingenre="17" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="32" speed="70" outcome="70" />
 		</programme>
-		<programme id="5f4ca0c0-da05-4c55-a162-17897bb1a950" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0057076" rt_id="0" creator="">
+		<programme id="5f4ca0c0-da05-4c55-a162-17897bb1a950" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0057076" creator="">
 			<title>
 				<de>Yams Pond 005 - Moskauer Liebesbotschaft</de>
 				<en></en>
@@ -6383,7 +6383,7 @@ Im zweiten Pond wurde die wiederkehrende Figur des Q eingeführt</de>
 			<data country="GB" year="1963" distribution="1" maingenre="17" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="42" speed="70" outcome="65" />
 		</programme>
-		<programme id="6f68649d-18b8-4f1c-8d91-622a418d53a0" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0066995" rt_id="0" creator="">
+		<programme id="6f68649d-18b8-4f1c-8d91-622a418d53a0" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0066995" creator="">
 			<title>
 				<de>Yams Pond 005 - Rubinfieber</de>
 				<en></en>
@@ -6407,7 +6407,7 @@ Im zweiten Pond wurde die wiederkehrende Figur des Q eingeführt</de>
 			<data country="GB" year="1971" distribution="1" maingenre="17" subgenre="" flags="0" blocks="3" price_mod="0.67" />
 			<ratings critics="37" speed="70" outcome="75" />
 		</programme>
-		<programme id="1043932e-931f-4e79-ae39-626924901c4c" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0064757" rt_id="0" creator="">
+		<programme id="1043932e-931f-4e79-ae39-626924901c4c" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0064757" creator="">
 			<title>
 				<de>Yams Pond 005 - Zu Diensten der Queen</de>
 				<en></en>
@@ -6432,7 +6432,7 @@ Zum ersten und zum letzten Mal verkörperte[1|Full] Yams Pond 005</de>
 			<data country="GB" year="1969" distribution="1" maingenre="17" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="18" speed="65" outcome="51" />
 		</programme>
-		<programme id="9fa36b9c-a7cc-4284-9c34-6865f02cce85" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0055928" rt_id="0" creator="">
+		<programme id="9fa36b9c-a7cc-4284-9c34-6865f02cce85" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0055928" creator="">
 			<title>
 				<de>Yams Pond 005 jagt Dr. Yeah</de>
 				<en></en>
@@ -6457,7 +6457,7 @@ Jan Fleme schuf mit seinem Yams Pond eine Legende</de>
 			<data country="GB" year="1962" distribution="1" maingenre="17" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="42" speed="61" outcome="65" />
 		</programme>
-		<programme id="74fd4ce0-6dbd-400f-8964-e06a7fda76ab" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0106697" rt_id="0" creator="">
+		<programme id="74fd4ce0-6dbd-400f-8964-e06a7fda76ab" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0106697" creator="">
 			<title>
 				<de>Zerstörungswut</de>
 				<en></en>
@@ -6479,7 +6479,7 @@ Jan Fleme schuf mit seinem Yams Pond eine Legende</de>
 			<data country="USA" year="1993" distribution="1" maingenre="16" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="18" speed="56" outcome="37" />
 		</programme>
-		<programme id="82eb2072-d82d-494d-9e60-d04ba4e67077" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0285823" rt_id="0" creator="">
+		<programme id="82eb2072-d82d-494d-9e60-d04ba4e67077" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0285823" creator="">
 			<title>
 				<de>Zu unbekannter Zeit in Mexiko</de>
 				<en></en>
@@ -6504,7 +6504,7 @@ El-Mariachi-Fans wurden von [0|Last] gänzlich enttäuscht</de>
 			<data country="USA" year="2003" distribution="1" maingenre="2" subgenre="" flags="64" blocks="2" price_mod="1.33" />
 			<ratings critics="14" speed="84" outcome="37" />
 		</programme>
-		<programme id="6bda71ba-e56a-46c3-9762-9ae18c587839" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0258000" rt_id="0" creator="">
+		<programme id="6bda71ba-e56a-46c3-9762-9ae18c587839" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0258000" creator="">
 			<title>
 				<de>Zufluchtsstätte</de>
 				<en></en>
@@ -6530,7 +6530,7 @@ Originelle Idee, gut und spannend ausgeführt</de>
 			<data country="USA" year="2002" distribution="1" maingenre="17" subgenre="" flags="0" blocks="2" price_mod="1" />
 			<ratings critics="56" speed="61" outcome="51" />
 		</programme>
-		<programme id="9b67a604-a3ab-480f-ba64-44485c2d2547" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0060196" rt_id="0" creator="">
+		<programme id="9b67a604-a3ab-480f-ba64-44485c2d2547" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0060196" creator="">
 			<title>
 				<de>Zwei heldenhafte Gauner</de>
 				<en></en>
@@ -6557,7 +6557,7 @@ Originelle Idee, gut und spannend ausgeführt</de>
 			<data country="I" year="1966" distribution="1" maingenre="18" subgenre="" flags="0" blocks="4" price_mod="0.67" />
 			<ratings critics="51" speed="42" outcome="70" />
 		</programme>
-		<programme id="b666104b-1157-4996-97da-2a4253d6bfd3" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0069697" rt_id="0" creator="">
+		<programme id="b666104b-1157-4996-97da-2a4253d6bfd3" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0069697" creator="">
 			<title>
 				<de>Zwei wie Teer und Gänsefedern</de>
 				<en></en>
@@ -6581,7 +6581,7 @@ Herrliche Hau-Drauf-Action mit [1|Full] und [2|Full], cooler Soundtrack</de>
 			<data country="I" year="1973" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="9" speed="70" outcome="56" />
 		</programme>
-		<programme id="a3de54f3-a6bf-447a-a6cb-d3186d41b76d" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0099334" rt_id="0" creator="">
+		<programme id="a3de54f3-a6bf-447a-a6cb-d3186d41b76d" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0099334" creator="">
 			<title>
 				<de>Zynissimo von Bercherack</de>
 				<en></en>
@@ -6606,7 +6606,7 @@ Tragische Liebesgeschichte</de>
 			<data country="F" year="1990" distribution="1" maingenre="15" subgenre="" flags="0" blocks="3" price_mod="1" />
 			<ratings critics="56" speed="28" outcome="42" />
 		</programme>
-		<programme id="4544c5b6-59e8-4869-a0e5-7c184c1c0d98" product="6" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="4544c5b6-59e8-4869-a0e5-7c184c1c0d98" product="6" licence_type="3" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>BBWr - Best-Of Bolivian Wrestling</de>
 				<en></en>
@@ -6628,7 +6628,7 @@ Tragische Liebesgeschichte</de>
 			<data country="BOL" year="2005" distribution="2" maingenre="203" subgenre="" flags="0" blocks="2" price_mod="0.80" />
 			<ratings critics="7" speed="19" outcome="20" />
 			<children>
-				<programme id="3ca74c27-5958-4603-bf65-7ccc0be8b83f" product="6" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="3ca74c27-5958-4603-bf65-7ccc0be8b83f" product="6" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Hart - Hoden</de>
 						<en></en>
@@ -6639,7 +6639,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="27" speed="27" />
 				</programme>
-				<programme id="d24b258f-654a-4d2c-8c13-39c4191613bc" product="6" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="d24b258f-654a-4d2c-8c13-39c4191613bc" product="6" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Der neue wird eingewiesen</de>
 						<en></en>
@@ -6653,7 +6653,7 @@ Tragische Liebesgeschichte</de>
 					</staff>
 					<ratings critics="15" speed="16" />
 				</programme>
-				<programme id="0c080897-ff79-4244-b551-d7929afd42a8" product="6" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="0c080897-ff79-4244-b551-d7929afd42a8" product="6" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Snake - Gravedigger</de>
 						<en></en>
@@ -6664,7 +6664,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="15" speed="39" />
 				</programme>
-				<programme id="2125c95f-d6c2-4472-b2d5-38e203a6e266" product="6" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="2125c95f-d6c2-4472-b2d5-38e203a6e266" product="6" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Stahlhammer - Perez</de>
 						<en></en>
@@ -6678,7 +6678,7 @@ Tragische Liebesgeschichte</de>
 					</staff>
 					<ratings critics="7" speed="35" />
 				</programme>
-				<programme id="effdf7ed-0738-4711-a3e7-ca5003cef73a" product="6" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="effdf7ed-0738-4711-a3e7-ca5003cef73a" product="6" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Tag-Team-Match</de>
 						<en></en>
@@ -6691,7 +6691,7 @@ Tragische Liebesgeschichte</de>
 				</programme>
 			</children>
 		</programme>
-		<programme id="04439fd1-e89f-4922-a48e-6f8ddf96f7ab" product="7" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+		<programme id="04439fd1-e89f-4922-a48e-6f8ddf96f7ab" product="7" licence_type="3" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 			<title>
 				<de>Ronny hilft...</de>
 				<en></en>
@@ -6707,7 +6707,7 @@ Tragische Liebesgeschichte</de>
 			<data country="D" year="2011" distribution="2" maingenre="0" subgenre="" flags="16" blocks="4" price_mod="0.21" />
 			<ratings critics="6" speed="3" outcome="0" />
 			<children>
-				<programme id="39803483-0800-46e3-a153-5534c3d212da" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="39803483-0800-46e3-a153-5534c3d212da" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Marios Wohnzimmer</de>
 						<en></en>
@@ -6718,7 +6718,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="6" speed="3" />
 				</programme>
-				<programme id="4c062f49-f1e8-400a-9c11-852e95327873" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="4c062f49-f1e8-400a-9c11-852e95327873" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Sandros Handyvertrag</de>
 						<en></en>
@@ -6729,7 +6729,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="5" speed="4" />
 				</programme>
-				<programme id="dc0b1ca6-c1c1-496f-9882-06f51fe0ab97" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="dc0b1ca6-c1c1-496f-9882-06f51fe0ab97" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Ok, OP...</de>
 						<en></en>
@@ -6740,7 +6740,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="6" speed="3" />
 				</programme>
-				<programme id="fc7b481e-33b5-4113-89b3-9998ef8c66a6" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="fc7b481e-33b5-4113-89b3-9998ef8c66a6" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>...sich selbst</de>
 						<en></en>
@@ -6753,7 +6753,7 @@ Tragische Liebesgeschichte</de>
 				</programme>
 			</children>
 		</programme>
-		<programme id="e3065f58-7e56-49f4-8978-89f6dfe18b57" product="7" licence_type="3" fictional="1" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+		<programme id="e3065f58-7e56-49f4-8978-89f6dfe18b57" product="7" licence_type="3" fictional="1" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 			<title>
 				<de>Aus dem Leben gegriffen</de>
 				<en></en>
@@ -6770,7 +6770,7 @@ Tragische Liebesgeschichte</de>
 			<data country="D" year="2009" distribution="2" maingenre="301" subgenre="" flags="0" blocks="1" price_mod="0.2" />
 			<ratings critics="3" speed="7" outcome="0" />
 			<children>
-				<programme id="3daec432-9b89-493d-806a-74b39ef9d7c4" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="3daec432-9b89-493d-806a-74b39ef9d7c4" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Der Malocher</de>
 						<en></en>
@@ -6781,7 +6781,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="3" speed="7" />
 				</programme>
-				<programme id="62fdaea6-a012-4430-a442-cedb78a10e82" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="62fdaea6-a012-4430-a442-cedb78a10e82" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Frivole Liebschaften</de>
 						<en></en>
@@ -6792,7 +6792,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="5" speed="10" />
 				</programme>
-				<programme id="2d98454f-f768-447b-bbd1-070ac621927f" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="2d98454f-f768-447b-bbd1-070ac621927f" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Nachbars Nebenberuf</de>
 						<en></en>
@@ -6803,7 +6803,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="3" speed="9" />
 				</programme>
-				<programme id="5f96e1bc-5c96-4289-b020-972d657e0d39" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="5f96e1bc-5c96-4289-b020-972d657e0d39" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Ohne Schulabschluss</de>
 						<en></en>
@@ -6814,7 +6814,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="5" speed="10" />
 				</programme>
-				<programme id="7448b9f0-f470-409a-afb6-e2763a4b536c" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="7448b9f0-f470-409a-afb6-e2763a4b536c" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Der fiese Chef</de>
 						<en></en>
@@ -6825,7 +6825,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="11" speed="16" />
 				</programme>
-				<programme id="0d33b686-a7d7-4649-859c-5033e1c64686" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="0d33b686-a7d7-4649-859c-5033e1c64686" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Der Drogenkurier</de>
 						<en></en>
@@ -6841,7 +6841,7 @@ Tragische Liebesgeschichte</de>
 				</programme>
 			</children>
 		</programme>
-		<programme id="e3d2d499-8a03-4149-9e1e-2f52f2621f9a" product="2" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="e3d2d499-8a03-4149-9e1e-2f52f2621f9a" product="2" licence_type="3" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Robota Cup: Erstdirektive</de>
 				<en></en>
@@ -6862,7 +6862,7 @@ Tragische Liebesgeschichte</de>
 			<data country="CAN" year="1994" distribution="2" maingenre="16" subgenre="2" flags="0" blocks="1" price_mod="0.67" />
 			<ratings critics="4" speed="70" outcome="28" />
 			<children>
-				<programme id="10700e05-245c-49fe-a317-ba9ff97c83f3" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="10700e05-245c-49fe-a317-ba9ff97c83f3" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Fiese Gerechtigkeit</de>
 						<en></en>
@@ -6872,7 +6872,7 @@ Tragische Liebesgeschichte</de>
 						<en></en>
 					</description>
 				</programme>
-				<programme id="df149799-d107-4226-a0aa-790896efc1b0" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="df149799-d107-4226-a0aa-790896efc1b0" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Schmelztiegel</de>
 						<en></en>
@@ -6885,7 +6885,7 @@ Tragische Liebesgeschichte</de>
 						<member index="0" function="1">3e82947f-9094-4ee5-b1d7-a22557d07062</member>
 					</staff>
 				</programme>
-				<programme id="71b957a1-f0b7-440a-8b60-d301d97a1c82" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="71b957a1-f0b7-440a-8b60-d301d97a1c82" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Die Wiedergeburt</de>
 						<en></en>
@@ -6898,7 +6898,7 @@ Tragische Liebesgeschichte</de>
 						<member index="0" function="1">3e82947f-9094-4ee5-b1d7-a22557d07062</member>
 					</staff>
 				</programme>
-				<programme id="23cace5d-9d0c-457a-a399-399a12237d5b" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="23cace5d-9d0c-457a-a399-399a12237d5b" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Chaos</de>
 						<en></en>
@@ -6910,7 +6910,7 @@ Tragische Liebesgeschichte</de>
 				</programme>
 			</children>
 		</programme>
-		<programme id="b528cab3-ec3d-43fc-b76a-2cb1724a7055" product="3" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+		<programme id="b528cab3-ec3d-43fc-b76a-2cb1724a7055" product="3" licence_type="3" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 			<title>
 				<de>Ein Päuschen zum Gewinn</de>
 				<en></en>
@@ -6927,7 +6927,7 @@ Tragische Liebesgeschichte</de>
 			<data country="D" year="2009" distribution="2" maingenre="0" subgenre="" flags="128" blocks="1" price_mod="0.85" />
 			<ratings critics="5" speed="25" outcome="15" />
 			<children>
-				<programme id="8aedcc43-c63d-4ab3-aec9-dfd858ba3f1e" product="3" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="8aedcc43-c63d-4ab3-aec9-dfd858ba3f1e" product="3" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Leichte Gewinne</de>
 						<en></en>
@@ -6938,7 +6938,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="3" speed="28" />
 				</programme>
-				<programme id="a2ac67b0-6689-4c50-9489-d516bb15b771" product="3" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="a2ac67b0-6689-4c50-9489-d516bb15b771" product="3" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Harte Brocken</de>
 						<en></en>
@@ -6949,7 +6949,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="3" speed="20" />
 				</programme>
-				<programme id="82a377c0-4950-40cb-9813-9bb5c8ad9ad8" product="3" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="82a377c0-4950-40cb-9813-9bb5c8ad9ad8" product="3" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Genie gesucht</de>
 						<en></en>
@@ -6960,7 +6960,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="3" speed="25" />
 				</programme>
-				<programme id="81800e30-c387-4a29-9c21-c306a542cd7a" product="3" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="81800e30-c387-4a29-9c21-c306a542cd7a" product="3" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Dürft ich Fragen?</de>
 						<en></en>
@@ -6973,7 +6973,7 @@ Tragische Liebesgeschichte</de>
 				</programme>
 			</children>
 		</programme>
-		<programme id="7ff3171c-9064-4bbd-bfbb-f0b13e5f5a8a" product="64" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="7ff3171c-9064-4bbd-bfbb-f0b13e5f5a8a" product="64" licence_type="3" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Fußball-Weltmeisterschaft Italien 1990</de>
 				<en></en>
@@ -6989,7 +6989,7 @@ Tragische Liebesgeschichte</de>
 			<data country="I" year="1990" distribution="2" maingenre="203" subgenre="" flags="0" blocks="2" price_mod="0.90" />
 			<ratings critics="32" speed="75" outcome="80" />
 			<children>
-				<programme id="98a65c7a-10d6-45d6-96e4-653ef6decf62" product="64" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="98a65c7a-10d6-45d6-96e4-653ef6decf62" product="64" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Kamerun - Kolumbien 2:1</de>
 						<en></en>
@@ -7003,7 +7003,7 @@ Tragische Liebesgeschichte</de>
 						<member index="2" function="2">b360f7b8-3d87-4f6a-96c5-cc7a8ab8c488</member>
 					</staff>
 				</programme>
-				<programme id="3ed6d2bf-ad36-430a-965f-68ea8f00c36f" product="64" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="3ed6d2bf-ad36-430a-965f-68ea8f00c36f" product="64" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>CSFR - Costa Rica 4:1</de>
 						<en></en>
@@ -7017,7 +7017,7 @@ Tragische Liebesgeschichte</de>
 						<member index="2" function="2">b11fed5e-9636-4a9d-b13a-f5d490fef1b9</member>
 					</staff>
 				</programme>
-				<programme id="67f527f4-5d82-442f-9eaa-418710c35bbb" product="64" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="67f527f4-5d82-442f-9eaa-418710c35bbb" product="64" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Brasilien - Argentinien 0:1</de>
 						<en></en>
@@ -7033,7 +7033,7 @@ Tragische Liebesgeschichte</de>
 				</programme>
 			</children>
 		</programme>
-		<programme id="d0b61022-2ec0-4a6c-a496-92c102e41cde" product="7" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+		<programme id="d0b61022-2ec0-4a6c-a496-92c102e41cde" product="7" licence_type="3" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 			<title>
 				<de>Nur wer anruft kann gewinnen</de>
 				<en></en>
@@ -7049,7 +7049,7 @@ Tragische Liebesgeschichte</de>
 			<data country="D" year="2009" distribution="2" maingenre="8" subgenre="" flags="192" blocks="2" price_mod="0.85" />
 			<ratings critics="2" speed="35" outcome="15" />
 			<children>
-				<programme id="03f5cdc1-b20f-4db2-b23b-c8bede5b99ca" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="03f5cdc1-b20f-4db2-b23b-c8bede5b99ca" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Anrufer Tommy wird abgezockt</de>
 						<en></en>
@@ -7060,7 +7060,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="5" speed="30" />
 				</programme>
-				<programme id="f9278cc4-8468-4158-995f-59cc4ffa2230" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="f9278cc4-8468-4158-995f-59cc4ffa2230" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Haarige Erkenntnis</de>
 						<en></en>
@@ -7071,7 +7071,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="8" speed="25" />
 				</programme>
-				<programme id="28b4c473-e977-44c0-a593-4ac951f7d277" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="28b4c473-e977-44c0-a593-4ac951f7d277" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Mella Melone</de>
 						<en></en>
@@ -7084,7 +7084,7 @@ Tragische Liebesgeschichte</de>
 				</programme>
 			</children>
 		</programme>
-		<programme id="13cf3270-5458-460e-8360-75e0adc73a49" product="7" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+		<programme id="13cf3270-5458-460e-8360-75e0adc73a49" product="7" licence_type="3" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 			<title>
 				<de>Die Hellseher</de>
 				<en></en>
@@ -7101,7 +7101,7 @@ Tragische Liebesgeschichte</de>
 			<data country="D" year="1999" distribution="2" maingenre="0" subgenre="" flags="128" blocks="2" price_mod="1.05" />
 			<ratings critics="3" speed="15" outcome="8" />
 			<children>
-				<programme id="36bdc248-0924-4c43-9fd2-2aab51a804b1" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="36bdc248-0924-4c43-9fd2-2aab51a804b1" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Vaters Geist</de>
 						<en></en>
@@ -7112,7 +7112,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="2" speed="18" />
 				</programme>
-				<programme id="358da90b-2c5c-4796-acb3-6ae69490d7cf" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="358da90b-2c5c-4796-acb3-6ae69490d7cf" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Rudi der Pudel</de>
 						<en></en>
@@ -7123,7 +7123,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="5" speed="13" />
 				</programme>
-				<programme id="eeaf10fd-4105-4e53-b70d-c1a32316176e" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="eeaf10fd-4105-4e53-b70d-c1a32316176e" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Transmediale Olympiade</de>
 						<en></en>
@@ -7136,7 +7136,7 @@ Tragische Liebesgeschichte</de>
 				</programme>
 			</children>
 		</programme>
-		<programme id="5aa779f8-8140-4bef-912a-4aa7a760e1a6" product="4" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+		<programme id="5aa779f8-8140-4bef-912a-4aa7a760e1a6" product="4" licence_type="3" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 			<title>
 				<de>Maler vergangener Zeiten</de>
 				<en></en>
@@ -7153,7 +7153,7 @@ Tragische Liebesgeschichte</de>
 			<data country="D" year="1981" distribution="2" maingenre="6" subgenre="" flags="4" blocks="1" price_mod="1.0" />
 			<ratings critics="49" speed="17" outcome="0" />
 			<children>
-				<programme id="b1c87d59-cffe-4696-ac75-8f4e7fbbed76" product="4" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="b1c87d59-cffe-4696-ac75-8f4e7fbbed76" product="4" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Michelangelo</de>
 						<en></en>
@@ -7164,7 +7164,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="49" speed="17" />
 				</programme>
-				<programme id="02613833-d54e-4b6b-8de8-2370f4d5bb57" product="4" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="02613833-d54e-4b6b-8de8-2370f4d5bb57" product="4" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Monet</de>
 						<en></en>
@@ -7175,7 +7175,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="47" speed="12" />
 				</programme>
-				<programme id="9ada2a37-6ff5-4ff0-9766-7d0b2d98cff4" product="4" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="9ada2a37-6ff5-4ff0-9766-7d0b2d98cff4" product="4" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Picasso</de>
 						<en></en>
@@ -7186,7 +7186,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="49" speed="18" />
 				</programme>
-				<programme id="494fa370-4744-4616-aa14-910aa692af25" product="4" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="494fa370-4744-4616-aa14-910aa692af25" product="4" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Rembrandt</de>
 						<en></en>
@@ -7197,7 +7197,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="22" speed="15" />
 				</programme>
-				<programme id="6eccf754-bb87-40e5-bb5c-931fd2124a1b" product="4" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="6eccf754-bb87-40e5-bb5c-931fd2124a1b" product="4" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Kandinsky</de>
 						<en></en>
@@ -7210,7 +7210,7 @@ Tragische Liebesgeschichte</de>
 				</programme>
 			</children>
 		</programme>
-		<programme id="7ad20bf5-c4c6-4237-b52a-b7b189ede0bf" product="7" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+		<programme id="7ad20bf5-c4c6-4237-b52a-b7b189ede0bf" product="7" licence_type="3" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 			<title>
 				<de>Rolf Krall besucht...</de>
 				<en></en>
@@ -7228,7 +7228,7 @@ Tragische Liebesgeschichte</de>
 			<releaseTime year_relative="-1" year_relative_min="1985" year_relative_max="1990" />
 			<ratings critics="20" speed="42" outcome="35" />
 			<children>
-				<programme id="8258fb18-d138-49b4-b07c-0519eec12d2c" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="8258fb18-d138-49b4-b07c-0519eec12d2c" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Rolf Krall besucht... Madame Krussaud</de>
 						<en></en>
@@ -7239,7 +7239,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="28" speed="32" />
 				</programme>
-				<programme id="b7f87935-b1ec-44a8-b544-398b010af809" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="b7f87935-b1ec-44a8-b544-398b010af809" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Rolf Krall besucht... Jens Flumme</de>
 						<en></en>
@@ -7250,7 +7250,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="37" speed="42" />
 				</programme>
-				<programme id="ff1cff05-d8a8-43dc-9765-a975bcc49e7b" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="ff1cff05-d8a8-43dc-9765-a975bcc49e7b" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Rolf Krall besucht... Martin Zeck</de>
 						<en></en>
@@ -7261,7 +7261,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="37" speed="45" />
 				</programme>
-				<programme id="44db9d84-e8d5-46b4-bed5-70b228a74bcb" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="44db9d84-e8d5-46b4-bed5-70b228a74bcb" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Rolf Krall besucht... Peter Kruste</de>
 						<en></en>
@@ -7272,7 +7272,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="28" speed="56" />
 				</programme>
-				<programme id="ec7fe439-49ad-40d4-b1b3-fb89504184c7" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="ec7fe439-49ad-40d4-b1b3-fb89504184c7" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Rolf Krall besucht... seine Mutter</de>
 						<en></en>
@@ -7285,7 +7285,7 @@ Tragische Liebesgeschichte</de>
 				</programme>
 			</children>
 		</programme>
-		<programme id="c4ce4cc9-1c7e-4d25-ad83-8077e7a710b8" product="7" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+		<programme id="c4ce4cc9-1c7e-4d25-ad83-8077e7a710b8" product="7" licence_type="3" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 			<title>
 				<de>Seniorensause</de>
 				<en></en>
@@ -7302,7 +7302,7 @@ Tragische Liebesgeschichte</de>
 			<data country="D" year="2001" distribution="2" maingenre="301" subgenre="" flags="0" blocks="2" price_mod="0.80" />
 			<ratings critics="7" speed="1" outcome="0" />
 			<children>
-				<programme id="062287d0-1de3-47e9-b365-5ab5d163aef5" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="062287d0-1de3-47e9-b365-5ab5d163aef5" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Svetlana aus Hamburg</de>
 						<en></en>
@@ -7313,7 +7313,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="11" speed="4" />
 				</programme>
-				<programme id="afcac328-c1ec-4018-8fbb-f01e724463a3" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="afcac328-c1ec-4018-8fbb-f01e724463a3" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Renate aus Chemnitz</de>
 						<en></en>
@@ -7324,7 +7324,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="7" speed="1" />
 				</programme>
-				<programme id="37c8b5a1-f289-4061-96d9-51207ee850bc" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="37c8b5a1-f289-4061-96d9-51207ee850bc" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Erich aus Köln</de>
 						<en></en>
@@ -7335,7 +7335,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="5" speed="7" />
 				</programme>
-				<programme id="fe6f1e06-6c20-42a2-8164-bf357ac3c0d6" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="fe6f1e06-6c20-42a2-8164-bf357ac3c0d6" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Bolle aus Berlin</de>
 						<en></en>
@@ -7346,7 +7346,7 @@ Tragische Liebesgeschichte</de>
 					</description>
 					<ratings critics="11" speed="7" />
 				</programme>
-				<programme id="f2cc0b2e-43a0-4e39-8861-43e5c95d172f" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="f2cc0b2e-43a0-4e39-8861-43e5c95d172f" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Sepp aus München</de>
 						<en></en>
@@ -7359,7 +7359,7 @@ Tragische Liebesgeschichte</de>
 				</programme>
 			</children>
 		</programme>
-		<programme id="50b89ce5-a59b-4108-b4e0-0f82b2c6b15f" product="3" licence_type="3" fictional="1" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+		<programme id="50b89ce5-a59b-4108-b4e0-0f82b2c6b15f" product="3" licence_type="3" fictional="1" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 			<title>
 				<de>Die Patty Glansen Show</de>
 				<en></en>
@@ -7376,7 +7376,7 @@ Tragische Liebesgeschichte</de>
 			<data country="D" year="1997" distribution="2" maingenre="100" subgenre="" flags="0" blocks="2" price_mod="0.67" />
 			<ratings critics="51" speed="28" outcome="18" />
 			<children>
-				<programme id="ba5e8d69-ef29-4a26-8db0-1865c0b53e80" product="3" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="ba5e8d69-ef29-4a26-8db0-1865c0b53e80" product="3" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Lothar Molch</de>
 						<en></en>
@@ -7393,7 +7393,7 @@ Bieten die beiden genügend Stoff für eine spannende Runde?</de>
 					</staff>
 					<ratings critics="61" speed="42" />
 				</programme>
-				<programme id="9570f151-042a-4913-8873-759f791ffbdd" product="3" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="9570f151-042a-4913-8873-759f791ffbdd" product="3" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>James Glatzkowski und Lara Luftig</de>
 						<en></en>
@@ -7408,7 +7408,7 @@ Bieten die beiden genügend Stoff für eine spannende Runde?</de>
 					</staff>
 					<ratings critics="23" speed="56" />
 				</programme>
-				<programme id="7e610bb4-9327-4bc6-bccd-c7b996946e84" product="3" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="7e610bb4-9327-4bc6-bccd-c7b996946e84" product="3" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>[1|Full] selbst</de>
 						<en></en>
@@ -7423,7 +7423,7 @@ Bieten die beiden genügend Stoff für eine spannende Runde?</de>
 					</staff>
 					<ratings critics="47" speed="42" />
 				</programme>
-				<programme id="8ffd3e59-e711-45ca-9810-b22c221bad9b" product="3" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="8ffd3e59-e711-45ca-9810-b22c221bad9b" product="3" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>[2|Full]</de>
 						<en></en>
@@ -7441,7 +7441,7 @@ Bieten die beiden genügend Stoff für eine spannende Runde?</de>
 				</programme>
 			</children>
 		</programme>
-		<programme id="9ad21f32-6e2d-45c9-b3c2-7d758fa30d25" product="7" licence_type="3" fictional="1" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+		<programme id="9ad21f32-6e2d-45c9-b3c2-7d758fa30d25" product="7" licence_type="3" fictional="1" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 			<title>
 				<de>Dynamit - Das Magazin</de>
 				<en></en>
@@ -7460,35 +7460,35 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<data country="D" year="1991" distribution="2" maingenre="301" subgenre="" flags="0" blocks="1" price_mod="1" />
 			<ratings critics="28" speed="61" outcome="0" />
 			<children>
-				<programme id="178fcb7d-b54d-4064-b3c3-4e577f56d2bf" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="178fcb7d-b54d-4064-b3c3-4e577f56d2bf" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Dynamit - Das Magazin - Startfolge</de>
 						<en></en>
 					</title>
 					<ratings critics="42" speed="56" />
 				</programme>
-				<programme id="39bdbcf8-7865-4d95-b874-18031947c36e" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="39bdbcf8-7865-4d95-b874-18031947c36e" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Dynamit - Das Magazin Folge 1</de>
 						<en></en>
 					</title>
 					<ratings critics="42" speed="56" />
 				</programme>
-				<programme id="558991e0-7971-4489-912b-c7ab299c5062" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="558991e0-7971-4489-912b-c7ab299c5062" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Dynamit - Das Magazin Folge 2</de>
 						<en></en>
 					</title>
 					<ratings critics="28" speed="51" />
 				</programme>
-				<programme id="a45a7dd5-af5b-4365-80c5-4cf6d7c441c3" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="a45a7dd5-af5b-4365-80c5-4cf6d7c441c3" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Dynamit - Das Magazin Folge 3</de>
 						<en></en>
 					</title>
 					<ratings critics="70" speed="42" />
 				</programme>
-				<programme id="d8f1c57b-feac-483e-9689-80252d487126" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="d8f1c57b-feac-483e-9689-80252d487126" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Dynamit - Das Magazin Folge 4</de>
 						<en></en>
@@ -7497,7 +7497,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 				</programme>
 			</children>
 		</programme>
-		<programme id="0cefc3bc-f628-4b50-a466-682e7d117a2e" product="7" licence_type="3" fictional="1" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+		<programme id="0cefc3bc-f628-4b50-a466-682e7d117a2e" product="7" licence_type="3" fictional="1" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 			<title>
 				<de>Entstehung des Kosmos</de>
 				<en></en>
@@ -7515,7 +7515,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<releaseTime year_relative="-1" year_relative_min="2006" year_relative_max="2008" />
 			<ratings critics="35" speed="7" outcome="0" />
 			<children>
-				<programme id="c68b6bc1-f0c0-4b36-85e7-d7f32dd86063" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="c68b6bc1-f0c0-4b36-85e7-d7f32dd86063" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Der Urknall</de>
 						<en></en>
@@ -7526,7 +7526,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 					</description>
 					<ratings critics="24" speed="7" />
 				</programme>
-				<programme id="5aed6755-d022-46fd-9ca8-04e8b150bd74" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="5aed6755-d022-46fd-9ca8-04e8b150bd74" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Ferne Galaxien</de>
 						<en></en>
@@ -7537,7 +7537,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 					</description>
 					<ratings critics="29" speed="9" />
 				</programme>
-				<programme id="79687626-d749-4b16-923c-0644fd9c3298" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="79687626-d749-4b16-923c-0644fd9c3298" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Lecker Milch...straße</de>
 						<en></en>
@@ -7548,7 +7548,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 					</description>
 					<ratings critics="35" speed="17" />
 				</programme>
-				<programme id="03f36865-c8d4-46ea-a6bb-edc11ee39fa3" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="03f36865-c8d4-46ea-a6bb-edc11ee39fa3" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Unser Sonnensystem</de>
 						<en></en>
@@ -7559,7 +7559,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 					</description>
 					<ratings critics="28" speed="9" />
 				</programme>
-				<programme id="974003d6-44f3-47a5-b945-450a68d81d64" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="974003d6-44f3-47a5-b945-450a68d81d64" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Der noch blaue Planet</de>
 						<en></en>
@@ -7572,7 +7572,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 				</programme>
 			</children>
 		</programme>
-		<programme id="cf19bea6-f3ae-4ea1-92fb-3bccc8d5c9e3" product="7" licence_type="3" fictional="1" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+		<programme id="cf19bea6-f3ae-4ea1-92fb-3bccc8d5c9e3" product="7" licence_type="3" fictional="1" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 			<title>
 				<de>Hot Quiz</de>
 				<en></en>
@@ -7585,7 +7585,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<data country="D" year="2005" distribution="2" maingenre="8" subgenre="" flags="192" blocks="2" price_mod="0.8" />
 			<ratings critics="5" speed="30" outcome="0" />
 			<children>
-				<programme id="a710207e-6dff-4583-a015-94292f152ba9" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="a710207e-6dff-4583-a015-94292f152ba9" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Daniela</de>
 						<en></en>
@@ -7596,7 +7596,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 					</description>
 					<ratings critics="4" speed="32" />
 				</programme>
-				<programme id="f9579b28-072d-4027-8807-1c45326928d5" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="f9579b28-072d-4027-8807-1c45326928d5" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Sabine</de>
 						<en></en>
@@ -7607,7 +7607,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 					</description>
 					<ratings critics="8" speed="28" />
 				</programme>
-				<programme id="ee67bae0-ba95-4cef-8e0a-4aa03c130264" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
+				<programme id="ee67bae0-ba95-4cef-8e0a-4aa03c130264" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
 						<de>Mandy</de>
 						<en></en>
@@ -7618,7 +7618,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 					</description>
 					<ratings critics="5" speed="23" />
 				</programme>
-				<programme id="4c067d5a-18a9-4646-ab7e-ef240fe18ab0" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="4c067d5a-18a9-4646-ab7e-ef240fe18ab0" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Peggy</de>
 						<en></en>
@@ -7633,7 +7633,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 		</programme>
 
 		<!-- programmes from "therob.xml" -->
-		<programme id="TheRob-mov-dram-NurmitdieserbestimmtenFrau" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0029650" rt_id="8751" creator="TheRob">
+		<programme id="TheRob-mov-dram-NurmitdieserbestimmtenFrau" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0029650" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Diese bestimmte Frau, Drama, Sub Romance -->
 				<de>Nur mit dieser bestimmen Frau</de>
@@ -7650,13 +7650,14 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<staff>
 				<member index="0" function="1">TheRob-TowerTV-EdmundGulden</member>
 				<member index="1" function="2">506bc383-259e-4a36-9278-081aafc8f35c</member>
-				<member index="2" function="2">a80152d6-43dc-4f9c-a562-a5dbf821bc1f</member>                                                                                             			</staff>
+				<member index="2" function="2">a80152d6-43dc-4f9c-a562-a5dbf821bc1f</member>
+			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
 			<data country="USA" year="1937" distribution="1" maingenre="7" subgenre="15" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="69" speed="37" outcome="52" />
 		</programme>
 
-		<programme id="TheRob-mov-dram-JazzeineboeseDame" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0030287" rt_id="8751" creator="TheRob">
+		<programme id="TheRob-mov-dram-JazzeineboeseDame" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0030287" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Jezebel - Die boshafte Lady, Drama, Sub Romance -->
 				<de>Jazz - eine böse Dame</de>
@@ -7673,13 +7674,14 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<staff>
 				<member index="0" function="1">c6431bc0-a0c6-4638-ab30-573066975d0f</member>
 				<member index="1" function="2">b82a17d5-e597-4900-8808-5dd8f195995a</member>
-				<member index="2" function="2">a80152d6-43dc-4f9c-a562-a5dbf821bc1f</member>                                                                                          			</staff>
+				<member index="2" function="2">a80152d6-43dc-4f9c-a562-a5dbf821bc1f</member>
+			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
 			<data country="USA" year="1938" distribution="1" maingenre="7" subgenre="15" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="78" speed="52" outcome="67" />
 		</programme>
 
-		<programme id="TheRob-mov-dram-PfadindieBerge" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0028401" rt_id="8751" creator="TheRob">
+		<programme id="TheRob-mov-dram-PfadindieBerge" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0028401" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Kampf in den Bergen, Drama, Sub Romance -->
 				<de>Pfad in die Berge</de>
@@ -7697,13 +7699,14 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 				<member index="0" function="1">TheRob-TowerTV-HenryHastAway</member>
 				<member index="1" function="2">TheRob-celebritypeople-SilvyMelbourne</member>
 				<member index="2" function="2">a80152d6-43dc-4f9c-a562-a5dbf821bc1f</member>
-				<member index="3" function="2">3288623a-bed4-4c85-8670-47c991164df4</member>                                                                                               			</staff>
+				<member index="3" function="2">3288623a-bed4-4c85-8670-47c991164df4</member>
+			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
 			<data country="USA" year="1936" distribution="1" maingenre="7" subgenre="15" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="58" speed="62" outcome="57" />
 		</programme>
 
-		<programme id="TheRob-mov-dram-TrommelnamFluss" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0031252" rt_id="8751" creator="TheRob">
+		<programme id="TheRob-mov-dram-TrommelnamFluss" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0031252" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Trommeln am Mohawk, Drama, Sub Romance -->
 				<de>Trommeln am Fluß</de>
@@ -7727,7 +7730,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<ratings critics="58" speed="62" outcome="57" />
 		</programme>
 
-		<programme id="TheRob-4497-film-mon-Wiegehtesweiter" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0043949" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-4497-film-mon-Wiegehtesweiter" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0043949" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Quo Vadis -->
 				<de>Wie geht es weiter?</de>
@@ -7752,7 +7755,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<ratings critics="52" speed="47" outcome="41" />
 		</programme>
 
-		<programme id="54084557-4497-48d5-8e3a-TheRobRiesenstadt" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0017136" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="54084557-4497-48d5-8e3a-TheRobRiesenstadt" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0017136" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Metropolis, als Cult geflagt -->
 				<de>Riesenstadt - Long Cut</de>
@@ -7771,14 +7774,14 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 				<member index="1" function="2">TheRob-celebritypeople-WalfredWederSabel</member>
 				<member index="2" function="2">TheRob-celebritypeople-PipernetteSelm</member>
 				<member index="3" function="2">TheRob-celebritypeople-MustafLustig</member>
-				<member index="1" function="2">TheRob-TowerTV-RudolfKleineWeize</member>
+				<member index="4" function="2">TheRob-TowerTV-RudolfKleineWeize</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
 			<data country="D" year="1927" distribution="1" maingenre="13" subgenre="7" flags="8" blocks="5" price_mod="1.00" />
 			<ratings critics="83" speed="23" outcome="62" />
 		</programme>
 
-		<programme id="TheRob-4497-48d5-8e3a-grossemenschen" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0049261" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-4497-48d5-8e3a-grossemenschen" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0049261" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Giganten, Monumental -->
 				<de>Große Menschen</de>
@@ -7804,7 +7807,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<ratings critics="79" speed="32" outcome="69" />
 		</programme>
 
-		<programme id="TheRob-4497-48d5-8e3a-koeniginaegyptens" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0056937" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-4497-48d5-8e3a-koeniginaegyptens" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0056937" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Cleopatra, Monumental -->
 				<de>Die Königin Ägyptens</de>
@@ -7828,7 +7831,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<ratings critics="49" speed="49" outcome="49" />
 		</programme>
 
-		<programme id="04439fd1-e89f-TheRobTestSerie01" product="2" licence_type="3" tmdb_id="0" imdb_id="tt2757036" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="04439fd1-e89f-TheRobTestSerie01" product="2" licence_type="3" tmdb_id="0" imdb_id="tt2757036" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Western von gestern, Orginal Serie wird auf 1975 datiert -->
 				<de>Gestern gab es Western</de>
@@ -7850,7 +7853,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<data country="USA" year="1949" distribution="2" maingenre="18" subgenre="" flags="0" blocks="1" price_mod="1.00" />
 			<ratings critics="40" speed="29" outcome="29" />
 			<children>
-				<programme id="39803483-0800-46e3-a153-TheRobEpisode1" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="39803483-0800-46e3-a153-TheRobEpisode1" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Jerry das Pferd</de>
 						<en>Jerry the horse</en>
@@ -7861,7 +7864,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 					</description>
 					<ratings critics="42" speed="42" />
 				</programme>
-				<programme id="4c062f49-f1e8-400a-9c11-TheRobEpisode2" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="4c062f49-f1e8-400a-9c11-TheRobEpisode2" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Lozzo lernt peitschen</de>
 						<en>Lozzo trains whipping</en>
@@ -7872,7 +7875,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 					</description>
 					<ratings critics="53" speed="39" />
 				</programme>
-				<programme id="dc0b1ca6-c1c1-496f-9882-TheRobEpisode3" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="dc0b1ca6-c1c1-496f-9882-TheRobEpisode3" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Niklas sucht James</de>
 						<en>Niklas looking for James</en>
@@ -7883,7 +7886,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 					</description>
 					<ratings critics="19" speed="25" />
 				</programme>
-				<programme id="fc7b481e-33b5-4113-89b3-TheRobEpisode4" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="fc7b481e-33b5-4113-89b3-TheRobEpisode4" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Njamba der Fotograf</de>
 						<en>Njamba the photograph</en>
@@ -7894,7 +7897,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 					</description>
 					<ratings critics="29" speed="5" />
 				</programme>
-				<programme id="fc7b481e-33b5-4113-89b3-TheRobEpisode5" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="fc7b481e-33b5-4113-89b3-TheRobEpisode5" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Farmer gen Osten</de>
 						<en>Farmers go east</en>
@@ -7905,7 +7908,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 					</description>
 					<ratings critics="32" speed="79" />
 				</programme>
-				<programme id="fc7b481e-33b5-4113-89b3-TheRobEpisode6" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="fc7b481e-33b5-4113-89b3-TheRobEpisode6" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Mensch Jimmy</de>
 						<en>Well, Jimmy</en>
@@ -7916,7 +7919,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 					</description>
 					<ratings critics="19" speed="55" />
 				</programme>
-				<programme id="fc7b481e-33b5-4113-89b3-TheRobEpisode7" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="fc7b481e-33b5-4113-89b3-TheRobEpisode7" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>IIIk, wird das Wononza?</de>
 						<en>OMG, will this end in Wononza?</en>
@@ -7930,7 +7933,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			</children>
 		</programme>
 
-		<programme id="TheRob-a9f6-thr-NichtinderNacht" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0051588" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a9f6-thr-NichtinderNacht" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0051588" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Es geschah am helllichten Tage -->
 				<de>Es passierte nicht in der Nacht</de>
@@ -7955,7 +7958,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 		</programme>
 
 
-		<programme id="TheRob-a4d6-4cf2-b022-ZyanidundSpitzenhoeschen" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0036613" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-4cf2-b022-ZyanidundSpitzenhoeschen" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0036613" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Arsen und Spitzenhäubchen -->
 				<de>Zyanid und Spitzenhöschen</de>
@@ -7979,7 +7982,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<ratings critics="77" speed="68" outcome="71" />
 		</programme>
 
-		<programme id="TheRob-mov-dok-b022-HinterderfeindlichenLinie" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0274560" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-mov-dok-b022-HinterderfeindlichenLinie" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0274560" creator="8751" created_by="TheRob">
 			<title>
 				<!-- How to Operate Behind Enemy Lines, Doku -->
 				<de>Hinter der feindlichen Linie</de>
@@ -8003,7 +8006,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<ratings critics="37" speed="23" outcome="0" />
 		</programme>
 
-		<programme id="TheRob-mov-4cf2-dok-StufedieIndustriekraftein" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0274519" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-mov-4cf2-dok-StufedieIndustriekraftein" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0274519" creator="8751" created_by="TheRob">
 			<title>
 				<!-- German Industrial Manpower, Doku -->
 				<de>Stufe die Industriekraft ein</de>
@@ -8025,7 +8028,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<ratings critics="21" speed="12" outcome="0" />
 		</programme>
 
-		<programme id="TheRob-b0db-439c-a852-Wosselnaht" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0059372" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-439c-a852-Wosselnaht" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0059372" creator="8751" created_by="TheRob">
 			<!-- König Drosselbart, Zielgruppe Kinder -->
 			<title>
 				<de>Prinz Wosselnaht</de>
@@ -8048,7 +8051,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<ratings critics="63" speed="47" outcome="36" />
 		</programme>
 
-		<programme id="TheRob-b0db-439c-a852-RaucherladenBrooklin" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0114478" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-439c-a852-RaucherladenBrooklin" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0114478" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Smoke. Laut IMDB Comedy, Drama. Ich habe den Film gesehen und würde ihn niccht als Komödie bezeichnen. Als Drama auch nicht. Die Kategorie Sonstiges passt hier -->
 				<de>Raucherladen Brooklyn</de>
@@ -8072,7 +8075,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<ratings critics="79" speed="57" outcome="18" />
 		</programme>
 
-		<programme id="TheRob-b0db-439c-a852-RauchinBrooklin" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0112541" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-439c-a852-RauchinBrooklin" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0112541" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Blue in the Face. Laut IMDB Comedy. Ich habe den Film gesehen und würde ihn nicht als Komödie bezeichnen. Die Kategorie Sonstiges passt hier -->
 				<de>Rauch in Brooklyn</de>
@@ -8097,7 +8100,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<!-- Erscheinungsjahr in Deutschland war 1996. 95 ist in der USA gewesen. -->
 		</programme>
 
-		<programme id="TheRob-400d-8f9c-curlyhorror" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0073629" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-400d-8f9c-curlyhorror" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0073629" creator="8751" created_by="TheRob">
 			<!-- Rocky Horror Picture Show -->
 			<title>
 				<de>Die Locken Horror Show</de>
@@ -8122,7 +8125,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<ratings critics="52" speed="69" outcome="87" />
 		</programme>
 
-		<programme id="TheRob-400d-8f9c-blaueausdemhimmel" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0020697" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-400d-8f9c-blaueausdemhimmel" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0020697" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Der blaue Engel -->
 				<de>Die Blaue aus dem Himmel</de>
@@ -8145,7 +8148,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<ratings critics="59" speed="39" outcome="67" />
 		</programme>
 
-		<programme id="TheRob-916a-47bf-FeindNachbar" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0089092" rt_id="0" creator="">
+		<programme id="TheRob-916a-47bf-FeindNachbar" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0089092" creator="">
 			<title>
 				<!-- Enemy Mine - Geliebter Feind -->
 				<de>Feind - Mein böser Nachbar</de>
@@ -8170,7 +8173,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 		</programme>
 
 
-		<programme id="TheRob-1756-400d-8f9c-BlauBembelsche" product="1" licence_type="1" tmdb_id="0" imdb_id="tt1086209" rt_id="0" creator="">
+		<programme id="TheRob-1756-400d-8f9c-BlauBembelsche" product="1" licence_type="1" tmdb_id="0" imdb_id="tt1086209" creator="">
 			<title>
   				<!-- Blauer Bock, imdb ID ist die aus Idstein. Bei IMDB sind alle Folgen einzeln gelistet. -->
 				<de>Blau Bembelsche - Best of</de>
@@ -8194,7 +8197,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<ratings critics="52" speed="69" outcome="0" />
 		</programme>
 
-		<programme id="TheRob-35e9-4e56-8e6e-DerBraveOsten" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0056085" rt_id="0" creator="">
+		<programme id="TheRob-35e9-4e56-8e6e-DerBraveOsten" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0056085" creator="">
 			<title>
 				<!-- Das war der wilde Westen -->
 				<de>Der brave Osten</de>
@@ -8220,7 +8223,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<ratings critics="87" speed="66" outcome="75" />
 		</programme>
 
-		<programme id="5c4c567b-dda6-4d7e-b90a-RobTheTest11" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0032551" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="5c4c567b-dda6-4d7e-b90a-RobTheTest11" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0032551" creator="8751" created_by="TheRob">
 			<title>
   				<!-- Früchte des Zorns -->
 				<de>Zorniges Obst</de>
@@ -8245,7 +8248,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<ratings critics="98" speed="19" outcome="69" />
 		</programme>
 
-		<programme id="TheRob-dda6-4d7e-b90a-greasybiker" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0064276" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-dda6-4d7e-b90a-greasybiker" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0064276" creator="8751" created_by="TheRob">
 			<title>
   				<!-- Easy Rider, Kinokasse ist so hoch, da der Film laut IMDB beu 400k Budget über 40 Mio eingespielt hat, wegen Budget als B-Movie geflagt und noch Kult dazu -->
 				<de>Greasy Biker</de>
@@ -8269,7 +8272,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<ratings critics="68" speed="51" outcome="92" />
 		</programme>
 
-		<programme id="TheRob-dda6-4d7e-b90a-Nachtvogel" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0056592" rt_id="0" creator="">
+		<programme id="TheRob-dda6-4d7e-b90a-Nachtvogel" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0056592" creator="">
 			<title>
 				<!-- Wer die Nachtigall stoert -->
 				<de>Töte nicht die Spottdrossel</de>
@@ -8292,7 +8295,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<ratings critics="96" speed="29" outcome="69" />
 		</programme>
 
-		<programme id="TheRob-b9c6190d-a9f6-4a94-8092-chasingL" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0022100" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b9c6190d-a9f6-4a94-8092-chasingL" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0022100" creator="8751" created_by="TheRob">
 			<title>
   				<!-- M Eine Stadt sucht einen Mörder -->
 				<de>Ein Dorf jagt L.</de>
@@ -8317,7 +8320,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<ratings critics="74" speed="26" outcome="83" />
 		</programme>
 
-		<programme id="TheRob-a9f6-4a94-8092-unperfektesLand" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0107808" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a9f6-4a94-8092-unperfektesLand" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0107808" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Perfect World -->
 				<de>Unperfektes Land</de>
@@ -8341,7 +8344,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<ratings critics="71" speed="46" outcome="63" />
 		</programme>
 
-		<programme id="therob-programme-speiuebelunddubrovnik" product="2" licence_type="3" tmdb_id="series_258516" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="therob-programme-speiuebelunddubrovnik" product="2" licence_type="3" tmdb_id="series_258516" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Spejbl und Hurvinek keine IMDB ID gefunden -->
 				<de>Speiübel und Dubrovnik</de>
@@ -8361,7 +8364,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<data country="CSSR" year="1973" distribution="2" maingenre="9" subgenre="5" flags="2" blocks="1" price_mod="1.00" />
 			<ratings critics="47" speed="29" outcome="0" />
 			<children>
-				<programme id="therob-programme-speiuebelunddubrovnik-ep201" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="therob-programme-speiuebelunddubrovnik-ep201" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Speiübel kommt in die Schule</de>
 						<en>Spyble goes to school</en>
@@ -8372,7 +8375,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 					</description>
 					<ratings critics="43" speed="26" />
 				</programme>
-				<programme id="therob-programme-speiuebelunddubrovnik-ep202" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="therob-programme-speiuebelunddubrovnik-ep202" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Hausaufgaben</de>
 						<en>Homework</en>
@@ -8383,7 +8386,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 					</description>
 					<ratings critics="49" speed="31" />
 				</programme>
-				<programme id="therob-programme-speiuebelunddubrovnik-ep203" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="therob-programme-speiuebelunddubrovnik-ep203" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Musikunterricht</de>
 						<en>The music lesson</en>
@@ -8394,7 +8397,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 					</description>
 					<ratings critics="56" speed="28" />
 				</programme>
-				<programme id="therob-programme-speiuebelunddubrovnik-ep204" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-speiuebelunddubrovnik-ep204" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Speiübel lernt schwimmen</de>
 						<en>Spyble learns to swim</en>
@@ -8405,7 +8408,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 					</description>
 					<ratings critics="44" speed="32" />
 				</programme>
-				<programme id="therob-programme-speiuebelunddubrovnik-ep205" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-speiuebelunddubrovnik-ep205" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Plätzchen backen</de>
 						<en>Baking cookies</en>
@@ -8419,7 +8422,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			</children>
 		</programme>
 
-		<programme id="TheRob-b5dc-4663-bd81-JayEfKay" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0102138" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b5dc-4663-bd81-JayEfKay" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0102138" creator="8751" created_by="TheRob">
 			<title>
 				<!-- JFK - Tatort Dallas, laut Liste schon im Spiel, aber nicht in der Database gefunden -->
 				<de>Jay Ef Kay - Es geschah in Dallas</de>
@@ -8444,7 +8447,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<ratings critics="73" speed="51" outcome="51" />
 		</programme>
 
-		<programme id="TheRob-b0db-439c-a852-ZugnachPeking" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0023458" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-439c-a852-ZugnachPeking" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0023458" creator="8751" created_by="TheRob">
 			<title>
 	  			<!--Shanghai Express -->
 				<de>Zug nach Peking</de>
@@ -8467,7 +8470,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<ratings critics="57" speed="34" outcome="56" />
 		</programme>
 
-		<programme id="TheRob-b0db-439c-a852-LodinRoot" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0102798" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-439c-a852-LodinRoot" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0102798" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Robin Hood - König der Diebe -->
 				<de>Lodin Root</de>
@@ -8492,7 +8495,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<ratings critics="53" speed="47" outcome="71" />
 		</programme>
 
-		<programme id="TheRob-dda6-4d7e-b90a-DasLebenistschoen" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0038650" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-dda6-4d7e-b90a-DasLebenistschoen" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0038650" creator="8751" created_by="TheRob">
 			<title>
   				<!-- Ist das Leben nicht schön? -->
 				<de>Das Leben ist schön</de>
@@ -8516,7 +8519,7 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 			<ratings critics="91" speed="49" outcome="39" />
 		</programme>
 
-		<programme id="5c4c567b-dda6-4d7e-b90a-geballteHand" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0163624" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="5c4c567b-dda6-4d7e-b90a-geballteHand" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0163624" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Faust -->
 				<de>Geballte Hand</de>
@@ -8541,7 +8544,7 @@ Die legendäre Verfilmung des deutschen Literaturklassikers mit [1|Full] und [2|
 			<ratings critics="99" speed="12" outcome="55" />
 		</programme>
 
-		<programme id="TheRob-dda6-4d7e-b90a-derhundaufdempappdach" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0051459" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-dda6-4d7e-b90a-derhundaufdempappdach" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0051459" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Die Katze auf dem heißen Blechdach -->
 				<de>Der Hund auf dem Pappdach</de>
@@ -8565,7 +8568,7 @@ Die legendäre Verfilmung des deutschen Literaturklassikers mit [1|Full] und [2|
 			<ratings critics="74" speed="42" outcome="51" />
 		</programme>
 
-		<programme id="TheRob-916a-47bf-9e2e-PlanetRoin" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0052077" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-916a-47bf-9e2e-PlanetRoin" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0052077" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Planet Nine - From Outer Space, geflagt als Trash, BMovie und Cult -->
 				<de>Planet Roin - Louder Space</de>
@@ -8589,7 +8592,7 @@ Die legendäre Verfilmung des deutschen Literaturklassikers mit [1|Full] und [2|
 			<ratings critics="8" speed="22" outcome="12" />
 		</programme>
 
-		<programme id="TheRob-b0db-myst-DieFaecherderPizza" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0048728" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-myst-DieFaecherderPizza" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0048728" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Über den Dächern von Nizza,  Mysterie mit Subgenre Romance aus IMDB übernommen -->
 				<de>Über die Fächer der Pizza</de>
@@ -8613,7 +8616,7 @@ Die legendäre Verfilmung des deutschen Literaturklassikers mit [1|Full] und [2|
 			<ratings critics="69" speed="48" outcome="51" />
 		</programme>
 
-		<programme id="TheRob-b0db-myst-DashaesslicheEntlein" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0049815" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-myst-DashaesslicheEntlein" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0049815" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Der Schwan,  Romance mit Subgenre Comedy aus IMDB übernommen -->
 				<de>Das häßliche Entlein</de>
@@ -8637,7 +8640,7 @@ Die legendäre Verfilmung des deutschen Literaturklassikers mit [1|Full] und [2|
 			<ratings critics="62" speed="28" outcome="41" />
 		</programme>
 
-		<programme id="TheRob-b0db-thr-NutzdasTelefon" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0046912" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-thr-NutzdasTelefon" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0046912" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Bei Anruf Mord, Krimi -->
 				<de>Nutze das Telefon</de>
@@ -8661,7 +8664,7 @@ Die legendäre Verfilmung des deutschen Literaturklassikers mit [1|Full] und [2|
 			<ratings critics="86" speed="63" outcome="51" />
 		</programme>
 
-		<programme id="TheRob-b0db-thr-MeinZwilling" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0053247" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-thr-MeinZwilling" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0053247" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Der Sündenbock, Krimi -->
 				<de>Mein Zwilling</de>
@@ -8685,7 +8688,7 @@ Die legendäre Verfilmung des deutschen Literaturklassikers mit [1|Full] und [2|
 			<ratings critics="66" speed="33" outcome="41" />
 		</programme>
 
-		<programme id="TheRob-b0db-adv-LaurenceausderWueste" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0056172" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-adv-LaurenceausderWueste" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0056172" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Lawrence von Arabien, Abenteuer -->
 				<de>Laurence aus der Wüste</de>
@@ -8704,14 +8707,14 @@ Die legendäre Verfilmung des deutschen Literaturklassikers mit [1|Full] und [2|
 				<member index="1" function="2">TheRob-TowerTV-PetrORuler</member>
 				<member index="2" function="2">becc2ecd-d309-46a1-b9c2-30253915af0c</member>
 				<member index="3" function="2">5e971716-fbd8-403f-a0df-9aae68c04d85</member>
-				<member index="2" function="2">TheRob-TowerTV-ArchieRemedy</member>
+				<member index="4" function="2">TheRob-TowerTV-ArchieRemedy</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
 			<data country="UK" year="1962" distribution="1" maingenre="1" subgenre="" flags="0" blocks="4" price_mod="1.00" />
 			<ratings critics="86" speed="53" outcome="53" />
 		</programme>
 
-		<programme id="TheRob-b0db-hist-AllRitt" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0054847" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-hist-AllRitt" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0054847" creator="8751" created_by="TheRob">
 			<title>
 				<!-- El Cid, Historisch -->
 				<de>All Ritt</de>
@@ -8735,7 +8738,7 @@ Die legendäre Verfilmung des deutschen Literaturklassikers mit [1|Full] und [2|
 			<ratings critics="59" speed="58" outcome="53" />
 		</programme>
 
-		<programme id="TheRob-b0db-hist-MarcusAureliusundCommundus" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0058085" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-hist-MarcusAureliusundCommundus" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0058085" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Der Untergang der römischen Reiches, Historisch -->
 				<de>Marcus Aurelius und Commundus</de>
@@ -8760,7 +8763,7 @@ Die legendäre Verfilmung des deutschen Literaturklassikers mit [1|Full] und [2|
 			<ratings critics="36" speed="49" outcome="33" />
 		</programme>
 
-		<programme id="TheRob-b0db-love-FamilieaufdemBoot" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0051745" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-love-FamilieaufdemBoot" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0051745" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Hausboot, Rommance, subgenre Comedy -->
 				<de>Familie auf dem Boot</de>
@@ -8784,7 +8787,7 @@ Die legendäre Verfilmung des deutschen Literaturklassikers mit [1|Full] und [2|
 			<ratings critics="31" speed="51" outcome="32" />
 		</programme>
 
-		<programme id="TheRob-b0db-love-TheaterundKritiken" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0054188" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-love-TheaterundKritiken" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0054188" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Meisterschaft im Seitensprung, Genre Comedy, subgenre romance -->
 				<de>Theater und Kritiken</de>
@@ -8808,7 +8811,7 @@ Die legendäre Verfilmung des deutschen Literaturklassikers mit [1|Full] und [2|
 			<ratings critics="26" speed="49" outcome="38" />
 		</programme>
 
-		<programme id="therob-programme-famser-AlsoPapa" product="2" licence_type="3" tmdb_id="0" imdb_id="tt0070964" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+		<programme id="therob-programme-famser-AlsoPapa" product="2" licence_type="3" tmdb_id="0" imdb_id="tt0070964" creator="8751/7430" created_by="Sjaele/TheRob">
 			<title>
 				<!-- Aber Vati von Gast2 umgesetzt. Familie und Kult -->
 				<de>Also Papa</de>
@@ -8826,14 +8829,14 @@ Dreh- und Angelpunkt sind die Versuche, Vati Neu zu verheiraten.</de>
 			<staff>
 				<member index="0" function="1">TheRob-TowerTV-PaulBentris</member>
 				<member index="1" function="2">TheRob-TowerTV-AlvinTWein</member>
-				<member index="1" function="2">TheRob-TowerTV-RolleWenke</member>
-				<member index="1" function="2">TheRob-TowerTV-RalleWenke</member>
+				<member index="2" function="2">TheRob-TowerTV-RolleWenke</member>
+				<member index="3" function="2">TheRob-TowerTV-RalleWenke</member>
 			</staff>
 			<groups target_groups="1" pro_pressure_groups="0" contra_pressure_groups="0" />
 			<data country="DDR" year="1979" distribution="2" maingenre="9" subgenre="5" flags="8" blocks="2" price_mod="1.00" />
 			<ratings critics="77" speed="35" outcome="40" />
 			<children>
-				<programme id="therob-programme-famser-AlsoPapa-ep101" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+				<programme id="therob-programme-famser-AlsoPapa-ep101" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751/7430" created_by="Sjaele/TheRob">
 					<title>
 						<de>Vati will nicht heiraten</de>
 						<en>Dad does not want to marry</en>
@@ -8846,7 +8849,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					<data country="DDR" year="1974" price_mod="1.00" />
 					<ratings critics="79" speed="36" />
 				</programme>
-				<programme id="therob-programme-famser-AlsoPapa-ep102" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+				<programme id="therob-programme-famser-AlsoPapa-ep102" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751/7430" created_by="Sjaele/TheRob">
 					<title>
 						<de>Vati will heiraten</de>
 						<en>Dad wants to marry</en>
@@ -8858,7 +8861,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					<data country="DDR" year="1974" />
 					<ratings critics="77" speed="36" />
 				</programme>
-				<programme id="therob-programme-famser-AlsoPapa-ep103" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+				<programme id="therob-programme-famser-AlsoPapa-ep103" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751/7430" created_by="Sjaele/TheRob">
 					<title>
 						<de>Vati hat geheiratet</de>
 						<en>Dad has married</en>
@@ -8870,7 +8873,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					<data country="DDR" year="1974" />
 					<ratings critics="77" speed="38" />
 				</programme>
-				<programme id="therob-programme-famser-AlsoPapa-ep104" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+				<programme id="therob-programme-famser-AlsoPapa-ep104" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751/7430" created_by="Sjaele/TheRob">
 					<title>
 						<de>5 Jahre danach</de>
 						<en>5 years later</en>
@@ -8884,7 +8887,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 			</children>
 		</programme>
 
-		<programme id="therob-programme-KaltkabelindieZukunft" product="2" fictional="1" licence_type="3" tmdb_id="tv_62451" imdb_id="" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+		<programme id="therob-programme-KaltkabelindieZukunft" product="2" fictional="1" licence_type="3" tmdb_id="tv_62451" imdb_id="" creator="8751/7430" created_by="Sjaele/TheRob">
 			<title>
 				<!-- Kinderserie, Heißer Draht ins Jenseits, keine IMDB ID, von Gast2 -->
 				<de>Kaltkabel in die Zukunft</de>
@@ -8905,7 +8908,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 			<data country="HUN" year="1969" distribution="2" maingenre="3" subgenre="" flags="0" blocks="1" price_mod="1.00" />
 			<ratings critics="27" speed="36" outcome="0" />
 			<children>
-				<programme id="therob-programme-KaltkabelindieZukunft-ep201" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+				<programme id="therob-programme-KaltkabelindieZukunft-ep201" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751/7430" created_by="Sjaele/TheRob">
 					<title>
 						<de>3D voll echt</de>
 						<en>3D completely real</en>
@@ -8916,7 +8919,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					</description>
 					<ratings critics="28" speed="35" />
 				</programme>
-				<programme id="therob-programme-KaltkabelindieZukunft-ep202" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+				<programme id="therob-programme-KaltkabelindieZukunft-ep202" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751/7430" created_by="Sjaele/TheRob">
 					<title>
 						<de>Fischersatz</de>
 						<en>Fish substitute</en>
@@ -8927,7 +8930,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					</description>
 					<ratings critics="26" speed="37" />
 				</programme>
-				<programme id="therob-programme-KaltkabelindieZukunft-ep203" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+				<programme id="therob-programme-KaltkabelindieZukunft-ep203" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751/7430" created_by="Sjaele/TheRob">
 					<title>
 						<de>Sauschnell zur Fete</de>
 						<en>Very fast to the party</en>
@@ -8938,7 +8941,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					</description>
 					<ratings critics="27" speed="36" />
 				</programme>
-				<programme id="therob-programme-KaltkabelindieZukunft-ep204" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+				<programme id="therob-programme-KaltkabelindieZukunft-ep204" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751/7430" created_by="Sjaele/TheRob">
 					<title>
 						<de>Wettermacher</de>
 						<en>The weather generator</en>
@@ -8949,7 +8952,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					</description>
 					<ratings critics="27" speed="39" />
 				</programme>
-				<programme id="therob-programme-KaltkabelindieZukunft-ep205" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+				<programme id="therob-programme-KaltkabelindieZukunft-ep205" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751/7430" created_by="Sjaele/TheRob">
 					<title>
 						<de>Hilfe, Androiden</de>
 						<en></en>
@@ -8960,7 +8963,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					</description>
 					<ratings critics="30" speed="33" />
 				</programme>
-				<programme id="therob-programme-KaltkabelindieZukunft-ep206" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+				<programme id="therob-programme-KaltkabelindieZukunft-ep206" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751/7430" created_by="Sjaele/TheRob">
 					<title>
 						<de>Planetenurlaub</de>
 						<en>Hollidays on an other planet</en>
@@ -8971,7 +8974,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					</description>
 					<ratings critics="25" speed="38" />
 				</programme>
-				<programme id="therob-programme-KaltkabelindieZukunft-ep207" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+				<programme id="therob-programme-KaltkabelindieZukunft-ep207" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751/7430" created_by="Sjaele/TheRob">
 					<title>
 						<de>Doof und glücklich</de>
 						<en>Stupid but happy</en>
@@ -8982,7 +8985,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					</description>
 					<ratings critics="27" speed="36" />
 				</programme>
-				<programme id="therob-programme-KaltkabelindieZukunft-ep208" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+				<programme id="therob-programme-KaltkabelindieZukunft-ep208" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751/7430" created_by="Sjaele/TheRob">
 					<title>
 						<de>Zeitreise</de>
 						<en>Timemachine</en>
@@ -8993,7 +8996,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					</description>
 					<ratings critics="26" speed="35" />
 				</programme>
-				<programme id="therob-programme-KaltkabelindieZukunft-ep209" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+				<programme id="therob-programme-KaltkabelindieZukunft-ep209" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751/7430" created_by="Sjaele/TheRob">
 					<title>
 						<de>Der Manipulator</de>
 						<en>The manipulator</en>
@@ -9004,7 +9007,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					</description>
 					<ratings critics="28" speed="34" />
 				</programme>
-				<programme id="therob-programme-KaltkabelindieZukunft-ep210" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+				<programme id="therob-programme-KaltkabelindieZukunft-ep210" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751/7430" created_by="Sjaele/TheRob">
 					<title>
 						<de>Treibhauslegende</de>
 						<en>Green house legend</en>
@@ -9015,7 +9018,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					</description>
 					<ratings critics="21" speed="42" />
 				</programme>
-				<programme id="therob-programme-KaltkabelindieZukunft-ep211" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+				<programme id="therob-programme-KaltkabelindieZukunft-ep211" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751/7430" created_by="Sjaele/TheRob">
 					<title>
 						<de>Die Tarnkappenpille</de>
 						<en>The invisibility pill</en>
@@ -9026,7 +9029,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					</description>
 					<ratings critics="26" speed="34" />
 				</programme>
-				<programme id="therob-programme-KaltkabelindieZukunft-ep212" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+				<programme id="therob-programme-KaltkabelindieZukunft-ep212" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751/7430" created_by="Sjaele/TheRob">
 					<title>
 						<de>Rhythmus der Kuh</de>
 						<en>The cow rythm</en>
@@ -9037,7 +9040,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					</description>
 					<ratings critics="28" speed="30" />
 				</programme>
-				<programme id="therob-programme-KaltkabelindieZukunft-ep213" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+				<programme id="therob-programme-KaltkabelindieZukunft-ep213" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751/7430" created_by="Sjaele/TheRob">
 					<title>
 						<de>Das Traumhaus</de>
 						<en>The perfect house</en>
@@ -9051,7 +9054,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 			</children>
 		</programme>
 
-		<programme id="TheRob-b0db-dok-ZugnachBombay" product="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="tt0320653" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-dok-ZugnachBombay" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0320653" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Train arriving at bombay station Dokumantation -->
 				<de>Zug nach Bombay</de>
@@ -9070,7 +9073,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 			<ratings critics="81" speed="2" outcome="5" />
 		</programme>
 
-		<programme id="TheRob-serie-dok-WunderderMeere" product="4" licence_type="3" tmdb_id="0" imdb_id="tt0192937" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-dok-WunderderMeere" product="4" licence_type="3" tmdb_id="0" imdb_id="tt0192937" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Geheimnisse des Meeres , Dokumention mit Subgenre Familie -->
 				<de>Wunder der Meere</de>
@@ -9093,7 +9096,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 			<data country="F" year="1975" distribution="2" maingenre="6" subgenre="9" flags="0" blocks="1" price_mod="1.00" />
 			<ratings critics="75" speed="50" outcome="" />
 			<children>
-				<programme id="TheRob-serie-WunderderMeere-Ep001" product="4"  licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-WunderderMeere-Ep001" product="4"  licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Die Haie</de>
 						<en>The sharks</en>
@@ -9104,7 +9107,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					</description>
 					<ratings critics="73" speed="53" />
 				</programme>
-				<programme id="TheRob-serie-WunderderMeere-Ep002" product="4" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="7430" created_by="TheRob">
+				<programme id="TheRob-serie-WunderderMeere-Ep002" product="4" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="7430" created_by="TheRob">
 					<title>
 						<de>Die Wale</de>
 						<en>The whales</en>
@@ -9115,7 +9118,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					</description>
 					<ratings critics="77" speed="48" />
 				</programme>
-				<programme id="TheRob-serie-WunderderMeere-Ep003" product="4" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-WunderderMeere-Ep003" product="4" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>In der Tiefe</de>
 						<en>In the deep</en>
@@ -9126,7 +9129,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					</description>
 					<ratings critics="77" speed="49" />
 				</programme>
-				<programme id="TheRob-serie-WunderderMeere-Ep004" product="4" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-WunderderMeere-Ep004" product="4" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Die Seevögel</de>
 						<en>The sea birds</en>
@@ -9137,7 +9140,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					</description>
 					<ratings critics="67" speed="40" />
 				 </programme>
-				<programme id="TheRob-serie-WunderderMeere-Ep005" product="4" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-WunderderMeere-Ep005" product="4" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Schätze der See</de>
 						<en>Treasure of the ocean</en>
@@ -9151,7 +9154,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 			</children>
 		</programme>
 
-		<programme id="TheRob-serie-crime-Sensemannhechelt" product="2" licence_type="3" tmdb_id="0" imdb_id="tt0061305" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-crime-Sensemannhechelt" product="2" licence_type="3" tmdb_id="0" imdb_id="tt0061305" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Der Tod läuft hinterher -->
 				<de>Der Sensenmann hechelt hinterher</de>
@@ -9174,7 +9177,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 			<data country="D" year="1967" distribution="2" maingenre="4" subgenre="" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="76" speed="58" outcome="" />
 			<children>
-				<programme id="TheRob-serie-Sensemannhechelt-Ep001" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-Sensemannhechelt-Ep001" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Eddie kommt zurück</de>
 						<en>Eddie returns</en>
@@ -9185,7 +9188,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					</description>
 					<ratings critics="77" speed="58" />
 				</programme>
-				<programme id="TheRob-serie-Sensemannhechelt-Ep002" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-Sensemannhechelt-Ep002" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Unschuldig oder nicht?</de>
 						<en>Guilty or not?</en>
@@ -9196,7 +9199,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					</description>
 					<ratings critics="76" speed="58" />
 				</programme>
-				<programme id="TheRob-serie-Sensemannhechelt-Ep003" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-Sensemannhechelt-Ep003" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Eddie im Schlusspurt</de>
 						<en>Eddie on the final lane</en>
@@ -9210,7 +9213,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 			</children>
 		</programme>
 
-		<programme id="TheRob-serie-Moumental-FuchsunterFuechsen" product="2" licence_type="3" tmdb_id="0" imdb_id="tt0057800" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-Moumental-FuchsunterFuechsen" product="2" licence_type="3" tmdb_id="0" imdb_id="tt0057800" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Wolf unter Wölfen, Monumental -->
 				<de>Fuchs unter Füchsen</de>
@@ -9232,7 +9235,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 			<data country="DDR" year="1964" distribution="2" maingenre="13" subgenre="" flags="8" blocks="2" price_mod="1.00" />
 			<ratings critics="67" speed="54" outcome="" />
 			<children>
-				<programme id="TheRob-serie-FuchsunterFuechsen-Ep001" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-FuchsunterFuechsen-Ep001" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Das Dorf und seine Rastlosen</de>
 						<en>The village and the restless within</en>
@@ -9243,7 +9246,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					</description>
 					<ratings critics="67" speed="53" />
 				</programme>
-				<programme id="TheRob-serie-FuchsunterFuechsen-Ep002" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-FuchsunterFuechsen-Ep002" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Feuchtes Land</de>
 						<en>Moist land</en>
@@ -9254,7 +9257,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					</description>
 					<ratings critics="62" speed="57" />
 				</programme>
-				<programme id="TheRob-serie-FuchsunterFuechsen-Ep003" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-FuchsunterFuechsen-Ep003" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Des Teufels Jäger nahe</de>
 						<en>The hunters of the devil are coming closer</en>
@@ -9265,7 +9268,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 					</description>
 					<ratings critics="69" speed="56" />
 				</programme>
-				<programme id="TheRob-serie-FuchsunterFuechsen-Ep004" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-FuchsunterFuechsen-Ep004" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Der Kreis schließt sich</de>
 						<en>The circle is getting closed</en>
@@ -9280,7 +9283,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 			</children>
 		</programme>
 
-		<programme id="TheRob-b5dc-4663-bd81-LetzterTanzinParis" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0070849" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b5dc-4663-bd81-LetzterTanzinParis" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0070849" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Der letzte Tango in Paris, Erotik Sub Romance  -->
 				<de>Letzter Tanz in Paris</de>
@@ -9304,7 +9307,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 			<ratings critics="63" speed="61" outcome="71" />
 		</programme>
 
-		<programme id="TheRob-b5dc-4663-bd81-Tigergekuesst" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0029947" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b5dc-4663-bd81-Tigergekuesst" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0029947" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Leoparden küsst man nicht, Comedy mit Subgenre Romance -->
 				<de>Tiger geküsst?</de>
@@ -9328,7 +9331,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 			<ratings critics="73" speed="81" outcome="47" />
 		</programme>
 
-		<programme id="TheRob-b5dc-4663-bd81-NachtvorderHochzeit" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0032904" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b5dc-4663-bd81-NachtvorderHochzeit" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0032904" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Die Nacht vor der Hochzeit, Romance mit Subgenre Comedy -->
 				<de>Hochzeitsnacht in Philadelphia</de>
@@ -9353,7 +9356,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 			<ratings critics="73" speed="71" outcome="67" />
 		</programme>
 
-		<programme id="TheRob-b5dc-4663-bd81-FantRicky" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0095174" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b5dc-4663-bd81-FantRicky" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0095174" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Frantic, Krimi -->
 				<de>Fant Ricky</de>
@@ -9371,14 +9374,14 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 				<member index="0" function="1">ccf79c86-dd25-49bc-91fa-536de8e4267b</member>
 				<member index="1" function="2">070bd0dd-1a11-4b2b-80b7-922dae98c3ca</member>
 				<member index="2" function="2">TheRob-TowerTV-BethBurgley</member>
-				<member index="2" function="2">00dad245-0097-4bae-84bd-d4ae6d5a1172</member>
+				<member index="3" function="2">00dad245-0097-4bae-84bd-d4ae6d5a1172</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
 			<data country="USA" year="1988" distribution="1" maingenre="4" subgenre="17" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="63" speed="41" outcome="47" />
 		</programme>
 
-		<programme id="TheRob-serie-Horror-DasVerborgene" product="2" licence_type="3" tmdb_id="0" imdb_id="tt0255763" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-Horror-DasVerborgene" product="2" licence_type="3" tmdb_id="0" imdb_id="tt0255763" creator="8751" created_by="TheRob">
 			<title>
 				<!-- The Veil, Horror, Sub Mystery Test: Konstante Wertung. -->
 				<de>Das Verborgene</de>
@@ -9400,7 +9403,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 			<data country="USA" year="1958" distribution="2" maingenre="12" subgenre="14" flags="8" blocks="1" price_mod="1.00" />
 			<ratings critics="76" speed="54" outcome="40" />
 			<children>
-				<programme id="TheRob-serie-DasVerborgene-Ep001" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DasVerborgene-Ep001" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Visionen</de>
 						<en>Visions</en>
@@ -9410,7 +9413,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 						<en>In Paris a man has the vision, that his brother is murdered. As he returns home, he discovers that it is true. What happened?</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-DasVerborgenen-Ep002" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DasVerborgenen-Ep002" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Anhalter</de>
 						<en>Hitchhiker</en>
@@ -9420,7 +9423,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 						<en>A man takes a female hitchhiker to the next village. In the bar a name is mentioned, she gets nuts and flees. Nobody wants to say why. Why not?</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-DasVerborgene-Ep003" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DasVerborgene-Ep003" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Essen ist fertig</de>
 						<en>The meal is ready</en>
@@ -9430,7 +9433,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 						<en>A husband rescues the live of his wife after she is bitten by a snake. But then he is told that the his truely beloved is a widower.</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-DasVerborgene-Ep004" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DasVerborgene-Ep004" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>What is up, Doc</de>
 						<en>What is up, Doc</en>
@@ -9440,7 +9443,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 						<en>Up, up and away to Italy. A young doctor wants to take his father, who is also a doctor, with him home to America. But the village wont let the real doctor leave.</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-DasVerborgene-Ep005" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DasVerborgene-Ep005" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Schaue tief</de>
 						<en>Look into depth</en>
@@ -9450,7 +9453,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 						<en>A young lady gives her ex-lover a gift. A crstal ball. Now he can see how she is cheating on her husband.</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-DasVerborgene-Ep006" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DasVerborgene-Ep006" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Letzter Wille</de>
 						<en>Last will</en>
@@ -9460,7 +9463,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 						<en>Two brothers are quarreling about the last will of their father. Well, time for the father to stop this dispute. Leaving his grave?</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-DasVerborgene-Ep007" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DasVerborgene-Ep007" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Alpträume</de>
 						<en>Nightmares</en>
@@ -9470,7 +9473,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 						<en>A pilot is suddenly in trance. The copilot rescues the plane in front of a crash. The bilot himself has to move into the hidden to find out the truth.</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-DasVerborgene-Ep008" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DasVerborgene-Ep008" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Was eine Hitze</de>
 						<en>OMG how hot the summer is</en>
@@ -9480,7 +9483,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 						<en>A brave inhabitant calls the police, when he sees a burglary. When they arive, they find an uninhabitant apartment.</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-DasVerborgene-Ep009" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DasVerborgene-Ep009" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Die Dame kehrt zurück</de>
 						<en>The lady returns</en>
@@ -9490,7 +9493,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 						<en>Died? Not really. Rebirth in India. Time to return home and get some things straight with the family.</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-DasVerborgene-Ep010" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DasVerborgene-Ep010" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Londons meistgesuchter Star</de>
 						<en>Londons most wanted star</en>
@@ -9503,7 +9506,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 			</children>
 		</programme>
 
-		<programme id="TheRob-b5dc-4663-bd81-Ronnyunddasbyte" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0061418" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b5dc-4663-bd81-Ronnyunddasbyte" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0061418" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Bonnie und Clyde, Krimi, sub romance -->
 				<de>Ronny und das Byte</de>
@@ -9527,7 +9530,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 			<ratings critics="63" speed="61" outcome="87" />
 		</programme>
 
-		<programme id="TheRob-b5dc-mov-com-Schlagzeile" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0071524" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b5dc-mov-com-Schlagzeile" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0071524" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Extrablatt, Comedy mit Subgenre Dramma -->
 				<de>Schlagzeile</de>
@@ -9552,7 +9555,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 			<ratings critics="53" speed="71" outcome="67" />
 		</programme>
 
-		<programme id="TheRob-b5dc-mov-com-MachesnichtKumpel" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0082111" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b5dc-mov-com-MachesnichtKumpel" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0082111" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Buddy Buddy, Comedy -->
 				<de>Mach es nicht Kumpel</de>
@@ -9577,7 +9580,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 			<ratings critics="53" speed="64" outcome="37" />
 		</programme>
 
-		<programme id="TheRob-b5dc-mov-com-SchraegesDuo" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0063374" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b5dc-mov-com-SchraegesDuo" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0063374" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Ein seltsames Paar, Comedy -->
 				<de>Schräges Duo</de>
@@ -9601,7 +9604,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 			<ratings critics="63" speed="84" outcome="77" />
 		</programme>
 
-		<programme id="TheRob-916a-47bf-HogansJagd" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0074812" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-916a-47bf-HogansJagd" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0074812" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Logans Run, SciFi -->
 				<de>Hogans Jagd</de>
@@ -9628,7 +9631,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 		</programme>
 
 
-		<programme id="TheRob-mov-4a9d-rom-Lehrerliebenauch" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0052278" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-mov-4a9d-rom-Lehrerliebenauch" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0052278" creator="8751" created_by="TheRob">
 				<!-- Reporter der Liebe, Romance, Sub Comedy -->
 			<title>
 				<de>Lehrer lieben auch</de>
@@ -9652,7 +9655,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 			<ratings critics="69" speed="73" outcome="71" />
 		</programme>
 
-		<programme id="TheRob-mov-cri-DasManifestdesDRWaruse" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0023563" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-mov-cri-DasManifestdesDRWaruse" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0023563" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Das Testament des Dr. Mabuse -->
 				<de>Das Manifest des Dr. Waruse</de>
@@ -9670,14 +9673,14 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 				<member index="0" function="1">TheRob-celebritypeople-FizzieWang</member>
 				<member index="1" function="2">TheRob-TowerTV-RudolfKleineWeize</member>
 				<member index="2" function="2">TheRob-TowerTV-OttoPernickel</member>
-				<member index="2" function="2">a0111f16-cb88-41c9-a44e-b508cbeb35f6</member>
+				<member index="3" function="2">a0111f16-cb88-41c9-a44e-b508cbeb35f6</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
 			<data country="D" year="1933" distribution="1" maingenre="4" subgenre="" flags="0" blocks="3" price_mod="1.00" />
 			<ratings critics="84" speed="57" outcome="87" />
 		</programme>
 
-		<programme id="TheRob-mov-act-BrennendesHochhaus" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0072308" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-mov-act-BrennendesHochhaus" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0072308" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Flammendes Inferno, Action -->
 				<de>Wolkenkratzer in Flammen</de>
@@ -9703,7 +9706,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 			<ratings critics="47" speed="67" outcome="81" />
 		</programme>
 
-		<programme id="TheRob-mov-act-SchmetterlinaufderInsel" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0070511" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-mov-act-SchmetterlinaufderInsel" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0070511" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Papillon, Drama, Sub Crime -->
 				<de>Farfallino - die Flucht</de>
@@ -9727,7 +9730,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 			<ratings critics="69" speed="61" outcome="96" />
 		</programme>
 
-		<programme id="TheRob-mov-drama-KleinIwan" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0056111" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+		<programme id="TheRob-mov-drama-KleinIwan" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0056111" creator="8751/7430" created_by="Sjaele/TheRob">
 			<title>
 				<!-- Iwans Kindheit, Drama sub Action -->
 				<de>Klein Iwan</de>
@@ -9753,7 +9756,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="77" speed="29" outcome="72" />
 		</programme>
 
-		<programme id="TheRob-mov-hist-AndyKopekjow" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0060107" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+		<programme id="TheRob-mov-hist-AndyKopekjow" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0060107" creator="8751/7430" created_by="Sjaele/TheRob">
 			<title>
 				<!-- Andrej Rubljow, Hostorie, Sub Drama -->
 				<de>Andy Kopekjow</de>
@@ -9778,7 +9781,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="81" speed="22" outcome="63" />
 		</programme>
 
-		<programme id="TheRob-mov-dram-StraßenwalzenpilotundGeiger" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0053987" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+		<programme id="TheRob-mov-dram-StraßenwalzenpilotundGeiger" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0053987" creator="8751/7430" created_by="Sjaele/TheRob">
 			<title>
 				<!-- Die Straßenwalze und die Geige, drama -->
 				<de>Straßenwalzenpilot und Geiger</de>
@@ -9802,7 +9805,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="93" speed="26" outcome="22" />
 		</programme>
 
-		<programme id="TheRob-mov-scifi-Soljaris" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0069293" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+		<programme id="TheRob-mov-scifi-Soljaris" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0069293" creator="8751/7430" created_by="Sjaele/TheRob">
 			<title>
 				<!-- Solaris, scifi sub mystery -->
 				<de>Soljaris</de>
@@ -9827,7 +9830,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="84" speed="36" outcome="83" />
 		</programme>
 
-		<programme id="TheRob-mov-drama-Serkalo" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0072443" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+		<programme id="TheRob-mov-drama-Serkalo" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0072443" creator="8751/7430" created_by="Sjaele/TheRob">
 			<title>
 				<!-- Der Spiegel, Drama -->
 				<de>Serkalo</de>
@@ -9852,7 +9855,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="73" speed="36" outcome="43" />
 		</programme>
 
-		<programme id="TheRob-mov-drama-PicknickamWegesrand" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0079944" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+		<programme id="TheRob-mov-drama-PicknickamWegesrand" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0079944" creator="8751/7430" created_by="Sjaele/TheRob">
 			<title>
 				<!-- Stalker, SciFi sub drama -->
 				<de>Picknick am Wegesrand</de>
@@ -9877,7 +9880,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="82" speed="56" outcome="81" />
 		</programme>
 
-		<programme id="TheRob-mov-drama-DertoteBaum" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0091670" rt_id="0" creator="8751/7430" created_by="Sjaele/TheRob">
+		<programme id="TheRob-mov-drama-DertoteBaum" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0091670" creator="8751/7430" created_by="Sjaele/TheRob">
 			<title>
 				<!-- Opfer, drama -->
 				<de>Der tote Baum</de>
@@ -10294,7 +10297,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="53" speed="68" outcome="61" />
 		</programme>
 
-		<programme id="TheRob-serie-SamuraiAdam" product="2" licence_type="3" tmdb_id="0" imdb_id="tt0080274" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-SamuraiAdam" product="2" licence_type="3" tmdb_id="0" imdb_id="tt0080274" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Shogun, Serie Abenteuer, Sub Historie -->
 				<de>Samurai Adam</de>
@@ -10312,14 +10315,14 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="0" function="1">TheRob-TowerTV-JerryHeathrow</member>
 				<member index="1" function="2">TheRob-TowerTV-RicardoKammerlein</member>
 				<member index="2" function="2">TheRob-TowerTV-ToshinoSisune</member>
-				<member index="2" function="2">TheRob-TowerTV-YokoDiewada</member>
-				<member index="2" function="2">8fd0eba6-3ac0-41eb-8a86-514fa77dc9a2</member>
+				<member index="3" function="2">TheRob-TowerTV-YokoDiewada</member>
+				<member index="4" function="2">8fd0eba6-3ac0-41eb-8a86-514fa77dc9a2</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
 			<data country="USA" year="1980" distribution="1" maingenre="1" subgenre="11" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="88" speed="67" outcome="" />
 			<children>
-				<programme id="TheRob-serie-SamuraiAdam-Episode001" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1488968" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-SamuraiAdam-Episode001" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1488968" creator="8751" created_by="TheRob">
 					<title>
 						<de>Episode 1.1</de>
 						<en>Episode 1.1</en>
@@ -10330,7 +10333,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 					</description>
 					<ratings critics="91" speed="62" />
 				</programme>
-				<programme id="TheRob-serie-SamuraiAdam-Episode002" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1488969" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-SamuraiAdam-Episode002" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1488969" creator="8751" created_by="TheRob">
 					<title>
 						<de>Episode 1.2</de>
 						<en>Episode 1.2</en>
@@ -10341,7 +10344,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 					</description>
 					<ratings critics="88" speed="67" />
 				</programme>
-				<programme id="TheRob-serie-SamuraiAdam-Episode003" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1488970" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-SamuraiAdam-Episode003" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1488970" creator="8751" created_by="TheRob">
 					<title>
 						<de>Episode 1.3</de>
 						<en>Episode 1.3</en>
@@ -10352,7 +10355,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 					</description>
 					<ratings critics="86" speed="65" />
 				</programme>
-				<programme id="TheRob-serie-SamuraiAdam-Episode004" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1484292" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-SamuraiAdam-Episode004" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1484292" creator="8751" created_by="TheRob">
 					<title>
 						<de>Episode 1.4</de>
 						<en>Episode 1.4</en>
@@ -10363,7 +10366,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 					</description>
 					<ratings critics="83" speed="72" />
 				</programme>
-				<programme id="TheRob-serie-SamuraiAdam-Episode005" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-SamuraiAdam-Episode005" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Episode 1.5</de>
 						<en>Episode 1.5</en>
@@ -10377,7 +10380,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			</children>
 		</programme>
 
-		<programme id="TheRob-serie-Sanddornkahn" product="2" fictional="1" licence_type="3" tmdb_id="0" imdb_id="tt0074050" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-Sanddornkahn" product="2" fictional="1" licence_type="3" tmdb_id="0" imdb_id="tt0074050" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Sandokan, Action -->
 				<de>Sanddornkahn</de>
@@ -10395,13 +10398,13 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="0" function="1">TheRob-TowerTV-SergeWolltihnka</member>
 				<member index="1" function="2">TheRob-TowerTV-KabiraWedira</member>
 				<member index="2" function="2">TheRob-TowerTV-RolfoBella</member>
-				<member index="2" function="2">TheRob-TowerTV-PhilliGemoy</member>
+				<member index="3" function="2">TheRob-TowerTV-PhilliGemoy</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
 			<data country="I" year="1976" distribution="2" maingenre="2" subgenre="" flags="0" blocks="1" price_mod="1.00" />
 			<ratings critics="42" speed="46" outcome="" />
 			<children>
-				<programme id="TheRob-serie-Sanddornkahn-Episode001" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1306736" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-Sanddornkahn-Episode001" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1306736" creator="8751" created_by="TheRob">
 					<title>
 						<de>Episode 1.1</de>
 						<en>Episode 1.1</en>
@@ -10411,7 +10414,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 						<en>Sanddornkahn sees how mean the British people are to the citizens and decides to fight back.</en>
 					</description>
 				</programme>
-					<programme id="TheRob-serie-Sanddornkahn-Episode002" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1306737" rt_id="0" creator="8751" created_by="TheRob">
+					<programme id="TheRob-serie-Sanddornkahn-Episode002" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1306737" creator="8751" created_by="TheRob">
 					<title>
 						<de>Episode 1.2</de>
 						<en>Episode 1.2</en>
@@ -10421,7 +10424,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 						<en>Sanddornkahn chases the first British ship and destroys it.</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-Sanddornkahn-Episode003" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1306738" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-Sanddornkahn-Episode003" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1306738" creator="8751" created_by="TheRob">
 					<title>
 						<de>Episode 1.3</de>
 						<en>Episode 1.3</en>
@@ -10432,7 +10435,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 					</description>
 					<ratings critics="54" speed="30" />
 				</programme>
-				<programme id="TheRob-serie-Sanddornkahn-Episode004" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1306739" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-Sanddornkahn-Episode004" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1306739" creator="8751" created_by="TheRob">
 					<title>
 						<de>Episode 1.4</de>
 						<en>Episode 1.4</en>
@@ -10442,7 +10445,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 						<en>The Royal navy invests more in the chase of Sanddornkahn. They want to arrest him as fast as possible.</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-Sanddornkahn-Episode005" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1306740" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-Sanddornkahn-Episode005" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1306740" creator="8751" created_by="TheRob">
 					<title>
 						<de>Episode 1.5</de>
 						<en>Episode 1.5</en>
@@ -10453,7 +10456,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 					</description>
 					<ratings critics="30" speed="59" />
 				</programme>
-				<programme id="TheRob-serie-Sanddornkahn-Episode006" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1306741" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-Sanddornkahn-Episode006" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1306741" creator="8751" created_by="TheRob">
 					<title>
 						<de>Episode 1.6</de>
 						<en>Episode 1.6</en>
@@ -10466,7 +10469,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			</children>
 		</programme>
 
-		<programme id="TheRob-mov-west-BaldipuhdasGespenst" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0063674" rt_id="8751" creator="TheRob">
+		<programme id="TheRob-mov-west-BaldipuhdasGespenst" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0063674" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Rache für Jesse James, western -->
 				<de>Baldipuh - das Gespenst</de>
@@ -10730,7 +10733,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="18" speed="32" outcome="14" />
 		</programme>
 
-		<programme id="TheRob-81d9-com-StandOlgestohleneJuwelen" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0022402" rt_id="8751" creator="TheRob">
+		<programme id="TheRob-81d9-com-StandOlgestohleneJuwelen" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0022402" creator="8751" created_by="TheRob">
 			<title>
 				<de>[1|Last] &amp; [2|Last] - Gestohlene Juwelen</de>
 				<en>[1|Last] &amp; [2|Last] - Stolen Gems</en>
@@ -10755,7 +10758,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="37" speed="53" outcome="53" />
 		</programme>
 
-		<programme id="TheRob-a4d6-adv-GoldfeverinSanFransisco" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0026097" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-adv-GoldfeverinSanFransisco" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0026097" creator="8751" created_by="TheRob">
 			<title>
 				<!-- San Francisco im Goldfieber -->
 				<de>Goldrausch in San Fransisco</de>
@@ -10780,7 +10783,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="48" speed="62" outcome="67" />
 		</programme>
 
-		<programme id="TheRob-a4d6-act-DenTeufelbesiegt" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0046414" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-act-DenTeufelbesiegt" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0046414" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Schach dem Teufel -->
 				<de>Den Teufel besiegt</de>
@@ -10805,7 +10808,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="68" speed="62" outcome="59" />
 		</programme>
 
-		<programme id="TheRob-a4d6-mus-Sichgroßartigfühlen" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0041515" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-mus-Sichgroßartigfühlen" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0041515" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Ein tolles Gefühl  -->
 				<de>Sich großartig fühlen</de>
@@ -10831,7 +10834,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="61" speed="46" outcome="53" />
 		</programme>
 
-		<programme id="TheRob-a4d6-myst-UeberlebeninNewYork" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0070723" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-myst-UeberlebeninNewYork" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0070723" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Jahr 2022... die überleben wollen -->
 				<de>Überleben in New York</de>
@@ -10856,7 +10859,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="81" speed="69" outcome="74" />
 		</programme>
 
-		<programme id="TheRob-a4d6-myst-Gemaelderaub" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0063341" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-myst-Gemaelderaub" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0063341" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Wie klaut man ein Gemälde? -->
 				<de>Gemälderaub</de>
@@ -10881,7 +10884,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="47" speed="62" outcome="51" />
 		</programme>
 
-		<programme id="TheRob-a4d6-com-KardinalBeige" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0061324" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-com-KardinalBeige" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0061324" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Die Abenteuer des Kardinal Braun -->
 				<de>Kardinal Beige</de>
@@ -10906,7 +10909,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="47" speed="59" outcome="41" />
 		</programme>
 
-		<programme id="TheRob-a4d6-com-DieGeboteGottes" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0049833" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-com-DieGeboteGottes" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0049833" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Die zehn Gebote -->
 				<de>Die Gebote Gottes</de>
@@ -10931,7 +10934,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="87" speed="61" outcome="81" />
 		</programme>
 
-		<programme id="TheRob-a4d6-com-DasLiedSkandinaviens" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0066393" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-com-DasLiedSkandinaviens" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0066393" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Song of Norway -->
 				<de>Das Lied Skandinaviens</de>
@@ -10956,7 +10959,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="57" speed="9" outcome="12" />
 		</programme>
 
-		<programme id="TheRob-a4d6-hist-DrPaulEhrlich" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0032413" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-hist-DrPaulEhrlich" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0032413" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Paul Ehrlich - Ein Leben für die Forschung -->
 				<de>Dr. Paul Ehrlich</de>
@@ -10980,7 +10983,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="91" speed="26" outcome="72" />
 		</programme>
 
-		<programme id="TheRob-a4d6-dram-ShakespearesMacbeth" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0040558" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-dram-ShakespearesMacbeth" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0040558" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Macbeth -->
 				<de>Shakespeares Macbeth</de>
@@ -11004,7 +11007,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="83" speed="27" outcome="71" />
 		</programme>
 
-		<programme id="TheRob-a4d6-dram-ShakespearesOthello" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0045251" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-dram-ShakespearesOthello" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0045251" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Orson Welles' Othello -->
 				<de>Shakespeares Othello</de>
@@ -11028,7 +11031,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="93" speed="29" outcome="76" />
 		</programme>
 
-		<programme id="TheRob-a4d6-dram-LeopoldLoeb" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0052700" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-dram-LeopoldLoeb" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0052700" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Der Zwang zum Bösen -->
 				<de>Der Fall Leopold Loeb</de>
@@ -11052,7 +11055,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="81" speed="41" outcome="71" />
 		</programme>
 
-		<programme id="TheRob-a4d6-adv-AlbinoWal" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0049513" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-adv-AlbinoWal" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0049513" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Moby Dick -->
 				<de>Albino Wal</de>
@@ -11077,7 +11080,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="71" speed="67" outcome="74" />
 		</programme>
 
-		<programme id="TheRob-a4d6-dram-KeyenIndianer" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0057940" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-dram-KeyenIndianer" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0057940" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Cheyenne -->
 				<de>Keyen Indianer</de>
@@ -11103,7 +11106,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="71" speed="67" outcome="74" />
 		</programme>
 
-		<programme id="TheRob-a4d6-act-Fallschirmspringer" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0064397" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-act-Fallschirmspringer" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0064397" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Die den Hals riskieren -->
 				<de>Fallschirmspringer</de>
@@ -11128,7 +11131,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="51" speed="71" outcome="66" />
 		</programme>
 
-		<programme id="TheRob-a4d6-adv-DerGeisterseemann" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0064307" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-adv-DerGeisterseemann" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0064307" creator="8751" created_by="TheRob">
 			<title>
 				<!-- The Extraordinary Seaman -->
 				<de>Der Geisterseemann</de>
@@ -11154,7 +11157,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="12" speed="31" outcome="14" />
 		</programme>
 
-		<programme id="TheRob-a4d6-adv-GoldschatzimWesten" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0064615" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-adv-GoldschatzimWesten" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0064615" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Mackenna's Gold -->
 				<de>Goldschatz im Westen</de>
@@ -11180,7 +11183,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="62" speed="72" outcome="61" />
 		</programme>
 
-		<programme id="TheRob-a4d6-hist-VogelkundeinAlcatraz" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0055798" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-hist-VogelkundeinAlcatraz" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0055798" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Der Gefangene von Alcatraz -->
 				<de>Vogelkunde in Alcatraz</de>
@@ -11205,7 +11208,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="87" speed="52" outcome="81" />
 		</programme>
 
-		<programme id="TheRob-a4d6-act-WildeKerle" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0055633" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-act-WildeKerle" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0055633" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Die jungen Wilden -->
 				<de>Wilde Kerle</de>
@@ -11229,7 +11232,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="47" speed="76" outcome="71" />
 		</programme>
 
-		<programme id="TheRob-a4d6-dram-Mein Kind" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0040087" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-dram-Mein Kind" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0040087" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Alle meine Söhne -->
 				<de>Mein Kind</de>
@@ -11253,7 +11256,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="79" speed="48" outcome="71" />
 		</programme>
 
-		<programme id="TheRob-a4d6-rom-Frauensindbewaffnet" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0051579" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-rom-Frauensindbewaffnet" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0051579" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Mit den Waffen einer Frau -->
 				<de>Frauen sind bewaffnet</de>
@@ -11277,7 +11280,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="69" speed="53" outcome="71" />
 		</programme>
 
-		<programme id="TheRob-a4d6-act-EineNachtinParis" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0046451" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-act-EineNachtinParis" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0046451" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Wenn es Nacht wird in Paris -->
 				<de>Eine Nacht in Paris</de>
@@ -11302,7 +11305,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="79" speed="91" outcome="76" />
 		</programme>
 
-		<programme id="TheRob-a4d6-mon-Bonaparte" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0048413" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-mon-Bonaparte" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0048413" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Napoléon -->
 				<de>Bonaparte</de>
@@ -11327,7 +11330,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="69" speed="31" outcome="67" />
 		</programme>
 
-		<programme id="TheRob-a4d6-act-Rettungsmission" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0034093" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-act-Rettungsmission" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0034093" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Der Orkan -->
 				<de>Rettungsmission</de>
@@ -11352,7 +11355,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="59" speed="67" outcome="76" />
 		</programme>
 
-		<programme id="TheRob-serie-crim-DelanoandChefs" product="2" fictional="0" licence_type="3" tmdb_id="0" imdb_id="tt0084997" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-crim-DelanoandChefs" product="2" fictional="0" licence_type="3" tmdb_id="0" imdb_id="tt0084997" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Die Polizei-Chiefs von Delano -->
 				<de>Delano und seine Polizeichefs</de>
@@ -11376,7 +11379,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<data country="USA" year="1983" distribution="0" maingenre="4" subgenre="7" flags="8" blocks="2" price_mod="1.00" />
 			<ratings critics="95" speed="80" outcome="85" />
 			<children>
-				<programme id="TheRob-serie-DelanoandChefs-Ep001" product="2" fictional="0" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DelanoandChefs-Ep001" product="2" fictional="0" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Die Zwanziger Jaher</de>
 						<en>The Twenties</en>
@@ -11387,7 +11390,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 					</description>
 					<ratings critics="99" speed="75" />
 				</programme>
-				<programme id="TheRob-serie-DelanoandChefs-Ep002" product="2" fictional="0" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DelanoandChefs-Ep002" product="2" fictional="0" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Die Vierziger Jahre</de>
 						<en>The Fourties</en>
@@ -11398,7 +11401,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 					</description>
 					<ratings critics="90" speed="83" />
 				</programme>
-				<programme id="TheRob-serie-DelanoandChefs-Ep003" product="2" fictional="0" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DelanoandChefs-Ep003" product="2" fictional="0" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Die Sechziger Jahre</de>
 						<en>The Sixties</en>
@@ -11412,7 +11415,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			</children>
 		</programme>
 
-		<programme id="TheRob-serie-dram-HinterEden" product="2" fictional="0" licence_type="3" tmdb_id="0" imdb_id="tt0083409" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-dram-HinterEden" product="2" fictional="0" licence_type="3" tmdb_id="0" imdb_id="tt0083409" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Jenseits von Eden -->
 				<de>Steinbecks Hinter Eden</de>
@@ -11435,7 +11438,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<data country="USA" year="1981" distribution="0" maingenre="7" subgenre="0" flags="0" blocks="3" price_mod="1.00" />
 			<ratings critics="92" speed="57" outcome="65" />
 			<children>
-				<programme id="TheRob-serie-HinterEden-Ep001" product="2" fictional="0" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-HinterEden-Ep001" product="2" fictional="0" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Brüder</de>
 						<en>Brothers</en>
@@ -11446,7 +11449,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 					</description>
 					<ratings critics="97" speed="42" />
 				</programme>
-				<programme id="TheRob-serie-HinterEden-Ep002" product="2" fictional="0" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-HinterEden-Ep002" product="2" fictional="0" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Cathy</de>
 						<en>Cathy</en>
@@ -11457,7 +11460,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 					</description>
 					<ratings critics="83" speed="78" />
 				</programme>
-				<programme id="TheRob-serie-HinterEden-Ep003" product="2" fictional="0" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-HinterEden-Ep003" product="2" fictional="0" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Rivalen</de>
 						<en>Rivals</en>
@@ -11470,7 +11473,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				</programme>
 			</children>
 		</programme>
-		<programme id="TheRob-mov-dram-Hoellewirsindda" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0077416" rt_id="8751" creator="TheRob">
+		<programme id="TheRob-mov-dram-Hoellewirsindda" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0077416" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Die durch die Hölle gehen, Drama, Sub Action -->
 				<de>Hölle, wir sind da!</de>
@@ -11495,7 +11498,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="88" speed="82" outcome="94" />
 		</programme>
 
-		<programme id="TheRob-mov-act-DervonSizilien" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0093966" rt_id="8751" creator="TheRob">
+		<programme id="TheRob-mov-act-DervonSizilien" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0093966" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Der Sizilianer, Action, Sub Crime -->
 				<de>Der von Sizilien</de>
@@ -11520,7 +11523,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="53" speed="82" outcome="47" />
 		</programme>
 
-		<programme id="TheRob-mov-dram-nurEinerbehaeltdenkopf" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0091203" rt_id="8751" creator="TheRob">
+		<programme id="TheRob-mov-dram-nurEinerbehaeltdenkopf" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0091203" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Highlander, Adventure, Sub Fantasy -->
 				<de>Nur einer behält den Kopf</de>
@@ -11544,7 +11547,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="48" speed="62" outcome="34" />
 		</programme>
 
-		<programme id="TheRob-a4d6-dram-OhioKid" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0059037" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-dram-OhioKid" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0059037" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Cincinnati Kid -->
 				<de>Ohio Kid</de>
@@ -11570,7 +11573,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="74" speed="56" outcome="68" />
 		</programme>
 
-		<programme id="TheRob-a4d6-west-RenoSmith" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0060748" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-west-RenoSmith" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0060748" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Nevada Smith -->
 				<de>Reno Smith</de>
@@ -11595,7 +11598,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="57" speed="59" outcome="62" />
 		</programme>
 
-		<programme id="TheRob-a4d6-act-BulltheHit" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0062765" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-act-BulltheHit" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0062765" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Bullitt -->
 				<de>Bullthehit</de>
@@ -11621,7 +11624,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="57" speed="79" outcome="72" />
 		</programme>
 
-		<programme id="TheRob-a4d6-act-24StundenRennen" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0067334" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-act-24StundenRennen" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0067334" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Le Mans -->
 				<de>24 Stunden Rennen</de>
@@ -11646,7 +11649,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="48" speed="82" outcome="53" />
 		</programme>
 
-		<programme id="TheRob-a4d6-act-RunAway" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0068638" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-act-RunAway" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0068638" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Getaway -->
 				<de>Run Away</de>
@@ -11671,7 +11674,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="63" speed="66" outcome="64" />
 		</programme>
 
-		<programme id="TheRob-a4d6-act-BreaktheChain" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0057115" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-act-BreaktheChain" product="1" fictional="0" licence_type="1" tmdb_id="0" imdb_id="tt0057115" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Gesprengte Kette -->
 				<de>Break the Chain</de>
@@ -11698,7 +11701,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<ratings critics="83" speed="69" outcome="84" />
 		</programme>
 
-		<programme id="TheRob-serie-adv-RobinWusoe" product="2" licence_type="3" tmdb_id="0" imdb_id="tt0167516" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-adv-RobinWusoe" product="2" licence_type="3" tmdb_id="0" imdb_id="tt0167516" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Robinson Crusoe, Abenteuer -->
 				<de>Robin Wusoe</de>
@@ -11720,7 +11723,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<data country="D/F" year="1964" distribution="2" maingenre="1" subgenre="" flags="8" blocks="2" price_mod="1.00" />
 			<ratings critics="67" speed="44" outcome="" />
 			<children>
-				<programme id="TheRob-serie-RobinWusoe-Ep001" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-RobinWusoe-Ep001" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Wie es begann</de>
 						<en>How it began</en>
@@ -11730,7 +11733,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 						<en>Robin Wusoe describes the beginning of his journey. And his wishes and dreams.</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-RobinWusoe-Ep002" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-RobinWusoe-Ep002" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Freitag?</de>
 						<en>Friday?</en>
@@ -11740,7 +11743,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 						<en>Stranded on an island Robin meets a stranger.</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-RobinWusoe-Ep003" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-RobinWusoe-Ep003" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Kannibalen!!</de>
 						<en>Canibals!</en>
@@ -11750,7 +11753,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 						<en>Robin and Friday are getting aware that they are sharing with some unfriendly humans.</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-RobinWusoe-Ep004" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-RobinWusoe-Ep004" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Endlich Heimat</de>
 						<en>Home! Sweet Home</en>
@@ -11765,7 +11768,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			</children>
 		</programme>
 
-		<programme id="TheRob-serie-fant-RingeundRosen" product="2" licence_type="3" tmdb_id="0" imdb_id="tt3636830" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-fant-RingeundRosen" product="2" licence_type="3" tmdb_id="0" imdb_id="tt3636830" creator="8751" created_by="TheRob">
 			<title>
 				<!-- The Rose and the Ring, Fantasy -->
 				<de>Ringe und Rosen</de>
@@ -11787,7 +11790,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 			<data country="USA" year="1953" distribution="2" maingenre="10" subgenre="" flags="8" blocks="1" price_mod="1.00" />
 			<ratings critics="47" speed="38" outcome="30" />
 			<children>
-				<programme id="TheRob-serie-RingeundRosen-Ep001" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-RingeundRosen-Ep001" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Das Frühstück</de>
 						<en>Breakfast</en>
@@ -11797,7 +11800,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 						<en>Indroducing the family. The breakfast of the whole bunch together is the perfect start.</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-RingeundRosen-Ep002" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-RingeundRosen-Ep002" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Der Ring</de>
 						<en>The Ring</en>
@@ -11807,7 +11810,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 						<en>The fantasy part starts. A magic ring appears.</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-RingeundRosen-Ep003" product="2" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-RingeundRosen-Ep003" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Die Flucht</de>
 						<en>The Escape</en>
@@ -11907,7 +11910,7 @@ Educational precious and absolutly ecological.</en>
 				     gender = 0 [random]  1 [male]  2 [female]
 				     levelup = 0 [no levelup]  1 [levelup]
 				-->
-				<member index="1" function="64" generator="es,0"></member>
+				<member index="2" function="64" generator="es,0"></member>
 			</staff>
 			<groups target_groups="0" />
 			<data country="D" distribution="2" maingenre="0" blocks="1" />
@@ -12223,4 +12226,4 @@ Terrific final.</en>
 		</programme>
 	</allprogrammes>
 	<exportOptions onlyFakes="true" onlyCustom="false" dataStructure="FakeData" />
-</tvgdb>
+</tvtdb>

--- a/res/database/Default/database_programmes.xml
+++ b/res/database/Default/database_programmes.xml
@@ -7224,7 +7224,8 @@ Tragische Liebesgeschichte</de>
 				<member index="1" function="2">a6055f37-ab53-425e-9332-14e0dfabc424</member>
 			</staff>
 			<groups target_groups="64" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="D" year_relative="-1" year_relative_min="1985" year_relative_max="1990" distribution="2" maingenre="6" subgenre="" flags="4" blocks="1" price_mod="0.85" />
+			<data country="D" distribution="2" maingenre="6" subgenre="" flags="4" blocks="1" price_mod="0.85" />
+			<releaseTime year_relative="-1" year_relative_min="1985" year_relative_max="1990" />
 			<ratings critics="20" speed="42" outcome="35" />
 			<children>
 				<programme id="8258fb18-d138-49b4-b07c-0519eec12d2c" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
@@ -7510,7 +7511,8 @@ Ein Muss für jede Hausfrau, ein Fluch für harte Männer.</de>
 				<member index="1" function="2">396f8bfa-a414-4a25-85c7-4e05c687f6a0</member>
 			</staff>
 			<groups target_groups="3" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="AUT" year_relative="-1" year_relative_min="2006" year_relative_max="2008" distribution="2" maingenre="6" subgenre="" flags="4" blocks="2" price_mod="0.85" />
+			<data country="AUT" distribution="2" maingenre="6" subgenre="" flags="4" blocks="2" price_mod="0.85" />
+			<releaseTime year_relative="-1" year_relative_min="2006" year_relative_max="2008" />
 			<ratings critics="35" speed="7" outcome="0" />
 			<children>
 				<programme id="c68b6bc1-f0c0-4b36-85e7-d7f32dd86063" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="5578" created_by="Ronny">
@@ -10749,7 +10751,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="4" function="2">TheRob-TowerTV-EddiePMobison</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1931" distribution="0" maingenre="5" subgenre="0" flags="0" blocks="1" time="0" price_mod="1" />
+			<data country="USA" year="1931" distribution="0" maingenre="5" subgenre="0" flags="0" blocks="1" price_mod="1" />
 			<ratings critics="37" speed="53" outcome="53" />
 		</programme>
 
@@ -10774,7 +10776,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="3" function="2">TheRob-TowerTV-WaltherRunman</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1935" distribution="0" maingenre="1" subgenre="7" flags="0" blocks="2" time="0" price_mod="1.00" />
+			<data country="USA" year="1935" distribution="0" maingenre="1" subgenre="7" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="48" speed="62" outcome="67" />
 		</programme>
 
@@ -10799,7 +10801,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="3" function="2">TheRob-TowerTV-PeteWore</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1953" distribution="0" maingenre="2" subgenre="5" flags="0" blocks="2" time="0" price_mod="1.00" />
+			<data country="USA" year="1953" distribution="0" maingenre="2" subgenre="5" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="68" speed="62" outcome="59" />
 		</programme>
 
@@ -10825,7 +10827,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="4" function="2">TheRob-TowerTV-EddiePMobison</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1949" distribution="0" maingenre="202" subgenre="5" flags="0" blocks="2" time="0" price_mod="1.00" />
+			<data country="USA" year="1949" distribution="0" maingenre="202" subgenre="5" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="61" speed="46" outcome="53" />
 		</programme>
 
@@ -10850,7 +10852,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="3" function="2">c299b440-3684-48fa-bc21-85a76ae2c253</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1973" distribution="0" maingenre="14" subgenre="16" flags="0" blocks="2" time="0" price_mod="1.00" />
+			<data country="USA" year="1973" distribution="0" maingenre="14" subgenre="16" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="81" speed="69" outcome="74" />
 		</programme>
 
@@ -10875,7 +10877,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="3" function="2">41946f51-d770-40f4-807a-fd74b85c97b8</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1968" distribution="0" maingenre="9" subgenre="5" flags="0" blocks="2" time="0" price_mod="1.00" />
+			<data country="USA" year="1968" distribution="0" maingenre="9" subgenre="5" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="47" speed="62" outcome="51" />
 		</programme>
 
@@ -10900,7 +10902,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="3" function="2">TheRob-TowerTV-EddiePMobison</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="IT" year="1967" distribution="0" maingenre="5" subgenre="4" flags="0" blocks="2" time="0" price_mod="1.00" />
+			<data country="IT" year="1967" distribution="0" maingenre="5" subgenre="4" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="47" speed="59" outcome="41" />
 		</programme>
 
@@ -10925,7 +10927,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="3" function="2">TheRob-TowerTV-EddiePMobison</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1956" distribution="0" maingenre="13" subgenre="11" flags="0" blocks="3" time="0" price_mod="1.00" />
+			<data country="USA" year="1956" distribution="0" maingenre="13" subgenre="11" flags="0" blocks="3" price_mod="1.00" />
 			<ratings critics="87" speed="61" outcome="81" />
 		</programme>
 
@@ -10950,7 +10952,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="3" function="2">TheRob-TowerTV-EddiePMobison</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1970" distribution="0" maingenre="11" subgenre="202" flags="0" blocks="2" time="0" price_mod="1.00" />
+			<data country="USA" year="1970" distribution="0" maingenre="11" subgenre="202" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="57" speed="9" outcome="12" />
 		</programme>
 
@@ -10974,7 +10976,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="2" function="2">TheRob-TowerTV-GaryRavenport</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1940" distribution="0" maingenre="7" subgenre="11" flags="0" blocks="2" time="0" price_mod="1.00" />
+			<data country="USA" year="1940" distribution="0" maingenre="7" subgenre="11" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="91" speed="26" outcome="72" />
 		</programme>
 
@@ -10998,7 +11000,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="2" function="2">TheRob-TowerTV-RonnyMcdawoll</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1948" distribution="0" maingenre="7" subgenre="11" flags="0" blocks="2" time="0" price_mod="1.00" />
+			<data country="USA" year="1948" distribution="0" maingenre="7" subgenre="11" flags="0" blocks="2"  price_mod="1.00" />
 			<ratings critics="83" speed="27" outcome="71" />
 		</programme>
 
@@ -11022,7 +11024,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="2" function="2">TheRob-TowerTV-MikeMcPiamoir</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1952" distribution="0" maingenre="7" subgenre="15" flags="0" blocks="2" time="0" price_mod="1.00" />
+			<data country="USA" year="1952" distribution="0" maingenre="7" subgenre="15" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="93" speed="29" outcome="76" />
 		</programme>
 
@@ -11046,7 +11048,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="2" function="2">1355577f-9afa-4240-9add-e043b1c03797</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1959" distribution="0" maingenre="11" subgenre="4" flags="0" blocks="2" time="0" price_mod="1.00" />
+			<data country="USA" year="1959" distribution="0" maingenre="11" subgenre="4" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="81" speed="41" outcome="71" />
 		</programme>
 
@@ -11071,7 +11073,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="3" function="2">8fd0eba6-3ac0-41eb-8a86-514fa77dc9a2</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1956" distribution="0" maingenre="1" subgenre="7" flags="12" blocks="3" time="0" price_mod="1.00" />
+			<data country="USA" year="1956" distribution="0" maingenre="1" subgenre="7" flags="12" blocks="3" price_mod="1.00" />
 			<ratings critics="71" speed="67" outcome="74" />
 		</programme>
 
@@ -11097,7 +11099,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="4" function="2">788fa2a0-7908-4e96-b3c0-51ff9386a16e</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1964" distribution="0" maingenre="7" subgenre="11" flags="8" blocks="3" time="0" price_mod="1.00" />
+			<data country="USA" year="1964" distribution="0" maingenre="7" subgenre="11" flags="8" blocks="3" price_mod="1.00" />
 			<ratings critics="71" speed="67" outcome="74" />
 		</programme>
 
@@ -11122,7 +11124,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="3" function="2">7af27da0-4abf-482c-b8a3-00612c1e4d53</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1969" distribution="0" maingenre="2" subgenre="7" flags="0" blocks="2" time="0" price_mod="1.00" />
+			<data country="USA" year="1969" distribution="0" maingenre="2" subgenre="7" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="51" speed="71" outcome="66" />
 		</programme>
 
@@ -11148,7 +11150,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="4" function="2">TheRob-TowerTV-Bobmailour</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1961" distribution="0" maingenre="1" subgenre="5" flags="0" blocks="2" time="0" price_mod="1.00" />
+			<data country="USA" year="1961" distribution="0" maingenre="1" subgenre="5" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="12" speed="31" outcome="14" />
 		</programme>
 
@@ -11174,7 +11176,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="4" function="2">fd49c0ab-3619-4f7a-80cf-82488f5256bc</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1969" distribution="0" maingenre="1" subgenre="15" flags="0" blocks="3" time="0" price_mod="1.00" />
+			<data country="USA" year="1969" distribution="0" maingenre="1" subgenre="15" flags="0" blocks="3" price_mod="1.00" />
 			<ratings critics="62" speed="72" outcome="61" />
 		</programme>
 
@@ -11199,7 +11201,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="3" function="2">TheRob-TowerTV-CharlieWalden</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1962" distribution="0" maingenre="11" subgenre="7" flags="0" blocks="3" time="0" price_mod="1.00" />
+			<data country="USA" year="1962" distribution="0" maingenre="11" subgenre="7" flags="0" blocks="3" price_mod="1.00" />
 			<ratings critics="87" speed="52" outcome="81" />
 		</programme>
 
@@ -11223,7 +11225,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="2" function="2">TheRob-TowerTV-JellyWinter</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1961" distribution="0" maingenre="2" subgenre="4" flags="0" blocks="2" time="0" price_mod="1.00" />
+			<data country="USA" year="1961" distribution="0" maingenre="2" subgenre="4" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="47" speed="76" outcome="71" />
 		</programme>
 
@@ -11247,7 +11249,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="2" function="2">TheRob-TowerTV-EddiePMobison</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1948" distribution="0" maingenre="7" subgenre="0" flags="0" blocks="2" time="0" price_mod="1.00" />
+			<data country="USA" year="1948" distribution="0" maingenre="7" subgenre="0" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="79" speed="48" outcome="71" />
 		</programme>
 
@@ -11271,7 +11273,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="2" function="2">TheRob-TowerTV-GoddessBardo</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="F" year="1958" distribution="0" maingenre="15" subgenre="7" flags="0" blocks="2" time="0" price_mod="1.00" />
+			<data country="F" year="1958" distribution="0" maingenre="15" subgenre="7" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="69" speed="53" outcome="71" />
 		</programme>
 
@@ -11296,7 +11298,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="3" function="2">TheRob-TowerTV-RennyDiary</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="F" year="1954" distribution="0" maingenre="2" subgenre="4" flags="0" blocks="2" time="0" price_mod="1.00" />
+			<data country="F" year="1954" distribution="0" maingenre="2" subgenre="4" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="79" speed="91" outcome="76" />
 		</programme>
 
@@ -11321,7 +11323,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="3" function="2">TheRob-TowerTV-ReanWarin</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="F" year="1955" distribution="0" maingenre="13" subgenre="11" flags="0" blocks="4" time="0" price_mod="1.00" />
+			<data country="F" year="1955" distribution="0" maingenre="13" subgenre="11" flags="0" blocks="4" price_mod="1.00" />
 			<ratings critics="69" speed="31" outcome="67" />
 		</programme>
 
@@ -11346,7 +11348,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="3" function="2">TheRob-TowerTV-MichelleMorsand</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="F" year="1941" distribution="0" maingenre="2" subgenre="7" flags="0" blocks="2" time="0" price_mod="1.00" />
+			<data country="F" year="1941" distribution="0" maingenre="2" subgenre="7" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="59" speed="67" outcome="76" />
 		</programme>
 
@@ -11371,7 +11373,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="3" function="2">ca53b0fc-53cb-443f-aba8-408d8b0bbdd8</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1983" distribution="0" maingenre="4" subgenre="7" flags="8" blocks="2" time="0" price_mod="1.00" />
+			<data country="USA" year="1983" distribution="0" maingenre="4" subgenre="7" flags="8" blocks="2" price_mod="1.00" />
 			<ratings critics="95" speed="80" outcome="85" />
 			<children>
 				<programme id="TheRob-serie-DelanoandChefs-Ep001" product="2" fictional="0" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
@@ -11430,7 +11432,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="2" function="2">47d20e57-dff8-4120-8450-49119e6e0aae</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1981" distribution="0" maingenre="7" subgenre="0" flags="0" blocks="3" time="0" price_mod="1.00" />
+			<data country="USA" year="1981" distribution="0" maingenre="7" subgenre="0" flags="0" blocks="3" price_mod="1.00" />
 			<ratings critics="92" speed="57" outcome="65" />
 			<children>
 				<programme id="TheRob-serie-HinterEden-Ep001" product="2" fictional="0" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
@@ -11486,9 +11488,10 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="0" function="1">TheRob-TowerTV-MikaelCinamon</member>
 				<member index="1" function="2">506bc383-259e-4a36-9278-081aafc8f35c</member>
 				<member index="2" function="2">770dc8b2-a364-4cdf-99a3-6b8157c5cf92</member>
-				<member index="3" function="2">58cb1013-fa4c-42a8-9467-c931925109b6</member>                                                                                             			</staff>
+				<member index="3" function="2">58cb1013-fa4c-42a8-9467-c931925109b6</member>
+			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1978" distribution="0" maingenre="7" subgenre="2" flags="0" blocks="4" time="0" price_mod="1.00" />
+			<data country="USA" year="1978" distribution="0" maingenre="7" subgenre="2" flags="0" blocks="4" price_mod="1.00" />
 			<ratings critics="88" speed="82" outcome="94" />
 		</programme>
 
@@ -11510,9 +11513,10 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="0" function="1">TheRob-TowerTV-MikaelCinamon</member>
 				<member index="1" function="2">TheRob-TowerTV-ChristianLampnerd</member>
 				<member index="2" function="2">TheRob-TowerTV-LawrenceStempel</member>
-				<member index="3" function="2">e8d8fc33-b2ad-4998-8516-52182ef3911d</member>                                                                                             			</staff>
+				<member index="3" function="2">e8d8fc33-b2ad-4998-8516-52182ef3911d</member>
+			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1987" distribution="0" maingenre="2" subgenre="4" flags="0" blocks="2" time="0" price_mod="1.00" />
+			<data country="USA" year="1987" distribution="0" maingenre="2" subgenre="4" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="53" speed="82" outcome="47" />
 		</programme>
 
@@ -11536,7 +11540,7 @@ Traumszenen und Stimmungen verzerren die Handlung. </de>
 				<member index="2" function="2">e0807a2d-e04d-4abf-9422-afa44b202438</member>
 				</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1986" distribution="0" maingenre="1" subgenre="10" flags="0" blocks="2" time="0" price_mod="1.00" />
+			<data country="USA" year="1986" distribution="0" maingenre="1" subgenre="10" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="48" speed="62" outcome="34" />
 		</programme>
 
@@ -11834,7 +11838,8 @@ Educational precious and absolutly ecological.</en>
 				<member index="1" function="128">ronny-programmeperson-bennyjameson</member>
 			</staff>
 			<groups target_groups="256" />
-			<data country="USA" year="0" year_relative="-5" year_relative_min="1978" year_relative_max="1984" distribution="2" maingenre="0" subgenre="9" flags="0" blocks="1" price_mod="0.95" />
+			<data country="USA" distribution="2" maingenre="0" subgenre="9" flags="0" blocks="1" price_mod="0.95" />
+			<releaseTime year_relative="-5" year_relative_min="1978" year_relative_max="1984" />
 			<ratings critics="20" speed="30" outcome="0" />
 			<!-- Episodes -->
 			<children>
@@ -11905,7 +11910,8 @@ Educational precious and absolutly ecological.</en>
 				<member index="1" function="64" generator="es,0"></member>
 			</staff>
 			<groups target_groups="0" />
-			<data country="D" year="0" year_relative="-2" year_relative_min="1984" year_relative_max="1989" distribution="2" maingenre="0" blocks="1" tags="cooking,80s" />
+			<data country="D" distribution="2" maingenre="0" blocks="1" />
+			<releaseTime year_relative="-2" year_relative_min="1984" year_relative_max="1989" />
 			<modifiers>
 				<!-- the programme ages faster than average -->
 				<modifier name="topicality::age" value="1.5" />
@@ -11977,7 +11983,8 @@ Educational precious and absolutly ecological.</en>
 				<member index="1" function="2">common-amateur-actors</member>
 			</staff>
 			<groups target_groups="0" />
-			<data country="D" year="0" year_relative="-3" year_relative_min="1977" year_relative_max="1988" distribution="2" maingenre="0" blocks="1" />
+			<data country="D" distribution="2" maingenre="0" blocks="1" />
+			<releaseTime year_relative="-3" year_relative_min="1977" year_relative_max="1988" />
 			<ratings critics="44" speed="20" />
 			<!-- Episodes -->
 			<children>
@@ -12145,7 +12152,8 @@ Instructive stories convey current findings of recognized child and youth psycho
 				<member index="2" function="2">ronny-programmeperson-gertkalischke</member>
 			</staff>
 			<groups target_groups="0" />
-			<data country="D/F" year="0" year_relative="-2" year_relative_min="1980" year_relative_max="1990" distribution="2" maingenre="15" blocks="2" />
+			<data country="D/F" distribution="2" maingenre="15" blocks="2" />
+			<releaseTime year_relative="-2" year_relative_min="1980" year_relative_max="1990" />
 			<ratings critics="31" speed="30" />
 			<!-- Episodes -->
 			<children>

--- a/res/database/Default/database_scripts.xml
+++ b/res/database/Default/database_scripts.xml
@@ -399,8 +399,8 @@
 			<jobs>
 				<job index="0" function="1" required="1" />
 				<job index="1" function="2" required="1" gender="1" />
-				<job index="2" function="6" required="0" gender="2" />
-				<job index="3" function="6" required="0" />
+				<job index="2" function="32" required="0" gender="2" />
+				<job index="3" function="32" required="0" />
 			</jobs>
 
 			<!-- mandatory: xrated  |  optional: cult -->
@@ -564,31 +564,31 @@
 					</title>
 					<blocks min="1" max="1" />
 				</scripttemplate>
-				<scripttemplate index="0" product="2" licence_type="2" guid="scripttemplate-random-ron-animalseries01_02">
+				<scripttemplate index="1" product="2" licence_type="2" guid="scripttemplate-random-ron-animalseries01_02">
 					<title>
 						<de>%TITLEEPISODE2%</de>
 					</title>
 					<blocks min="1" max="1" />
 				</scripttemplate>
-				<scripttemplate index="0" product="2" licence_type="2" guid="scripttemplate-random-ron-animalseries01_03">
+				<scripttemplate index="2" product="2" licence_type="2" guid="scripttemplate-random-ron-animalseries01_03">
 					<title>
 						<de>%TITLEEPISODE3%</de>
 					</title>
 					<blocks min="1" max="1" />
 				</scripttemplate>
-				<scripttemplate index="0" product="2" licence_type="2" guid="scripttemplate-random-ron-animalseries01_04">
+				<scripttemplate index="3" product="2" licence_type="2" guid="scripttemplate-random-ron-animalseries01_04">
 					<title>
 						<de>%TITLEEPISODE4%</de>
 					</title>
 					<blocks min="1" max="1" />
 				</scripttemplate>
-				<scripttemplate index="0" product="2" licence_type="2" guid="scripttemplate-random-ron-animalseries01_05">
+				<scripttemplate index="4" product="2" licence_type="2" guid="scripttemplate-random-ron-animalseries01_05">
 					<title>
 						<de>%TITLEEPISODE5%</de>
 					</title>
 					<blocks min="1" max="1" />
 				</scripttemplate>
-				<scripttemplate index="0" product="2" licence_type="2" guid="scripttemplate-random-ron-animalseries01_06">
+				<scripttemplate index="5" product="2" licence_type="2" guid="scripttemplate-random-ron-animalseries01_06">
 					<title>
 						<de>%TITLEEPISODE6%</de>
 					</title>
@@ -693,13 +693,13 @@
 		<programmerole guid="script-roles-sco-002" first_name="Harry" last_name="Wallace" title="Dr." gender="1" country="SCO" />
 		<programmerole guid="script-roles-sco-003" first_name="Charlie" last_name="McCallum" title="" gender="1" country="SCO" />
 
-		<programmerole guid="script-roles-swe-001" first_name="Liam" last_name="Bengtsson" title="" gender="1" country="SWE" />
-		<programmerole guid="script-roles-swe-002" first_name="Alva" last_name="Lindberg" title="Prof." gender="1" country="SWE" />
-		<programmerole guid="script-roles-swe-003" first_name="Filip" last_name="Jönsson" title="" gender="1" country="SWE" />
+		<programmerole guid="script-roles-swe-001" first_name="Liam" last_name="Bengtsson" title="" gender="1" country="S" />
+		<programmerole guid="script-roles-swe-002" first_name="Alva" last_name="Lindberg" title="Prof." gender="1" country="S" />
+		<programmerole guid="script-roles-swe-003" first_name="Filip" last_name="Jönsson" title="" gender="1" country="S" />
 
-		<programmerole guid="script-roles-eng-001" first_name="Molly" last_name="Winfield" title="" gender="2" country="UK" />
-		<programmerole guid="script-roles-eng-002" first_name="Callum" last_name="Winston" title="" gender="1" country="UK" />
-		<programmerole guid="script-roles-eng-003" first_name="Abigail" last_name="Wyler" title="" gender="2" country="UK" />
+		<programmerole guid="script-roles-eng-001" first_name="Molly" last_name="Winfield" title="" gender="2" country="GB" />
+		<programmerole guid="script-roles-eng-002" first_name="Callum" last_name="Winston" title="" gender="1" country="GB" />
+		<programmerole guid="script-roles-eng-003" first_name="Abigail" last_name="Wyler" title="" gender="2" country="GB" />
 
 		<programmerole guid="script-roles-ger-001" first_name="Vincent" last_name="Graf" gender="1" country="D" />
 		<programmerole guid="script-roles-ger-002" first_name="Emelie" last_name="Schulte" gender="2" country="D" />

--- a/res/database/Default/database_scripts.xml
+++ b/res/database/Default/database_scripts.xml
@@ -182,7 +182,7 @@
 				<job index="3" function="32" required="0" />
 			</jobs>
 			<!-- mandatory: /  |  optional: xrated, bmovie, trash -->
-			<data flags="0" optional_flags="112" />
+			<data flags="0" flags_optional="112" />
 			<genres main_genre="1" />
 			<blocks min="2" max="3" slope="25" />
 			<price min="8000" max="12000" slope="40" />
@@ -269,7 +269,7 @@
 			</jobs>
 
 			<!-- mandatory: xrated  |  optional: bmovie, trash -->
-			<data flags="64" optional_flags="48"/>
+			<data flags="64" flags_optional="48"/>
 			<studio_size min="1" max="2" slope="20" /> 
 			<genres maingenre="8" subgenres="15"/>
 			<blocks min="2" max="3" slope="20" />
@@ -336,7 +336,7 @@
 			</jobs>
 
 			<!-- optional: xrated | cult -->
-			<data optional_flags="72" />
+			<data flags_optional="72" />
 			<genres maingenre="12" subgenres="14"/>
 			<blocks min="2" max="3" slope="20" />
 			<price min="9500" max="30000" slope="50" />
@@ -404,7 +404,7 @@
 			</jobs>
 
 			<!-- mandatory: xrated  |  optional: cult -->
-			<data optional_flags="8" />
+			<data flags_optional="8" />
 			<genres maingenre="7" subgenres="9"/>
 			<blocks min="2" max="3" slope="20" />
 			<price min="7500" max="25000" slope="40" />

--- a/res/database/Default/database_scripts.xml
+++ b/res/database/Default/database_scripts.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tvgdb>
+<tvtdb>
 	<version value="3" comment="script data" />
 	<!--
 		title, description, variables, roles and quality are FIXED parts
@@ -183,7 +183,7 @@
 			</jobs>
 			<!-- mandatory: /  |  optional: xrated, bmovie, trash -->
 			<data flags="0" flags_optional="112" />
-			<genres main_genre="1" />
+			<genres maingenre="1" />
 			<blocks min="2" max="3" slope="25" />
 			<price min="8000" max="12000" slope="40" />
 			<potential min="30" max="70" slope="45" />
@@ -701,28 +701,28 @@
 		<programmerole guid="script-roles-eng-002" first_name="Callum" last_name="Winston" title="" gender="1" country="UK" />
 		<programmerole guid="script-roles-eng-003" first_name="Abigail" last_name="Wyler" title="" gender="2" country="UK" />
 
-		<programmerole id="script-roles-ger-001" first_name="Vincent" last_name="Graf" gender="1" country="D" />
-		<programmerole id="script-roles-ger-002" first_name="Emelie" last_name="Schulte" gender="2" country="D" />
-		<programmerole id="script-roles-ger-003" first_name="Adrian" last_name="Dietrich" gender="1" country="D" />
-		<programmerole id="script-roles-ger-004" first_name="Jana" last_name="Ziegler" gender="2" country="D" />
-		<programmerole id="script-roles-ger-005" first_name="Jonathan" last_name="Kuhn" gender="1" country="D" />
-		<programmerole id="script-roles-ger-006" first_name="Viktoria" last_name="Kühn" gender="2" country="D" />
-		<programmerole id="script-roles-ger-007" first_name="Theo" last_name="Engel" gender="1" country="D" />
-		<programmerole id="script-roles-ger-008" first_name="Josefine" last_name="Horn" gender="2" country="D" />
-		<programmerole id="script-roles-ger-009" first_name="Niko" last_name="Bergmann" gender="1" country="D" />
-		<programmerole id="script-roles-ger-010" first_name="Finja" last_name="Thomas" gender="2" country="D" />
-		<programmerole id="script-roles-ger-011" first_name="Till" last_name="Voigt" gender="1" country="D" />
-		<programmerole id="script-roles-ger-012" first_name="Isabel" last_name="Sauer" gender="2" country="D" />
-		<programmerole id="script-roles-ger-013" first_name="Benjamin" last_name="Arnold" gender="1" country="D" />
-		<programmerole id="script-roles-ger-014" first_name="Helena" last_name="Wolff" gender="2" country="D" />
-		<programmerole id="script-roles-ger-015" first_name="Florian" last_name="Pfeiffer" gender="1" country="D" />
-		<programmerole id="script-roles-ger-016" first_name="Isabella" last_name="Hansen" gender="2" country="D" />
-		<programmerole id="script-roles-ger-017" first_name="Marlon" last_name="Huber" gender="1" country="D" />
-		<programmerole id="script-roles-ger-018" first_name="Elisa" last_name="Petersen" gender="2" country="D" />
-		<programmerole id="script-roles-ger-019" first_name="Bernd" last_name="Orlowski" gender="1" country="D" />
-		<programmerole id="script-roles-ger-020" first_name="Manfred" last_name="Schimanski" gender="1" country="D" />
-		<programmerole id="script-roles-ger-021" first_name="Klaus" last_name="Rudzinski" gender="1" country="D" />
+		<programmerole guid="script-roles-ger-001" first_name="Vincent" last_name="Graf" gender="1" country="D" />
+		<programmerole guid="script-roles-ger-002" first_name="Emelie" last_name="Schulte" gender="2" country="D" />
+		<programmerole guid="script-roles-ger-003" first_name="Adrian" last_name="Dietrich" gender="1" country="D" />
+		<programmerole guid="script-roles-ger-004" first_name="Jana" last_name="Ziegler" gender="2" country="D" />
+		<programmerole guid="script-roles-ger-005" first_name="Jonathan" last_name="Kuhn" gender="1" country="D" />
+		<programmerole guid="script-roles-ger-006" first_name="Viktoria" last_name="Kühn" gender="2" country="D" />
+		<programmerole guid="script-roles-ger-007" first_name="Theo" last_name="Engel" gender="1" country="D" />
+		<programmerole guid="script-roles-ger-008" first_name="Josefine" last_name="Horn" gender="2" country="D" />
+		<programmerole guid="script-roles-ger-009" first_name="Niko" last_name="Bergmann" gender="1" country="D" />
+		<programmerole guid="script-roles-ger-010" first_name="Finja" last_name="Thomas" gender="2" country="D" />
+		<programmerole guid="script-roles-ger-011" first_name="Till" last_name="Voigt" gender="1" country="D" />
+		<programmerole guid="script-roles-ger-012" first_name="Isabel" last_name="Sauer" gender="2" country="D" />
+		<programmerole guid="script-roles-ger-013" first_name="Benjamin" last_name="Arnold" gender="1" country="D" />
+		<programmerole guid="script-roles-ger-014" first_name="Helena" last_name="Wolff" gender="2" country="D" />
+		<programmerole guid="script-roles-ger-015" first_name="Florian" last_name="Pfeiffer" gender="1" country="D" />
+		<programmerole guid="script-roles-ger-016" first_name="Isabella" last_name="Hansen" gender="2" country="D" />
+		<programmerole guid="script-roles-ger-017" first_name="Marlon" last_name="Huber" gender="1" country="D" />
+		<programmerole guid="script-roles-ger-018" first_name="Elisa" last_name="Petersen" gender="2" country="D" />
+		<programmerole guid="script-roles-ger-019" first_name="Bernd" last_name="Orlowski" gender="1" country="D" />
+		<programmerole guid="script-roles-ger-020" first_name="Manfred" last_name="Schimanski" gender="1" country="D" />
+		<programmerole guid="script-roles-ger-021" first_name="Klaus" last_name="Rudzinski" gender="1" country="D" />
 
 
 	</programmeroles>
-</tvgdb>
+</tvtdb>

--- a/res/database/Default/user/jorgaeff.xml
+++ b/res/database/Default/user/jorgaeff.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tvgdb>
+<tvtdb>
 	<version value="3" comment="jorgaeffs Nachrichten" />
 	<allnews>
 
@@ -11,7 +11,7 @@
 			<description>
 				<de>Die Volksrepublik Duban hat Donald Dumb zu ihrem neuen Präsidenten ernannt. Für die nächsten vier Jahre wird der Multi-Millionär die Geschicke der Volksrepublik leiten.</de>
 			</description>
-			<data genre="0" price="0.9" quality="75" fictional="True" />
+			<data genre="0" price="0.9" quality="75" fictional="1" />
 			<effects>
 				<!-- "morgen 9-12 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,1,1,9,12" news="news-jorgaeff-dumb-02" />
@@ -25,7 +25,7 @@
 			<description>
 				<de>In seiner Eröffnungsrede bezeichnete Dumb die Freie Republik Duban als "... Abschaum, der beseitigt werden muss!". Die Freie Republik Duban drohte daraufhin Konsequenzen an.</de>
 			</description>
-			<data genre="0" price="0.9" quality="75" fictional="True" />
+			<data genre="0" price="0.9" quality="75" fictional="1" />
 			<effects>
 				<!-- "uebermorgen 8-16 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,2,2,8,16" news="news-jorgaeff-dumb-03" />
@@ -39,7 +39,7 @@
 			<description>
 				<de>Weil sein hölzerner Gartenzaun schon wieder kaputt ist, möchte der Präsident der Volksrepublik Duban nun eine Mauer um sein Grundstück bauen. Sein Kommentar: "Steine halten einfach länger.".</de>
 			</description>
-			<data genre="0" price="0.7" quality="55" fictional="True" />
+			<data genre="0" price="0.7" quality="55" fictional="1" />
 			<effects>
 				<!-- "morgen 2-7 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,1,1,2,7" news="news-jorgaeff-dumb-04" />
@@ -53,7 +53,7 @@
 			<description>
 				<de>Donald Dumb ist traurig da er schon seit Tagen seine Quietsche-Ente nicht mehr finden kann. "Ohne die Quietsche-Ente macht dem Präsidenten das Baden keinen Spaß mehr und er duscht lieber", wird Dumb von seinem Pressesprecher zitiert.</de>
 			</description>
-			<data genre="0" price="0.7" quality="55" fictional="True" />
+			<data genre="0" price="0.7" quality="55" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-1987-0-01" type="0" creator="8936" created_by="jorgaeff">
@@ -64,7 +64,7 @@
 			<description>
 				<de>Zu einem schwarzen Montag kam es heute an den internationalen Börsen. Weltweit sanken die Kurse um über 20%. Es ist der erste Börsenkrach seit dem 2. Weltkrieg.</de>
 			</description>
-			<data genre="0" price="0.8" quality="80" fictional="True" flags="2" />
+			<data genre="0" price="0.8" quality="80" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1988-0-01" type="0" creator="8936" created_by="jorgaeff">
@@ -75,7 +75,7 @@
 			<description>
 				<de>An der Deutschen Börse in Frankfurt wurde das deutsche Aktien-System (Daks) eingeführt. Es misst die Wertentwicklung der 30 größten und liquidesten Unternehmen des deutschen Aktienmarktes.</de>
 			</description>
-			<data genre="0" price="0.8" quality="80" fictional="False" flags="2" />
+			<data genre="0" price="0.8" quality="80" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1985-0-BRD-01" type="0" thread_id="news-jorgaeff-1985-0-BRD" creator="8936" created_by="jorgaeff">
@@ -86,7 +86,7 @@
 			<description>
 				<de>Bei der Landtagswahl in Nordrhein-Westfalen erzielt die Arbeiterpartei Deutschland (APD) unter Ministerpräsident Hannes Reif mit 52,1% der Stimmen das beste Wahlergebnis ihrer Geschichte in diesem Bundesland.</de>
 			</description>
-			<data genre="0" price="0.6" quality="60" fictional="False" flags="2" />
+			<data genre="0" price="0.6" quality="60" fictional="0" flags="2" />
 			<effects>
 				<!-- "in 2 Tagen 14-20 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,2,2,14,20" news="news-jorgaeff-1985-0-BRD-02" />
@@ -101,7 +101,7 @@
 			<description>
 				<de>Die Arbeiterpartei Deutschland (APD) nominiert den nordrhein-westfälischen Ministerpräsidenten Hannes Reif zum Kanzlerkandidaten für die Bundestagswahl 1987.</de>
 			</description>
-			<data genre="0" price="0.5" quality="50" fictional="False" flags="2" />
+			<data genre="0" price="0.5" quality="50" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1987-0-BRD-01" type="0" creator="8936" created_by="jorgaeff">
@@ -112,7 +112,7 @@
 			<description>
 				<de>Historische Rede von US-Präsident Robert Keagan anlässlich der 750-Jahr-Feier West-Berlins: "Mr. Michailow - Tear down this wall!"</de>
 			</description>
-			<data genre="0" price="0.5" quality="50" fictional="False" flags="2" />
+			<data genre="0" price="0.5" quality="50" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1987-0-BRD-02" type="0" creator="8936" created_by="jorgaeff">
@@ -123,7 +123,7 @@
 			<description>
 				<de>Die großen Parteien gehen als Verlierer aus der Bundestagswahl hervor. Dennoch hat die Scheinheiligen-Partei Deutschland (ShPD) auch weiterhin die Mehrheit. Eine weitere Amtszeit von Herbert Kappes steht bevor.</de>
 			</description>
-			<data genre="0" price="0.5" quality="50" fictional="False" flags="2" />
+			<data genre="0" price="0.5" quality="50" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1988-0-BRD-01" type="0" creator="8936" created_by="jorgaeff">
@@ -134,7 +134,7 @@
 			<description>
 				<de>Bundeskanzler Herbert Kappes besucht den sowjetischen Staats- und Parteichef Sergei Michailow in Moskau. Beide erklären ihre Bereitschaft die „Zeit des Eises“ durch ein freundlicheres Klima abzulösen.</de>
 			</description>
-			<data genre="0" price="0.5" quality="50" fictional="False" flags="2" />
+			<data genre="0" price="0.5" quality="50" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1985-0-DDR-01" type="0" creator="8936" created_by="jorgaeff">
@@ -145,7 +145,7 @@
 			<description>
 				<de>Im geteilten Berlin kommt es zum größten Agentenaustausch in der Nachkriegsära. 25 Westspione wechseln auf der Glienicker Brücke gegen vier Ostagenten die Demarkationslinie. 25:4? Ja, das liegt am Wechselkurs!</de>
 			</description>
-			<data genre="0" price="0.6" quality="60" fictional="False" flags="2" />
+			<data genre="0" price="0.6" quality="60" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1986-0-DDR-01" type="0" creator="8936" created_by="jorgaeff">
@@ -156,7 +156,7 @@
 			<description>
 				<de>Hoher Besuch beim Parteitag der sozialistischen Partei Ost-Deutschland (SPOD) im Palast der Republik: KPdvSS-Generalsekretär, Sergei Michailow, spricht vor den Genossen und hat auch ein paar Geschenke dabei.</de>
 			</description>
-			<data genre="0" price="0.8" quality="80" fictional="False" flags="2" />
+			<data genre="0" price="0.8" quality="80" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1987-0-DDR-01" type="0" creator="8936" created_by="jorgaeff">
@@ -167,7 +167,7 @@
 			<description>
 				<de>Emil Hoecker besucht als erster DDR-Staatschef die Bundesrepublik Deutschland und überrascht Bundeskanzler Herbert Kappes mit Senf aus Bautzen und einer Dose Spreewald-Gurken.</de>
 			</description>
-			<data genre="0" price="0.8" quality="80" fictional="False" flags="2" />
+			<data genre="0" price="0.8" quality="80" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1988-0-DDR-01a" type="0" thread_id="news-jorgaeff-1988-0-DDR" creator="8936" created_by="jorgaeff">
@@ -178,7 +178,7 @@
 			<description>
 				<de>Der rumänische Präsident Nicolae Grotesko trifft sich in Ost-Berlin zu Gesprächen mit Emil Hoecker und wird anlässlich seines 70. Geburtstages mit dem Karl-Marx-Orden ausgezeichnet.</de>
 			</description>
-			<data genre="0" price="0.8" quality="80" fictional="False" flags="2" />
+			<data genre="0" price="0.8" quality="80" fictional="0" flags="2" />
 			<effects>
 				<!-- "in 4-8 Stunden" -->
 				<effect trigger="happen" type="triggernews" time="1,4,8" news="news-jorgaeff-1988-0-DDR-01b" />
@@ -193,7 +193,7 @@
 			<description>
 				<de>Am Rande des Treffens mit dem rumänischen Präsidenten Nicolaoe Grotesko kündigt Emil Hoecker einen früheren Abbau von Atomraketen mittlerer Reichweite an.</de>
 			</description>
-			<data genre="0" price="0.8" quality="80" fictional="False" flags="2" />
+			<data genre="0" price="0.8" quality="80" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1985-0-UdSSR-01" type="0" creator="8936" created_by="jorgaeff">
@@ -204,7 +204,7 @@
 			<description>
 				<de>Im Alter von 54 Jahren wird Sergei Michailow zum jüngsten Generalsekretär in der Geschichte der Kommunistischen Partei der vereinigten Sowjet-Staaten (KPdvSS) gewählt.</de>
 			</description>
-			<data genre="0" price="0.8" quality="80" fictional="False" flags="2" />
+			<data genre="0" price="0.8" quality="80" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1986-0-UdSSR-01" type="0" creator="8936" created_by="jorgaeff">
@@ -215,7 +215,7 @@
 			<description>
 				<de>Forderungen von KPdvSS-Generalsekretär, Sergei Michailow, nach mehr Rede- und Pressefreiheit waren das zentrale Thema auf dem 27. Parteitag der Kommunistischen Partei der vereinigten Sowjet-Staaten.</de>
 			</description>
-			<data genre="0" price="0.8" quality="80" fictional="False" flags="2" />
+			<data genre="0" price="0.8" quality="80" fictional="0" flags="2" />
 		</news>
 
 		<!-- triggers other thread...-->
@@ -227,7 +227,7 @@
 			<description>
 				<de>KPdvSS-Generalsekretär, Sergei Michailow, schlägt dem Westen vor, alle Kernwaffen bis zum Jahr 2000 abzurüsten. Das eingesparte Uran soll in den Kraftwerken zur Energie-Gewinnung verwendet werden.</de>
 			</description>
-			<data genre="0" price="0.8" quality="80" fictional="False" flags="2" />
+			<data genre="0" price="0.8" quality="80" fictional="0" flags="2" />
 			<effects>
 				<!-- "in 3 Tagen 18-23 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,3,3,18,23" news="news-jorgaeff-1986-4-UdSSR-02b" />
@@ -242,7 +242,7 @@
 			<description>
 				<de>KPdvSS-Generalsekretär Sergei Michailow hat den Verteidigungsminister und den Chef der sowjetischen Luftverteidigung wegen der Landung des deutschen Piloten, Markus Lahr, auf dem Roten Platz in Moskau entlassen.</de>
 			</description>
-			<data genre="0" price="0.6" quality="60" fictional="False" flags="2" />
+			<data genre="0" price="0.6" quality="60" fictional="0" flags="2" />
 			<effects>
 				<!-- "in 2 Tagen 14-16 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,1,1,10,16" news="news-jorgaeff-1987-0-UdSSR-01c" />
@@ -257,7 +257,7 @@
 			<description>
 				<de>KPdvSS-Generalsekretär Sergei Michailow hat über 300 weitere perestroika- und glasnostfeindlich eingestellte Generäle entlassen. Er möchte die Wende im Ostblock weiter voran treiben.</de>
 			</description>
-			<data genre="0" price="0.6" quality="60" fictional="False" flags="2" />
+			<data genre="0" price="0.6" quality="60" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1985-0-USA-01" type="0" creator="8936" created_by="jorgaeff">
@@ -268,7 +268,7 @@
 			<description>
 				<de>Bundeskanzler Herbert Kappes erwartet einen ganz besonderen Gast: Robert Keagan besucht die Bundesrepublik Deutschland. Der US-Präsident möchte aber auch ein Fußballspiel besuchen.</de>
 			</description>
-			<data genre="0" price="0.5" quality="50" fictional="False" flags="2" />
+			<data genre="0" price="0.5" quality="50" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1987-0-USA-01" type="0" creator="8936" created_by="jorgaeff">
@@ -279,7 +279,7 @@
 			<description>
 				<de>Der sowjetische Staatschef Sergei Michailow und US-Präsident Robert Keagan unterzeichnen in Washington den INF-Vertrag über den vollständigen Abbau aller nuklearen Mittelstreckenwaffen kürzerer und längerer Reichweite.</de>
 			</description>
-			<data genre="0" price="0.5" quality="50" fictional="False" flags="2" />
+			<data genre="0" price="0.5" quality="50" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1988-0-USA-01a" type="0" thread_id="news-jorgaeff-1988-0-USA-01" creator="8936" created_by="jorgaeff">
@@ -290,7 +290,7 @@
 			<description>
 				<de>Da die 2. Amtszeit von Robert Keagan zu Ende geht und er kein drittes Mal kandidieren darf, streiten sich Vize-Präsident Gregory H. W. Cush und Senator Michael "Mc" Monco um das Amt des US-Präsidenten.</de>
 			</description>
-			<data genre="0" price="0.5" quality="50" fictional="False" flags="2" />
+			<data genre="0" price="0.5" quality="50" fictional="0" flags="2" />
 			<effects>
 				<!-- "in 2 Tagen 3-12 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,2,2,3,12" news="news-jorgaeff-1988-0-USA-01b" />
@@ -305,7 +305,7 @@
 			<description>
 				<de>Gregory H. W. Cush setzt sich mit 426 zu 111 Wahlmännerstimmen klar gegen seinen Kontrahanten Michael "Mc" Monco durch und wird 41. Präsident der Vereinigten Staaten.</de>
 			</description>
-			<data genre="0" price="0.5" quality="50" fictional="False" flags="2" />
+			<data genre="0" price="0.5" quality="50" fictional="0" flags="2" />
 		</news>
 
 
@@ -319,7 +319,7 @@
 			<description>
 				<de>Mit einem Alterdurchschnitt von 89 Jahren touren die Rolling Bricks durch die Altersheime der Nation. Für ihren Pressesprecher ist es "... die perfekte Möglichkeit sich einen Ruhesitz auszusuchen.".</de>
 			</description>
-			<data genre="1" price="0.45" quality="45" fictional="True" />
+			<data genre="1" price="0.45" quality="45" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-chorris-01" type="0" thread_id="news-jorgaeff-chorris" creator="8936" created_by="jorgaeff">
@@ -329,7 +329,7 @@
 			<description>
 				<de>Das hat vor ihm noch keiner geschafft, doch nun ist es Kampfkünstler und Action-Schauspieler Nuck Chorris gelungen die Zeit tot zu schlagen. Und das Beste: Es ist völlig legal!</de>
 			</description>
-			<data genre="1" price="0.3" quality="30" fictional="True" />
+			<data genre="1" price="0.3" quality="30" fictional="1" />
 			<effects>
 				<!-- "in 3 Tagen 20-23 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,3,3,20,23" news="news-jorgaeff-chorris-02" />
@@ -343,7 +343,7 @@
 			<description>
 				<de>Laut eigenen Angaben hat Nuck Chorris bereits 2x bis zur Unendlichkeit gezählt. Die Mathe-Experten dieser Erde rätseln immer noch darüber ob das stimmt.</de>
 			</description>
-			<data genre="1" price="0.3" quality="30" fictional="True" />
+			<data genre="1" price="0.3" quality="30" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-drops-01" type="0" thread_id="news-jorgaeff-drops" creator="8936" created_by="jorgaeff">
@@ -353,7 +353,7 @@
 			<description>
 				<de>Beim Dreh von "Mein Grog - dein Grog" hat sich Jonnie Drops an einer zerbrochenen Grogflasche verletzt. Die Dreharbeiten verzögern sich.</de>
 			</description>
-			<data genre="1" price="0.4" quality="40" fictional="True" />
+			<data genre="1" price="0.4" quality="40" fictional="1" />
 			<effects>
 				<!-- "morgen 10-12 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,1,1,10,12" news="news-jorgaeff-drops-02" />
@@ -409,7 +409,7 @@
 			<description>
 				<de>Am Rande der Filmpreisverleihungen gesteht Patty Glansen, die zusammen mit Jonnie Drops in "Mein Grog - dein Grog" vor der Kamera stand, eine Affaire mit dem Schauspieler.</de>
 			</description>
-			<data genre="1" price="0.35" quality="35" fictional="True" />
+			<data genre="1" price="0.35" quality="35" fictional="1" />
 			<effects>
 				<!-- "in 0-3 Stunden" -->
 				<effect trigger="happen" type="triggernews" time="1,0,3" news="news-jorgaeff-drops-06" />
@@ -424,7 +424,7 @@
 			<description>
 				<de>Weil er bei den Filmpreisverleihungen keinen Preis erhalten hat, klaut sich Benny Jameson einfach einen und verschwindet durch die Hintertür.</de>
 			</description>
-			<data genre="1" price="0.45" quality="40" fictional="True" />
+			<data genre="1" price="0.45" quality="40" fictional="1" />
 			<effects>
 				<!-- "übermorgen 17-23 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,2,2,17,23" news="news-jorgaeff-drops-07" />
@@ -439,7 +439,7 @@
 			<description>
 				<de>Den geklauten Filmpreis hat er zurück gegeben. Trotzdem wurde Benny Jameson zu einer dreitägigen Gefängnisstrafe verurteilt, die er bereits angetreten hat.</de>
 			</description>
-			<data genre="1" price="0.5" quality="45" fictional="True" />
+			<data genre="1" price="0.5" quality="45" fictional="1" />
 			<effects>
 				<!-- "übermorgen 10-16 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,2,2,10,16" news="news-jorgaeff-drops-08" />
@@ -454,7 +454,7 @@
 			<description>
 				<de>Aufgrund guter Führung wurde Benny Jameson einen Tag früher aus dem Gefängnis entlassen. Der Schauspieler möchte seine Erfahrungen nun in einem Film verarbeiten.</de>
 			</description>
-			<data genre="1" price="0.55" quality="50" fictional="True" />
+			<data genre="1" price="0.55" quality="50" fictional="1" />
 			<effects>
 				<!-- "in 7 Tagen 0-23 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,7,7,0,23" news="news-jorgaeff-drops-09" />
@@ -469,7 +469,7 @@
 			<description>
 				<de>Für die Rolle eines Häftlings wurde Benny Jameson mit einem Filmpreis geehrt. Die Kritiker loben die besonders realistische Darstellung des Schauspielers.</de>
 			</description>
-			<data genre="1" price="0.6" quality="55" fictional="True" />
+			<data genre="1" price="0.6" quality="55" fictional="1" />
 			<effects>
 				<effect trigger="happen" type="modifyPersonPopularity" referenceGUID="ronny-programmeperson-bennyjameson" valueMin="0.03" valueMax="0.07" />
 			</effects>
@@ -483,7 +483,7 @@
 			<description>
 				<de>"Brake on me", der #1-Hit der finnischen Popgruppe hoi-hoi, hält sich seit 14 Wochen an der Spitze der Charts. Weltweit konnte die nordeuropäische Band in 26 Ländern die höchste Chartplatzierung errreichen.</de>
 			</description>
-			<data genre="1" price="0.5" quality="50" fictional="True" flags="2" />
+			<data genre="1" price="0.5" quality="50" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1985-1-02" type="0" creator="8936" created_by="jorgaeff">
@@ -494,7 +494,7 @@
 			<description>
 				<de>"Born in the States", das Musikalbum des amerikanischen Sängers Chris Springfield, wurde zum einflussreichsten Musikalbum des Jahres gewählt. Springfield verwendet darin erstmals Synthesizer.</de>
 			</description>
-			<data genre="1" price="0.4" quality="40" fictional="False" flags="2" />
+			<data genre="1" price="0.4" quality="40" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1985-1-03" type="0" creator="8936" created_by="jorgaeff">
@@ -505,7 +505,7 @@
 			<description>
 				<de>Bei den diesjährigen deutschen Filmpreisverleihungen wurde das Werk der norddeutschen Komikerin, Anna Friese, ausgezeichnet. Dietbert von den Hallern ging mit "Die Rache der Entthronten" leer aus.</de>
 			</description>
-			<data genre="1" price="0.4" quality="40" fictional="False" flags="2" />
+			<data genre="1" price="0.4" quality="40" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1986-1-01" type="0" creator="8936" created_by="jorgaeff">
@@ -516,7 +516,7 @@
 			<description>
 				<de>Die Thrash-Metal-Band Palladium bringt heute ihr Album "Der Puppenspieler" heraus. Es wird einmal als Meilenstein des Thrash Metal und eines der besten Metal-Alben überhaupt angesehen werden.</de>
 			</description>
-			<data genre="1" price="0.3" quality="30" fictional="False" flags="2" />
+			<data genre="1" price="0.3" quality="30" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1986-1-02" type="0" creator="8936" created_by="jorgaeff">
@@ -527,7 +527,7 @@
 			<description>
 				<de>Mater Dolorosa schafft mit ihrem dritten Album "Real Green" den Sprung auf Platz 1 der Hitparaden in 28 Ländern. Für eine weibliche Interpretin ein noch nie da gewesener Erfolg.</de>
 			</description>
-			<data genre="1" price="0.35" quality="35" fictional="False" flags="2" />
+			<data genre="1" price="0.35" quality="35" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1986-1-03" type="0" creator="8936" created_by="jorgaeff">
@@ -538,7 +538,7 @@
 			<description>
 				<de>Bei den diesjährigen Filmpreisverleihungen wurde George Weismans Film "Jenseits von Eden" als bester Film ausgezeichnet. Der Film basiert auf Briefen der kanadischen Schriftstellerin Elke Beauford.</de>
 			</description>
-			<data genre="1" price="0.4" quality="40" fictional="False" flags="2" />
+			<data genre="1" price="0.4" quality="40" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1987-1-01" type="0" creator="8936" created_by="jorgaeff">
@@ -549,7 +549,7 @@
 			<description>
 				<de>Michel Jacobson veröffentlicht mit dem Album "Bed" sein neues und lange erwartetes Nachfolge-Album von "Table". "Bed" wird Nummer 1 in 25 Ländern und verkauft sich über 30 Millionen mal.</de>
 			</description>
-			<data genre="1" price="0.3" quality="30" fictional="False" flags="2" />
+			<data genre="1" price="0.3" quality="30" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1987-1-02" type="0" creator="8936" created_by="jorgaeff">
@@ -560,7 +560,7 @@
 			<description>
 				<de>Mit Elysium hat sich an der nordamerikanischen Ostküste eine neue Band gegründet. Die Musiker um Band-Leader Kurt Kokain möchten "dieses Grunge-Rock-Ding" weiterentwickeln und die Band weltweit berühmt machen.</de>
 			</description>
-			<data genre="1" price="0.3" quality="30" fictional="False" flags="2" />
+			<data genre="1" price="0.3" quality="30" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1987-1-03" type="0" creator="8936" created_by="jorgaeff">
@@ -571,7 +571,7 @@
 			<description>
 				<de>Bei den diesjährigen Filmpreisverleihungen wurde Bulli Steins Film "Squad" als bester Film ausgezeichnet. Der Kriegsfilm zeigt die Auswüchse des Vietnamkrieges und seine Wirkung auf Infanteriesoldaten.</de>
 			</description>
-			<data genre="1" price="0.4" quality="40" fictional="False" flags="2" />
+			<data genre="1" price="0.4" quality="40" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1987-1-04" type="0" creator="8936" created_by="jorgaeff">
@@ -582,7 +582,7 @@
 			<description>
 				<de>Zum erfolgreichsten Song des Jahres hat es leider nicht gereicht. Mater Dolorosas Hit "The Isle of Bel Air" wurde von Eagernesses Chart-Breaker "Travel travel" noch knapp übertroffen.</de>
 			</description>
-			<data genre="1" price="0.4" quality="40" fictional="False" flags="2" />
+			<data genre="1" price="0.4" quality="40" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1988-1-DDR-01" type="0" creator="8936" created_by="jorgaeff">
@@ -593,7 +593,7 @@
 			<description>
 				<de>160.000 Ost-Berliner waren gekommen um US-Rocklegende Chris Springfield zu sehen. Das Konzert auf der Radrennbahn Hiddensee ist das größte DDR-Konzert aller Zeiten und ein weiterer Beweis, dass der Osten sich dem Westen öffnet.</de>
 			</description>
-			<data genre="1" price="0.6" quality="60" fictional="False" flags="2" />
+			<data genre="1" price="0.6" quality="60" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1988-1-01" type="0" creator="8936" created_by="jorgaeff">
@@ -604,7 +604,7 @@
 			<description>
 				<de>Hubert Obermeyer veröffentlicht mit "Ä" sein siebtes Studioalbum. Der Rock-Poet aus Bochum ist der kommerziell erfolgreichste zeitgenössische Musiker Deutschlands; seine auffällige Gesangsart und eine marcatoartige Gestik beim Singen gehören zu seinen Markenzeichen.</de>
 			</description>
-			<data genre="1" price="0.6" quality="60" fictional="False" flags="2" />
+			<data genre="1" price="0.6" quality="60" fictional="0" flags="2" />
 		</news>
 
 
@@ -619,7 +619,7 @@
 			<description>
 				<de>Zum ersten Mal seit 26 Jahren haben die Blue Socks wieder die Meisterschaft gewonnen. In einer packenden Finalserie konnten Sie sich letztendlich gegen die Rednecks mit 4:3 durchsetzen.</de>
 			</description>
-			<data genre="2" price="0.2" quality="30" fictional="False" />
+			<data genre="2" price="0.2" quality="30" fictional="0" />
 		</news>
 
 		<news id="news-jorgaeff-fufa-01" type="0" creator="8936" created_by="jorgaeff">
@@ -629,7 +629,7 @@
 			<description>
 				<de>Ginge es nach den Vorstellungen der FUFA würden ab dem kommenden Jahr die Fußball-Weltmeisterschaften erstmals ohne die Nationalteams stattfinden. Die Teilnehmer sollen dann durch Casting-Shows ermittelt werden.</de>
 			</description>
-			<data genre="2" price="0.35" quality="40" fictional="False" />
+			<data genre="2" price="0.35" quality="40" fictional="0" />
 		</news>
 
 		<news id="news-jorgaeff-abstieg-01" type="0" thread_id="news-jorgaeff-abstieg" creator="8936" created_by="jorgaeff">
@@ -639,7 +639,7 @@
 			<description>
 				<de>Der Glubb kämpft gegen den SV Hamburg um den Aufstieg in die Fußball-Bundesliga. Wird der Bundesliga-Dino aus dem Norden dem Abstieg erneut entgehen oder werden die Herausforderer aus Franken siegreich sein?</de>
 			</description>
-			<data genre="2" price="0.3" quality="30" fictional="True" />
+			<data genre="2" price="0.3" quality="30" fictional="1" />
 			<effects>
 				<!-- "morgen 6-10 Uhr / News a oder b" -->
 				<effect trigger="happen" type="triggernewschoice" choose="or" probability="100" time="2,1,1,6,10" news1="news-jorgaeff-abstieg-02a" probability1="50" news2="news-jorgaeff-abstieg-02b" probability2="50"/>
@@ -653,7 +653,7 @@
 			<description>
 				<de>Erstmalig in seiner Vereinsgeschichte ist der SV Hamburg aus der Bundesliga abgestiegen. Er unterlag dem Glubb in einem spannenden Spiel mit 0:1 nach Verlängerung. Wackelt jetzt der Stuhl von Trainer Knut Knolle?</de>
 			</description>
-			<data genre="2" price="0.3" quality="30" fictional="True" />
+			<data genre="2" price="0.3" quality="30" fictional="1" />
 			<effects>
 				<!-- "in 4-8 Stunden / News a oder b" -->
 				<effect trigger="happen" type="triggernewschoice" choose="or" probability="100" time="1,4,8" news1="news-jorgaeff-abstieg-03a" probability1="50" news2="news-jorgaeff-abstieg-03b" probability2="50"/>
@@ -667,7 +667,7 @@
 			<description>
 				<de>Nicht ganz gereicht hat es für den Glubb. Die Franken zogen gegen die Hamburger den Kürzeren und verpassten mit einem knappen 0:1 den Aufstieg in die Bundesliga.</de>
 			</description>
-			<data genre="2" price="0.3" quality="0" fictional="True" />
+			<data genre="2" price="0.3" quality="0" fictional="1" />
 			<effects>
 				<!-- "in 4-8 Stunden / News c oder d" -->
 				<effect trigger="happen" type="triggernewschoice" choose="or" probability="100" time="1,4,8" news1="news-jorgaeff-abstieg-03c" probability1="50" news2="news-jorgaeff-abstieg-03d" probability2="50"/>
@@ -681,7 +681,7 @@
 			<description>
 				<de>Aufgrund des erstmaligen Abstiegs des SV Hamburg zieht Präsident Uwe Gehler die Reißleine und entlässt Trainer Knut Knolle. Geeler möchte nun den Trainermarkt sondieren und nach geeigneten Nachfolgern Ausschau halten.</de>
 			</description>
-			<data genre="2" price="0.25" quality="25" fictional="True" />
+			<data genre="2" price="0.25" quality="25" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-abstieg-03b" type="2" thread_id="news-jorgaeff-abstieg" creator="8936" created_by="jorgaeff">
@@ -691,7 +691,7 @@
 			<description>
 				<de>Trotz des Abstiegs aus der Bundesliga möchte Präsident Uwe Geeler am Trainer festhalten: "Knut Knolle ist unser Mann auch für die 2. Liga. Mit ihm werden wir wieder aufsteigen.".</de>
 			</description>
-			<data genre="2" price="0.25" quality="25" fictional="True" />
+			<data genre="2" price="0.25" quality="25" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-abstieg-03c" type="2" thread_id="news-jorgaeff-abstieg" creator="8936" created_by="jorgaeff">
@@ -701,7 +701,7 @@
 			<description>
 				<de>Viel wurde investiert um nach Jahren der Zweitklassigkeit endlich wieder im Oberhaus mitspielen zu können, doch gebracht hat es leider nichts. Gewachsen ist nur der Schuldenberg und der könnte den Glubberern jetzt zum Verhängnis werden.</de>
 			</description>
-			<data genre="2" price="0.25" quality="25" fictional="True" />
+			<data genre="2" price="0.25" quality="25" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-abstieg-03d" type="2" thread_id="news-jorgaeff-abstieg" creator="8936" created_by="jorgaeff">
@@ -711,7 +711,7 @@
 			<description>
 				<de>Bedingt durch die hohe Aufstiegsprämie konnte der Glubb alle seine Schulden abbauen und steht somit wieder auf gesunden Füßen. Die Glubberer hoffen, dass dies auch so bleibt.</de>
 			</description>
-			<data genre="2" price="0.25" quality="25" fictional="True" />
+			<data genre="2" price="0.25" quality="25" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-racing-01" type="0" thread_id="news-jorgaeff-racing" creator="8936" created_by="jorgaeff">
@@ -721,7 +721,7 @@
 			<description>
 				<de>Zu einem Dreikampf kommt es heute Abend beim letzten Rennen der Formel X zwischen den punktgleichen Piloten Luis Pamelton, Bastian Kettel und Ferdinando Alfonso. Wer wird Fahrer-Weltmeister?</de>
 			</description>
-			<data genre="2" price="0.45" quality="45" fictional="True" />
+			<data genre="2" price="0.45" quality="45" fictional="1" />
 			<effects>
 				<!-- "möglicher Effekt: Live-Übertragung" -->
 				<!-- "morgen 6-12 Uhr / News a, b, c oder d" -->
@@ -736,7 +736,7 @@
 			<description>
 				<de>Der neue Formel-X-Weltmeister heißt Luis Pamelton. In einem spannenden Rennen konnte er sich gegen seine Rivalen Bastian Kettel und Ferdinando Alfonso trotz einer 10-Sekunden-Strafe wegen zu schnellem Fahren durchsetzen.</de>
 			</description>
-			<data genre="2" price="0.5" quality="50" fictional="True" />
+			<data genre="2" price="0.5" quality="50" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-racing-02b" type="2" thread_id="news-jorgaeff-racing" creator="8936" created_by="jorgaeff">
@@ -746,7 +746,7 @@
 			<description>
 				<de>Der neue Formel-X-Weltmeister heißt Bastian Kettel. In einem spannenden Rennen konnte er sich gegen seine Rivalen Luis Pamelton und Ferdinando Alfonso trotz einer 10-Sekunden-Strafe wegen zu schnellem Fahren durchsetzen.</de>
 			</description>
-			<data genre="2" price="0.5" quality="50" fictional="True" />
+			<data genre="2" price="0.5" quality="50" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-racing-02c" type="2" thread_id="news-jorgaeff-racing" creator="8936" created_by="jorgaeff">
@@ -756,7 +756,7 @@
 			<description>
 				<de>Der neue Formel-X-Weltmeister heißt Ferdinando Alfonso. In einem spannenden Rennen konnte er sich gegen seine Rivalen Luis Pamelton und Bastian Kettel trotz einer 10-Sekunden-Strafe wegen zu schnellem Fahren durchsetzen.</de>
 			</description>
-			<data genre="2" price="0.5" quality="50" fictional="True" />
+			<data genre="2" price="0.5" quality="50" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-racing-02d" type="2" thread_id="news-jorgaeff-racing" creator="8936" created_by="jorgaeff">
@@ -766,7 +766,7 @@
 			<description>
 				<de>Zu einem Novum kam es beim letzten Rennen der Formel X: Alle drei WM-Führenden schieden nach Reifenplatzern aus. Somit gibt es erstmalig in der Geschichte der Formel X drei Weltmeister.</de>
 			</description>
-			<data genre="2" price="0.6" quality="60" fictional="True" />
+			<data genre="2" price="0.6" quality="60" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-nachtrennen-01" type="0" thread_id="news-jorgaeff-nachtrennen" creator="8936" created_by="jorgaeff">
@@ -776,7 +776,7 @@
 			<description>
 				<de>Heute Abend startet das erste Nachtrennen der Formel Öko. Die solarbetriebenen Boliden sollen eine Alternative zu den aus fossilen Rohstoffen betriebenen Flitzern der Formel X sein.</de>
 			</description>
-			<data genre="2" price="0.30" quality="30" fictional="True" />
+			<data genre="2" price="0.30" quality="30" fictional="1" />
 			<effects>
 				<!-- "möglicher Effekt: Live-Übertragung" -->
 				<!-- "in 1 Tagen 0-23 Uhr" -->
@@ -791,7 +791,7 @@
 			<description>
 				<de>Ein Novum in der Geschichte des Rennsports! Erstmalig muss ein Rennen aufgrund von Energiemangel abgebrochen werden. Die Initiatoren haben wohl vergessen, dass die solarbetriebenen Boliden das Sonnenlicht benötigen um fahren zu können.</de>
 			</description>
-			<data genre="2" price="0.35" quality="40" fictional="True" />
+			<data genre="2" price="0.35" quality="40" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-kurzer-01" type="0" creator="8936" created_by="jorgaeff">
@@ -801,7 +801,7 @@
 			<description>
 				<de>Mit dem ersten Hole-in-one seiner Profikarriere sichert sich Golf-Ikone Denkward Kurzer den Turniersieg beim Major-Turnier der Senioren in Key Briscane.</de>
 			</description>
-			<data genre="2" price="0.25" quality="25" fictional="True" />
+			<data genre="2" price="0.25" quality="25" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-dyson-01" type="0" thread_id="news-jorgaeff-dyson" creator="8936" created_by="jorgaeff">
@@ -813,7 +813,7 @@
 			<description>
 				<de>Auch der 49. Herausforderer hat es nicht geschafft Eugen Klatschkowski als Weltmeister im Schwergewicht zu entthronen. Die Suche nach weiteren Herausforderern gestaltet sich schwer.</de>
 			</description>
-			<data genre="2" price="0.35" quality="35" fictional="True" />
+			<data genre="2" price="0.35" quality="35" fictional="1" />
 			<effects>
 				<!-- "Montag 12-16.00 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,1,1,12,16" news="news-jorgaeff-dyson-02" />
@@ -827,7 +827,7 @@
 			<description>
 				<de>Aufgrund des Mangels an Herausforderern spricht der aktuelle Meister im Schwergewicht, Eugen Klatschkowski, eine offene Herausforderung "...an alle die Manns genug sind um mit mir in den Ring zu steigen" aus.</de>
 			</description>
-			<data genre="2" price="0.4" quality="40" fictional="True" />
+			<data genre="2" price="0.4" quality="40" fictional="1" />
 			<effects>
 				<!-- "in 4-8 Stunden" -->
 				<effect trigger="happen" type="triggernews" time="1,4,8" news="news-jorgaeff-dyson-03" />
@@ -841,7 +841,7 @@
 			<description>
 				<de>Spike Dyson, der ehemalige mehrfache Weltmeister im Schwergewicht, nimmt die offene Herausforderung des aktuellen Champions, Eugen Klatschkowski, an und möchte mit diesem in einer Woche in Vas Legas in den Ring steigen.</de>
 			</description>
-			<data genre="2" price="0.45" quality="45" fictional="True" />
+			<data genre="2" price="0.45" quality="45" fictional="1" />
 			<effects>
 				<!-- "Dienstag 12-16 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,1,1,12,16" news="news-jorgaeff-dyson-04" />
@@ -855,7 +855,7 @@
 			<description>
 				<de>Trotz seines fortgeschrittenen Alters trainiert der Ex-Weltmeister im Schwergewicht, Spike Dyson, für ein Comeback im Boxring. Ziel ist den amtierenden Champion, Eugen Klatschkowski, beim "Kampf der Titanen" am Samstag zu besiegen.</de>
 			</description>
-			<data genre="2" price="0.5" quality="50" fictional="True" />
+			<data genre="2" price="0.5" quality="50" fictional="1" />
 			<effects>
 				<!-- "Freitag 12-16 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,1,1,12,16" news="news-jorgaeff-dyson-05" />
@@ -869,7 +869,7 @@
 			<description>
 				<de>Das Wiegen vor dem Fight zwischen Spike Dyson und Eugen Klatschkowski hat sich zum Spektakel entwickelt: Während die Kontrahenten auf die Waage traten eskalierte Dysons Sohn Shawn und trat Klatschkowski mit Anlauf in die Klöten.</de>
 			</description>
-			<data genre="2" price="0.55" quality="55" fictional="True" />
+			<data genre="2" price="0.55" quality="55" fictional="1" />
 			<effects>
 				<!-- "Samstag 18-20 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,1,1,18,20" news="news-jorgaeff-dyson-06" />
@@ -883,7 +883,7 @@
 			<description>
 				<de>Wird es heute Abend einen neuen Box-Champion geben, oder kann Eugen Klatschkowski auch den 50. Herausforderer besiegen? Die Wetten stehen 7:1 für eine erfolgreiche Titelverteidigung.</de>
 			</description>
-			<data genre="2" price="0.6" quality="60" fictional="True" />
+			<data genre="2" price="0.6" quality="60" fictional="1" />
 			<effects>
 				<!-- "möglicher Effekt: Live-Übertragung" -->
 				<!-- "in 4 Stunden / News a oder b" -->
@@ -898,7 +898,7 @@
 			<description>
 				<de>Der 50. Herausforderer war einer zu viel: Spike Dyson ist trotz seiner 52 Jahre der neue Box-Weltmeister. In einem spannenden Kampf konnte er den Dauer-Champion Eugen Klatschkowski nach klarem K.o. in der 12. Runde den Gürtel abnehmen.</de>
 			</description>
-			<data genre="2" price="0.7" quality="70" fictional="True" />
+			<data genre="2" price="0.7" quality="70" fictional="1" />
 			<effects>
 				<!-- "morgen 10-18 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,1,1,10,18" news="news-jorgaeff-dyson-07a" />
@@ -912,7 +912,7 @@
 			<description>
 				<de>Auch der 50. Herausforderer hat es nicht geschafft Eugen Klatschkowski zu entthronen. Dyson blieb in dem rund 30-minütigen Kampf letztendlich chancenlos. Somit bleibt Klatschkowski weiterhin Champion.</de>
 			</description>
-			<data genre="2" price="0.7" quality="70" fictional="True" />
+			<data genre="2" price="0.7" quality="70" fictional="1" />
 			<effects>
 				<!-- "morgen 10-18 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,1,1,10,18" news="news-jorgaeff-dyson-07b" />
@@ -926,7 +926,7 @@
 			<description>
 				<de>Spike Dyson lüftet sein Geheimnis: Eine spezielle Yoga-Therapie hat ihm beim Sieg über Klatschkowski geholfen. Dyson möchte nun ein Buch darüber schreiben und eine DVD herausbringen.</de>
 			</description>
-			<data genre="2" price="0.55" quality="55" fictional="True" />
+			<data genre="2" price="0.55" quality="55" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-dyson-07b" type="2" thread_id="news-jorgaeff-dyson" creator="8936" created_by="jorgaeff">
@@ -936,7 +936,7 @@
 			<description>
 				<de>Wenn es am schönsten ist soll man aufhören. Nach 50 erfolgreichen Titelverteidigungen beendet Rekord-Champion Klatschkowski seine Karriere und hängt seine Boxhandschuhe an den Nagel.</de>
 			</description>
-			<data genre="2" price="0.55" quality="55" fictional="True" />
+			<data genre="2" price="0.55" quality="55" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-holland-01" type="0" creator="8936" created_by="jorgaeff">
@@ -948,7 +948,7 @@
 			<description>
 				<de>Die niederländische Fußball-Nationalmannschaft hat die Weltmeisterschaft im Sommer des nächsten Jahres verpasst. Am letzten Spieltag der Qualifikation unterlag "Oranje" dem Erzrivalen aus Belgien.</de>
 			</description>
-			<data genre="2" price="0.4" quality="40" fictional="False" />
+			<data genre="2" price="0.4" quality="40" fictional="0" />
 		</news>
 
 		<news id="news-jorgaeff-badminton-01" type="0" creator="8936" created_by="jorgaeff">
@@ -958,7 +958,7 @@
 			<description>
 				<de>Alle Badminton-Ergebnisse mit aktuellen Tabellen.</de>
 			</description>
-			<data genre="2" price="0.20" quality="20" fictional="True" />
+			<data genre="2" price="0.20" quality="20" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-schach-01" type="0" creator="8936" created_by="jorgaeff">
@@ -968,7 +968,7 @@
 			<description>
 				<de>Alle Schach-Ergebnisse mit aktuellen Tabellen.</de>
 			</description>
-			<data genre="2" price="0.20" quality="20" fictional="True" />
+			<data genre="2" price="0.20" quality="20" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-hockey-01" type="0" creator="8936" created_by="jorgaeff">
@@ -978,7 +978,7 @@
 			<description>
 				<de>Alle Hockey-Ergebnisse mit aktuellen Tabellen.</de>
 			</description>
-			<data genre="2" price="0.20" quality="20" fictional="True" />
+			<data genre="2" price="0.20" quality="20" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-billard-01" type="0" creator="8936" created_by="jorgaeff">
@@ -988,7 +988,7 @@
 			<description>
 				<de>Alle Ergebnisse vom Billard mit aktuellen Tabellen.</de>
 			</description>
-			<data genre="2" price="0.20" quality="20" fictional="True" />
+			<data genre="2" price="0.20" quality="20" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-ringen-01" type="0" creator="8936" created_by="jorgaeff">
@@ -998,7 +998,7 @@
 			<description>
 				<de>Alle Ergebnisse vom Ringen mit aktuellen Tabellen.</de>
 			</description>
-			<data genre="2" price="0.20" quality="20" fictional="True" />
+			<data genre="2" price="0.20" quality="20" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-tennis-01" type="0" creator="8936" created_by="jorgaeff">
@@ -1008,7 +1008,7 @@
 			<description>
 				<de>Alle Tennis-Ergebnisse mit aktuellen Tabellen.</de>
 			</description>
-			<data genre="2" price="0.20" quality="20" fictional="True" />
+			<data genre="2" price="0.20" quality="20" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-tischtennis-01" type="0" creator="8936" created_by="jorgaeff">
@@ -1018,7 +1018,7 @@
 			<description>
 				<de>Alle Tischtennis-Ergebnisse mit aktuellen Tabellen.</de>
 			</description>
-			<data genre="2" price="0.20" quality="20" fictional="True" />
+			<data genre="2" price="0.20" quality="20" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-volleyball-01" type="0" creator="8936" created_by="jorgaeff">
@@ -1028,7 +1028,7 @@
 			<description>
 				<de>Alle Volleyball-Ergebnisse mit aktuellen Tabellen.</de>
 			</description>
-			<data genre="2" price="0.20" quality="20" fictional="True" />
+			<data genre="2" price="0.20" quality="20" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-1985-2-01" type="0" creator="8936" created_by="jorgaeff">
@@ -1039,7 +1039,7 @@
 			<description>
 				<de>Ein ungewohnt langer Wettkampf zur Ermittlung des Schachweltmeisters zwischen Ayatollah Andropow und Kasper Garripow wird nach 48 Partien ohne Ergebnis abgebrochen.</de>
 			</description>
-			<data genre="2" price="0.25" quality="25" fictional="False" flags="2" />
+			<data genre="2" price="0.25" quality="25" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1985-2-02a" type="0" thread_id="news-jorgaeff-1985-2-02" creator="8936" created_by="jorgaeff">
@@ -1054,7 +1054,7 @@
 				<!-- "morgen 3-7 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,1,1,3,7" news="news-jorgaeff-1985-2-02b" />
 			</effects>
-			<data genre="2" price="0.3" quality="3" fictional="False" />
+			<data genre="2" price="0.3" quality="3" fictional="0" />
 		</news>
 
 		<news id="news-jorgaeff-1985-2-02b" type= "2" thread_id="news-jorgaeff-1985-2-02" creator="8936" created_by="jorgaeff">
@@ -1065,7 +1065,7 @@
 			<description>
 				<de>Hollywood-Schauspieler Mr. Y greift im Weltmeisterschaftskampf zwischen "Rowdy" Pfeifer und Horst Hogen zugunsten des Titelträgers ein. Hogen somit weiterhin Weltmeister im Schwergewicht!</de>
 			</description>
-			<data genre="2" price="0.35" quality="35" fictional="False" flags="2" />
+			<data genre="2" price="0.35" quality="35" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1985-2-03" type="0" creator="8936" created_by="jorgaeff">
@@ -1076,7 +1076,7 @@
 			<description>
 				<de>Denkward Kurzer gewinnt als erster deutscher Golfer die mit 500.000 $US dotierten US-Masters in Augusta (Georgia).</de>
 			</description>
-			<data genre="2" price="0.3" quality="30" fictional="False" flags="2" />
+			<data genre="2" price="0.3" quality="30" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1985-2-04" type="0" creator="8936" created_by="jorgaeff">
@@ -1087,7 +1087,7 @@
 			<description>
 				<de>Bas Bode siegt als erster Deutscher und (mit 17 Jahren) jüngster Tennisspieler aller Zeiten beim Grand-Slam-Turnier von Wimbledon.</de>
 			</description>
-			<data genre="2" price="0.6" quality="60" fictional="False" flags="2" />
+			<data genre="2" price="0.6" quality="60" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1986-2-01" type="0" creator="8936" created_by="jorgaeff">
@@ -1098,7 +1098,7 @@
 			<description>
 				<de>Wie auch im Vorjahr wurde das Schach-Finale zwischen Ayatollah Andropow und Kasper Garripow ohne Sieger abgebrochen. Der internationale Schachverband kürt somit zwei Spieler zum Schach-Weltmeister.</de>
 			</description>
-			<data genre="2" price="0.35" quality="35" fictional="False" flags="2" />
+			<data genre="2" price="0.35" quality="35" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1986-2-02" type="0" creator="8936" created_by="jorgaeff">
@@ -1109,7 +1109,7 @@
 			<description>
 				<de>Bas Bode siegt als erster Deutscher und (mit 18 Jahren) jüngster Tennisspieler aller Zeiten zum zweiten Mal beim Grand-Slam-Turnier von Wimbledon.</de>
 			</description>
-			<data genre="2" price="0.6" quality="60" fictional="False" flags="2" />
+			<data genre="2" price="0.6" quality="60" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1986-2-03" type="0" creator="8936" created_by="jorgaeff">
@@ -1120,7 +1120,7 @@
 			<description>
 				<de>Bei der 13. Fußball-WM in Mexiko gewinnt Argentinien gegen die Bundesrepublik Deutschland im Finale mit 3:2.</de>
 			</description>
-			<data genre="2" price="0.6" quality="60" fictional="False" flags="2" />
+			<data genre="2" price="0.6" quality="60" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1986-2-04" type="0" creator="8936" created_by="jorgaeff">
@@ -1131,7 +1131,7 @@
 			<description>
 				<de>Siegwart Messier hat als erster Mensch alle 14 Achttausender erstiegen. Während sich andere für Gipfelfotos vom Helikopter absetzen lassen kletterte der Bergsteiger aus Südtirol jeden Berg selbst hinauf.</de>
 			</description>
-			<data genre="2" price="0.3" quality="30" fictional="False" flags="2" />
+			<data genre="2" price="0.3" quality="30" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1987-2-01" type="0" creator="8936" created_by="jorgaeff">
@@ -1142,7 +1142,7 @@
 			<description>
 				<de>Deutschlands Tennis-Ikone, Bas Bode, ist gescheitert. Im Halbfinale der australischen Tennis-Meisterschaften verlor der Weltranglisten-18. gegen den Lokal-Matadoren Wolly Maser.</de>
 			</description>
-			<data genre="2" price="0.3" quality="30" fictional="False" flags="2" />
+			<data genre="2" price="0.3" quality="30" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1987-2-02a" type="0" thread_id="news-jorgaeff-1987-2-02" creator="8936" created_by="jorgaeff">
@@ -1153,7 +1153,7 @@
 			<description>
 				<de>Betty Lord gewinnt mit den in Paris ausgetragenen French Open ihren ersten von insgesamt 22 Grand Slam-Titeln.</de>
 			</description>
-			<data genre="2" price="0.3" quality="30" fictional="False" flags="2" />
+			<data genre="2" price="0.3" quality="30" fictional="0" flags="2" />
 			<effects>
 				<!-- "in 1 Tag, 10-18 Uhr " -->
 				<effect trigger="happen" type="triggernews" time="2,1,1,10,18" news="news-jorgaeff-1987-2-02b" />
@@ -1167,7 +1167,7 @@
 			<description>
 				<de>Betty Lord hat nach dem Gewinn der französischen Tennis-Meisterschaften erstmals die Führung in der Tennis-Weltrangliste der Damen übernommen.</de>
 			</description>
-			<data genre="2" price="0.3" quality="30" fictional="False" flags="2" />
+			<data genre="2" price="0.3" quality="30" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1988-2-01" type="0" creator="8936" created_by="jorgaeff">
@@ -1178,7 +1178,7 @@
 			<description>
 				<de>Die deutsche Ausnahme-Tennisspielerin Betty Lord gewinnt mit ihrem Sieg bei den US Open gegen die Argentinierin Santina Morella als erste Deutsche und dritte Spielerin überhaupt alle Grand-Slam-Turniere.</de>
 			</description>
-			<data genre="2" price="0.3" quality="30" fictional="False" flags="2" />
+			<data genre="2" price="0.3" quality="30" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1988-2-02" type="0" creator="8936" created_by="jorgaeff">
@@ -1189,7 +1189,7 @@
 			<description>
 				<de>Die deutsche Tennis-Nationalmannschaft Deutschland (mit Bas Bode, Charly Raab, Erich Gielen und Peter Kühne) gewinnt das Navy-Cup-Finale gegen Schweden.</de>
 			</description>
-			<data genre="2" price="0.3" quality="30" fictional="False" flags="2" />
+			<data genre="2" price="0.3" quality="30" fictional="0" flags="2" />
 		</news>
 
 
@@ -1202,7 +1202,7 @@
 			<description>
 				<de>Ein Auto das keinen einzigen Liter Benzin verbraucht wurde von Faulkswagen entwickelt. Der Clou: Faulkswagen gibt den Verbrauch ab sofort nur noch in Gallonen an.</de>
 			</description>
-			<data genre="3" price="0.55" quality="55" fictional="True" />
+			<data genre="3" price="0.55" quality="55" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-blitzenergie-01" type="0" creator="8936" created_by="jorgaeff">
@@ -1212,7 +1212,7 @@
 			<description>
 				<de>Forscher haben endlich eine Möglichkeit gefunden, die Energie der Blitze zu nutzen. Sollte das Projekt seine Serienreife erlangen, so könte dies die Energieprobleme des Planeten lösen.</de>
 			</description>
-			<data genre="3" price="0.45" quality="45" fictional="True" />
+			<data genre="3" price="0.45" quality="45" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-orange-01" type="0" thread_id="news-jorgaeff-orange" creator="8936" created_by="jorgaeff">
@@ -1224,7 +1224,7 @@
 			<description>
 				<de>Heute beginnt Orange mit dem Verkauf des neuen my-phones. Das neue Smartphone ist natürlich viel besser als sein Vorgänger. Deshalb werden auch wieder alle eines kaufen und das alte wegschmeißen. Scheiß auf die seltenen Erden.</de>
 			</description>
-			<data genre="3" price="0.45" quality="45" fictional="True" />
+			<data genre="3" price="0.45" quality="45" fictional="1" />
 			<effects>
 				<!-- "in 6-10 Stunden" -->
 				<effect trigger="happen" type="triggernews" time="1,6,10" news="news-jorgaeff-orange-02" />
@@ -1238,7 +1238,7 @@
 			<description>
 				<de>Bereits wenige Stunden nach Ladenöffnung waren alle my-phones ausverkauft. In den Läden wurden vielerorts traurige Gesichter gesehen. Der Hersteller möchte jetzt kurzfristig nachproduzieren.</de>
 			</description>
-			<data genre="3" price="0.55" quality="50" fictional="True" />
+			<data genre="3" price="0.55" quality="50" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-milch-01" type="0" creator="8936" created_by="jorgaeff">
@@ -1248,7 +1248,7 @@
 			<description>
 				<de>Alle haben es gewusst - niemand hat es geglaubt. Aber es stimmt! Milch macht müde Männer munter. Diese Nachricht wurde Ihnen präsentiert von der Milchindustrie.</de>
 			</description>
-			<data genre="3" price="0.15" quality="15" fictional="True" />
+			<data genre="3" price="0.15" quality="15" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-space-1985-3-01" type="0" thread_id="news-jorgaeff-space-1985-3" creator="8936" created_by="jorgaeff">
@@ -1259,7 +1259,7 @@
 			<description>
 				<de>Gestern der Mond und morgen der Mars? Die nordamerikanische Raumfahrtbehörde NASE möchte auch im All die Nase vorn haben und startet ein neues Raumfahrtprogramm. Es soll der Erkundung neuer Planeten dienen.</de>
 			</description>
-			<data genre="3" price="0.6" quality="60" fictional="False" flags="2" />
+			<data genre="3" price="0.6" quality="60" fictional="0" flags="2" />
 			<effects>
 				<!-- "in 7 Tagen, 6-20 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,4,4,6,20" news="news-jorgaeff-space-1985-3-02" />
@@ -1274,7 +1274,7 @@
 			<description>
 				<de>Es ist der erste orbitale Flug eines unbemannten Space-Shuttles. Die Raumfähre Kolumbus soll den Start und die Landung eines Space-Shuttles erproben. Der Start erfolgt heute Nacht in Cap Carneval.</de>
 			</description>
-			<data genre="3" price="0.65" quality="65" fictional="False" flags="2" />
+			<data genre="3" price="0.65" quality="65" fictional="0" flags="2" />
 			<effects>
 				<!-- "möglicher Effekt: Live-Übertragung" -->
 				<!-- "morgen 1-8 Uhr" -->
@@ -1290,7 +1290,7 @@
 			<description>
 				<de>Strahlende Gesichter beim NASE-Bodenpersonal in Cap Carneval. Der erste Start eines unbemannten Space-Shuttles war erfolgreich. Wird auch die Landung gelingen?</de>
 			</description>
-			<data genre="3" price="0.7" quality="70" fictional="False" flags="2" />
+			<data genre="3" price="0.7" quality="70" fictional="0" flags="2" />
 			<effects>
 				<!-- "morgen 1-8 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,1,1,1,8" news="news-jorgaeff-space-1985-3-04" />
@@ -1305,7 +1305,7 @@
 			<description>
 				<de>Nach 2 Tagen in der Erdumlaufbahn ist die Raumfähre Kolumbus erfolgreich in Cap Carneval gelandet. Durch den vollen Erfolg dieser Mission sollten weitere Gelder für zukünftige Missionen bewilligt werden. </de>
 			</description>
-			<data genre="3" price="0.65" quality="65" fictional="False" flags="2" />
+			<data genre="3" price="0.65" quality="65" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-space-1986-3-01" type="0" thread_id="news-jorgaeff-space-1986-3" creator="8936" created_by="jorgaeff">
@@ -1316,7 +1316,7 @@
 			<description>
 				<de>Die nordamerikanische Raumfahrtbehörde NASE möchte wieder ein unbemanntes Shuttle ins All schicken. Die Raumfähre Contender soll einen Kommunikations-Satelliten aussetzen, sowie bekannte Kometen analysieren.</de>
 			</description>
-			<data genre="3" price="0.5" quality="50" fictional="False" flags="2" />
+			<data genre="3" price="0.5" quality="50" fictional="0" flags="2" />
 			<effects>
 				<!-- "morgen 1-8 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,1,1,1,8" news="news-jorgaeff-space-1986-3-02" />
@@ -1331,7 +1331,7 @@
 			<description>
 				<de>Schwerer Rückschlag für das nordamerikanische Raumfahrtprogramm! Nur wenige Sekunden nach dem Start ist die Raumfähre Contender explodiert. Die Raumfahrtbehörde NASE rätselt über die Ursachen des Unglücks.</de>
 			</description>
-			<data genre="3" price="1" quality="100" fictional="False" flags="2" />
+			<data genre="3" price="1" quality="100" fictional="0" flags="2" />
 			<effects>
 				<!-- "übermorgen 1-10 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,2,2,1,10" news="news-jorgaeff-space-1986-3-03" />
@@ -1346,7 +1346,7 @@
 			<description>
 				<de>Die nordamerikanische Raumfahrtbehörde NASE hat die Ursache für die Explosion der Raumfähre Contender gefunden und macht einen fehlenden Dichtungsring für das Unglück verantwortlich.</de>
 			</description>
-			<data genre="3" price="0.85" quality="85" fictional="False" flags="2" />
+			<data genre="3" price="0.85" quality="85" fictional="0" flags="2" />
 			<effects>
 				<!-- "morgen 4-12 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,1,1,4,12" news="news-jorgaeff-space-1986-3-04" />
@@ -1361,7 +1361,7 @@
 			<description>
 				<de>Die nordamerikanische Raumfahrtbehörde NASE möchte vorerst von weiteren Shuttle-Starts absehen. Es sollen zunächst Technologien erforscht werden, die für einen sichereren Start sorgen.</de>
 			</description>
-			<data genre="3" price="0.75" quality="75" fictional="False" flags="2" />
+			<data genre="3" price="0.75" quality="75" fictional="0" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-c256-01" type="0" thread_id="news-jorgaeff-space-c256a" creator="8936" created_by="jorgaeff">
@@ -1373,7 +1373,7 @@
 			<description>
 				<de>Der nordamerikanische Technologie-Konzern Cormoran stattet seinen neuen Mikro-Computer mit einem RAM von 256 KB aus. Fans sind begeistert von der tollen Grafik und der schnellen Rechenleistung.</de>
 			</description>
-			<data genre="3" price="0.5" quality="50" fictional="True" flags="2" />
+			<data genre="3" price="0.5" quality="50" fictional="1" flags="2" />
 			<effects>
 				<!-- "in 3 Tagen 4-8 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,3,3,4,8" news="news-jorgaeff-c256-02" />
@@ -1387,7 +1387,7 @@
 			<description>
 				<de>Der neue C256 von Cormoran geht weg wie warme Semmeln. Viele Nutzer kaufen sich ein Zweitgerät, da der Mikro-Computer, der mittlerweile sogar in eine Butterdose passt, auch mal verlegt werden kann.</de>
 			</description>
-			<data genre="3" price="0.55" quality="55" fictional="True" flags="2" />
+			<data genre="3" price="0.55" quality="55" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-c256-03" type="0" thread_id="news-jorgaeff-space-c256b" creator="8936" created_by="jorgaeff">
@@ -1399,7 +1399,7 @@
 			<description>
 				<de>Der nordamerikanische Technologie-Konzern Cormoran stattet seinen neuen Mikro-Computer mit einem RAM von 512 KB aus. Fans sind begeistert von der tollen Grafik und der schnellen Rechenleistung.</de>
 			</description>
-			<data genre="3" price="0.5" quality="50" fictional="True" flags="2" />
+			<data genre="3" price="0.5" quality="50" fictional="1" flags="2" />
 			<effects>
 				<!-- "in 3 Tagen 4-8 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,3,3,4,8" news="news-jorgaeff-c256-04" />
@@ -1413,7 +1413,7 @@
 			<description>
 				<de>Der neue C512 von Cormoran übertrifft sogar seinen Vorgänger. Viele Nutzer kaufen sich ein Dritt- und Viertgerät, da der Mikro-Computer, der nun in einen Eierbecher passt, auch mal verlegt werden kann.</de>
 			</description>
-			<data genre="3" price="0.55" quality="55" fictional="True" flags="2" />
+			<data genre="3" price="0.55" quality="55" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-c256-05" type="0" thread_id="news-jorgaeff-space-c256c" creator="8936" created_by="jorgaeff">
@@ -1425,7 +1425,7 @@
 			<description>
 				<de>Der nordamerikanische Technologie-Konzern Cormoran stattet seinen neuen Mikro-Computer mit einem RAM von 1024 KB aus. Fans sind begeistert von der tollen Grafik und der schnellen Rechenleistung.</de>
 			</description>
-			<data genre="3" price="0.5" quality="50" fictional="True" flags="2" />
+			<data genre="3" price="0.5" quality="50" fictional="1" flags="2" />
 			<effects>
 				<!-- "in 3 Tagen 4-8 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,3,3,4,8" news="news-jorgaeff-c256-06" />
@@ -1439,7 +1439,7 @@
 			<description>
 				<de>Mal eben locker den Verkaufserfolg des Vorgängers pulverisiert. Viele Nutzer kaufen sich den C1k024 von Cormoran im 10er-Pack, da der in einen Fingerhut passende Mikro-Computer, auch mal verlegt werden kann.</de>
 			</description>
-			<data genre="3" price="0.55" quality="55" fictional="True" flags="2" />
+			<data genre="3" price="0.55" quality="55" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-c256-07" type="0" thread_id="news-jorgaeff-space-c256d" creator="8936" created_by="jorgaeff">
@@ -1451,7 +1451,7 @@
 			<description>
 				<de>Der nordamerikanische Technologie-Konzern Cormoran stattet seinen neuen Mikro-Computer mit einem RAM von 2048 KB aus. Fans sind begeistert von der tollen Grafik und der schnellen Rechenleistung.</de>
 			</description>
-			<data genre="3" price="0.5" quality="50" fictional="True" flags="2" />
+			<data genre="3" price="0.5" quality="50" fictional="1" flags="2" />
 			<effects>
 				<!-- "in 3 Tagen 4-8 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,3,3,4,8" news="news-jorgaeff-c256-08" />
@@ -1465,7 +1465,7 @@
 			<description>
 				<de>Diese Rechnung geht nicht auf: Der auf einen Stecknadelkopf passende Mikro-Computer kann teilweise in den Läden nicht mehr aufgefunden werden. Cormoran hat die Produktion eingestellt.</de>
 			</description>
-			<data genre="3" price="0.55" quality="55" fictional="True" flags="2" />
+			<data genre="3" price="0.55" quality="55" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-btx-01" type="0" creator="8936" created_by="jorgaeff">
@@ -1477,7 +1477,7 @@
 			<description>
 				<de>Kurz vor seinem 19. Geburtstag wird der interaktive Online-Dienst im deutschsprachigen Raum zum Ende des Jahres abgeschaltet. Kommt jetzt das World Wide Web?</de>
 			</description>
-			<data genre="3" price="0.4" quality="40" fictional="True" flags="2" />
+			<data genre="3" price="0.4" quality="40" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-dvd-01" type="0" creator="8936" created_by="jorgaeff">
@@ -1489,7 +1489,7 @@
 			<description>
 				<de>Die DVD ist der neue Star unter den Speichermedien. Endlich entfällt das lästige Spulen der Bänder oder Umdrehen bei Laser-Disc und Video-CD. Mit brillianter Bild- und Tonqualität!</de>
 			</description>
-			<data genre="3" price="0.4" quality="40" fictional="True" flags="2" />
+			<data genre="3" price="0.4" quality="40" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-dvd-02" type="0" creator="8936" created_by="jorgaeff">
@@ -1501,7 +1501,7 @@
 			<description>
 				<de>Die Blu-Ray ist der neue Star unter den Speichermedien. Die Disc schillert in schönen blauen Farben, ermöglicht brilliante Bild- und Tonqualität, sowie genug Platz für Filme in Überlänge.</de>
 			</description>
-			<data genre="3" price="0.4" quality="40" fictional="True" flags="2" />
+			<data genre="3" price="0.4" quality="40" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-tv-01" type="0" creator="8936" created_by="jorgaeff">
@@ -1513,7 +1513,7 @@
 			<description>
 				<de>Eine enorme Verbesserung in Sachen Bildschärfe und Stromverbrauch bieten die endlich erhältlichen LCD-Fernseher und Computer-Monitore. Auch das Gewicht und der damit verbundene Materialverbrauch haben sich start verbessert.</de>
 			</description>
-			<data genre="3" price="0.4" quality="40" fictional="True" flags="2" />
+			<data genre="3" price="0.4" quality="40" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1985-3-01" type="0" creator="8936" created_by="jorgaeff">
@@ -1524,7 +1524,7 @@
 			<description>
 				<de>Die von Makrohart endgültig freigegebene Version Proof 1.01 wurde auf einer Pressekonferenz im südschwedischen Helsingborg vorgestellt. Das Betriebssystem benötigt einen Arbeitsspeicher von 256 KByte und ein 5.25"-Diskettenlaufwerk.</de>
 			</description>
-			<data genre="3" price="0.4" quality="40" fictional="True" flags="2" />
+			<data genre="3" price="0.4" quality="40" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1985-3-02" type="0" creator="8936" created_by="jorgaeff">
@@ -1535,7 +1535,7 @@
 			<description>
 				<de>Die Bahn feiert 150 Jahre Eisenbahn. Zum Jubiläum gibt es das ganze Jahr über Veranstaltungen und Sonderfahrten mit historischen Lokomotiven zu Schleuderpreisen.</de>
 			</description>
-			<data genre="3" price="0.3" quality="30" fictional="True" flags="2" />
+			<data genre="3" price="0.3" quality="30" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1987-3-01" type="0" creator="8936" created_by="jorgaeff">
@@ -1546,7 +1546,7 @@
 			<description>
 				<de>Die Supernova 1987A wird entdeckt. Sie ist die erste Supernova seit 1604, die mit bloßem Auge beobachtet werden kann. Eine Supernova ist das kurze, helle Aufleuchten eines Sterns am Ende seiner Lebenszeit, durch eine Explosion bei der er vernichtet wird.</de>
 			</description>
-			<data genre="3" price="0.85" quality="85" fictional="True" flags="2" />
+			<data genre="3" price="0.85" quality="85" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1987-3-02" type="0" creator="8936" created_by="jorgaeff">
@@ -1557,7 +1557,7 @@
 			<description>
 				<de>Der russische Kosmonaut Juri Victorvox kehrt nach 326 Tagen Aufenthalt an Bord der Raumstation Mir zur Erde zurück. Er war es leid ständig nur auf die Erde hinabzuschauen und sich zu langweilen.</de>
 			</description>
-			<data genre="3" price="0.85" quality="85" fictional="True" flags="2" />
+			<data genre="3" price="0.85" quality="85" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1987-3-03" type="0" creator="8936" created_by="jorgaeff">
@@ -1568,7 +1568,7 @@
 			<description>
 				<de>Die italienische Rennwagen-Schmiede Fellaini stellt zum 40. Firmenjubiläum den Fellaini F40 vor. Das Basismodell gibt es ab 444.000 DM und ist in den Farben hellrot, dunkelrot und neonrot erhältlich.</de>
 			</description>
-			<data genre="3" price="0.85" quality="85" fictional="True" flags="2" />
+			<data genre="3" price="0.85" quality="85" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1988-3-01a" type="0" thread_id="news-jorgaeff-1988-3" creator="8936" created_by="jorgaeff">
@@ -1579,7 +1579,7 @@
 			<description>
 				<de>In der Bundesrepublik Deutschland wird verbleites Normalbenzin verboten. So sollen Luftverunreinigungen durch Bleiverbindungen in Ottokraftstoffen verringert werden.</de>
 			</description>
-			<data genre="3" price="0.85" quality="85" fictional="True" flags="2" />
+			<data genre="3" price="0.85" quality="85" fictional="1" flags="2" />
 			<effects>
 				<!-- "in 2 Tagen 16-22 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,1,1,10,12" news="news-jorgaeff-1988-3-01b" />
@@ -1594,7 +1594,7 @@
 			<description>
 				<de>Die Einführung des bleifreien Benzin sorgt für Verunsicherung an den Zapfsäulen. Die Verbraucher befürchten, der neue Sprit könnte ihrem Auto schaden und tanken weiterhin bleihaltig.</de>
 			</description>
-			<data genre="3" price="0.85" quality="85" fictional="True" flags="2" />
+			<data genre="3" price="0.85" quality="85" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1988-3-02" type="0" creator="8936" created_by="jorgaeff">
@@ -1605,7 +1605,7 @@
 			<description>
 				<de>Im Rahmen der ICE-Weltrekordfahrt stellt der ICE-Vorläuferzug InterCityExperimental mit 406,9 km/h einen neuen Geschwindigkeitsrekord für Schienenfahrzeuge auf.</de>
 			</description>
-			<data genre="3" price="0.85" quality="85" fictional="True" flags="2" />
+			<data genre="3" price="0.85" quality="85" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1988-3-03" type="0" creator="8936" created_by="jorgaeff">
@@ -1616,7 +1616,7 @@
 			<description>
 				<de>Der sogenannte Philipp-Wurm verbreitet sich unter Ausnutzung von Unix-Diensten. Zwar hat der Wurm keine direkte Schadensroutine, trotzdem legt er wegen seiner aggressiven Weiterverbreitung ca. 6000 Rechner lahm.</de>
 			</description>
-			<data genre="3" price="0.85" quality="85" fictional="True" flags="2" />
+			<data genre="3" price="0.85" quality="85" fictional="1" flags="2" />
 		</news>
 
 
@@ -1630,7 +1630,7 @@
 			<description>
 				<de>Das Zentralkomitee der Volonen plant den Neubau einer Hyperraum-Umgehungsstraße in Erdnähe. Gefahr für die Erde?</de>
 			</description>
-			<data genre="4" price="1" quality="75" fictional="True" />
+			<data genre="4" price="1" quality="75" fictional="1" />
 			<effects>
 				<!-- "morgen 10-12 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,1,1,10,12" news="news-jorgaeff-hyperraum-02" />
@@ -1688,7 +1688,7 @@
 			<description>
 				<de>Von einem an der Wand hängenden singenden Fisch mit Bewegungsmelder wurde ein Einbrecher im TV-Tower vertrieben. Der Dieb hatte es wohl auf Betty Butterblooms Geschenke-Sammlung abgesehen.</de>
 			</description>
-			<data genre="4" price="0.1" quality="20" fictional="True" />
+			<data genre="4" price="0.1" quality="20" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-oma-01" type="0" creator="8936" created_by="jorgaeff">
@@ -1698,7 +1698,7 @@
 			<description>
 				<de>Da staunten die Polizisten nicht schlecht als sie eine alte Frau auf einem Motorrad sitzend durch einen Hühnerstall fahren sahen. Die betagte Seniorin hatte sich wohl verfahren.</de>
 			</description>
-			<data genre="4" price="0.3" quality="30" fictional="True" />
+			<data genre="4" price="0.3" quality="30" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-junge-01" type="0" creator="8936" created_by="jorgaeff">
@@ -1708,7 +1708,7 @@
 			<description>
 				<de>Weil ihm der Musikgeschmack seiner Eltern missfiel hielt ein 12-jähriger Junge während einer Autofahrt einen Zettel mit der Aufschrift "Hilfe" an die Fensterscheibe. Besorgte Autofahrer alarmierten die Polizei.</de>
 			</description>
-			<data genre="4" price="0.15" quality="25" fictional="True" />
+			<data genre="4" price="0.15" quality="25" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-fluchttunnel-01" type="0" creator="8936" created_by="jorgaeff">
@@ -1718,7 +1718,7 @@
 			<description>
 				<de>Zwei Fünfjährige haben mehrere Tage lang mit ihren Sandschaufeln einen Fluchttunnel aus ihrem Kindergarten gegraben und sind geflohen. Die Polizei konnte die beiden finden und wohlbehalten ihren Eltern übergeben.</de>
 			</description>
-			<data genre="4" price="0.25" quality="35" fictional="True" />
+			<data genre="4" price="0.25" quality="35" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-newsschreiber-01" type="0" creator="8936" created_by="jorgaeff">
@@ -1728,7 +1728,7 @@
 			<description>
 				<de>Zahlreiche Newsschreiber sind dem Aufruf ihrer Gewerkschaft gefolgt und streiken. Sie erhoffen sich bessere Arbeitsbedingungen sowie kostenloses Wasser und Brot während der Arbeitszeit.</de>
 			</description>
-			<data genre="4" price="0.3" quality="25" fictional="True" />
+			<data genre="4" price="0.3" quality="25" fictional="1" />
 			<!-- "Effekt: es stehen weniger Nachrichten zur Verfügung" -->
 		</news>
 
@@ -1741,7 +1741,7 @@
 			<description>
 				<de>Hier die aktuellen Lottozahlen vom Mittwochs-Lotto präsentiert von Lotto-Fee Gudrun Heinemann. Wurde der Jackpot diesmal geknackt?</de>
 			</description>
-			<data genre="4" price="0.4" quality="40" fictional="True" />
+			<data genre="4" price="0.4" quality="40" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-lotto-02" type="0" creator="8936" created_by="jorgaeff">
@@ -1753,7 +1753,7 @@
 			<description>
 				<de>Hier die aktuellen Lottozahlen vom Samstags-Lotto präsentiert von Lotto-Fee Else Polsbäck. Wurde der Jackpot diesmal geknackt?.</de>
 			</description>
-			<data genre="4" price="0.6" quality="60" fictional="True" />
+			<data genre="4" price="0.6" quality="60" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-sonntag-01" type="0" creator="8936" created_by="jorgaeff">
@@ -1765,7 +1765,7 @@
 			<description>
 				<de>Fernseh-Pfarrer Benno Breitkopf wendet sich in seiner allwöchentlichen Kolumne an das deutsche Volk und prangert den zunehmenden Sittenverfall an. Wen's interessiert...</de>
 			</description>
-			<data genre="4" price="0.20" quality="20" fictional="True" />
+			<data genre="4" price="0.20" quality="20" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-1985-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -1776,7 +1776,7 @@
 			<description>
 				<de>Der Neuntöter ist eine Vogelart aus der Familie der Würger und in Mitteleuropa die häufigste Würgerart. Er ist vor allem durch sein Verhalten bekannt, Beutetiere auf Dornen aufzuspießen. </de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1986-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -1787,7 +1787,7 @@
 			<description>
 				<de>Die große Krähe mit markantem Schnabel und metallisch glänzendem schwarzem Gefieder ist in einem breiten Gürtel von Westeuropa bis in die Steppen des Altaigebietes verbreitet.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1987-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -1798,7 +1798,7 @@
 			<description>
 				<de>Das Braunkehlchen ist ein Singvogel aus der Gattung der Wiesenschmätzer und der Familie der Fliegenschnäpper. In Deutschland zählt das Braunkehlchen zu den gefährdeten Arten.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1988-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -1809,7 +1809,7 @@
 			<description>
 				<de>Der Wendehals ist ist von Nordwestafrika ostwärts in einem breiten Gürtel bis an die asiatische Pazifikküste verbreitet; Europa ist fast flächendeckend besiedelt.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1989-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -1820,7 +1820,7 @@
 			<description>
 				<de>Der Teichrohrsänger, im Volksmund auch Rohrspatz genannt, ist eine Singvogelart aus der Gattung der Rohrsänger und der Familie der Rohrsängerartigen. Er ist ist etwa 13 cm lang und hat eine Flügelspannweite von 17 bis 21 cm.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1990-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -1831,7 +1831,7 @@
 			<description>
 				<de>Der Pirol ist ein Singvogel aus der Familie der Pirole. Er ist im Norden und Westen Eurasiens verbreitet; ebenso in Mitteleuropa, im südlichen Zentralasien und im Norden von Indien.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1991-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -1842,7 +1842,7 @@
 			<description>
 				<de>Das Rebhuhn ist eine Vogelart aus der Ordnung der Hühnervögel. Rebhühner bewohnen Steppen- und Heidelandschaften in weiten Teilen Europas und Asiens. Sie ernähren sich überwiegend von Sämereien, Wildkräutern und Getreidekörnern.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1992-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -1853,7 +1853,7 @@
 			<description>
 				<de>Das Rotkehlchen ist eine Vogelart aus der Familie der Fliegenschnäpper. Es besiedelt Nordafrika, Europa und Kleinasien sowie die Mittelmeerinseln. Seine Nahrung besteht vor allem aus Insekten, kleinen Spinnen, Würmern und Schnecken.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1993-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -1864,7 +1864,7 @@
 			<description>
 				<de>Der Flussregenpfeifer ist eine Vogelart aus der Familie der Regenpfeifer. In Mitteleuropa ist er ein verbreiteter, aber wenig häufiger Brut- und Sommervogel. Während der Zugzeiten ist er verhältnismäßig häufig als Durchzügler und Rastvogel zu beobachten.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1994-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -1875,7 +1875,7 @@
 			<description>
 				<de>Der Weißstorch, auch Klapperstorch genannt, ist eine Vogelart aus der Familie der Störche. Weißstörche sind etwa 80 bis 100 cm lang und haben eine Flügelspannweite von etwa 200 bis 220 cm. Weißstörche haben ein Gewicht von etwa 2,5 bis 4,5 kg.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1995-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -1886,7 +1886,7 @@
 			<description>
 				<de>Die Nachtigall ist eine Vogelart aus der Ordnung der Sperlingsvögel, Unterordnung Singvögel. Nach neueren molekularbiologischen Erkenntnissen zur Phylogenese der Singvögel wird sie heute meist zur Familie der Fliegenschnäpper gestellt.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1996-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -1897,7 +1897,7 @@
 			<description>
 				<de>Der Kiebitz ist eine Vogelart aus der Familie der Regenpfeifer. Er brütet typischerweise in den Marschwiesen, auf Vordeichwiesenflächen und anderen Weidelandschaften der Niederungen.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1997-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -1908,7 +1908,7 @@
 			<description>
 				<de>Der Buntspecht ist eine Vogelart aus der Familie der Spechte. Der kleine Specht besiedelt große Teile des nördlichen Eurasiens sowie Nordafrika und bewohnt Wälder fast jeder Art sowie Parks und baumreiche Gärten.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1998-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -1919,7 +1919,7 @@
 			<description>
 				<de>Die Feldlerche ist eine Vogelart aus der Familie der Lerchen. Diese mittelgroße Lerchenart besiedelt fast die gesamte Paläarktis von Irland und Portugal bis Kamtschatka und Japan.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1999-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -1930,7 +1930,7 @@
 			<description>
 				<de>Die Goldammer ist eine Vogelart aus der Familie der Ammern. Sie ist die häufigste Ammer in Europa und einer der charakteristischen Brutvögel der Feldmark.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-2000-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -1941,7 +1941,7 @@
 			<description>
 				<de>Der Rotmilan, auch Roter Milan, Gabelweihe oder Königsweihe genannt, ist eine etwa mäusebussardgroße Greifvogelart aus der Familie der Habichtartigen. Über 50 Prozent des Gesamtbestandes dieser Art brütet in Deutschland.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-2001-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -1952,7 +1952,7 @@
 			<description>
 				<de>Der Haubentaucher ist eine Vogelart aus der Familie der Lappentaucher. Der etwa stockentengroße Vogel ist der größte, häufigste und bekannteste Vertreter dieser Familie von Wasservögeln.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-2002-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -1963,7 +1963,7 @@
 			<description>
 				<de>Der Haussperling - auch Spatz oder Hausspatz genannt – ist eine Vogelart aus der Familie der Sperlinge und einer der bekanntesten und am weitesten verbreiteten Singvögel.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-2003-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -1974,7 +1974,7 @@
 			<description>
 				<de>Der Mauersegler ist eine Vogelart aus der Familie der Segler. Er ähnelt den Schwalben, ist aber mit diesen nicht näher verwandt; die Ähnlichkeiten beruhen auf konvergenter Evolution. Der Mauersegler ist ein Langstreckenzieher.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-2004-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -1985,7 +1985,7 @@
 			<description>
 				<de>Der Zaunkönig ist nach dem Winter- und Sommergoldhähnchen der drittkleinste Vogel Europas. Lange Zeit wurde er „Schneekönig“ genannt, da er auch im Winter lebhaft singt. Der Zaunkönig besiedelt Europa, Nordafrika, Vorder-, Zentral- und Ostasien und Nordamerika.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-2005-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -1996,7 +1996,7 @@
 			<description>
 				<de>Der Uhu ist eine Vogelart aus der Gattung der Uhus, die zur Ordnung der Eulen gehört. Er ist die größte Eulenart, hat einen massigen Körper und einen auffällig dicken Kopf mit Federohren. Die Augen sind orangegelb. Das Gefieder weist dunkle Längs- und Querzeichnungen auf.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-2006-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -2007,7 +2007,7 @@
 			<description>
 				<de>Der Name bezieht sich darauf, dass der Kleiber den Eingang von Bruthöhlen anderer Vögel, zum Beispiel die von Spechten, mit Lehm verklebt, um sie selbst zu nutzen. Um die Höhle zu schützen, „mauern“ die Kleiber den Eingang zu ihren Bruthöhlen mit einer Mischung aus Lehm und Speichel so weit zu, dass sie gerade durchpassen.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-2007-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -2018,7 +2018,7 @@
 			<description>
 				<de>Der Turmfalke ist der häufigste Falke in Mitteleuropa. Vielen ist der Turmfalke vertraut, da er sich auch Städte als Lebensraum erobert hat und oft beim Rüttelflug zu beobachten ist.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-2008-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -2029,7 +2029,7 @@
 			<description>
 				<de>Der Kuckuck gehört zur Ordnung der Kuckucksvögel und zur Familie der Kuckucke. Er kommt in Nordafrika und in Eurasien von Portugal und Irland nach Osten bis Japan und Kamtschatka vor. Er ist etwa taubengroß, sein Gefieder ist größtenteils grau.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-2009-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -2040,7 +2040,7 @@
 			<description>
 				<de>Der Eisvogel besiedelt weite Teile Europas, Asiens sowie das westliche Nordafrika und lebt an mäßig schnell fließenden oder stehenden, klaren Gewässern mit Kleinfischbestand und Sitzwarten. Seine Nahrung setzt sich aus Fischen, Wasserinsekten, Kleinkrebsen und Kaulquappen zusammen.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-2010-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -2051,7 +2051,7 @@
 			<description>
 				<de>Das Verbreitungsgebiet des Kormorans umfasst große Teile Europas, Asiens und Afrikas, außerdem Australien und Neuseeland sowie Grönland und die Ostküste Nordamerikas. Die Nahrung besteht wie bei allen Vertretern der Gattung Phalacrocorax fast ausschließlich aus Fisch.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-2011-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -2062,7 +2062,7 @@
 			<description>
 				<de>Der Gartenrotschwanz besiedelt Eurasien ostwärts bis zum Baikalsee sowie Teile Nordafrikas und des Nahen Ostens. Als Höhlen- und Halbhöhlenbrüter bewohnt er vorwiegend lichte Laubwälder, Parkanlagen und Gärten mit altem Baumbestand.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-2012-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -2073,7 +2073,7 @@
 			<description>
 				<de>Die Dohle ist eine Singvogelart aus der Familie der Rabenvögel. Unter den Raben und Krähen ist sie einer der kleinsten Vertreter. Sie zeichnet sich durch schwarz-graues Gefieder, einen stämmigen Schnabel und hellblaue Augen aus. Ihr Verbreitungsgebiet reicht vom nordafrikanischen Atlasgebirge über Europa bis zum Baikalsee.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-2013-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -2084,7 +2084,7 @@
 			<description>
 				<de>Die Bekassine ist eine sehr langschnäbelige, mittelgroße Art aus der Familie der Schnepfenvögel. Sie ist über große Teile der Paläarktis verbreitet und überwintert überwiegend in den Subtropen und Tropen der Alten Welt.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-2014-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -2095,7 +2095,7 @@
 			<description>
 				<de>Der Grünspecht, manchmal auch Grasspecht oder Erdspecht genannt, ist eine Vogelart aus der Familie der Spechte. Der Grünspecht und seine Schwesterart, der Grauspecht, sind die einzigen Vertreter der Gattung Picus in Mitteleuropa.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-2015-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -2106,7 +2106,7 @@
 			<description>
 				<de>Der Habicht ist ein Greifvogel, dessen Verbreitungsgebiet die arktischen bis subtropischen Zonen der Holarktis umfasst. Habichte ernähren sich überwiegend von kleinen bis mittelgroßen Vögeln und Säugetieren bis zu einem Gewicht von etwa 1,0 kg. Die Art ist nicht gefährdet.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-2016-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -2117,7 +2117,7 @@
 			<description>
 				<de>Der Stieglitz, auch Distelfink genannt, ist eine Vogelart aus der Familie der Finken. Er besiedelt Eurasien von Westeuropa bis Zentralasien und Mittelsibirien sowie Nordafrika. In Südamerika und Australien sowie auf Neuseeland und einigen Inseln Ozeaniens wurde er eingeführt.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-2017-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -2128,7 +2128,7 @@
 			<description>
 				<de>Der Waldkauz ist eine mittelgroße Eulenart mit einer Verbreitung von Europa bis nach Westsibirien und Iran. Er kommt außerdem in Südostasien vor. In Mitteleuropa ist der Waldkauz gemeinsam mit der Waldohreule die häufigste Eule.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-2018-4-99" type="0" creator="8936" created_by="jorgaeff">
@@ -2139,7 +2139,7 @@
 			<description>
 				<de>Der Star, auch als Gemeiner Star bezeichnet, ist der in Eurasien am weitesten verbreitete und häufigste Vertreter der Familie der Stare. Durch zahlreiche Einbürgerungen auf anderen Kontinenten ist der Star heute einer der häufigsten Vögel der Welt. Im Niederdeutschen werden Stare Spreen genannt. </de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1986-4-UdSSR-02b" type="2" thread_id="news-jorgaeff-1986-4-UdSSR-02" creator="8936" created_by="jorgaeff">
@@ -2149,7 +2149,7 @@
 			<description>
 				<de>Vor 3 Tagen ist ein Reaktor im russischen Atomkraftwerk Nobyliwostok explodiert. Schwerwiegende Folgen für Mensch und Natur befürchtet.</de>
 			</description>
-			<data genre="4" price="1" quality="100" fictional="False" flags="2" />
+			<data genre="4" price="1" quality="100" fictional="0" flags="2" />
 			<effects>
 				<!-- "morgen 4-11 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,1,1,4,11" news="news-jorgaeff-1986-4-UdSSR-02c" />
@@ -2163,7 +2163,7 @@
 			<description>
 				<de>Die bei der Explosion des russischen Atomkraftwerks Nobyliwostok entstandene atomare Wolke breitet sich über weite Teile Europas aus. Weitere Ausbreitung über die gesamte nördliche Halbkugel befürchtet.</de>
 			</description>
-			<data genre="4" price="1.05" quality="95" fictional="False" flags="2" />
+			<data genre="4" price="1.05" quality="95" fictional="0" flags="2" />
 			<effects>
 				<!-- "morgen 13-19 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,1,1,13,19" news="news-jorgaeff-1986-4-UdSSR-02d" />
@@ -2178,7 +2178,7 @@
 			<description>
 				<de>Der explodierte Atomreaktor wird mit einem provisorischen Schutzmantel aus Stahlbeton versehen. Der "Sarkophag" soll die Strahlenausbreitung eindämmen.</de>
 			</description>
-			<data genre="4" price="0.85" quality="85" fictional="False" flags="2" />
+			<data genre="4" price="0.85" quality="85" fictional="0" flags="2" />
 			<effects>
 				<!-- "in 2 Tagen 16-20 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,2,2,16,20" news="news-jorgaeff-1986-4-UdSSR-02e" />
@@ -2192,7 +2192,7 @@
 			<description>
 				<de>Zu einem Wandel in der deutschen Atom-Politik ist es trotz der Explosion des russischen Atomkraftwerks Nobyliwostok nicht gekommen. Deutschland hält weiterhin an einem Ausbau der Kernenergie fest.</de>
 			</description>
-			<data genre="4" price="0.7" quality="70" fictional="True" flags="2" />
+			<data genre="4" price="0.7" quality="70" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1987-4-01" type="0" creator="8936" created_by="jorgaeff">
@@ -2203,7 +2203,7 @@
 			<description>
 				<de>Das 2. Deutsche Fernsehen (2DF) hat versehentlich die vorjährige Neujahrsansprache von Bundeskanzler Herbert Kappes gesendet. Der Programmdirektor wurde entlassen.</de>
 			</description>
-			<data genre="4" price="0.4" quality="40" fictional="False" flags="2" />
+			<data genre="4" price="0.4" quality="40" fictional="0" flags="2" />
 		</news>
 
 		<!-- triggers other thread...-->
@@ -2215,7 +2215,7 @@
 			<description>
 				<de>Der deutsche Pilot Markus Lahr ist mit seiner Cessna auf dem Roten Platz in Moskau gelandet.</de>
 			</description>
-			<data genre="4" price="0.8" quality="80" fictional="False" flags="2" />
+			<data genre="4" price="0.8" quality="80" fictional="0" flags="2" />
 			<effects>
 				<!-- "in 1 Tagen 10-16 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,1,1,10,16" news="news-jorgaeff-1987-0-UdSSR-01b" />
@@ -2230,7 +2230,7 @@
 			<description>
 				<de>Im West-Pazifik wird morgen Mittag eine totale Sonnenfinsternis erwartet. Die Sonnenfinsternis kann auf den Inseln Indonesiens und der Philippinen beobachtet werden. Verkehrschaos erwartet.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 			<effects>
 				<!-- "morgen, 12-16.00 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,1,1,12,16" news="news-jorgaeff-1988-4-01b" />
@@ -2245,7 +2245,7 @@
 			<description>
 				<de>Ohne besondere Vorkommnisse ist die Sonnenfinsternis im West-Pazifik zu Ende gegangen. Die gut informierte Bevölkerung hatte genug Zeit sich vorzubereiten; das befürchtete Verkehrschaos blieb aus.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 			<effects>
 				<!-- "in 1-2 Stunden" -->
 				<effect trigger="happen" type="triggernews" time="1,1,2" news="news-jorgaeff-1988-4-01c" />
@@ -2260,7 +2260,7 @@
 			<description>
 				<de>Gute Nachricht für alle, welche die heutige Sonnenfinsternis verpasst haben: Die majestätische Himmelserscheinung wiederholt sich heute Abend gegen 18.30 Uhr. Die Sonne verschwindet, es wird dunkel, kalt und still.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-2018-4-01" type="0" creator="8936" created_by="jorgaeff">
@@ -2271,7 +2271,7 @@
 			<description>
 				<de>Jorgaeff, der legendäre News-Schreiber von TVTower, gesteht, seit Jahren selbst ausgedachte Nachrichten geschrieben zu haben: Vieles sei gar nicht so passiert und Ähnlichkeiten mit lebenden Personen rein zufällig.</de>
 			</description>
-			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
+			<data genre="4" price="0.1" quality="10" fictional="1" flags="2" />
 		</news>
 
 
@@ -2287,7 +2287,7 @@
 			<description>
 				<de>Klaas Klinskis kaukasische Kaugummi-Klumpen-Sammlung wurde beim Auktionshaus ii-bääh für 1,2 Millionen € versteigert.</de>
 			</description>
-			<data genre="5" price="0.4" quality="30" fictional="True" />
+			<data genre="5" price="0.4" quality="30" fictional="1" />
 			<effects>
 				<!-- "übermorgen 8-11 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,2,2,8,11" news="news-jorgaeff-klinski-02" />
@@ -2325,7 +2325,7 @@
 			<description>
 				<de>Drei Tage lang finden die Kulturfestspiele statt. Zahlreiche Städte bieten eine unzählbare Menge an kulturellen Veranstaltungen an.</de>
 			</description>
-			<data genre="5" price="0.3" quality="30" fictional="True" />
+			<data genre="5" price="0.3" quality="30" fictional="1" />
 			<!-- "möglicher Effekt: höhere Zuschauerzahlen bei Kultursendungen" -->
 		</news>
 
@@ -2336,7 +2336,7 @@
 			<description>
 				<de>Das Werk "Bei Hempels unterm Sofa" von Georg Hempel wurde im Nationalmuseum von einer Putzfrau zerstört. Der Reinigungskraft war nicht klar ein 800.000€ teures Kunstwerk vor sich zu haben.</de>
 			</description>
-			<data genre="5" price="0.35" quality="35" fictional="True" />
+			<data genre="5" price="0.35" quality="35" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-fanta-01" type="0" thread_id="news-jorgaeff-fanta" creator="8936" created_by="jorgaeff">
@@ -2346,7 +2346,7 @@
 			<description>
 				<de>Der Bestseller des deutsch-syrisch-libanesischen Autors Heribert Fanta über einen Fischer im Jemen bricht sämtliche Rekorde und ist mit dem diesjährigen Literaturpreis ausgezeichnet worden.</de>
 			</description>
-			<data genre="5" price="0.3" quality="30" fictional="True" />
+			<data genre="5" price="0.3" quality="30" fictional="1" />
 			<effects>
 				<!-- "in 2 Tagen 13-17 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,2,2,13,17" news="news-jorgaeff-fanta-02" />
@@ -2360,7 +2360,7 @@
 			<description>
 				<de>Nur wenige Menschen leiden an Easiophobie - der Angst zu schreiben. Der deutsche Erfolgsautor Heribert Fanta ist einer von Ihnen. Er möchte sich künftig nur noch auf die Produktion von Film-Dokumentationen konzentrieren.</de>
 			</description>
-			<data genre="5" price="0.4" quality="40" fictional="True" />
+			<data genre="5" price="0.4" quality="40" fictional="1" />
 			<effects>
 				<!-- "in 3 Tagen 10-16 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,3,3,10,16" news="news-jorgaeff-fanta-03" />
@@ -2374,7 +2374,7 @@
 			<description>
 				<de>Die neue Dokumentation des deutsch-syrisch-libanesischen Ex-Autors über einen Bäcker im Sudan hat die Herzen der Juroren erweicht. Sie statten das Werk Fantas mit dem Prädikat "Besonders wertvoll" aus.</de>
 			</description>
-			<data genre="5" price="0.35" quality="35" fictional="True" />
+			<data genre="5" price="0.35" quality="35" fictional="1" />
 			<effects>
 				<!-- "in 5 Tagen 18-22 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,5,5,18,22" news="news-jorgaeff-fanta-04" />
@@ -2388,7 +2388,7 @@
 			<description>
 				<de>Easiophobiker und Ex-Autor, Heribert Fanta, hat seine Schreibangst überwunden und erstmalig seit zwei Jahren einen Einkaufszettel geschrieben. "Ohne war das immer doof, weil ich die Hälfte vergessen habe", so der Autor.</de>
 			</description>
-			<data genre="5" price="0.45" quality="45" fictional="True" />
+			<data genre="5" price="0.45" quality="45" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-gamseier-01" type="0" creator="8936" created_by="jorgaeff">
@@ -2398,7 +2398,7 @@
 			<description>
 				<de>Der wohl erfolgloseste Nachrichtensprecher aller Zeiten war der Erste im deutschen Fernsehen, der weder "Bonn" noch "Berlin" aussprechen konnte. Er starb gestern im Alter von 63 Jahren beim Versuch die Wetterkarten neu zu mischen.</de>
 			</description>
-			<data genre="5" price="0.3" quality="30" fictional="True" />
+			<data genre="5" price="0.3" quality="30" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-grafitti-01" type="0" thread_id="news-jorgaeff-grafitti" creator="8936" created_by="jorgaeff">
@@ -2408,7 +2408,7 @@
 			<description>
 				<de>Für die einen ist es Vandalismus, für die anderen eine Ausdrucksweise urbaner Kultur. Im vergangenen Jahr musste die Bahn Millionen für die Reinigung beschmierter Waggons aufbringen, was sich natürlich auch auf die Fahrpreise auswirkt.</de>
 			</description>
-			<data genre="5" price="0.35" quality="35" fictional="True" />
+			<data genre="5" price="0.35" quality="35" fictional="1" />
 			<effects>
 				<!-- "in 7 Tagen 14-20 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,7,7,14,20" news="news-jorgaeff-grafitti-02" />
@@ -2422,7 +2422,7 @@
 			<description>
 				<de>Lange Zeit waren Grafittis nur als Schmierereien angesehen. Doch langsam steigt in der Gesellschaft die Akzeptanz für die bunten Bilder. Sogar Prominente greifen öffentlich zur Sprühdose und besprühen ungeniert Wände und Bahnwaggons.</de>
 			</description>
-			<data genre="5" price="0.4" quality="40" fictional="True" />
+			<data genre="5" price="0.4" quality="40" fictional="1" />
 			<effects>
 				<!-- "in 4 Tagen 10-20 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,4,4,10,20" news="news-jorgaeff-grafitti-03" />
@@ -2436,7 +2436,7 @@
 			<description>
 				<de>Die Bahn hat einige ihrer besprühten Waggons verkauft. Bei dem derzeitigen Grafitti-Hype sei es lukrativer die alten Waggons zu verscherbeln und neue zu kaufen. Gartenzwerge waren gestern - heute stellt man sich einen Waggon in den Vorgarten.</de>
 			</description>
-			<data genre="5" price="0.45" quality="45" fictional="True" />
+			<data genre="5" price="0.45" quality="45" fictional="1" />
 			<effects>
 				<!-- "in 2 Tagen 7-12 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,2,2,7,12" news="news-jorgaeff-grafitti-04" />
@@ -2450,7 +2450,7 @@
 			<description>
 				<de>Die von DASF entwickelte unübersprühbare Farbe könnte das Ende für Grafittis bedeuten. Dennoch ist sich die Bahn unschlüssig, ob sie die Farbe einsetzen soll, da der Verkauf besprühter Waggons sehr lukrativ zu sein scheint.</de>
 			</description>
-			<data genre="5" price="0.5" quality="50" fictional="True" />
+			<data genre="5" price="0.5" quality="50" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-1985-5-01" type="0" creator="8936" created_by="jorgaeff">
@@ -2461,7 +2461,7 @@
 			<description>
 				<de>Nach jahrelanger Sanierung wurde die Dresdner Staatsoper mit der Uraufführung der Oper "Der Schäfer und seine Zicklein" von Hannes Lotz wieder eröffnet.</de>
 			</description>
-			<data genre="5" price="0.4" quality="40" fictional="True" flags="2" />
+			<data genre="5" price="0.4" quality="40" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1985-5-02" type="0" creator="8936" created_by="jorgaeff">
@@ -2472,7 +2472,7 @@
 			<description>
 				<de>In Rüsselsheim wurde das Museum des ersten avantgardistischen Dichters und Dramaturgen der Neuzeit, Edward Swanstein, eröffnet. Das Museum zeigt Werke des Künstlers und bildet sein Leben anhand von Pantomimen nach.</de>
 			</description>
-			<data genre="5" price="0.3" quality="30" fictional="True" flags="2" />
+			<data genre="5" price="0.3" quality="30" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1985-5-03" type="0" creator="8936" created_by="jorgaeff">
@@ -2483,7 +2483,7 @@
 			<description>
 				<de>Durch einen Säureanschlag wird im Kunsthaus Wanne-Eickel das Gemälde "Die Rubensdame" von Hans-Dieter Blasewitz völlig zerstört.</de>
 			</description>
-			<data genre="5" price="0.35" quality="35" fictional="True" />
+			<data genre="5" price="0.35" quality="35" fictional="1" />
 		</news>
 
 		<news id="news-jorgaeff-1985-5-04a" type="0" thread_id="news-jorgaeff-1985-5-04" creator="8936" created_by="jorgaeff">
@@ -2498,7 +2498,7 @@
 				<!-- "morgen, 12 bis 18.00 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,1,1,12,18" news="news-jorgaeff-1985-5-04b" />
 			</effects>
-			<data genre="5" price="0.35" quality="35" fictional="True" flags="2" />
+			<data genre="5" price="0.35" quality="35" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1985-5-04b" type="2" thread_id="news-jorgaeff-1985-5-04" creator="8936" created_by="jorgaeff">
@@ -2509,7 +2509,7 @@
 			<description>
 				<de>Nur wenig Applaus gab es zum Ende der erstmalig ungekürzt aufgeführten Ulm-Oper "Der Kolibri". Die meisten der 1200 Zuschauer waren bereits zum Ende des ersten Akts eingeschlafen. Kritiker bemängeln die Langatmigkeit des Werks.</de>
 			</description>
-			<data genre="5" price="0.35" quality="35" fictional="True" flags="2" />
+			<data genre="5" price="0.35" quality="35" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1985-5-05" type="0" creator="8936" created_by="jorgaeff">
@@ -2520,7 +2520,7 @@
 			<description>
 				<de>Die Stadt Augsburg in Bayern feiert ihren 2000. Geburtstag. Sie ist eine der ältesten Städte Deutschlands und war im 16. Jahrhundert Heimat der wohlhabenden Kaufmannsfamilie Fugger.</de>
 			</description>
-			<data genre="5" price="0.25" quality="25" fictional="True" flags="2" />
+			<data genre="5" price="0.25" quality="25" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1986-5-01" type="0" creator="8936" created_by="jorgaeff">
@@ -2531,7 +2531,7 @@
 			<description>
 				<de>Jean-Pierre Moreau spielt anlässlich des 150. Geburtstags des US-Bundesstaats Texas und dem 25. Jubiläum des NASE-Space-Centers Houston ein Konzert vor mindestens 1.300.000 Zuhörern und erhält einen Eintrag im Guinness-Buch der Rekorde.</de>
 			</description>
-			<data genre="5" price="0.45" quality="45" fictional="True" flags="2" />
+			<data genre="5" price="0.45" quality="45" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1986-5-02" type="0" creator="8936" created_by="jorgaeff">
@@ -2542,7 +2542,7 @@
 			<description>
 				<de>Mit der Welturaufführung des Musicals „Das Gespenst des Theaters“ startet der Dichtungskunstzyklus im Herman-Sherman-Theater in London.</de>
 			</description>
-			<data genre="5" price="0.35" quality="35" fictional="True" flags="2" />
+			<data genre="5" price="0.35" quality="35" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1987-5-01" type="0" creator="8936" created_by="jorgaeff">
@@ -2553,7 +2553,7 @@
 			<description>
 				<de>Die 750-Jahr-Feier der Stadt Berlin wird mit zahlreichen Veranstaltungen beiderseits der Mauer begangen. Als Highlight wird die Rede von US-Präsident Keagan an der Siegessäule erwartet.</de>
 			</description>
-			<data genre="5" price="0.35" quality="35" fictional="True" flags="2" />
+			<data genre="5" price="0.35" quality="35" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1987-5-02" type="0" creator="8936" created_by="jorgaeff">
@@ -2564,7 +2564,7 @@
 			<description>
 				<de>Die erfolgreichste Live-Sendung im 2. Deutschen Fernsehen (2DF) "Wer wird Wettkönig?" hat einen neuen Moderator: Tommy Göttinger wettet ab sofort mit den Kandidaten um die Wette bis sich die Balken biegen.</de>
 			</description>
-			<data genre="5" price="0.35" quality="35" fictional="True" flags="2" />
+			<data genre="5" price="0.35" quality="35" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1988-5-01" type="0" creator="8936" created_by="jorgaeff">
@@ -2575,7 +2575,7 @@
 			<description>
 				<de>Die Kulturstadt Europas ist ein Titel, der jährlich von der EU vergeben wird. Die Benennung soll dazu beitragen, den Reichtum, die Vielfalt und die Gemeinsamkeiten des kulturellen Erbes in Europa herauszustellen und ein besseres Verständnis der Bürger füreinander zu ermöglichen.</de>
 			</description>
-			<data genre="5" price="0.35" quality="35" fictional="True" flags="2" />
+			<data genre="5" price="0.35" quality="35" fictional="1" flags="2" />
 		</news>
 
 		<news id="news-jorgaeff-1988-5-02" type="0" creator="8936" created_by="jorgaeff">
@@ -2586,7 +2586,7 @@
 			<description>
 				<de>Im Londoner Embley-Park-Stadion findet anlässlich des 70. Geburtstags des westafrikanischen Politikers, Nestor Candela, ein Solidaritätskonzert statt. Namhafte Künstler wie die Ghee Bees, UB60 oder Simple Thoughts spielen für lau. </de>
 			</description>
-			<data genre="5" price="0.35" quality="35" fictional="True" flags="2" />
+			<data genre="5" price="0.35" quality="35" fictional="1" flags="2" />
 		</news>
 	</allnews>
-</tvgdb>
+</tvtdb>

--- a/res/database/Default/user/jorgaeff.xml
+++ b/res/database/Default/user/jorgaeff.xml
@@ -4,7 +4,7 @@
 	<allnews>
 
 	<!-- "POLITIK + WIRTSCHAFT" -->
-		<news id="news-jorgaeff-dumb-01" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-dumb-01" type="0" thread_id="news-jorgaeff-dumb" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Donald Dumb wird Präsident der VR Duban</de>
 			</title>
@@ -18,7 +18,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-dumb-02" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-dumb-02" type="2" thread_id="news-jorgaeff-dumb" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Donald Dumb provoziert Freie Republik Duban</de>
 			</title>
@@ -32,7 +32,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-dumb-03" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-dumb-03" type="2" thread_id="news-jorgaeff-dumb" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Donald Dumb möchte Mauer bauen</de>
 			</title>
@@ -46,7 +46,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-dumb-04" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-dumb-04" thread_id="news-jorgaeff-dumb" type="2" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Donald Dumb vermisst Quietsche-Entchen</de>
 			</title>
@@ -57,7 +57,7 @@
 		</news>
 
 		<news id="news-jorgaeff-1987-0-01" type="0" creator="8936" created_by="jorgaeff">
-			<availability script="TIME_YEAR=1987 &amp;&amp; TIME_WEEKDAY=0 &amp;&amp; TIME_HOUR=>12" />
+			<availability script="TIME_YEAR=1987 &amp;&amp; TIME_WEEKDAY=0 &amp;&amp; TIME_HOUR>=12" />
 			<title>
 				<de>Schwerer Börsen-Crash</de>
 			</title>
@@ -78,7 +78,7 @@
 			<data genre="0" price="0.8" quality="80" fictional="False" flags="2" />
 		</news>
 
-		<news id="news-jorgaeff-1985-0-BRD-01" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1985-0-BRD-01" type="0" thread_id="news-jorgaeff-1985-0-BRD" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1985" />
 			<title>
 				<de>APD mit historischem Wahlergebnis</de>
@@ -93,7 +93,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-1985-0-BRD-02" type="1" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1985-0-BRD-02" type="2" thread_id="news-jorgaeff-1985-0-BRD" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1985" />
 			<title>
 				<de>APD nominiert Hannes Reif</de>
@@ -170,7 +170,7 @@
 			<data genre="0" price="0.8" quality="80" fictional="False" flags="2" />
 		</news>
 
-		<news id="news-jorgaeff-1988-0-DDR-01a" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1988-0-DDR-01a" type="0" thread_id="news-jorgaeff-1988-0-DDR" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1988" />
 			<title>
 				<de>Grotesko trifft Hoecker</de>
@@ -185,7 +185,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-1988-0-DDR-01b" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1988-0-DDR-01b" type="2" thread_id="news-jorgaeff-1988-0-DDR" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1988" />
 			<title>
 				<de>Hoeckers Abrüstungspläne</de>
@@ -218,6 +218,7 @@
 			<data genre="0" price="0.8" quality="80" fictional="False" flags="2" />
 		</news>
 
+		<!-- triggers other thread...-->
 		<news id="news-jorgaeff-1986-0-UdSSR-02a" type="0" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1986" />
 			<title>
@@ -233,7 +234,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-1987-0-UdSSR-01b" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1987-0-UdSSR-01b" type="2" thread_id="news-jorgaeff-1987-0-UdSSR-01" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1987" />
 			<title>
 				<de>Michailow entlässt Minister</de>
@@ -248,7 +249,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-1987-0-UdSSR-01c" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1987-0-UdSSR-01c" type="2" thread_id="news-jorgaeff-1987-0-UdSSR-01" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1987" />
 			<title>
 				<de>Weitere Entlassungen in Moskau</de>
@@ -281,7 +282,7 @@
 			<data genre="0" price="0.5" quality="50" fictional="False" flags="2" />
 		</news>
 
-		<news id="news-jorgaeff-1988-0-USA-01a" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1988-0-USA-01a" type="0" thread_id="news-jorgaeff-1988-0-USA-01" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1988" />
 			<title>
 				<de>US-Präsidentschaftswahlen</de>
@@ -296,7 +297,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-1988-0-USA-01b" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1988-0-USA-01b" type="2" thread_id="news-jorgaeff-1988-0-USA-01" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1988" />
 			<title>
 				<de>Cush wird US-Präsident</de>
@@ -321,7 +322,7 @@
 			<data genre="1" price="0.45" quality="45" fictional="True" />
 		</news>
 
-		<news id="news-jorgaeff-chorris-01" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-chorris-01" type="0" thread_id="news-jorgaeff-chorris" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Nuck Chorris schlägt Zeit tot</de>
 			</title>
@@ -335,7 +336,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-chorris-02" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-chorris-02" type="2" thread_id="news-jorgaeff-chorris" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Nuck Chorris zählt bis zur Unendlichkeit</de>
 			</title>
@@ -345,7 +346,7 @@
 			<data genre="1" price="0.3" quality="30" fictional="True" />
 		</news>
 
-		<news id="news-jorgaeff-drops-01" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-drops-01" type="0" thread_id="news-jorgaeff-drops" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Jonnie Drops bei Dreharbeiten schwer verletzt</de>
 			</title>
@@ -359,7 +360,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-drops-02" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-drops-02" type="2" thread_id="news-jorgaeff-drops" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>"Mein Grog - dein Grog": Dreh geht weiter</de>
 			</title>
@@ -373,7 +374,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-drops-03" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-drops-03" type="2" thread_id="news-jorgaeff-drops" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Neuer Drops-Film kommt in die Kinos</de>
 			</title>
@@ -387,7 +388,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-drops-04" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-drops-04" type="2" thread_id="news-jorgaeff-drops" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Goldene Brombeere für Jonnie Drops</de>
 			</title>
@@ -401,7 +402,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-drops-05" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-drops-05" type="2" thread_id="news-jorgaeff-drops" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Patty Glansen gesteht Affaire</de>
 			</title>
@@ -416,7 +417,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-drops-06" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-drops-06" type="2" thread_id="news-jorgaeff-drops" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Benny Jameson klaut Filmpreis</de>
 			</title>
@@ -431,7 +432,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-drops-07" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-drops-07" type="2" thread_id="news-jorgaeff-drops" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Benny Jameson zu Gefängnisstrafe verurteilt</de>
 			</title>
@@ -446,7 +447,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-drops-08" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-drops-08" type="2" thread_id="news-jorgaeff-drops" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Benny Jameson aus dem Gefängnis entlassen</de>
 			</title>
@@ -461,7 +462,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-drops-09" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-drops-09" type="2" thread_id="news-jorgaeff-drops" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Benny Jameson erhält Filmpreis</de>
 			</title>
@@ -631,7 +632,7 @@
 			<data genre="2" price="0.35" quality="40" fictional="False" />
 		</news>
 
-		<news id="news-jorgaeff-abstieg-01" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-abstieg-01" type="0" thread_id="news-jorgaeff-abstieg" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Bundesliga-Relegation: Wer steigt auf, wer ab?</de>
 			</title>
@@ -645,7 +646,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-abstieg-02a" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-abstieg-02a" type="2"thread_id="news-jorgaeff-abstieg"  creator="8936" created_by="jorgaeff">
 			<title>
 				<de>SV Hamburg steigt erstmalig ab</de>
 			</title>
@@ -659,7 +660,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-abstieg-02b" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-abstieg-02b" type="2" thread_id="news-jorgaeff-abstieg" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Glubb verpasst Aufstieg</de>
 			</title>
@@ -673,7 +674,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-abstieg-03a" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-abstieg-03a" type="2" thread_id="news-jorgaeff-abstieg" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>SV Hamburg trennt sich von Trainer</de>
 			</title>
@@ -683,7 +684,7 @@
 			<data genre="2" price="0.25" quality="25" fictional="True" />
 		</news>
 
-		<news id="news-jorgaeff-abstieg-03b" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-abstieg-03b" type="2" thread_id="news-jorgaeff-abstieg" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>SV Hamburg hält am Trainer fest</de>
 			</title>
@@ -693,7 +694,7 @@
 			<data genre="2" price="0.25" quality="25" fictional="True" />
 		</news>
 
-		<news id="news-jorgaeff-abstieg-03c" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-abstieg-03c" type="2" thread_id="news-jorgaeff-abstieg" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Muss der Glubb Insolvenz anmelden?</de>
 			</title>
@@ -703,7 +704,7 @@
 			<data genre="2" price="0.25" quality="25" fictional="True" />
 		</news>
 
-		<news id="news-jorgaeff-abstieg-03d" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-abstieg-03d" type="2" thread_id="news-jorgaeff-abstieg" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Der Glubb ist wieder schuldenfrei</de>
 			</title>
@@ -713,7 +714,7 @@
 			<data genre="2" price="0.25" quality="25" fictional="True" />
 		</news>
 
-		<news id="news-jorgaeff-racing-01" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-racing-01" type="0" thread_id="news-jorgaeff-racing" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Formel X: Wer holt sich die Fahrer-WM?</de>
 			</title>
@@ -728,7 +729,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-racing-02a" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-racing-02a" type="2" thread_id="news-jorgaeff-racing" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Luis Pamelton ist Weltmeister</de>
 			</title>
@@ -738,7 +739,7 @@
 			<data genre="2" price="0.5" quality="50" fictional="True" />
 		</news>
 
-		<news id="news-jorgaeff-racing-02b" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-racing-02b" type="2" thread_id="news-jorgaeff-racing" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Bastian Kettel ist Weltmeister</de>
 			</title>
@@ -748,7 +749,7 @@
 			<data genre="2" price="0.5" quality="50" fictional="True" />
 		</news>
 
-		<news id="news-jorgaeff-racing-02c" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-racing-02c" type="2" thread_id="news-jorgaeff-racing" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Ferdinando Alfonso ist Weltmeister</de>
 			</title>
@@ -758,7 +759,7 @@
 			<data genre="2" price="0.5" quality="50" fictional="True" />
 		</news>
 
-		<news id="news-jorgaeff-racing-02d" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-racing-02d" type="2" thread_id="news-jorgaeff-racing" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Sensation: Erstmalig drei Weltmeister</de>
 			</title>
@@ -768,7 +769,7 @@
 			<data genre="2" price="0.6" quality="60" fictional="True" />
 		</news>
 
-		<news id="news-jorgaeff-nachtrennen-01" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-nachtrennen-01" type="0" thread_id="news-jorgaeff-nachtrennen" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Erstes Nachtrennen der Formel Öko</de>
 			</title>
@@ -779,11 +780,11 @@
 			<effects>
 				<!-- "möglicher Effekt: Live-Übertragung" -->
 				<!-- "in 1 Tagen 0-23 Uhr" -->
-				<effect trigger="happen" type="triggernews" time="2,1,1,0,23" news="news-jorgaeff-nachtrennen-01" />
+				<effect trigger="happen" type="triggernews" time="2,1,1,0,23" news="news-jorgaeff-nachtrennen-02" />
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-nachtrennen-02" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-nachtrennen-02" type="2" thread_id="news-jorgaeff-nachtrennen" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Nachtrennen der Formel Öko abgebrochen</de>
 			</title>
@@ -803,7 +804,7 @@
 			<data genre="2" price="0.25" quality="25" fictional="True" />
 		</news>
 
-		<news id="news-jorgaeff-dyson-01" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-dyson-01" type="0" thread_id="news-jorgaeff-dyson" creator="8936" created_by="jorgaeff">
 				<!-- "Beginnt an einem Sonntag" -->
 			<availability script="TIME_WEEKDAY=6" />
 			<title>
@@ -819,7 +820,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-dyson-02" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-dyson-02" type="2" thread_id="news-jorgaeff-dyson" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Klatschkowski möchte Titel verteidigen</de>
 			</title>
@@ -833,7 +834,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-dyson-03" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-dyson-03" type="2" thread_id="news-jorgaeff-dyson" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Spike Dyson nimmt Herausforderung an</de>
 			</title>
@@ -847,7 +848,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-dyson-04" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-dyson-04" type="2" thread_id="news-jorgaeff-dyson" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Spike Dyson trainiert für Comeback</de>
 			</title>
@@ -861,7 +862,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-dyson-05" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-dyson-05" type="2" thread_id="news-jorgaeff-dyson" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Dyson vs. Klatschkowski: Tumulte vor Boxkampf</de>
 			</title>
@@ -875,7 +876,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-dyson-06" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-dyson-06" type="2" thread_id="news-jorgaeff-dyson" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Heute Abend: Dyson vs. Klatschkowski</de>
 			</title>
@@ -890,7 +891,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-dyson-06a" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-dyson-06a" type="2" thread_id="news-jorgaeff-dyson" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Spike Dyson neuer Box-Weltmeister</de>
 			</title>
@@ -904,7 +905,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-dyson-06b" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-dyson-06b" type="2" thread_id="news-jorgaeff-dyson" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Klatschkowski bleibt Box-Weltmeister</de>
 			</title>
@@ -918,7 +919,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-dyson-07a" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-dyson-07a" type="2" thread_id="news-jorgaeff-dyson" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Spike Dyson: Mit Yoga habe ich es geschafft</de>
 			</title>
@@ -928,7 +929,7 @@
 			<data genre="2" price="0.55" quality="55" fictional="True" />
 		</news>
 
-		<news id="news-jorgaeff-dyson-07b" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-dyson-07b" type="2" thread_id="news-jorgaeff-dyson" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Klatschkowski tritt zurück</de>
 			</title>
@@ -1041,7 +1042,7 @@
 			<data genre="2" price="0.25" quality="25" fictional="False" flags="2" />
 		</news>
 
-		<news id="news-jorgaeff-1985-2-02a" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1985-2-02a" type="0" thread_id="news-jorgaeff-1985-2-02" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1985" />
 			<title>
 				<de>Weltmeisterschaft im Show-Catchen</de>
@@ -1056,7 +1057,7 @@
 			<data genre="2" price="0.3" quality="3" fictional="False" />
 		</news>
 
-		<news id="news-jorgaeff-1985-2-02b" type="1" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1985-2-02b" type= "2" thread_id="news-jorgaeff-1985-2-02" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1985" />
 			<title>
 				<de>Mr. Y entscheidet Catchkampf</de>
@@ -1144,7 +1145,7 @@
 			<data genre="2" price="0.3" quality="30" fictional="False" flags="2" />
 		</news>
 
-		<news id="news-jorgaeff-1987-2-02a" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1987-2-02a" type="0" thread_id="news-jorgaeff-1987-2-02" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1987 &amp;&amp; TIME_SEASON=2" />
 			<title>
 				<de>Betty Lord gewinnt in Paris</de>
@@ -1159,7 +1160,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-1987-2-02b" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1987-2-02b" type="2" thread_id="news-jorgaeff-1987-2-02" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Betty Lord Weltranglistenerste</de>
 			</title>
@@ -1214,7 +1215,7 @@
 			<data genre="3" price="0.45" quality="45" fictional="True" />
 		</news>
 
-		<news id="news-jorgaeff-orange-01" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-orange-01" type="0" thread_id="news-jorgaeff-orange" creator="8936" created_by="jorgaeff">
 			<!-- "erscheint 2007" -->
 			<availability script="TIME_YEAR=2007" />
 			<title>
@@ -1230,7 +1231,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-orange-02" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-orange-02" type="2" thread_id="news-jorgaeff-orange" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Neues my-phone bereits ausverkauft</de>
 			</title>
@@ -1250,7 +1251,7 @@
 			<data genre="3" price="0.15" quality="15" fictional="True" />
 		</news>
 
-		<news id="news-jorgaeff-space-1985-3-01" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-space-1985-3-01" type="0" thread_id="news-jorgaeff-space-1985-3" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1985" />
 			<title>
 				<de>NASE startet Space-Shuttle-Programm</de>
@@ -1265,7 +1266,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-space-1985-3-02" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-space-1985-3-02" type="2" thread_id="news-jorgaeff-space-1985-3" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1985" />
 			<title>
 				<de>Kolumbus soll Erdumlaufbahn erkunden</de>
@@ -1281,7 +1282,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-space-1985-3-03" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-space-1985-3-03" type="2" thread_id="news-jorgaeff-space-1985-3" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1985" />
 			<title>
 				<de>Kolumbus erfolgreich gestartet</de>
@@ -1296,7 +1297,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-space-1985-3-04" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-space-1985-3-04" type="2" thread_id="news-jorgaeff-space-1985-3" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1985" />
 			<title>
 				<de>Kolumbus erfolgreich gelandet</de>
@@ -1307,7 +1308,7 @@
 			<data genre="3" price="0.65" quality="65" fictional="False" flags="2" />
 		</news>
 
-		<news id="news-jorgaeff-space-1986-3-01" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-space-1986-3-01" type="0" thread_id="news-jorgaeff-space-1986-3" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1986" />
 			<title>
 				<de>Wieder Shuttle-Start geplant</de>
@@ -1322,7 +1323,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-space-1986-3-02" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-space-1986-3-02" type="2" thread_id="news-jorgaeff-space-1986-3" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1986" />
 			<title>
 				<de>Raumfähre bei Start explodiert</de>
@@ -1337,7 +1338,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-space-1986-3-03" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-space-1986-3-03" type="2" thread_id="news-jorgaeff-space-1986-3" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1986" />
 			<title>
 				<de>Shuttle-Explosion: Unglücksursache geklärt</de>
@@ -1352,7 +1353,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-space-1986-3-04" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-space-1986-3-04" type="2" thread_id="news-jorgaeff-space-1986-3" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1986" />
 			<title>
 				<de>NASE legt Raumfahrtprogramm auf Eis</de>
@@ -1363,9 +1364,9 @@
 			<data genre="3" price="0.75" quality="75" fictional="False" flags="2" />
 		</news>
 
-		<news id="news-jorgaeff-c256-01" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-c256-01" type="0" thread_id="news-jorgaeff-space-c256a" creator="8936" created_by="jorgaeff">
 				<!-- "erscheint 1989-90" -->
-			<conditions year_range_from="1989" year_range_to="1990" />
+			<availability year_range_from="1989" year_range_to="1990" />
 			<title>
 				<de>Cormoran veröffentlicht C256</de>
 			</title>
@@ -1379,7 +1380,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-c256-02" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-c256-02" type="2" thread_id="news-jorgaeff-space-c256a" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>C256 entwickelt sich zum Verkaufsschlager</de>
 			</title>
@@ -1389,9 +1390,9 @@
 			<data genre="3" price="0.55" quality="55" fictional="True" flags="2" />
 		</news>
 
-		<news id="news-jorgaeff-c256-03" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-c256-03" type="0" thread_id="news-jorgaeff-space-c256b" creator="8936" created_by="jorgaeff">
 				<!-- "erscheint 1994-95" -->
-			<conditions year_range_from="1994" year_range_to="1995" />
+			<availability year_range_from="1994" year_range_to="1995" />
 			<title>
 				<de>Cormoran veröffentlicht C512</de>
 			</title>
@@ -1405,7 +1406,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-c256-04" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-c256-04" type="2" thread_id="news-jorgaeff-space-c256b" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>C512 übertrifft alle Erwartungen</de>
 			</title>
@@ -1415,9 +1416,9 @@
 			<data genre="3" price="0.55" quality="55" fictional="True" flags="2" />
 		</news>
 
-		<news id="news-jorgaeff-c256-05" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-c256-05" type="0" thread_id="news-jorgaeff-space-c256c" creator="8936" created_by="jorgaeff">
 				<!-- "erscheint 1999-00" -->
-			<conditions year_range_from="1999" year_range_to="2000" />
+			<availability year_range_from="1999" year_range_to="2000" />
 			<title>
 				<de>Cormoran veröffentlicht C1k024</de>
 			</title>
@@ -1431,7 +1432,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-c256-06" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-c256-06" type="2" thread_id="news-jorgaeff-space-c256c" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>C1k024 - der meistverkaufte aller Zeiten</de>
 			</title>
@@ -1441,9 +1442,9 @@
 			<data genre="3" price="0.55" quality="55" fictional="True" flags="2" />
 		</news>
 
-		<news id="news-jorgaeff-c256-07" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-c256-07" type="0" thread_id="news-jorgaeff-space-c256d" creator="8936" created_by="jorgaeff">
 				<!-- "erscheint 2004-05" -->
-			<conditions year_range_from="2004" year_range_to="2005" />
+			<availability year_range_from="2004" year_range_to="2005" />
 			<title>
 				<de>Cormoran veröffentlicht C2k048</de>
 			</title>
@@ -1457,7 +1458,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-c256-08" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-c256-08" type="2" thread_id="news-jorgaeff-space-c256d" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>C2k048 - ein Verkaufsflop</de>
 			</title>
@@ -1469,7 +1470,7 @@
 
 		<news id="news-jorgaeff-btx-01" type="0" creator="8936" created_by="jorgaeff">
 				<!-- "erscheint 2000-01" -->
-			<conditions year_range_from="2000" year_range_to="2001" />
+			<availability year_range_from="2000" year_range_to="2001" />
 			<title>
 				<de>Bildschirmtext wird abgeschaltet</de>
 			</title>
@@ -1481,7 +1482,7 @@
 
 		<news id="news-jorgaeff-dvd-01" type="0" creator="8936" created_by="jorgaeff">
 			<!-- "erscheint 1997" -->
-			<conditions year_range_from="1997" year_range_to="1997" />
+			<availability year_range_from="1997" year_range_to="1997" />
 			<title>
 				<de>DVD löst VHS-Kassette &amp; Co. ab</de>
 			</title>
@@ -1493,7 +1494,7 @@
 
 		<news id="news-jorgaeff-dvd-02" type="0" creator="8936" created_by="jorgaeff">
 			<!-- "erscheint 2009" -->
-			<conditions year_range_from="2009" year_range_to="2009" />
+			<availability year_range_from="2009" year_range_to="2009" />
 			<title>
 				<de>Blu-Ray löst DVD ab</de>
 			</title>
@@ -1570,7 +1571,7 @@
 			<data genre="3" price="0.85" quality="85" fictional="True" flags="2" />
 		</news>
 
-		<news id="news-jorgaeff-1988-3-01a" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1988-3-01a" type="0" thread_id="news-jorgaeff-1988-3" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1988" />
 			<title>
 				<de>Bleihaltiges Benzin verboten</de>
@@ -1585,7 +1586,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-1988-3-01b" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1988-3-01b" type="2" thread_id="news-jorgaeff-1988-3" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1988" />
 			<title>
 				<de>Bleifreier Ladenhüter</de>
@@ -1622,7 +1623,7 @@
 
 
 	<!-- "TAGESGESCHEHEN" -->
-		<news id="news-jorgaeff-hyperraum-01" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-hyperraum-01" type="0" thread_id="news-jorgaeff-hyperraum" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Hyperraum-Umgehungsstraße geplant</de>
 			</title>
@@ -1636,7 +1637,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-hyperraum-02" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-hyperraum-02" type="2" thread_id="news-jorgaeff-hyperraum" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Wird die Menschheit umgesiedelt?</de>
 			</title>
@@ -1650,7 +1651,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-hyperraum-03" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-hyperraum-03" type="2" thread_id="news-jorgaeff-hyperraum" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Suche nach Ersatzplaneten gescheitert</de>
 			</title>
@@ -2141,7 +2142,7 @@
 			<data genre="4" price="0.1" quality="10" fictional="True" flags="2" />
 		</news>
 
-		<news id="news-jorgaeff-1986-4-UdSSR-02b" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1986-4-UdSSR-02b" type="2" thread_id="news-jorgaeff-1986-4-UdSSR-02" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Atomkraftwerk in Russland explodiert</de>
 			</title>
@@ -2155,7 +2156,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-1986-4-UdSSR-02c" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1986-4-UdSSR-02c" type="2" thread_id="news-jorgaeff-1986-4-UdSSR-02" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Atomare Wolke breitet sich aus</de>
 			</title>
@@ -2170,7 +2171,7 @@
 				<!-- Menschen bleiben zu Hause und sehen mehr fern / Interesse an Nachrichten(-sendungen) steigt -->
 		</news>
 
-		<news id="news-jorgaeff-1986-4-UdSSR-02d" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1986-4-UdSSR-02d" type="2" thread_id="news-jorgaeff-1986-4-UdSSR-02"  creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Atomreaktor bekommt Sarkophag</de>
 			</title>
@@ -2184,7 +2185,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-1986-4-UdSSR-02e" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1986-4-UdSSR-02e" type="2" thread_id="news-jorgaeff-1986-4-UdSSR-02" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Atomenergie wird weiter ausgebaut</de>
 			</title>
@@ -2205,6 +2206,7 @@
 			<data genre="4" price="0.4" quality="40" fictional="False" flags="2" />
 		</news>
 
+		<!-- triggers other thread...-->
 		<news id="news-jorgaeff-1987-4-UdSSR-01a" type="0" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1987" />
 			<title>
@@ -2220,7 +2222,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-1988-4-01a" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1988-4-01a" type="0" thread_id="news-jorgaeff-1988-4-01" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1988" />
 			<title>
 				<de>Sonnenfinsternis im West-Pazifik</de>
@@ -2235,7 +2237,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-1988-4-01b" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1988-4-01b" type="2" thread_id="news-jorgaeff-1988-4-01" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1988" />
 			<title>
 				<de>Verkehrschaos blieb aus</de>
@@ -2250,7 +2252,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-1988-4-01c" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1988-4-01c" type="2" thread_id="news-jorgaeff-1988-4-01" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1988" />
 			<title>
 				<de>Nächste Sonnenfinsternis in Kürze</de>
@@ -2278,7 +2280,7 @@
 
 
 	<!-- "KULTUR" -->
-		<news id="news-jorgaeff-klinski-01" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-klinski-01" type="0" thread_id="news-jorgaeff-klinski" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Kaugummi-Klumpen-Sammlung versteigert</de>
 			</title>
@@ -2292,7 +2294,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-klinski-02" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-klinski-02" type="2" thread_id="news-jorgaeff-klinski" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Dieb klaut Kaugummi-Klumpen-Sammlung</de>
 			</title>
@@ -2306,7 +2308,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-klinski-03" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-klinski-03" type="2" thread_id="news-jorgaeff-klinski" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Polizei fängt Kaugummi-Klumpen-Klauer</de>
 			</title>
@@ -2337,7 +2339,7 @@
 			<data genre="5" price="0.35" quality="35" fictional="True" />
 		</news>
 
-		<news id="news-jorgaeff-fanta-01" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-fanta-01" type="0" thread_id="news-jorgaeff-fanta" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Heribert Fanta erhält Literaturpreis</de>
 			</title>
@@ -2351,7 +2353,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-fanta-02" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-fanta-02" type="2" thread_id="news-jorgaeff-fanta" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Heribert Fanta ist Easiophobiker</de>
 			</title>
@@ -2365,7 +2367,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-fanta-03" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-fanta-03" type="2" thread_id="news-jorgaeff-fanta" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Neue Dokomentation von Heribert Fanta</de>
 			</title>
@@ -2379,7 +2381,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-fanta-04" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-fanta-04" type="2" thread_id="news-jorgaeff-fanta" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Heribert Fanta überwindet Schreibangst</de>
 			</title>
@@ -2399,7 +2401,7 @@
 			<data genre="5" price="0.3" quality="30" fictional="True" />
 		</news>
 
-		<news id="news-jorgaeff-grafitti-01" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-grafitti-01" type="0" thread_id="news-jorgaeff-grafitti" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Bahn beklagt Millionenschaden durch Grafittis</de>
 			</title>
@@ -2413,7 +2415,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-grafitti-02" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-grafitti-02" type="2" thread_id="news-jorgaeff-grafitti" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Grafitti entwickelt sich zur Kunstform</de>
 			</title>
@@ -2427,7 +2429,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-grafitti-03" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-grafitti-03" type="2" thread_id="news-jorgaeff-grafitti" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Bahn verkauft Grafitti-Waggons</de>
 			</title>
@@ -2441,7 +2443,7 @@
 			</effects>
 		</news>
 
-		<news id="news-jorgaeff-grafitti-04" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-grafitti-04" type="2" thread_id="news-jorgaeff-grafitti" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>DASF entwickelt unübersprühbare Farbe</de>
 			</title>
@@ -2484,7 +2486,7 @@
 			<data genre="5" price="0.35" quality="35" fictional="True" />
 		</news>
 
-		<news id="news-jorgaeff-1985-5-04a" type="0" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1985-5-04a" type="0" thread_id="news-jorgaeff-1985-5-04" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1985" />
 			<title>
 				<de>Ulm-Oper ungekürzt aufgeführt</de>
@@ -2494,12 +2496,12 @@
 			</description>
 			<effects>
 				<!-- "morgen, 12 bis 18.00 Uhr" -->
-				<effect trigger="happen" type="triggernews" time="2,1,1,12,18" news="news-jorgaeff-chorris-02" />
+				<effect trigger="happen" type="triggernews" time="2,1,1,12,18" news="news-jorgaeff-1985-5-04b" />
 			</effects>
 			<data genre="5" price="0.35" quality="35" fictional="True" flags="2" />
 		</news>
 
-		<news id="news-jorgaeff-1985-5-04b" type="2" creator="8936" created_by="jorgaeff">
+		<news id="news-jorgaeff-1985-5-04b" type="2" thread_id="news-jorgaeff-1985-5-04" creator="8936" created_by="jorgaeff">
 			<availability script="TIME_YEAR=1985" />
 			<title>
 				<de>Ulm-Oper erhält wenig Beifall</de>

--- a/res/database/Default/user/jorgaeff.xml
+++ b/res/database/Default/user/jorgaeff.xml
@@ -1052,7 +1052,7 @@
 			</description>
 			<effects>
 				<!-- "morgen 3-7 Uhr" -->
-				<effect trigger="happen" type="triggernews" time="2,1,1,3,7" news="news-jorgaeff-1985-2-02b" flags="2" />
+				<effect trigger="happen" type="triggernews" time="2,1,1,3,7" news="news-jorgaeff-1985-2-02b" />
 			</effects>
 			<data genre="2" price="0.3" quality="3" fictional="False" />
 		</news>

--- a/res/database/Default/user/kieferer.xml
+++ b/res/database/Default/user/kieferer.xml
@@ -114,7 +114,7 @@ All means are right for them.</en>
 	</scripttemplates>
 
 	<allnews>
-		<news id="news-stockexchange-generic" type="0" creator="" created_by="Kieferer">
+		<news id="news-stockexchange-generic" type="0" thread_id="news-stockexchange-thread" creator="" created_by="Kieferer">
 			<title>
 				<de>Börsennachrichten für Tag %WORLDTIME:GAMEDAY%</de>
 				<en>Stock Exchange News for day %WORLDTIME:GAMEDAY%</en>

--- a/res/database/Default/user/kieferer.xml
+++ b/res/database/Default/user/kieferer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tvgdb>
+<tvtdb>
 	<version value="3" comment="Kieferers Daten" />
 	<scripttemplates>
 		<scripttemplate product="1" licence_type="1" guid="scripttemplate-random-kieferer-mysteriousisland">
@@ -221,4 +221,4 @@ All means are right for them.</en>
 			<data genre="0" flags="145" happen_time="8,1,9,11" quality_min="30" quality_max="40" quality_slope="50" price="0.9" />
 		</news>
 	</allnews>
-</tvgdb>
+</tvtdb>

--- a/res/database/Default/user/nichtdiebetty.xml
+++ b/res/database/Default/user/nichtdiebetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tvgdb>
+<tvtdb>
 	<version value="3" comment="Daten von Nicht_die_Betty" />
 	<!--
 		Personen die nur mal in einer Serie auftauchen und keine anderen
@@ -67,4 +67,4 @@ Am Schluss zeigt Fischer Matjes noch wie man richtig Granat pult.</de>
 	</allprogrammes>
 
 
-	</tvgdb>
+	</tvtdb>

--- a/res/database/Default/user/ronny.xml
+++ b/res/database/Default/user/ronny.xml
@@ -862,8 +862,10 @@ Illustrious guests and music by [3|Nick].</en>
 			<outcome min="30" max="45" slope="40" />
 			<review min="40" max="60" slope="40" />
 			<speed min="45" max="70" slope="50" />
-			<!-- live on next work day 20:00, production time is in minutes! -->
-			<data flags="1" live_date="8,1,20,20" production_time="120" />
+			<!-- production time is in minutes! -->
+			<production_time value="120" />
+			<!-- live on next work day 20:00 -->
+			<data flags="1" live_date="8,1,20,20" />
 		</scripttemplate>
 
 		<scripttemplate product="3" licence_type="1" guid="scripttemplate-ron-morningshow">
@@ -888,9 +890,10 @@ Illustrious guests and music by [3|Nick].</en>
 			<outcome min="30" max="50" slope="40" />
 			<review min="40" max="50" slope="40" />
 			<speed min="45" max="60" slope="50" />
+			<production_time value="60" />
 			<!-- live on next work day 5 - 10:00 - so 5,6,7 as start possible -->
 			<!-- licence flags: 4 + 32 (REMOVE_ON_REACHING_BROADCASTLIMIT + LICENCEPOOL_REMOVES_TRADEABILITY) -->
-			<data flags="1" broadcast_time_slot_start="5" broadcast_time_slot_end="10" live_date="8,1,5,5" production_time="60" production_limit="4" production_broadcast_limit="1" production_broadcast_flags="" production_licence_flags="36" />
+			<data flags="1" broadcast_time_slot_start="5" broadcast_time_slot_end="10" live_date="8,1,5,5" production_limit="4" production_broadcast_limit="1" production_broadcast_flags="" production_licence_flags="36" />
 		</scripttemplate>
 
 	</scripttemplates>

--- a/res/database/Default/user/ronny.xml
+++ b/res/database/Default/user/ronny.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tvgdb>
+<tvtdb>
 	<version value="3" comment="Ronnys Programme" />
 	<insignificantpeople>
 		<person id="ronny-people-generated-01" generator="de,2" last_name="Mueller" />
@@ -894,4 +894,4 @@ Illustrious guests and music by [3|Nick].</en>
 		</scripttemplate>
 
 	</scripttemplates>
-</tvgdb>
+</tvtdb>

--- a/res/database/Default/user/ronny.xml
+++ b/res/database/Default/user/ronny.xml
@@ -50,7 +50,8 @@
 				<member index="1" function="128">ronny-programmeperson-holgerpelz</member>
 			</staff>
 			<groups target_groups="64" />
-			<data country="D" year="0" year_relative="-4" year_relative_min="1975" year_relative_max="1990" distribution="2" maingenre="6" subgenre="11" flags="0" blocks="1" price_mod="0.95" />
+			<data country="D" distribution="2" maingenre="6" subgenre="11" flags="0" blocks="1" price_mod="0.95" />
+			<releaseTime year_relative="-4" year_relative_min="1975" year_relative_max="1990" />
 			<ratings critics="45" speed="20" outcome="24" />
 		</programme>
 		<programme id="ronny-programme-doku-kutler-alaaf" product="4" licence_type="1" fictional="1" creator="5578" created_by="Ronny">
@@ -67,7 +68,8 @@
 				<member index="1" function="128">ronny-programmeperson-holgerpelz</member>
 			</staff>
 			<groups target_groups="64" />
-			<data country="D" year="0" year_relative="-3" year_relative_min="1976" year_relative_max="1991" distribution="2" maingenre="6" subgenre="11" flags="0" blocks="1" price_mod="0.95" />
+			<data country="D" distribution="2" maingenre="6" subgenre="11" flags="0" blocks="1" price_mod="0.95" />
+			<releaseTime year_relative="-3" year_relative_min="1976" year_relative_max="1991" />
 			<ratings critics="38" speed="28" outcome="27" />
 		</programme>
 		<programme id="ronny-programme-doku-kutler-untergang" product="4" licence_type="1" fictional="1" creator="5578" created_by="Ronny">
@@ -84,7 +86,8 @@
 				<member index="1" function="128">ronny-programmeperson-holgerpelz</member>
 			</staff>
 			<groups target_groups="64" />
-			<data country="D" year="0" year_relative="+2" year_relative_min="1979" year_relative_max="1993" distribution="2" maingenre="6" subgenre="11" flags="0" blocks="1" price_mod="0.95" />
+			<data country="D" distribution="2" maingenre="6" subgenre="11" flags="0" blocks="1" price_mod="0.95" />
+			<releaseTime year_relative="+2" year_relative_min="1979" year_relative_max="1993" />
 			<ratings critics="49" speed="30" outcome="20" />
 		</programme>
 		<programme id="ronny-programme-doku-eyebeam-btx-digitalewelt" product="4" licence_type="1" fictional="1" creator="5578" created_by="Ronny">
@@ -101,7 +104,8 @@
 				<member index="1" function="128">ronny-programmeperson-samuelloew</member>
 			</staff>
 			<groups target_groups="256" />
-			<data country="D" year="0" year_relative="-4" year_relative_min="1981" year_relative_max="1983" distribution="2" maingenre="6" flags="0" blocks="2" price_mod="1.05" />
+			<data country="D" distribution="2" maingenre="6" flags="0" blocks="2" price_mod="1.05" />
+			<releaseTime year_relative="-4" year_relative_min="1981" year_relative_max="1983" />
 			<ratings critics="55" speed="15" outcome="25" />
 		</programme>
 		<programme id="ronny-programme-doku-mikroelektronik" product="4" licence_type="1" fictional="1" creator="5578" created_by="Ronny">
@@ -190,7 +194,8 @@ Contains an exclusive interview with investor Mark Mikikulla.</en>
 				<member index="0" function="1">8f93af7f-ac58-4573-bfae-ddf4698059bb</member>
 			</staff>
 			<groups target_groups="23" />
-			<data country="D" year="0" year_relative="-2" year_relative_min="1980" year_relative_max="2000" distribution="2" maingenre="300" subgenre="6" flags="0" blocks="2" price_mod="0.9" />
+			<data country="D" distribution="2" maingenre="300" subgenre="6" flags="0" blocks="2" price_mod="0.9" />
+			<releaseTime year_relative="-2" year_relative_min="1980" year_relative_max="2000" />
 			<ratings critics="18" speed="25" />
 		</programme>
 		<programme id="ronny-programme-feilschen-01" product="4" licence_type="1" fictional="1" creator="5578" created_by="Ronny">
@@ -206,7 +211,8 @@ Contains an exclusive interview with investor Mark Mikikulla.</en>
 				<member index="0" function="1">cebd1a68-cf97-4b93-b3f9-ac34bda4bdcc</member>
 			</staff>
 			<groups target_groups="0" />
-			<data country="D" year="0" year_relative="-8" year_relative_min="1976" year_relative_max="1990" distribution="2" maingenre="300" subgenre="6" flags="0" blocks="1" price_mod="1.05" />
+			<data country="D" distribution="2" maingenre="300" subgenre="6" flags="0" blocks="1" price_mod="1.05" />
+			<releaseTime year_relative="-8" year_relative_min="1976" year_relative_max="1990" />
 			<ratings critics="35" speed="15" />
 		</programme>
 		<programme id="ronny-programme-recyclingfueranfaenger-01" product="4" licence_type="1" fictional="1" creator="5578" created_by="Ronny">
@@ -326,7 +332,8 @@ The report accompanies two families for a summer in West Berlin.</en>
 			</staff>
 			<!-- men / male teenagers -->
 			<targetgroupattractivity men="1.05" teenagers_male="1.2" />
-			<data country="D" year="0" year_relative="-1" year_relative_min="1985" year_relative_max="1988" distribution="2" maingenre="300" subgenre="6" flags="0" blocks="2" price_mod="0.9" />
+			<data country="D" distribution="2" maingenre="300" subgenre="6" flags="0" blocks="2" price_mod="0.9" />
+			<releaseTime year_relative="-1" year_relative_min="1985" year_relative_max="1988" />
 			<ratings critics="25" speed="20" />
 		</programme>
 
@@ -347,7 +354,8 @@ Test winner: The "Little Twiddle".</en>
 			</staff>
 			<!-- men / male teenagers -->
 			<targetgroupattractivity men="1.2" teenagers_male="1.4" />
-			<data country="D" year="0" year_relative="+2" year_relative_min="1993" year_relative_max="2000" distribution="2" maingenre="300" subgenre="8" flags="64" blocks="1" />
+			<data country="D" distribution="2" maingenre="300" subgenre="8" flags="64" blocks="1" />
+			<releaseTime year_relative="+2" year_relative_min="1993" year_relative_max="2000" />
 			<ratings critics="15" speed="30" />
 		</programme>
 
@@ -368,7 +376,8 @@ Hold ready some handkerchiefs.</en>
 			</staff>
 			<!-- women / female teenagers -->
 			<targetgroupattractivity women="1.20" teenagers_female="1.25" />
-			<data country="D" year="0" year_relative="+2" year_relative_min="1995" year_relative_max="2005" distribution="2" maingenre="300" subgenre="6" blocks="1" />
+			<data country="D" distribution="2" maingenre="300" subgenre="6" blocks="1" />
+			<releaseTime year_relative="+2" year_relative_min="1995" year_relative_max="2005" />
 			<ratings critics="10" speed="30" />
 		</programme>
 
@@ -389,7 +398,8 @@ The hoped-for scandal helf off.</en>
 			</staff>
 			<!-- pensioners -->
 			<targetgroupattractivity pensioners="1.10" />
-			<data country="D" year="0" year_relative="+2" year_relative_min="1985" year_relative_max="2010" distribution="2" maingenre="300" subgenre="6" blocks="1" />
+			<data country="D" distribution="2" maingenre="300" subgenre="6" blocks="1" />
+			<releaseTime year_relative="+2" year_relative_min="1985" year_relative_max="2010" />
 			<ratings critics="11" speed="18" />
 		</programme>
 
@@ -414,7 +424,8 @@ Illustrious guests and music by [3|Nick].</en>
 				<!-- the programme ages faster than average -->
 				<modifier name="topicality::age" value="1.2" />
 			</modifiers>
-			<data country="D" year="0" year_relative="-1" year_relative_min="1986" year_relative_max="1992" distribution="2" maingenre="100" subgenre="5" blocks="3" />
+			<data country="D" distribution="2" maingenre="100" subgenre="5" blocks="3" />
+			<releaseTime year_relative="-1" year_relative_min="1986" year_relative_max="1992" />
 			<ratings critics="18" speed="35" />
 		</programme>
 
@@ -437,7 +448,8 @@ Illustrious guests and music by [3|Nick].</en>
 				<!-- the programme ages slower than average -->
 				<modifier name="topicality::age" value="0.75" />
 			</modifiers>
-			<data country="D" year="0" year_relative="-5" year_relative_min="1980" year_relative_max="1995" distribution="2" maingenre="300" subgenre="6" blocks="1" />
+			<data country="D" distribution="2" maingenre="300" subgenre="6" blocks="1" />
+			<releaseTime year_relative="-5" year_relative_min="1980" year_relative_max="1995" />
 			<ratings critics="25" speed="20" />
 		</programme>
 	</allprogrammes>
@@ -479,19 +491,6 @@ Illustrious guests and music by [3|Nick].</en>
 				Folgenachricht und ihre Wahrscheinlichkeit im Falle einer
 				"oder"-Verknuepfung
 		-->
-<ignore>
-		<news id="ronny-news-newskickersample-01" type="0" creator="5578" created_by="Ronny">
-			<!-- kicker sample - no texts needed -->
-
-			<effects>
-				<!-- triggers itself again each 7 days (at 0:00) -->
-				<effect trigger="happen" type="triggernews" time="2,7,7,0,0" news="ronny-news-newskickersample-01" />
-				<!-- (maybe) trigger other news on each of that 7 days -->
-				<effect trigger="happen" type="triggernews" time="1,1,2" news="ronny-news-spitzel-01" />
-			</effects>
-			<data genre="3" flags="273" happen_time="0" />
-		</news>
-</ignore>
 		<news id="ronny-news-spitzel-01" type="0" thread_id="ronny-news-spitzel" creator="5578" created_by="Ronny">
 			<title>
 				<de>Spitzelaffäre</de>

--- a/res/database/Default/user/ronny.xml
+++ b/res/database/Default/user/ronny.xml
@@ -492,7 +492,7 @@ Illustrious guests and music by [3|Nick].</en>
 			<data genre="3" flags="273" happen_time="0" />
 		</news>
 </ignore>
-		<news id="ronny-news-spitzel-01" type="0" creator="5578" created_by="Ronny">
+		<news id="ronny-news-spitzel-01" type="0" thread_id="ronny-news-spitzel" creator="5578" created_by="Ronny">
 			<title>
 				<de>Spitzelaffäre</de>
 				<en>Snooping scandal</en>
@@ -509,7 +509,7 @@ Illustrious guests and music by [3|Nick].</en>
 			</effects>
 			<data genre="0" price="1.0" quality="48" />
 		</news>
-		<news id="ronny-news-spitzel-02a" type="2" creator="5578" created_by="Ronny">
+		<news id="ronny-news-spitzel-02a" type="2" thread_id="ronny-news-spitzel" creator="5578" created_by="Ronny">
 			<title>
 				<de>Spitzelaffäre - Zensur herausgefiltert</de>
 				<en>Snooping scandal - censorship filtered out</en>
@@ -520,7 +520,7 @@ Illustrious guests and music by [3|Nick].</en>
 			</description>
 			<data genre="0" price="1.0" quality="44" />
 		</news>
-		<news id="ronny-news-spitzel-02b" type="2" creator="5578" created_by="Ronny">
+		<news id="ronny-news-spitzel-02b" type="2" thread_id="ronny-news-spitzel" creator="5578" created_by="Ronny">
 			<title>
 				<de>Spitzelaffäre - Experten uneinig</de>
 				<en>Snooping scandal - experts discordant</en>
@@ -542,7 +542,7 @@ Illustrious guests and music by [3|Nick].</en>
 			 |         /
 			 |_ Ep3 __/
 		-->
-		<news id="ronny-news-drucktaste-01" type="0" creator="5578" created_by="Ronny">
+		<news id="ronny-news-drucktaste-01" type="0" thread_id="ronny-news-drucktaste" creator="5578" created_by="Ronny">
 			<title>
 				<de>"DRUCK"-Taste: Abgaben geplant</de>
 				<en>"PRINT"-Key: planned duties</en>
@@ -559,7 +559,7 @@ Illustrious guests and music by [3|Nick].</en>
 			</effects>
 			<data genre="3" price="1" quality="38" />
 		</news>
-		<news id="ronny-news-drucktaste-02a" type="2" creator="5578" created_by="Ronny">
+		<news id="ronny-news-drucktaste-02a" type="2" thread_id="ronny-news-drucktaste" creator="5578" created_by="Ronny">
 			<title>
 				<de>"DRUCK"-Taste: Plombe spart Abgaben</de>
 				<en>"PRINT"-Key: Seal saves compensation</en>
@@ -574,7 +574,7 @@ Illustrious guests and music by [3|Nick].</en>
 			</effects>
 			<data genre="3" price="1.0" quality="35" />
 		</news>
-		<news id="ronny-news-drucktaste-02b" type="2" creator="5578" created_by="Ronny">
+		<news id="ronny-news-drucktaste-02b" type="2" thread_id="ronny-news-drucktaste" creator="5578" created_by="Ronny">
 			<title>
 				<de>"DRUCK"-Taste: Vereine demonstrieren</de>
 				<en>"PRINT"-Key: Associations demonstrating</en>
@@ -588,7 +588,7 @@ Illustrious guests and music by [3|Nick].</en>
 			</effects>
 			<data genre="3" price="1.0" quality="29" />
 		</news>
-		<news id="ronny-news-drucktaste-02b1" type="2" creator="5578" created_by="Ronny">
+		<news id="ronny-news-drucktaste-02b1" type="2" thread_id="ronny-news-drucktaste" creator="5578" created_by="Ronny">
 			<title>
 				<de>"DRUCK"-Taste: Für private Haushalte kostenlos</de>
 				<en>"PRINT"-Key: Free for private households</en>
@@ -603,7 +603,7 @@ Illustrious guests and music by [3|Nick].</en>
 			</effects>
 			<data genre="3" price="1.0" quality="35" />
 		</news>
-		<news id="ronny-news-drucktaste-03" type="2" creator="5578" created_by="Ronny">
+		<news id="ronny-news-drucktaste-03" type="2" thread_id="ronny-news-drucktaste" creator="5578" created_by="Ronny">
 			<title>
 				<de>"DRUCK"-Taste: Keine Abgaben mehr</de>
 				<en>"PRINT"-Key: No more compensation</en>
@@ -635,10 +635,10 @@ Illustrious guests and music by [3|Nick].</en>
 				<en>At the International Exhibition for Computer Accessories (ECA), the USB-Rat was presented. Unlike mice, USB-Rats are suitable for real men hands.</en>
 			</description>
 			<data genre="3" price="1.0" quality="32" />
-			<conditions year_range_from="1996" year_range_to="-1" />
+			<availability year_range_from="1996" year_range_to="-1" />
 		</news>
 
-		<news id="ronny-news-sandsturm-01" type="0" creator="5578" created_by="Ronny">
+		<news id="ronny-news-sandsturm-01" type="0" thread_id="ronny-news-sandsturm" creator="5578" created_by="Ronny">
 			<title>
 				<de>Sandsturm am nördlichen Polarkreis</de>
 				<en>Sandstorm near the Arctic Circle</en>
@@ -653,7 +653,7 @@ Illustrious guests and music by [3|Nick].</en>
 			</effects>
 			<data genre="4" price="1.0" quality="48" />
 		</news>
-		<news id="ronny-news-sandsturm-02" type="2" creator="5578" created_by="Ronny">
+		<news id="ronny-news-sandsturm-02" type="2" thread_id="ronny-news-sandsturm" creator="5578" created_by="Ronny">
 			<title>
 				<de>Sandsturm war nicht echt</de>
 				<en>Sandstorm was not real</en>
@@ -675,7 +675,7 @@ Illustrious guests and music by [3|Nick].</en>
 		</news>
 
 
-		<news id="ronny-news-katschminski-01" type="0" creator="5578" created_by="Ronny">
+		<news id="ronny-news-katschminski-01" type="0" thread_id="ronny-news-katschminski" creator="5578" created_by="Ronny">
 			<title>
 				<de>Leser lesen wieder, dank Katschminski</de>
 				<en>Readers read again. Thanks to Katschinski</en>
@@ -690,7 +690,7 @@ Illustrious guests and music by [3|Nick].</en>
 			</effects>
 			<data genre="5" price="1.0" quality="38" />
 		</news>
-		<news id="ronny-news-katschminski-02" type="2" creator="5578" created_by="Ronny">
+		<news id="ronny-news-katschminski-02" type="2" thread_id="ronny-news-katschminski" creator="5578" created_by="Ronny">
 			<title>
 				<de>Ansturm auf neues Buch</de>
 				<en>Rush for new book</en>
@@ -705,7 +705,7 @@ Illustrious guests and music by [3|Nick].</en>
 			</effects>
 			<data genre="5" price="1.0" quality="34" />
 		</news>
-		<news id="ronny-news-katschminski-03" type="2" creator="5578" created_by="Ronny">
+		<news id="ronny-news-katschminski-03" type="2" thread_id="ronny-news-katschminski" creator="5578" created_by="Ronny">
 			<title>
 				<de>Katschminski veröffentlicht neues Buch</de>
 				<en>Katschinski releases new book</en>
@@ -727,7 +727,7 @@ Illustrious guests and music by [3|Nick].</en>
 			</description>
 			<data genre="1" price="1.0" quality="32" />
 		</news>
-		<news id="ronny-news-karldingensbummens-01" type="0" creator="5578" created_by="Ronny">
+		<news id="ronny-news-karldingensbummens-01" type="0" thread_id="ronny-news-karldingensbummens" creator="5578" created_by="Ronny">
 			<title>
 				<de>Plastik „Karl Dingensbummens“ gestohlen</de>
 				<en>Plastic "Joe Thingamabob" stolen</en>
@@ -742,7 +742,7 @@ Illustrious guests and music by [3|Nick].</en>
 			</effects>
 			<data genre="5" price="1.0" quality="22" />
 		</news>
-		<news id="ronny-news-karldingensbummens-02" type="2" creator="5578" created_by="Ronny">
+		<news id="ronny-news-karldingensbummens-02" type="2" thread_id="ronny-news-karldingensbummens" creator="5578" created_by="Ronny">
 			<title>
 				<de>„Karl Dingensbummens“ wieder da</de>
 				<en>"Joe Thingamabob" is back</en>
@@ -755,7 +755,7 @@ Illustrious guests and music by [3|Nick].</en>
 		</news>
 
 
-		<news id="ronny-news-frauenbart-01" type="0" creator="5578" created_by="Ronny">
+		<news id="ronny-news-frauenbart-01" type="0" thread_id="ronny-news-frauenbart" creator="5578" created_by="Ronny">
 			<title>
 				<de>Ausstellung zum Thema Frauenbärte</de>
 				<en>Exhibition on Women's Beards</en>
@@ -774,7 +774,7 @@ Illustrious guests and music by [3|Nick].</en>
 			</effects>
 			<data genre="5" price="1.0" quality="15" />
 		</news>
-		<news id="ronny-news-frauenbart-02a" type="2" creator="5578" created_by="Ronny">
+		<news id="ronny-news-frauenbart-02a" type="2" thread_id="ronny-news-frauenbart" creator="5578" created_by="Ronny">
 			<title>
 				<de>Ausstellung "Frauenbärte %WORLDTIME:YEAR%" lockt Betrüger</de>
 				<en>Exhibition "Women's Beards %WORLDTIME:YEAR%" lures cheats</en>
@@ -785,7 +785,7 @@ Illustrious guests and music by [3|Nick].</en>
 			</description>
 			<data genre="5" price="1.0" quality="17" />
 		</news>
-		<news id="ronny-news-frauenbart-02b" type="2" creator="5578" created_by="Ronny">
+		<news id="ronny-news-frauenbart-02b" type="2" thread_id="ronny-news-frauenbart" creator="5578" created_by="Ronny">
 			<title>
 				<de>Frauenbärte: Frauen schwören auf Koteletten</de>
 				<en>Women's Beards: Women now like sideburns</en>
@@ -796,7 +796,7 @@ Illustrious guests and music by [3|Nick].</en>
 			</description>
 			<data genre="5" price="1.0" quality="18" />
 		</news>
-		<news id="ronny-news-frauenbart-02c" type="2" creator="5578" created_by="Ronny">
+		<news id="ronny-news-frauenbart-02c" type="2" thread_id="ronny-news-frauenbart" creator="5578" created_by="Ronny">
 			<title>
 				<de>Frauenbärte: Aus und Vorbei</de>
 				<en>Women's Beards: It's all over</en>

--- a/res/database/Default/user/rumpelfreddy.xml
+++ b/res/database/Default/user/rumpelfreddy.xml
@@ -35,18 +35,18 @@
 		<person id="Per_custom_Freddy_52" first_name="Charlie" last_name="Jonsson" nick_name="" gender="1" country="S" fictional="1" />
 		<person id="Per_custom_Freddy_53" first_name="Alicia" last_name="Hansson" nick_name="" gender="2" country="S" fictional="1" />
 		<!-- Polnisch -->
-		<person id="Per_custom_Freddy_57" first_name="Lena" last_name="Nowak" nick_name="" gender="2" country="POL" fictional="1" />
-		<person id="Per_custom_Freddy_58" first_name="Jakub" last_name="Wójcik" nick_name="" gender="1" country="POL" fictional="1" />
-		<person id="Per_custom_Freddy_59" first_name="Julia" last_name="Kowalczyk" nick_name="" gender="2" country="POL" fictional="1" />
-		<person id="Per_custom_Freddy_60" first_name="Kacper" last_name="Wozniak" nick_name="" gender="1" country="POL" fictional="1" />
-		<person id="Per_custom_Freddy_61" first_name="Zusanna" last_name="Kowalska" nick_name="" gender="2" country="POL" fictional="1" />
-		<person id="Per_custom_Freddy_62" first_name="Filip" last_name="Mazur" nick_name="" gender="1" country="POL" fictional="1" />
-		<person id="Per_custom_Freddy_63" first_name="Zofia" last_name="Kaczmarek" nick_name="" gender="2" country="POL" fictional="1" />
-		<person id="Per_custom_Freddy_64" first_name="Szymon" last_name="Wisniewski" nick_name="" gender="1" country="POL" fictional="1" />
-		<person id="Per_custom_Freddy_65" first_name="Hanna" last_name="Zajac" nick_name="" gender="2" country="POL" fictional="1" />
-		<person id="Per_custom_Freddy_66" first_name="Antoni" last_name="Król" nick_name="" gender="1" country="POL" fictional="1" />
-		<person id="Per_custom_Freddy_67" first_name="Wiktoria" last_name="Wisniewska" nick_name="" gender="2" country="POL" fictional="1" />
-		<person id="Per_custom_Freddy_68" first_name="Wojciech" last_name="Wieczorek" nick_name="" gender="1" country="POL" fictional="1" />
+		<person id="Per_custom_Freddy_57" first_name="Lena" last_name="Nowak" nick_name="" gender="2" country="PL" fictional="1" />
+		<person id="Per_custom_Freddy_58" first_name="Jakub" last_name="Wójcik" nick_name="" gender="1" country="PL" fictional="1" />
+		<person id="Per_custom_Freddy_59" first_name="Julia" last_name="Kowalczyk" nick_name="" gender="2" country="PL" fictional="1" />
+		<person id="Per_custom_Freddy_60" first_name="Kacper" last_name="Wozniak" nick_name="" gender="1" country="PL" fictional="1" />
+		<person id="Per_custom_Freddy_61" first_name="Zusanna" last_name="Kowalska" nick_name="" gender="2" country="PL" fictional="1" />
+		<person id="Per_custom_Freddy_62" first_name="Filip" last_name="Mazur" nick_name="" gender="1" country="PL" fictional="1" />
+		<person id="Per_custom_Freddy_63" first_name="Zofia" last_name="Kaczmarek" nick_name="" gender="2" country="PL" fictional="1" />
+		<person id="Per_custom_Freddy_64" first_name="Szymon" last_name="Wisniewski" nick_name="" gender="1" country="PL" fictional="1" />
+		<person id="Per_custom_Freddy_65" first_name="Hanna" last_name="Zajac" nick_name="" gender="2" country="PL" fictional="1" />
+		<person id="Per_custom_Freddy_66" first_name="Antoni" last_name="Król" nick_name="" gender="1" country="PL" fictional="1" />
+		<person id="Per_custom_Freddy_67" first_name="Wiktoria" last_name="Wisniewska" nick_name="" gender="2" country="PL" fictional="1" />
+		<person id="Per_custom_Freddy_68" first_name="Wojciech" last_name="Wieczorek" nick_name="" gender="1" country="PL" fictional="1" />
 		<!-- Dänisch -->
 		<person id="Per_custom_Freddy_69" first_name="Ida" last_name="Andersen" nick_name="" gender="2" country="DK" fictional="1" />
 		<person id="Per_custom_Freddy_70" first_name="Noah" last_name="Jensen" nick_name="" gender="1" country="DK" fictional="1" />
@@ -715,7 +715,7 @@
 		 <!-- Julia in der Feenwelt(1) -->
             <first_name>Hannah</first_name>
             <last_name>Hobkinns</last_name>
-            <details job="1" gender="2"  birthday="1984" deathday="" country="UK" />
+            <details job="1" gender="2"  birthday="1984" deathday="" country="GB" />
             <data popularity="14" affinity="35" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="60" topgenre="0" />
         </person>
 		<person id="Rumpelfreddy-fictionalperson-LenaLauterberg" fictional="1" creator="8667" created_by="Rumpelfreddy">
@@ -736,7 +736,7 @@
 		<!--  -->
             <first_name>Blondie</first_name>
             <last_name>Prall</last_name>
-            <details job="1" gender="2"  birthday="1976" deathday="" country="AUT" />
+            <details job="1" gender="2"  birthday="1976" deathday="" country="A" />
             <data popularity="12" affinity="11" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="55" topgenre="0" />
         </person>
 		<person id="Per_custom_Freddy_6" fictional="1" creator="8667" created_by="Rumpelfreddy">
@@ -921,7 +921,7 @@
 				<member index="2" function="2">Freddy-realperson-mariacornight</member>
             </staff>
             <groups target_groups="0" />
-            <data country="US" year="1957" distribution="0" maingenre="12" subgenre="16" flags="40" blocks="2" price_mod="1.0" />
+            <data country="USA" year="1957" distribution="0" maingenre="12" subgenre="16" flags="40" blocks="2" price_mod="1.0" />
             <ratings critics="8" speed="38" outcome="16" />
         </programme>
 		
@@ -941,7 +941,7 @@
 				<member index="2" function="2">Freddy-realperson-bedorahloonies</member>
             </staff>
             <groups target_groups="0" />
-            <data country="US" year="1970" distribution="0" maingenre="10" subgenre="1" flags="32" blocks="2" price_mod="1.0" />
+            <data country="USA" year="1970" distribution="0" maingenre="10" subgenre="1" flags="32" blocks="2" price_mod="1.0" />
             <ratings critics="6" speed="42" outcome="19" />
         </programme>
 		
@@ -960,7 +960,7 @@
 				<member index="1" function="2">Freddy-realperson-NailNorrissey</member>
             </staff>
             <groups target_groups="0" />
-            <data country="UK" year="1990" distribution="0" maingenre="5" subgenre="12" flags="32" blocks="2" price_mod="1.0" />
+            <data country="GB" year="1990" distribution="0" maingenre="5" subgenre="12" flags="32" blocks="2" price_mod="1.0" />
             <ratings critics="14" speed="53" outcome="14" />
         </programme>
 		
@@ -979,7 +979,7 @@
 				<member index="1" function="2">Freddy-realperson-TomHencs</member>
             </staff>
             <groups target_groups="0" />
-            <data country="US" year="1982" distribution="0" maingenre="17" subgenre="7" flags="32" blocks="2" price_mod="1.0" />
+            <data country="USA" year="1982" distribution="0" maingenre="17" subgenre="7" flags="32" blocks="2" price_mod="1.0" />
             <ratings critics="21" speed="31" outcome="25" />
         </programme>
 		
@@ -1019,7 +1019,7 @@
                 <member index="4" function="2">Per_custom_Freddy_361</member>
             </staff>
             <groups target_groups="0" />
-            <data country="CAN" year="1988" distribution="0" maingenre="1" subgenre="" flags="32" blocks="2" price_mod="1.0" />
+            <data country="CDN" year="1988" distribution="0" maingenre="1" subgenre="" flags="32" blocks="2" price_mod="1.0" />
             <ratings critics="11" speed="43" outcome="14" />
         </programme>
         
@@ -1040,7 +1040,7 @@
                 <member index="4" function="2">Per_custom_Freddy_362</member>
             </staff>
             <groups target_groups="0" />
-            <data country="CAN" year="1991" distribution="0" maingenre="1" subgenre="" flags="32" blocks="2" price_mod="1.0" />
+            <data country="CDN" year="1991" distribution="0" maingenre="1" subgenre="" flags="32" blocks="2" price_mod="1.0" />
             <ratings critics="10" speed="38" outcome="15" />
         </programme>
         
@@ -1061,7 +1061,7 @@
                 <member index="4" function="2">Per_custom_Freddy_363</member>            
             </staff>
             <groups target_groups="0" />
-            <data country="CAN" year="1994" distribution="0" maingenre="1" subgenre="12" flags="32" blocks="2" price_mod="1.0" />
+            <data country="CDN" year="1994" distribution="0" maingenre="1" subgenre="12" flags="32" blocks="2" price_mod="1.0" />
             <ratings critics="7" speed="39" outcome="18" />
         </programme>
         
@@ -1079,7 +1079,7 @@
                 <member index="1" function="2">Per_custom_Freddy_46</member>
             </staff>
             <groups target_groups="0" />
-            <data country="SWE" year="1952" distribution="0" maingenre="1" subgenre="7" flags="32" blocks="3" price_mod="1.0" />
+            <data country="S" year="1952" distribution="0" maingenre="1" subgenre="7" flags="32" blocks="3" price_mod="1.0" />
             <ratings critics="19" speed="12" outcome="9" />
         </programme>
         
@@ -1098,7 +1098,7 @@
                 <member index="2" function="2">Per_custom_Freddy_50</member>
             </staff>
             <groups target_groups="0" />
-            <data country="US" year="2002" distribution="0" maingenre="1" subgenre="15" flags="32" blocks="3" price_mod="1.0" />
+            <data country="USA" year="2002" distribution="0" maingenre="1" subgenre="15" flags="32" blocks="3" price_mod="1.0" />
             <ratings critics="8" speed="16" outcome="9" />
         </programme>
         
@@ -1158,7 +1158,7 @@
                 <member index="3" function="2">Per_custom_Freddy_168</member>
             </staff>
             <groups target_groups="0" />
-            <data country="US" year="1982" distribution="0" maingenre="2" subgenre="10" flags="32" blocks="2" price_mod="1.0" />
+            <data country="USA" year="1982" distribution="0" maingenre="2" subgenre="10" flags="32" blocks="2" price_mod="1.0" />
             <ratings critics="11" speed="43" outcome="19" />
         </programme>
         
@@ -1217,7 +1217,7 @@
                 <member index="3" function="2">Per_custom_Freddy_588</member>
             </staff>
             <groups target_groups="0" />
-            <data country="U" year="1989" distribution="0" maingenre="2" subgenre="" flags="32" blocks="2" price_mod="1.0" />
+            <data country="USA" year="1989" distribution="0" maingenre="2" subgenre="" flags="32" blocks="2" price_mod="1.0" />
             <ratings critics="13" speed="42" outcome="16" />
         </programme>
         
@@ -1235,7 +1235,7 @@
                 <member index="1" function="2">Per_custom_Freddy_219</member>
             </staff>
             <groups target_groups="0" />
-            <data country="US" year="1991" distribution="0" maingenre="2" subgenre="10" flags="32" blocks="2" price_mod="1.0" />
+            <data country="USA" year="1991" distribution="0" maingenre="2" subgenre="10" flags="32" blocks="2" price_mod="1.0" />
             <ratings critics="9" speed="47" outcome="10" />
         </programme>
         
@@ -1273,7 +1273,7 @@
                 <member index="3" function="2">Per_custom_Freddy_33</member>
             </staff>
             <groups target_groups="0" />
-            <data country="US" year="1959" distribution="0" maingenre="2" subgenre="9" flags="32" blocks="3" price_mod="1.0" />
+            <data country="USA" year="1959" distribution="0" maingenre="2" subgenre="9" flags="32" blocks="3" price_mod="1.0" />
             <ratings critics="7" speed="18" outcome="22" />
         </programme>
         
@@ -1307,7 +1307,7 @@
                 <member index="0" function="1">Per_custom_Freddy_117</member>
             </staff>
             <groups target_groups="0" />
-            <data country="US" year="2006" distribution="0" maingenre="3" subgenre="16" flags="32" blocks="2" price_mod="1.0" />
+            <data country="USA" year="2006" distribution="0" maingenre="3" subgenre="16" flags="32" blocks="2" price_mod="1.0" />
             <ratings critics="5" speed="41" outcome="16" />
         </programme>
     </allprogrammes>

--- a/res/database/Default/user/rumpelfreddy.xml
+++ b/res/database/Default/user/rumpelfreddy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tvgdb>
+<tvtdb>
     <version value="3" comment="Freddys_Krempel" />
     <insignificantpeople>
 		<!-- Schottisch -->
@@ -1154,8 +1154,8 @@
             <staff>
                 <member index="0" function="1">Per_custom_Freddy_37</member>
                 <member index="1" function="2">Per_custom_Freddy_109</member>
-                <member index="1" function="2">Per_custom_Freddy_150</member>
-                <member index="1" function="2">Per_custom_Freddy_168</member>
+                <member index="2" function="2">Per_custom_Freddy_150</member>
+                <member index="3" function="2">Per_custom_Freddy_168</member>
             </staff>
             <groups target_groups="0" />
             <data country="US" year="1982" distribution="0" maingenre="2" subgenre="10" flags="32" blocks="2" price_mod="1.0" />
@@ -1193,8 +1193,8 @@
             <staff>
                 <member index="0" function="1">Per_custom_Freddy_37</member>
                 <member index="1" function="2">Per_custom_Freddy_219</member>
-                <member index="1" function="2">Per_custom_Freddy_243</member>
-                <member index="1" function="2">Per_custom_Freddy_223</member>
+                <member index="2" function="2">Per_custom_Freddy_243</member>
+                <member index="3" function="2">Per_custom_Freddy_223</member>
             </staff>
             <groups target_groups="0" />
             <data country="D" year="2001" distribution="0" maingenre="2" subgenre="16" flags="96" blocks="2" price_mod="1.0" />
@@ -1269,8 +1269,8 @@
             <staff>
                 <member index="0" function="1">Per_custom_Freddy_167</member>
                 <member index="1" function="2">Per_custom_Freddy_142</member>
-                <member index="1" function="2">Per_custom_Freddy_27</member>
-                <member index="1" function="2">Per_custom_Freddy_33</member>
+                <member index="2" function="2">Per_custom_Freddy_27</member>
+                <member index="3" function="2">Per_custom_Freddy_33</member>
             </staff>
             <groups target_groups="0" />
             <data country="US" year="1959" distribution="0" maingenre="2" subgenre="9" flags="32" blocks="3" price_mod="1.0" />
@@ -1311,4 +1311,4 @@
             <ratings critics="5" speed="41" outcome="16" />
         </programme>
     </allprogrammes>
-</tvgdb>
+</tvtdb>

--- a/res/database/Default/user/sjaele.xml
+++ b/res/database/Default/user/sjaele.xml
@@ -331,7 +331,7 @@
 				<en>The author Gunther Raffwall worked under Turkish identity in Germany. Dreadful experiences in the German job landscape in the recently published book.</en>
 			</description>
 			<data genre="5" price="0.7" quality="55" />
-			<availability script="TIME_DAYOFYEAR=10" year_range_from="1985" year_range_to="1985" />
+			<availability script="TIME_MONTH=10" year_range_from="1985" year_range_to="1985" />
 		</news>
 
 		<news id="Sjaele-news-schach-abgebrochen" type="0" creator="7430" created_by="Sjaele">
@@ -358,7 +358,7 @@
 				<en>The American computer manufacturer Kormoran presents its home computer "Eterna". Its graphics performance is simply breathtaking.</en>
 			</description>
 			<data genre="3" price="1.0" quality="45" />
-			<availability script="TIME_DAYOFYEAR=7" year_range_from="1985" year_range_to="1985" />
+			<availability script="TIME_MONTH=7" year_range_from="1985" year_range_to="1985" />
 		</news>
 
 		<news id="Sjaele-news-Begehbarer-Hügel" type="0" creator="7430" created_by="Sjaele">
@@ -437,8 +437,8 @@
 				<de>Der fast 300 Meter hohe Rundfunk-Sendemast auf dem Bielstein stürzte aufgrund starker Vereisung und Bruch einer Pardune um. In der Folge kam es zu Sendeausfällen.</de>
 				<en>The almost 300 meter high broadcasting tower on the Bielstein collapsed due to heavy icing and a breaking guy wire. As a result, there were transmission failures.</en>
 			</description>
-			<data genre="3" price="1.0" quality="65" />
-			<availability script="TIME_DAYOFYEAR=1" year_range_from="1985" year_range_to="1985" />
+			<data genre="3" flags="2" price="1.0" quality="65" />
+			<availability script="TIME_SEASON=4" />
 		</news>
 
 		<news id="Sjaele-news-Computerspieler-Chirurgen" type="0" creator="7430" created_by="Sjaele">
@@ -491,22 +491,20 @@
 				<de>Der Energie-Konzern Wassenstieg sponsert die 20. Auflage der Berliner Märchentage parallel zu den Gesprächen um den Ausstieg aus der Braunkohleverstromung.</de>
 				<en>The energy company Wassenstieg is sponsoring the 20th edition of the Berlin Fairy Tale Days in parallel to the talks about phasing out lignite-fired power generation.</en>
 			</description>
-			<data genre="5" price="0.7" quality="25" />
-			<availability script="TIME_DAYOFYEAR=11" year_range_from="2010" year_range_to="2010" />
+			<data genre="5" flags="2" price="0.7" quality="25" happen_time="4,2010,11,1" />
 		</news>
 
 		<news id="Sjaele-news-Märchentage-gegründet" type="0" creator="7430" created_by="Sjaele">
 <!-- deutschbezogen -->
 			<title>
-				<de>Berliner Märchentage  gegründet</de>
+				<de>Berliner Märchentage gegründet</de>
 				<en>Berlin Fairy Tale Days founded</en>
 			</title>
 			<description>
 				<de>Am 2. April  dem Geburtstag von Hans Christian Andersen wurden vom Märchenlandverein die Berliner Märchentage gegründet. Sie sollen jährlich im November stattfinden.</de>
 				<en>The Berlin Fairytale Days were founded by the Fairytale Land Association on April 2nd, Hans Christian Andersen's birthday. They are to take place annually in November...</en>
 			</description>
-			<data genre="5" price="0.7" quality="25" />
-			<availability script="TIME_DAYOFYEAR=4" year_range_from="1990" year_range_to="1990" />
+			<data genre="5" flags="6" price="0.7" quality="25" happen_time="4,1990,4,3" />
 		</news>
 
 		<news id="Sjaele-news-Märchentage-begonnen" type="0" creator="7430" created_by="Sjaele">
@@ -520,7 +518,7 @@
 				<en>17 days in November are full of fairy tales. Supporters are also the Lottery company and the Federal Political Education Centre.</en>
 			</description>
 			<data genre="5" price="0.7" quality="25" />
-			<availability script="TIME_DAYOFYEAR=11" year_range_from="1990" year_range_to="" />
+			<availability script="TIME_MONTH=10" year_range_from="1990" year_range_to="" />
 		</news>
 
 		<news id="Sjaele-news-Crash-Kurse" type="0" creator="7430" created_by="Sjaele">
@@ -598,7 +596,7 @@
 				<en>This year's sale starts with an average discount of 600%. Dealers ask for suitable change.</en>
 			</description>
 			<data genre="4" price="0.7" quality="21" />
-			<availability script="TIME_DAYOFYEAR=1 || TIME_DAYOFYEAR=7" year_range_from="" year_range_to="" />
+			<availability script="TIME_MONTH=1 || TIME_MONTH=7" year_range_from="" year_range_to="" />
 		</news>
 
 		<news id="Sjaele-news-Spanner-Spanner" type="0" creator="7430" created_by="Sjaele">
@@ -772,7 +770,7 @@
 				<en>You're just a regular soccer team. The same name as the lemonade manufacturer is coincidental.</en>
 			</description>
 			<data genre="2" price="0.7" quality="11" />
-			<availability script="TIME_DAYOFYEAR=1,7" year_range_from="2010" year_range_to="" />
+			<availability script="TIME_MONTH=1 || TIME_MONTH=7" year_range_from="2010" year_range_to="" />
 		</news>
 
 		<news id="Sjaele-news-Fußballbund-vermutet" type="0" creator="7430" created_by="Sjaele">
@@ -784,8 +782,8 @@
 				<de>Das 75:1 im entscheidenden Aufstiegsspiel zur Verbandsliga West-Nord rief die Betrugsexperten des Fußballbundes auf den Plan.</de>
 				<en>The 75:1 in the decisive promotion match to the club league West-Nord catched attention of the fraud experts of the soccer federation.</en>
 			</description>
-			<data genre="2" price="1.0" quality="29" />
-			<availability script="TIME_DAYOFYEAR=6" year_range_from="1985" year_range_to="1985" />
+			<data genre="2" flags="2" price="1.0" quality="29" />
+			<availability script="TIME_MONTH=6" />
 		</news>
 
 		<news id="Sjaele-news-Aktena-8" type="0" creator="7430" created_by="Sjaele">
@@ -798,8 +796,7 @@
 				<de>Am 12. Juni öffnet die weltgrößte Kunstausstellung ihre Pforten. Sie widmet sich der künstlerischen Auseinandersetzung mit Krieg und Gewalt, mit Utopien und Utopieverlust.</de>
 				<en>The world's largest art exhibition opens its doors on June 12. It is dedicated to the artistic confrontation with war and violence, with utopias and loss of utopia.</en>
 			</description>
-			<data genre="5" price="0.7" quality="41" />
-			<availability script="TIME_DAYOFYEAR=5" year_range_from="1987" year_range_to="1987" />
+			<data genre="5" flags="6" price="0.7" quality="41" happen_time="4,1987,5,1" />
 		</news>
 
 		<news id="Sjaele-news-Aktena-8-eröffnet" type="0" creator="7430" created_by="Sjaele">
@@ -812,8 +809,7 @@
 				<de>Die Kunstschau mit über 400 austellenden Künstlern widmet sich erstmals verstärkt der Videokunst und breitet sich über das gesamte Stadtgebiet von Kassel aus.</de>
 				<en>The art show with over 400 exhibiting artists is increasingly dedicated to video art and spreads over the entire city of Kassel.</en>
 			</description>
-			<data genre="5" price="0.7" quality="41" />
-			<availability script="TIME_DAYOFYEAR=6" year_range_from="1987" year_range_to="1987" />
+			<data genre="5" flags="6" price="0.7" quality="41" happen_time="4,1987,6,12" />
 		</news>
 
 		<news id="Sjaele-news-Aktena-8-beendet" type="0" creator="7430" created_by="Sjaele">
@@ -826,8 +822,7 @@
 				<de>Nach 100 Tagen wurde die Weltkunstausstellung in Kassel mit fast einer halben Millionen Zuschauern beendet. Besucherrekord trotz beliebiger Kritiken aus Kritikerkreisen.</de>
 				<en>After 100 days, the world art exhibition in Kassel ended with almost half a million spectators. Record attendance despite criticism from critics.</en>
 			</description>
-			<data genre="5" price="0.7" quality="41" />
-			<availability script="TIME_DAYOFYEAR=10" year_range_from="1987" year_range_to="1987" />
+			<data genre="5" flags="6" price="0.7" quality="41" happen_time="4,1987,10,20" />
 		</news>
 
 		<news id="Sjaele-news-Festival-lebenden" type="0" creator="7430" created_by="Sjaele">
@@ -840,7 +835,7 @@
 				<en>For technical reasons, this year's festival of living images will take place in Sternheilig, as last year, and not on the Externsteine as planned.</en>
 			</description>
 			<data genre="5" price="0.7" quality="41" />
-			<availability script="TIME_DAYOFYEAR=11" year_range_from="2003" year_range_to="2003" />
+			<availability script="TIME_MONTH=11" year_range_from="2003" year_range_to="2003" />
 		</news>
 
 		<news id="Sjaele-news-Serienkanal-startet" type="0" creator="7430" created_by="Sjaele">
@@ -853,7 +848,7 @@
 				<en></en>
 			</description>
 			<data genre="5" price="0.7" quality="31" />
-			<availability script="TIME_DAYOFYEAR=5" year_range_from="1996" year_range_to="1996" />
+			<availability script="TIME_MONTH=5" year_range_from="1996" year_range_to="1996" />
 		</news>
 
 		<news id="Sjaele-news-Wintereinbruch-Engpässen" type="0" creator="7430" created_by="Sjaele">

--- a/res/database/Default/user/sjaele.xml
+++ b/res/database/Default/user/sjaele.xml
@@ -16,7 +16,7 @@
 				<en>The Russian gas giant is offering its help in solving the European currency crisis. Also other countries under discussion.</en>
 			</description>
 			<data genre="0" price="1.0" quality="49" />
-			<conditions year_range_from="2010" year_range_to="-1" />
+			<availability year_range_from="2010" year_range_to="-1" />
 		</news>
 		<news id="Sjaele-news-Urknall" type="0" creator="7430" created_by="Sjaele">
 			<title>
@@ -40,7 +40,7 @@
 				<en>The Finance Minister proposes an EU-wide e-mail postage of one cent per e-mail.</en>
 			</description>
 			<data genre="0" price="0.7" quality="39" />
-			<conditions year_range_from="1998" year_range_to="-1" />
+			<availability year_range_from="1998" year_range_to="-1" />
 		</news>
 
 		<news id="Sjaele-news-Update-Automaten" type="0" creator="7430" created_by="Sjaele">
@@ -53,7 +53,7 @@
 				<en>Several discounters want to set up vending machines at the beginning of the holiday where computer users can download their updates.</en>
 			</description>
 			<data genre="3" price="1.0" quality="29" />
-			<conditions year_range_from="1995" year_range_to="-1" />
+			<availability year_range_from="1995" year_range_to="-1" />
 		</news>
 
 		<news id="Sjaele-news-Internet-neu" type="0" creator="7430" created_by="Sjaele">
@@ -66,7 +66,7 @@
 				<en>A worldwide internet reboot will take place in the night from Thursday to Friday of this week in order to delete pirated copies.</en>
 			</description>
 			<data genre="3" price="1.0" quality="56" />
-			<conditions year_range_from="2000" year_range_to="-1" />
+			<availability year_range_from="2000" year_range_to="-1" />
 		</news>
 
 		<news id="Sjaele-news-Trickbetrüger" type="0" creator="7430" created_by="Sjaele">
@@ -80,7 +80,7 @@
 				<en>More and more high-quality WLAN cables were allegedly sold in Chemnitz city centre. However, a police spokesman warns that these are overpriced.</en>
 			</description>
 			<data genre="3" price="0.7" quality="29" />
-			<conditions year_range_from="1998" year_range_to="-1" />
+			<availability year_range_from="1998" year_range_to="-1" />
 		</news>
 
 		<news id="Sjaele-news-Saurierknochen" type="0" creator="7430" created_by="Sjaele">
@@ -93,7 +93,7 @@
 				<en>Gelatine from dinosaur bones has been used in several types of jelly babies. There was no danger to health.</en>
 			</description>
 			<data genre="3" price="1.0" quality="19" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 
 		<news id="Sjaele-news-Einweg-Telefon" type="0" creator="7430" created_by="Sjaele">
@@ -106,7 +106,7 @@
 				<en>The tap-proof telephone is no longer a dream of the future. North Korean scientists presented the world's first at the high-tech trade fair.</en>
 			</description>
 			<data genre="3" price="1.0" quality="25" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 
 		<news id="Sjaele-news-Drohnen-Honig" type="0" creator="7430" created_by="Sjaele">
@@ -119,7 +119,7 @@
 				<en>In response to bee deaths, the Ministry of the Environment has instructed all beekeepers to also use their drones to collect honey.</en>
 			</description>
 			<data genre="3" price="0.7" quality="35" />
-			<conditions year_range_from="2000" year_range_to="-1" />
+			<availability year_range_from="2000" year_range_to="-1" />
 		</news>
 
 		<news id="Sjaele-news-Wohnungsnot" type="0" creator="7430" created_by="Sjaele">
@@ -132,7 +132,7 @@
 				<en>Vermieterbund is pleased: The demolition subsidies in the East have finally created a situation that makes outrageous rent increases possible.</en>
 			</description>
 			<data genre="0" price="1.0" quality="35" />
-			<conditions year_range_from="1990" year_range_to="-1" />
+			<availability year_range_from="1990" year_range_to="-1" />
 		</news>
 
 		<news id="Sjaele-news-Neuntöter" type="0" creator="7430" created_by="Sjaele">
@@ -146,7 +146,6 @@
 				<en>TThe Environmental Alliance has now announced that the red-backed shrike is this year's Bird of the Year.</en>
 			</description>
 			<data genre="3" price="0.5" quality="29" />
-			<conditions year_range_from="1985" year_range_to="1985" />
 			<availability year_range_from="1985" year_range_to="1985" />
 		</news>
 
@@ -160,7 +159,6 @@
 				<en>Boring family life is to be encouraged by underemployed level designers via family-scripting. 50 workplaces planned.</en>
 			</description>
 			<data genre="0" price="1.0" quality="35" />
-			<conditions year_range_from="-1" year_range_to="-1" />
 			<availability year_range_from="" year_range_to="" />
 		</news>
 
@@ -174,7 +172,7 @@
 				<en>Walther F. from Chemnitz learned from the TV show "Das Superkindermädchen" that his wife left him two years ago and took the children with her.</en>
 			</description>
 			<data genre="1" price="1.0" quality="23" />
-			<conditions year_range_from="1990" year_range_to="-1" />
+			<availability year_range_from="1990" year_range_to="-1" />
 		</news>
 
 		<news id="Sjaele-news-Kindergarten-Trophy" type="0" creator="7430" created_by="Sjaele">
@@ -187,7 +185,7 @@
 				<en>32-year-old Melanie L. and her daughter Anna (3) have won the 12th "Kindergarten Trophy" in Karl-Marx-Stadt.</en>
 			</description>
 			<data genre="2" price="1.0" quality="22" />
-			<conditions year_range_from="-1" year_range_to="1989" />
+			<availability year_range_from="-1" year_range_to="1989" />
 		</news>
 		<news id="Sjaele-news-Kindergarten-Trophy_Chemnitz" type="0" creator="7430" created_by="Sjaele">
 			<title>
@@ -199,7 +197,7 @@
 				<en>32-year-old Melanie L. and her daughter Anna (3) have won the 12th "Kindergarten Trophy" in Chemnitz.</en>
 			</description>
 			<data genre="2" price="1.0" quality="22" />
-			<conditions year_range_from="1990" year_range_to="-1" />
+			<availability year_range_from="1990" year_range_to="-1" />
 		</news>
 
 		<news id="Sjaele-news-Witze-Rundweg" type="0" creator="7430" created_by="Sjaele">
@@ -213,7 +211,7 @@
 				<en>The small Saxon town of Calau between Spreewald and Lower Lusatia has opened a "Jokes round walk" in honour of the corny jokes.</en>
 			</description>
 			<data genre="5" price="1.0" quality="25" />
-			<conditions year_range_from="2011" year_range_to="2011" />
+			<availability year_range_from="2011" year_range_to="2011" />
 		</news>
 
 		<news id="Sjaele-news-Biertrinkende" type="0" creator="7430" created_by="Sjaele">
@@ -227,7 +225,7 @@
 				<en>"Every Saxon drinks around 150 litres a year," says the Saxon Brewers' Association. Three out of four beers brewed in Saxony are also drunk in Saxony.</en>
 			</description>
 			<data genre="4" price="1.0" quality="35" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 
 		<news id="Sjaele-news-Volksmusik-Show" type="0" creator="7430" created_by="Sjaele">
@@ -241,7 +239,7 @@
 				<en>After the withdrawal of the "Happy Musicians", Bard Heiner called on the folk music friends to retain a "folk music euro" from the radio fees.</en>
 			</description>
 			<data genre="5" price="1.0" quality="15" />
-			<conditions year_range_from="2007" year_range_to="2007" />
+			<availability year_range_from="2007" year_range_to="2007" />
 		</news>
 
 		<news id="Sjaele-news-Umweltminister" type="0" creator="7430" created_by="Sjaele">
@@ -254,7 +252,7 @@
 				<en>The Minister of the Environment becomes Managing Director of the Federation of Industry. He resigns from his seat in Parliament. "I have a lot to make up for."</en>
 			</description>
 			<data genre="0" price="1.0" quality="43" />
-			<conditions year_range_from="-1" year_range_to="-1" />
+			<availability year_range_from="-1" year_range_to="-1" />
 		</news>
 
 		<news id="Sjaele-news-Tattris-Eins" type="0" creator="7430" created_by="Sjaele">
@@ -881,7 +879,7 @@
 
 			</description>
 			<data genre="5" price="0.7" quality="31" />
-			<conditions year_range_from="-1" year_range_to="1989" />
+			<availability year_range_from="-1" year_range_to="1989" />
 		</news>
 
 		<news id="Sjaele-news-Kaffee-Ausstellung-beendet_Chemnitz" type="0" creator="7430" created_by="Sjaele">
@@ -894,7 +892,7 @@
 
 			</description>
 			<data genre="5" price="0.7" quality="31" />
-			<conditions year_range_from="1990" year_range_to="-1" />
+			<availability year_range_from="1990" year_range_to="-1" />
 		</news>
 
 		<news id="Sjaele-news-Winzer-Klimawandel" type="0" creator="7430" created_by="Sjaele">

--- a/res/database/Default/user/sjaele.xml
+++ b/res/database/Default/user/sjaele.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tvgdb>
+<tvtdb>
 	<version value="3" comment="Själes Kram" />
 <!-- Die mit "Episode?" kommentierten Nachrichten eignen sich für Nachrichtenketten -->
 <!-- Die mit "deutschbezogen" kommentierten Nachrichten beziehen sich auf die deutsche Senderkarte -->
@@ -1097,4 +1097,4 @@
 			<availability script="TIME_SEASON=1" year_range_from="2013" year_range_to="2013" />
 		</news>
 	</allnews>
-</tvgdb>
+</tvtdb>

--- a/res/database/Default/user/speedminister.xml
+++ b/res/database/Default/user/speedminister.xml
@@ -81,7 +81,7 @@
 
     <allprogrammes>
         <!-- ***** Serie: Die Stars der volksirrtümlichen Hitparade (fiktiv) ***** -->
-        <programme id="SpeedMinister-Serie-volksirrtuemliche-01" product="2" licence_type="3" fictional="1" creator="8605" created_by="SpeedMinister">
+        <programme id="SpeedMinister-Serie-volksirrtuemliche-01" product="3" licence_type="3" fictional="1" creator="8605" created_by="SpeedMinister">
             <title>
                 <de>Die Stars der volksirrtümlichen Hitparade</de>
                 <en>The stars of the tradidiotionally hit parade</en>
@@ -95,11 +95,11 @@
                 <member index="1" function="2">SpeedMinister-person-id002</member>
             </staff>
             <groups target_groups="0" />
-            <data country="D, A, CH" year="2005" distribution="2" maingenre="102" blocks="2" />
+            <data country="D/A/CH" year="2005" distribution="2" maingenre="102" blocks="2" />
             <ratings critics="55" speed="60" />
             <!-- Episodes -->
             <children>
-                <programme id="SpeedMinister-Serie-volksirrtuemliche-01-ep-01" product="4" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
+                <programme id="SpeedMinister-Serie-volksirrtuemliche-01-ep-01" product="3" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
                     <title>
                         <de>Die Debreciner Kuhfladen Schnüffler</de>
                         <en>The Debrecen Cowpat Snoopers</en>
@@ -110,7 +110,7 @@
                     </description>
                     <ratings critics="59" speed="70" />
                 </programme>
-                <programme id="SpeedMinister-Serie-volksirrtuemliche-01-ep-02" product="4" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
+                <programme id="SpeedMinister-Serie-volksirrtuemliche-01-ep-02" product="3" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
                     <title>
                         <de>Tuba Tinnitus</de>
                         <en>Tuba Tinnitus</en>
@@ -121,7 +121,7 @@
                     </description>
                     <ratings critics="40" speed="50" />
                 </programme>
-                <programme id="SpeedMinister-Serie-volksirrtuemliche-01-ep-03" product="4" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
+                <programme id="SpeedMinister-Serie-volksirrtuemliche-01-ep-03" product="3" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
                     <title>
                         <de>Karl Maische</de>
                         <en></en>
@@ -132,7 +132,7 @@
                     </description>
                     <ratings critics="49" speed="51" />
                 </programme>
-                <programme id="SpeedMinister-Serie-volksirrtuemliche-01-ep-04" product="4" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
+                <programme id="SpeedMinister-Serie-volksirrtuemliche-01-ep-04" product="3" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
                     <title>
                         <de>Frantius F. Freudius</de>
                         <en></en>
@@ -143,7 +143,7 @@
                     </description>
                     <ratings critics="62" speed="65" />
                 </programme>
-                <programme id="SpeedMinister-Serie-volksirrtuemliche-01-ep-05" product="4" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
+                <programme id="SpeedMinister-Serie-volksirrtuemliche-01-ep-05" product="3" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
                     <title>
                         <de>Bingo Bumerang</de>
                         <en>Bingo Boomerang</en>
@@ -154,7 +154,7 @@
                     </description>
                     <ratings critics="42" speed="70" />
                 </programme>
-                <programme id="SpeedMinister-Serie-volksirrtuemliche-01-ep-06" product="4" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
+                <programme id="SpeedMinister-Serie-volksirrtuemliche-01-ep-06" product="3" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
                     <title>
                         <de>Fette Fritten</de>
                         <en>Fat Fries</en>
@@ -165,7 +165,7 @@
                     </description>
                     <ratings critics="60" speed="68" />
                 </programme>
-                <programme id="SpeedMinister-Serie-volksirrtuemliche-01-ep-07" product="4" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
+                <programme id="SpeedMinister-Serie-volksirrtuemliche-01-ep-07" product="3" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
                     <title>
                         <de>Edmondia und die Schwanenhalsdreher</de>
                         <en>Edmondia and the gooseneck turners</en>
@@ -176,7 +176,7 @@
                     </description>
                     <ratings critics="45" speed="60" />
                 </programme>
-                <programme id="SpeedMinister-Serie-volksirrtuemliche-01-ep-08" product="4" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
+                <programme id="SpeedMinister-Serie-volksirrtuemliche-01-ep-08" product="3" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
                     <title>
                         <de>Finale</de>
                         <en>Final</en>
@@ -193,7 +193,7 @@
             </children>
         </programme>
         <!-- ***** Talkrunde, Serie: Andauernd Käse (fiktiv) ***** -->
-        <programme id="SpeedMinister-Serie-andauernd-käse-01" product="2" licence_type="3" creator="8605" created_by="SpeedMinister">
+        <programme id="SpeedMinister-Serie-andauernd-käse-01" product="4" licence_type="3" creator="8605" created_by="SpeedMinister">
             <title>
                 <de>Andauernd Käse</de>
                 <en>Cheese all around</en>
@@ -387,7 +387,7 @@
             </children>
         </programme>
         <!-- ***** Serie: Soldaten, Paviane und Co. (fiktiv) ***** -->
-        <programme id="SpeedMinister-Serie-SoldatenPavianeCo-01" product="2" licence_type="3" creator="8605" created_by="SpeedMinister">
+        <programme id="SpeedMinister-Serie-SoldatenPavianeCo-01" product="4" licence_type="3" creator="8605" created_by="SpeedMinister">
             <title>
                 <de>Soldaten, Paviane und Co.</de>
                 <en>Soldiers, baboons, etc.</en>
@@ -401,7 +401,7 @@
                 <member index="1" function="2">SpeedMinister-person-id020</member>
             </staff>
             <!-- Link: http://de.wikipedia.org/wiki/Kabuler_Zoo -->
-            <data country="D, AFG" year="2012" distribution="0" maingenre="300" blocks="1" />
+            <data country="D/AFG" year="2012" distribution="0" maingenre="300" blocks="1" />
             <ratings critics="29" speed="35" />
             <!-- Episodes -->
             <children>
@@ -527,7 +527,7 @@
         </programme>
 
         <!-- ***** Serie: Expeditionen ins Tierreich, Dokumentation (Originaltitel der Episoden nicht mehr verfügbar) (real) ***** -->
-        <programme id="SpeedMinister-Serie-Expeditionen-01" product="2" licence_type="3" creator="8605" created_by="SpeedMinister">
+        <programme id="SpeedMinister-Serie-Expeditionen-01" product="4" licence_type="3" creator="8605" created_by="SpeedMinister">
             <title>
                 <de>Ausflüge ins Tierreich</de>
                 <en>Excursions into the animal kingdom</en>

--- a/res/database/Default/user/speedminister.xml
+++ b/res/database/Default/user/speedminister.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tvgdb>
+<tvtdb>
     <version value="3" comment="SpeedMinisters Programme" />
     <insignificantpeople>
         <!-- Deutschland -->
@@ -429,8 +429,8 @@
                         <en>Inauguration ceremony and acclimatization of two black bears. Animal keepers and bears build a relationship of trust. Then there's explosions in the city.</en>
                     </description>
                     <staff>
-                        <member index="2" function="2">SpeedMinister-person-id021</member>
-                        <member index="2" function="2">SpeedMinister-person-id022</member>
+                        <member index="0" function="2">SpeedMinister-person-id021</member>
+                        <member index="1" function="2">SpeedMinister-person-id022</member>
                     </staff>
                     <ratings critics="36" speed="35" />
                 </programme>
@@ -444,8 +444,8 @@
                         <en>The Chinese ambassador hands over a bronze-coloured lion statue to the Kabul Zoo, which is unveiled in the central square of the zoo. In addition, 2 lions donated by China are released into the outside enclosure.</en>
                     </description>
                     <staff>
-                        <member index="2" function="2">SpeedMinister-person-id021</member>
-                        <member index="2" function="2">SpeedMinister-person-id023</member>
+                        <member index="0" function="2">SpeedMinister-person-id021</member>
+                        <member index="1" function="2">SpeedMinister-person-id023</member>
                         <member index="2" function="2">SpeedMinister-person-id024</member>
                     </staff>
                     <ratings critics="29" speed="24" />
@@ -488,8 +488,8 @@
                         <en>It's dwindling among guenons. They share an outside enclosure with the lions and meerkats. The males disappear in their caves, the guenons on the climbing trees. These are apparently not high enough.</en>
                     </description>
                     <staff>
-                        <member index="2" function="2">SpeedMinister-person-id021</member>
-                        <member index="2" function="2">SpeedMinister-person-id022</member>
+                        <member index="0" function="2">SpeedMinister-person-id021</member>
+                        <member index="1" function="2">SpeedMinister-person-id022</member>
                     </staff>
                     <ratings critics="40" speed="40" />
                 </programme>
@@ -503,8 +503,8 @@
                         <en>After the crisis in the lion enclosure, an outdoor enclosure is being renovated for the guenons in a lightning operation. Cement bags disappear from various construction sites in the city. A 20-foot standard container must be used as an animal house.</en>
                     </description>
                     <staff>
-                        <member index="2" function="2">SpeedMinister-person-id021</member>
-                        <member index="2" function="2">SpeedMinister-person-id022</member>
+                        <member index="0" function="2">SpeedMinister-person-id021</member>
+                        <member index="1" function="2">SpeedMinister-person-id022</member>
                     </staff>
                     <ratings critics="40" speed="40" />
                 </programme>
@@ -518,8 +518,8 @@
                         <en>At the opening of the snow leopard enclosure, the zoo management organizes a small party for the employees. The entrance of Afghanistan's landmark is celebrated with dancing and singing.</en>
                     </description>
                     <staff>
-                        <member index="2" function="2">SpeedMinister-person-id021</member>
-                        <member index="2" function="2">SpeedMinister-person-id022</member>
+                        <member index="0" function="2">SpeedMinister-person-id021</member>
+                        <member index="1" function="2">SpeedMinister-person-id022</member>
                     </staff>
                     <ratings critics="30" speed="30" />
                 </programme>
@@ -706,4 +706,4 @@
             <data genre="2" price="1.0" quality="32" />
         </news>
     </allnews>
-</tvgdb>
+</tvtdb>

--- a/res/database/Default/user/speedminister.xml
+++ b/res/database/Default/user/speedminister.xml
@@ -675,7 +675,7 @@
     </allprogrammes>
 
     <allnews>
-        <news id="SpeedMinister-news-Nessi-01" type="0" creator="8605" created_by="SpeedMinister">
+        <news id="SpeedMinister-news-Nessi-01" type="0" thread_id="SpeedMinister-news-Nessi" creator="8605" created_by="SpeedMinister">
             <title>
                 <de>Nessi will nach Hause</de>
                 <en>Nessi wants to go home</en>
@@ -689,7 +689,7 @@
 			</effects>
             <data genre="2" price="1.0" quality="40" />
         </news>
-        <news id="SpeedMinister-news-Nessi-02" type="2" creator="8605" created_by="SpeedMinister">
+        <news id="SpeedMinister-news-Nessi-02" type="2" thread_id="SpeedMinister-news-Nessi" creator="8605" created_by="SpeedMinister">
             <title>
                 <de>Nessi kommt nach Hause</de>
                 <en>Nessi arrives at home</en>
@@ -703,7 +703,7 @@
             </effects>
             <data genre="2" price="1.0" quality="30" />
         </news>
-        <news id="SpeedMinister-news-Nessi-03" type="2" creator="8605" created_by="SpeedMinister">
+        <news id="SpeedMinister-news-Nessi-03" type="2" thread_id="SpeedMinister-news-Nessi" creator="8605" created_by="SpeedMinister">
             <title>
                 <de>Bürgermeister erfreut über Nessi</de>
                 <en>Mayor pleased about Nessi</en>

--- a/res/database/Default/user/speedminister.xml
+++ b/res/database/Default/user/speedminister.xml
@@ -20,9 +20,9 @@
         <person id="SpeedMinister-person-id018" first_name="Berthold" last_name="Stauffer" creator="8605" created_by="speedminister" />
         <person id="SpeedMinister-person-id019" first_name="Prof. Dr. Raimund" last_name="Holzner" creator="8605" created_by="speedminister" />
         <person id="SpeedMinister-person-id027" first_name="Dirk" last_name="Kipling" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id032" first_name="Hans" last_name="Prielmann" real_first_name="Heinz" real_last_name="Sielmann" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id037" first_name="Den" last_name="Jakobson" real_first_name="Dennis" real_last_name="Jacobsen" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id038" first_name="Lianda" last_name="Mahoud" real_first_name="Randa" real_last_name="Chahoud" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id032" first_name="Hans" last_name="Prielmann" first_name_original="Heinz" last_name_original="Sielmann" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id037" first_name="Den" last_name="Jakobson" first_name_original="Dennis" last_name_original="Jacobsen" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id038" first_name="Lianda" last_name="Mahoud" first_name_original="Randa" last_name_original="Chahoud" creator="8605" created_by="speedminister" />
         <!-- Österreich -->
         <person id="SpeedMinister-person-id007" first_name="Frauke" last_name="Hasenhüttl" creator="8605" created_by="speedminister" />
         <person id="SpeedMinister-person-id009" first_name="Karl" last_name="Schneck" creator="8605" created_by="speedminister" />
@@ -38,52 +38,43 @@
         <!-- USA -->
         <person id="SpeedMinister-person-id025" first_name="C. J." last_name="Harper" creator="8605" created_by="speedminister" />
         <person id="SpeedMinister-person-id026" first_name="Franny" last_name="Tucker" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id033" first_name="Steven" last_name="Kessel" real_first_name="Steve" real_last_name="Ressel" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id034" first_name="Johan" last_name="Richcorner" real_first_name="Jordan" real_last_name="Reichek" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id035" first_name="Robby" last_name="Bumblebee" real_first_name="Rob" real_last_name="Hummel" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id036" first_name="J. Honey" last_name="Busquez" real_first_name="Jhonen" real_last_name="Vasquez" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id033" first_name="Steven" last_name="Kessel" first_name_original="Steve" last_name_original="Ressel" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id034" first_name="Johan" last_name="Richcorner" first_name_original="Jordan" last_name_original="Reichek" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id035" first_name="Robby" last_name="Bumblebee" first_name_original="Rob" last_name_original="Hummel" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id036" first_name="J. Honey" last_name="Busquez" first_name_original="Jhonen" last_name_original="Vasquez" creator="8605" created_by="speedminister" />
         <!-- Frankreich -->
-        <person id="SpeedMinister-person-id028" first_name="Manuel" last_name="Goldstein" real_first_name="Emmanuel" real_last_name="Gorinstein" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id029" first_name="Alex" last_name="de la Palletière" real_first_name="Alexandre" real_last_name="de La Patellière" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id030" first_name="Matthias" last_name="Pförtner" real_first_name="Mathieu" real_last_name="Delaporte" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id028" first_name="Manuel" last_name="Goldstein" first_name_original="Emmanuel" last_name_original="Gorinstein" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id029" first_name="Alex" last_name="de la Palletière" first_name_original="Alexandre" last_name_original="de La Patellière" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id030" first_name="Matthias" last_name="Pförtner" first_name_original="Mathieu" last_name_original="Delaporte" creator="8605" created_by="speedminister" />
         <!-- Belgien -->
-        <person id="SpeedMinister-person-id031" first_name="Rondo" last_name="van Lenk" real_first_name="Romain" real_last_name="van Liemt" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id031" first_name="Rondo" last_name="van Lenk" first_name_original="Romain" last_name_original="van Liemt" creator="8605" created_by="speedminister" />
         <!-- England -->
-        <person id="SpeedMinister-person-id039" first_name="Ilan J.W." last_name="Bubble Cap" real_first_name="Alan J.W." real_last_name="Bell" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id040" first_name="Douggy" last_name="Eves" real_first_name="Douglas" real_last_name="Adams" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id041" first_name="Joe" last_name="Nedlloyd" real_first_name="John" real_last_name="Lloyd" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id039" first_name="Ilan J.W." last_name="Bubble Cap" first_name_original="Alan J.W." last_name_original="Bell" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id040" first_name="Douggy" last_name="Eves" first_name_original="Douglas" last_name_original="Adams" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id041" first_name="Joe" last_name="Nedlloyd" first_name_original="John" last_name_original="Lloyd" creator="8605" created_by="speedminister" />
     </insignificantpeople>
 
     <celebritypeople>
         <person id="SpeedMinister-celebritypeople-KarlHeinzDorfmichel" tmdb_id="0" imdb_id="" creator="8605" created_by="SpeedMinister">
             <first_name>Karlheinz</first_name>
             <last_name>Dorfmichel</last_name>
-            <functions>
-                <function>2</function>
-            </functions>
-            <details gender="1"  birthday="1941" deathday="" country="D" />
+            <details job="2" gender="1"  birthday="1941" deathday="" country="D" />
             <data popularity="7" affinity="15" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="0" topgenre="0" />
         </person>
         <person id="SpeedMinister-celebritypeople-OttokarKahn" tmdb_id="0" imdb_id="" creator="8605" created_by="SpeedMinister">
             <first_name>Ottokar</first_name>
             <last_name>Kahn</last_name>
-            <real_first_name>Oliver</real_first_name>
-            <real_last_name>Jahn</real_last_name>
-            <functions>
-                <function>1,2</function>
-            </functions>
-            <details gender="1"  birthday="1969" deathday="" country="D" />
+            <first_name_original>Oliver</first_name_original>
+            <last_name_original>Jahn</last_name_original>
+            <details job="3" gender="1"  birthday="1969" deathday="" country="D" />
             <data popularity="7" affinity="20" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="0" topgenre="0" />
         </person>
         <person id="SpeedMinister-celebritypeople-CoraSchirmer" tmdb_id="0" imdb_id="" creator="8605" created_by="SpeedMinister">
             <first_name>Cora</first_name>
             <last_name>Schirmer</last_name>
-            <real_first_name>Nora</real_first_name>
-            <real_last_name>Tschirner</real_last_name>
-            <functions>
-                <function>2</function>
-            </functions>
-            <details gender="1"  birthday="1981" deathday="" country="D" />
+            <first_name_original>Nora</first_name_original>
+            <last_name_original>Tschirner</last_name_original>
+            <details job="2" gender="1"  birthday="1981" deathday="" country="D" />
             <data popularity="25" affinity="35" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="0" topgenre="0" />
         </person>
     </celebritypeople>

--- a/res/database/Default/user/therob.xml
+++ b/res/database/Default/user/therob.xml
@@ -2,7 +2,7 @@
 <tvtdb>
 <version value="3" comment="Programme von TheRob" />
 	<allprogrammes>
-		<programme id="TheRob-serie-KomissarWirsch" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-KomissarWirsch" product="7" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Komissar Wirsch -->
 				<de>Kommissar Wirsch</de>
@@ -572,7 +572,7 @@
 				<member index="3" function="2">Per_custom_Freddy_655</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="SUI" year="1961" distribution="1" maingenre="1" subgenre="" flags="0" blocks="2" price_mod="1.00" />
+			<data country="CH" year="1961" distribution="1" maingenre="1" subgenre="" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="36" speed="32" outcome="31" />
 		</programme>
 
@@ -593,7 +593,7 @@
 				<member index="3" function="2">Per_custom_Freddy_567</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="CSSR" year="1984" distribution="1" maingenre="1" subgenre="" flags="0" blocks="3" price_mod="1.00" />
+			<data country="CS" year="1984" distribution="1" maingenre="1" subgenre="" flags="0" blocks="3" price_mod="1.00" />
 			<ratings critics="56" speed="42" outcome="41" />
 		</programme>
 
@@ -666,7 +666,7 @@
 				<member index="2" function="2">Per_custom_Freddy_330</member>
 			</staff>
 			<groups target_groups="32" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="JPN" year="1978" distribution="2" maingenre="1" subgenre="2" flags="0" blocks="1" price_mod="1.00" />
+			<data country="J" year="1978" distribution="2" maingenre="1" subgenre="2" flags="0" blocks="1" price_mod="1.00" />
 			<ratings critics="38" speed="43" outcome="0" />
 			<children>
 				<programme id="therob-programme-adv-sinbadsreisen-ep101" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
@@ -906,7 +906,7 @@
 				<member index="1" function="2">Per_custom_Freddy_429</member>
 			</staff>
 			<groups target_groups="64" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="UDSSR" year="1964" distribution="2" maingenre="11" subgenre="" flags="0" blocks="2" price_mod="1.00" />
+			<data country="SU" year="1964" distribution="2" maingenre="11" subgenre="" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="25" speed="40" outcome="0" />
 		</programme>
 
@@ -924,7 +924,7 @@
 				<member index="1" function="2">Per_custom_Freddy_45</member>
 			</staff>
 			<groups target_groups="256" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="SWE" year="2006" distribution="2" maingenre="8" subgenre="" flags="192" blocks="2" price_mod="1.00" />
+			<data country="S" year="2006" distribution="2" maingenre="8" subgenre="" flags="192" blocks="2" price_mod="1.00" />
 			<ratings critics="24" speed="42" outcome="0" />
 			<modifiers>
 				<!-- Programmalter hat hoeheren Einfluss auf Preis -->
@@ -1017,7 +1017,7 @@
 				<member index="1" function="128">Per_custom_Freddy_624</member>
 			</staff>
 			<groups target_groups="4" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="Aut" year="1951" distribution="2" maingenre="9" subgenre="" flags="0" blocks="2" price_mod="1.00" />
+			<data country="A" year="1951" distribution="2" maingenre="9" subgenre="" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="35" speed="9" outcome="0" />
 			<children>
 				<programme id="therob-programme-HaFr-Marmeladenselbermachen-ep101" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
@@ -1411,7 +1411,7 @@
 			</children>
 		</programme>
 
-		<programme id="TheRob-serie-crime-DieZwillinge" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-crime-DieZwillinge" product="7" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Die Zwillinge, Crime mit Flag Mystery, letzte Folge mit subgenre Drama und Comedy -->
 				<de>Die Zwillinge</de>
@@ -1489,7 +1489,7 @@
 			</children>
 		</programme>
 
-		<programme id="TheRob-serie-myst-DasUnbekannte" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-myst-DasUnbekannte" product="7" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Das Unbekannte, Mystery und Subgenre Horror plus FSK18 -->
 				<de>Das Unbekannte</de>
@@ -1612,7 +1612,7 @@
 				<member index="2" function="2">283bdb7a-ea1f-4d33-8e72-a618515f4e40</member>
 			</staff>
 			<groups target_groups="128" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="FR" year="1983" distribution="2" maingenre="301" subgenre="" flags="0" blocks="4" price_mod="1.00" />
+			<data country="F" year="1983" distribution="2" maingenre="301" subgenre="" flags="0" blocks="4" price_mod="1.00" />
 			<ratings critics="35" speed="31" outcome="0" />
 		</programme>
 
@@ -1633,11 +1633,11 @@
 				<member index="3" function="2">TheRob-TowerTV-NikitaSergejewitschChruschtschow</member>
 			</staff>
 			<groups target_groups="32" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="SUI" year="1964" distribution="2" maingenre="201" subgenre="" flags="0" blocks="3" price_mod="1.00" />
+			<data country="CH" year="1964" distribution="2" maingenre="201" subgenre="" flags="0" blocks="3" price_mod="1.00" />
 			<ratings critics="65" speed="21" outcome="0" />
 		</programme>
 
-		<programme id="TheRob-serie-Sonst-TrendfuerMaenner" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="tt0192937" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-Sonst-TrendfuerMaenner" product="7" fictional="1" licence_type="3" tmdb_id="0" imdb_id="tt0192937" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Trend fuer Maenner, Sostiges -->
 				<de>Trend für Männer</de>
@@ -1779,7 +1779,7 @@
 			</children>
 		</programme>
 
-		<programme id="TheRob-serie-Moumental-BestofTVTower" product="5" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-Moumental-BestofTVTower" product="7" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Best of TVTower, Show 204 Wieder gleiche Wertung für alle Folgen. -->
 				<de>Best of TVTower</de>
@@ -1872,7 +1872,7 @@
 						<member index="4" function="8">3d37e02e-78f2-4749-9de5-429e31b5590b</member>
 					</staff>
 					<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-					<data country="UdSSR" year="1980" distribution="0" maingenre="204" subgenre="" flags="0" blocks="3" price_mod="1.00" />
+					<data country="SU" year="1980" distribution="0" maingenre="204" subgenre="" flags="0" blocks="3" price_mod="1.00" />
 				</programme>
 			</children>
 		</programme>
@@ -1896,7 +1896,7 @@
 			<ratings critics="29" speed="49" outcome="89" />
 		</programme>
 
-		<programme id="TheRob-serie-DieStraendederWelt" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-DieStraendederWelt" product="7" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Die Strände der Welt, fictional, Dok mit Sub Erotik, keine individuellen Werte -->
 				<de>Die Strände der Welt</de>
@@ -1911,7 +1911,7 @@
 				<member index="1" function="8">TheRob-TowerTV-VeraZottova</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="CSSR" year="1980" distribution="2" maingenre="6" subgenre="8" flags="0" blocks="1" price_mod="1.00" />
+			<data country="CS" year="1980" distribution="2" maingenre="6" subgenre="8" flags="0" blocks="1" price_mod="1.00" />
 			<ratings critics="29" speed="59" outcome="" />
 			<children>
 				<programme id="TheRob-serie-DieStraendederWelt-Episode001" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
@@ -1977,7 +1977,7 @@
 			</children>
 		</programme>
 
-		<programme id="TheRob-serie-Wirstellenvor" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-Wirstellenvor" product="7" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Wir stellen vor, Music show -->
 				<de>Wir stellen vor</de>
@@ -2625,9 +2625,9 @@
 			<jobs>
 				<job index="0" function="1" required="1"  />
 				<job index="1" function="2" required="1" gender="2" />
-				<job index="3" function="2" required="1" gender="2" />
-				<job index="2" function="2" required="1" gender="1" />
-				<job index="2" function="2" required="1" gender="1" />
+				<job index="2" function="2" required="1" gender="2" />
+				<job index="3" function="2" required="1" gender="1" />
+				<job index="4" function="2" required="1" gender="1" />
 				<job index="5" function="32" required="0" />
 				<job index="6" function="32" required="0" />
 				<job index="7" function="32" required="0" />
@@ -3029,7 +3029,7 @@
 			<review min="55" max="100" slope="50" />
 			<speed min="65" max="100" slope="50" />
 		</scripttemplate>
-		<scripttemplate product="7" licence_type="3" guid="TheRob-script-ser-CallIn-Abgezockt">
+		<scripttemplate product="3" licence_type="3" guid="TheRob-script-ser-CallIn-Abgezockt">
 			<title>
 				<de>TVTs: %TITLE1%</de>
 				<en>TVTs: %TITLE1%</en>
@@ -3040,43 +3040,43 @@
 			</description>
 
 			<children>
-				<scripttemplate index="0" product="2" licence_type="2" guid="TheRob-script-ser-CallIn-Abgezockt-Ep1">
+				<scripttemplate index="0" product="3" licence_type="2" guid="TheRob-script-ser-CallIn-Abgezockt-Ep1">
 					<title>
 						<de>Orte</de>
 						<en>Places</en>
 					</title>
 				</scripttemplate>
-				<scripttemplate index="1" product="2" licence_type="2" guid="TheRob-script-ser-CallIn-Abgezockt-Ep2">
+				<scripttemplate index="1" product="3" licence_type="2" guid="TheRob-script-ser-CallIn-Abgezockt-Ep2">
 					<title>
 						<de>Länder</de>
 						<en>Countries</en>
 					</title>
 				</scripttemplate>
-				<scripttemplate index="2" product="2" licence_type="2" guid="TheRob-script-ser-CallIn-Abgezockt-Ep3">
+				<scripttemplate index="2" product="3" licence_type="2" guid="TheRob-script-ser-CallIn-Abgezockt-Ep3">
 					<title>
 						<de>Unterwäsche</de>
 						<en>Underwear</en>
 					</title>
 				</scripttemplate>
-				<scripttemplate index="3" product="2" licence_type="2" guid="TheRob-script-ser-CallIn-Abgezockt-Ep4">
+				<scripttemplate index="3" product="3" licence_type="2" guid="TheRob-script-ser-CallIn-Abgezockt-Ep4">
 					<title>
 						<de>Parfum</de>
 						<en>Parfume</en>
 					</title>
 				</scripttemplate>
-				<scripttemplate index="4" product="2" licence_type="2" guid="TheRob-script-ser-CallIn-Abgezockt-Ep5">
+				<scripttemplate index="4" product="3" licence_type="2" guid="TheRob-script-ser-CallIn-Abgezockt-Ep5">
 					<title>
 						<de>Filme</de>
 						<en>Movies</en>
 					</title>
 				</scripttemplate>
-				<scripttemplate index="5" product="2" licence_type="2" guid="TheRob-script-ser-CallIn-Abgezockt-Ep6">
+				<scripttemplate index="5" product="3" licence_type="2" guid="TheRob-script-ser-CallIn-Abgezockt-Ep6">
 					<title>
 						<de>Keine Wörter diesmal</de>
 						<en>No Words This Time</en>
 					</title>
 				</scripttemplate>
-				<scripttemplate index="6" product="2" licence_type="2" guid="TheRob-script-ser-CallIn-Abgezockt-Ep7">
+				<scripttemplate index="6" product="3" licence_type="2" guid="TheRob-script-ser-CallIn-Abgezockt-Ep7">
 					<title>
 						<de>Künstler</de>
 						<en>Artists</en>
@@ -3089,8 +3089,8 @@
 					<en>Dancing Queen|Searching Wors|Winning Guaranteed|Screwed Up|Wunderfull Views</en>
 				</title1>
 				<name1>
-					<de>Jimmy|Bobby|Danny|Manni||Donny|Johny</de>
-					<en>Jimmy|Bobby|Danny|Manni||Donny|Johny</en>
+					<de>Jimmy|Bobby|Danny|Manni|Donny|Johny</de>
+					<en>Jimmy|Bobby|Danny|Manni|Donny|Johny</en>
 				</name1>
 			</variables>
 			<jobs>

--- a/res/database/Default/user/therob.xml
+++ b/res/database/Default/user/therob.xml
@@ -2161,7 +2161,6 @@
 			<first_name>Vera</first_name>
 			<last_name>Zottorova</last_name>
 			<nick_name></nick_name>
-			<images />
 			<details gender="2" fictional="1" birthday="" deathday="" country="" />
 			<data popularity="5" affinity="60" fame="60" scandalizing="20" price_mod="1" power="60" humor="24" charisma="78" appearance="88" topgenre="0" />
 		</person>
@@ -2170,7 +2169,6 @@
 			<first_name>Moris</first_name>
 			<last_name>Weverkov</last_name>
 			<nick_name></nick_name>
-			<images />
 			<details gender="1" fictional="1" birthday="" deathday="" country="" />
 			<data popularity="60" affinity="30" fame="40" scandalizing="80" price_mod="1" power="50" humor="40" charisma="90" appearance="40" topgenre="0" />
 		</person>
@@ -2330,7 +2328,7 @@
 				<job index="2" function="2" required="1" gender="2" />
 				<job index="3" function="2" required="1" gender="1" />
 			</jobs>
-			<data flags="64" optional_flags="16" />
+			<data flags="64" flags_optional="16" />
 			<genres maingenre="12" subgenres="14" />
 			<blocks min="1" max="4" slope="25" />
 			<price min="1000" max="19500" slope="20" />
@@ -2424,7 +2422,7 @@
 				<job index="4" function="32" required="1" gender="2" />
 				<job index="5" function="32" required="1" gender="1" />
 			</jobs>
-			<data flags="16" optional_flags="96" />
+			<data flags="16" flags_optional="96" />
 			<genres maingenre="4" subgenres="0" />
 			<blocks min="2" max="2" slope="25" />
 			<price min="30000" max="60000" slope="50" />
@@ -2448,7 +2446,7 @@
 				<job index="2" function="2" required="1" gender="2" />
 				<job index="3" function="32" required="1" gender="1" />
 			</jobs>
-			<data optional_flags="42" />
+			<data flags_optional="42" />
 			<genres maingenre="16" subgenres="5" />
 			<blocks min="2" max="4" slope="40" />
 			<price min="35000" max="69500" slope="60" />
@@ -2477,7 +2475,7 @@
 				<job index="1" function="8" required="0" gender="1" />
 				<job index="2" function="8" required="1" gender="2" />
 			</jobs>
-			<data flags="4" optional_flags="2" />
+			<data flags="4" flags_optional="2" />
 			<genres maingenre="6" subgenres="0" />
 			<blocks min="2" max="4" slope="70" />
 			<price min="7000" max="17500" slope="20" />
@@ -2507,7 +2505,7 @@
 				<job index="1" function="8" required="0" gender="1" />
 				<job index="2" function="8" required="1" gender="2" />
 			</jobs>
-			<data flags="4" optional_flags="2" />
+			<data flags="4" flags_optional="2" />
 			<genres maingenre="6" subgenres="0" />
 			<blocks min="2" max="4" slope="70" />
 			<price min="7000" max="17500" slope="20" />
@@ -2635,7 +2633,7 @@
 				<job index="7" function="32" required="0" />
 				<job index="8" function="32" required="0" />
 			</jobs>
-			<data flags="8" optional_flags="50" />
+			<data flags="8" flags_optional="50" />
 			<genres maingenre="7" subgenres="9" />
 			<episodes min="9" max="12" />
 			<blocks value="1" />
@@ -2690,7 +2688,7 @@
 			<jobs>
 				<job index="0" function="1" required="1"  />
 			</jobs>
-			<data flags="114" optional_flags="8" />
+			<data flags="114" flags_optional="8" />
 			<genres maingenre="3" subgenres="8" />
 			<episodes min="3" max="5" />
 			<blocks value="1" />
@@ -2745,7 +2743,7 @@
 			<jobs>
 				<job index="0" function="1" required="1"  />
 			</jobs>
-			<data flags="48" optional_flags="12" />
+			<data flags="48" flags_optional="12" />
 			<genres maingenre="102" subgenres="9" />
 			<episodes min="3" max="5" />
 			<blocks value="1" />
@@ -2829,7 +2827,7 @@
 				<job index="2" function="2" required="1" gender="2" />
 				<job index="3" function="32" required="1" gender="2" />
 			</jobs>
-			<data optional_flags="18" />
+			<data flags_optional="18" />
 			<genres maingenre="4" subgenres="2" />
 			<episodes min="4" max="7" />
 			<blocks min="1" max="2" slope="25" />
@@ -2860,7 +2858,7 @@
 				<job index="2" function="2" required="1" gender="2" />
 				<job index="3" function="2" required="1" gender="2" />
 			</jobs>
-			<data flags="8" optional_flags="66" />
+			<data flags="8" flags_optional="66" />
 			<groups target_groups="68" />
 			<genres maingenre="13" subgenres="15" />
 			<blocks min="3" max="5" slope="45" />
@@ -2895,7 +2893,7 @@
 				<job index="2" function="2" required="1" gender="2" />
 				<job index="3" function="32" required="1" gender="2" />
 			</jobs>
-			<data optional_flags="34" />
+			<data flags_optional="34" />
 			<groups target_groups="3" />
 			<genres maingenre="10" subgenres="1" />
 			<blocks min="1" max="2" slope="75" />
@@ -2926,8 +2924,8 @@
 				<job index="2" function="2" required="1" gender="2" />
 				<job index="3" function="2" required="0" gender="1" />
 			</jobs>
-			<data flags="2" optional_flags="16" />
-			<groups target_groups="3" optional_target_groups="4" />
+			<data flags="2" flags_optional="16" />
+			<groups target_groups="3" target_groups_optional="4" />
 			<genres maingenre="3" subgenres="5" />
 			<blocks min="1" max="2" slope="55" />
 			<price min="15000" max="39500" slope="50" />
@@ -2958,7 +2956,7 @@
 				<job index="3" function="32" required="1" gender="1" />
 				<job index="4" function="32" required="1" gender="1" />
 			</jobs>
-			<data flags="4" optional_flags="10" />
+			<data flags="4" flags_optional="10" />
 			<genres maingenre="11" subgenres="6" />
 			<blocks min="1" max="2" slope="65" />
 			<price min="20000" max="49500" slope="40" />
@@ -2986,7 +2984,7 @@
 				<job index="0" function="1" required="1" />
 				<job index="1" function="2" required="1" gender="1" />
 			</jobs>
-			<data optional_flags="64" />
+			<data flags_optional="64" />
 			<genres maingenre="1" subgenres="13" />
 			<blocks min="2" max="4" slope="30" />
 			<price min="15000" max="49500" slope="20" />
@@ -3021,7 +3019,7 @@
 				<job index="3" function="2" required="1" gender="2" />
 				<job index="4" function="32" required="1" gender="2" />
 			</jobs>
-			<data flags="8" optional_flags="66" />
+			<data flags="8" flags_optional="66" />
 			<groups target_groups="256" />
 			<genres maingenre="18" subgenres="7" />
 			<blocks min="2" max="3" slope="25" />
@@ -3101,7 +3099,7 @@
 				<job index="2" function="32" required="1" gender="2" />
 				<job index="3" function="32" required="1" gender="2" />
 			</jobs>
-			<data flags="144" optional_flags="67" />
+			<data flags="144" flags_optional="67" />
 			<groups target_groups="16" />
 			<genres maingenre="0" />
 			<episodes min="2" max="7" />

--- a/res/database/Default/user/therob.xml
+++ b/res/database/Default/user/therob.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tvgdb>
+<tvtdb>
 <version value="3" comment="Programme von TheRob" />
 	<allprogrammes>
-		<programme id="TheRob-serie-KomissarWirsch" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-KomissarWirsch" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Komissar Wirsch -->
 				<de>Kommissar Wirsch</de>
@@ -21,7 +21,7 @@
 			<data country="D" year="1951" distribution="2" maingenre="4" subgenre="" flags="0" blocks="1" price_mod="1.00" />
 			<ratings critics="30" speed="49" outcome="" />
 			<children>
-				<programme id="TheRob-serie-KommissarWirsch-Episode001" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-KommissarWirsch-Episode001" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Wirschi und der Tante Emma Laden</de>
 						<en>Wirschi and the small shop at the corner</en>
@@ -32,7 +32,7 @@
 					</description>
 					<ratings critics="29" speed="48" />
 				</programme>
-				<programme id="TheRob-serie-KommissarWirsch-Episode002" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-KommissarWirsch-Episode002" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Wirschi und der vermisste Bürgermeister</de>
 						<en>Wirschi and the missing major</en>
@@ -43,7 +43,7 @@
 					</description>
 					<ratings critics="30" speed="50" />
 				</programme>
-				<programme id="TheRob-serie-KommissarWirsch-Episode003" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-KommissarWirsch-Episode003" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Wirschi und das versteckte Gemälde</de>
 						<en>Wirschi an the hidden painting</en>
@@ -54,7 +54,7 @@
 					</description>
 					<ratings critics="30" speed="50" />
 				</programme>
-				<programme id="TheRob-serie-KommissarWirsch-Episode004" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-KommissarWirsch-Episode004" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Wirschi und der Fotograf</de>
 						<en>Wirschi and the photographer</en>
@@ -65,7 +65,7 @@
 					</description>
 					<ratings critics="32" speed="50" />
 				</programme>
-				<programme id="TheRob-serie-KommissarWirsch-Episode005" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-KommissarWirsch-Episode005" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Wirschi und der Grenzstein</de>
 						<en>Wirschi and the border stone</en>
@@ -76,7 +76,7 @@
 					</description>
 					<ratings critics="12" speed="8" />
 				</programme>
-				<programme id="TheRob-serie-KommissarWirsch-Episode006" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-KommissarWirsch-Episode006" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Die Assistentin wird Sängerin</de>
 						<en>The Assistant becomes a singstar</en>
@@ -90,7 +90,7 @@
 			</children>
 		</programme>
 
-		<programme id="TheRob-a4d6-act-Meinsallesmeins" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-a4d6-act-Meinsallesmeins" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Meins Alles Meins -->
 				<de>Meins! Alles MEINS!</de>
@@ -111,7 +111,7 @@
 			<ratings critics="27" speed="63" outcome="36" />
 		</programme>
 
-		<programme id="TheRob-b0db-fant-ReisemitSandmaennchen" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-fant-ReisemitSandmaennchen" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Zielgruppe Kinder -->
 				<de>Ich reiste mit dem Sandmännchen</de>
@@ -132,7 +132,7 @@
 			<ratings critics="33" speed="27" outcome="56" />
 		</programme>
 
-		<programme id="TheRob-b0db-myst-VerschwandmitSandmaennchen" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-myst-VerschwandmitSandmaennchen" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Als Mysterie Test mit Subgenre Horror -->
 				<de>Ich verschwand mit dem Sandmännchen</de>
@@ -153,7 +153,7 @@
 			<ratings critics="73" speed="58" outcome="76" />
 		</programme>
 
-		<programme id="TheRob-b5dc-hist-Neuschwanstein" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b5dc-hist-Neuschwanstein" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<de>Der Bau von Neuschwanstein</de>
 				<en>The construction of Neuschwanstein</en>
@@ -172,7 +172,7 @@
 			<ratings critics="65" speed="36" outcome="0" />
 		</programme>
 
-		<programme id="TheRob-dda6-ero-WuzzGeiersDamen" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-dda6-ero-WuzzGeiersDamen" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<de>Wuzz Geiers Damen</de>
 				<en>The girls of Wuzz Geier</en>
@@ -192,7 +192,7 @@
 			<ratings critics="12" speed="49" outcome="69" />
 		</programme>
 
-		<programme id="e61018ba-b0db-439c-a852-TheRob04" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="e61018ba-b0db-439c-a852-TheRob04" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<de>Wesensreiter</de>
 				<en>Creature Rider</en>
@@ -212,7 +212,7 @@
 			<ratings critics="33" speed="27" outcome="56" />
 		</programme>
 
-		<programme id="TheRob-b0db-439c-a852-BullshitBingo" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-439c-a852-BullshitBingo" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<de>Bullshit Bingo</de>
 				<en>Bullshit bingo</en>
@@ -230,7 +230,7 @@
 			<ratings critics="29" speed="27" outcome="10" />
 		</programme>
 
-		<programme id="TheRob-b0db-439c-a852-Sonstiges" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-439c-a852-Sonstiges" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<de>Sonstiges - das Thema</de>
 				<en>Various - the toppic</en>
@@ -251,7 +251,7 @@
 			<ratings critics="99" speed="47" outcome="0" />
 		</programme>
 
-		<programme id="TheRob-b0db-439c-a852-EditorundKI" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-439c-a852-EditorundKI" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<de>Editor und KI</de>
 				<en>Editor and KI</en>
@@ -269,7 +269,7 @@
 			<ratings critics="92" speed="27" outcome="0" />
 		</programme>
 
-		<programme id="TheRob-b0db-439c-a852-TVGigantderAnfang" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-439c-a852-TVGigantderAnfang" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<de>TVGigant - der Anfang</de>
 				<en>TVGigant - the beginning</en>
@@ -288,7 +288,7 @@
 			<ratings critics="92" speed="27" outcome="0" />
 		</programme>
 
-		<programme id="TheRob-b0db-439c-a852-RatTV" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-439c-a852-RatTV" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Geschichte über MadTV und Rainbow Arts -->
 				<de>RatTV - Quo Vadis</de>
@@ -309,7 +309,7 @@
 			<ratings critics="88" speed="51" outcome="0" />
 		</programme>
 
-		<programme id="TheRob-b0db-439c-a852-Goaaaaal" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-439c-a852-Goaaaaal" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<de>Goaaaaal</de>
 				<en>Goaaaaal</en>
@@ -329,7 +329,7 @@
 			<ratings critics="22" speed="95" outcome="0" />
 		</programme>
 
-		<programme id="5c4c567b-dda6-4d7e-b90a-RobTheTest01" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="5c4c567b-dda6-4d7e-b90a-RobTheTest01" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Iris entdeckt die Alm</de>
 				<en>Iris explores the alp</en>
@@ -348,7 +348,7 @@
 			<ratings critics="9" speed="19" outcome="29" />
 		</programme>
 
-		<programme id="8ef29506-1756-400d-8f9c-TheRobTest03" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="8ef29506-1756-400d-8f9c-TheRobTest03" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Weib, Wein und Gesang</de>
 				<en>Girls, wine and singing</en>
@@ -369,7 +369,7 @@
 			<ratings critics="32" speed="49" outcome="47" />
 		</programme>
 
-		<programme id="TheRob-916a-47bf-infinityjest" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="tt0089092" rt_id="0" creator="">
+		<programme id="TheRob-916a-47bf-infinityjest" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="tt0089092" creator="">
 			<title>
 				<!-- Idee basiert auf Unendlicher Spaß, Das Buch musste umgesetzt werden -->
 				<de>Der perfekte, unendlich spaßige Film</de>
@@ -384,7 +384,7 @@
 				<member index="1" function="2">TheRob-celebritypeople-DarleenSchluessel</member>
 				<member index="2" function="2">TheRob-celebritypeople-GaryGrunt</member>
 				<member index="3" function="2">af6a5525-6858-42b2-b313-6ca3e26d3b90</member>
-				<member index="3" function="2">TheRob-celebritypeople-LarryMoldman</member>
+				<member index="4" function="2">TheRob-celebritypeople-LarryMoldman</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
 			<data country="D" year="1985" distribution="1" maingenre="14" subgenre="" flags="0" blocks="3" price_mod="1.5" />
@@ -397,7 +397,7 @@
 			</modifiers>
 		</programme>
 
-		<programme id="TheRob-1756-400d-8f9c-JoMeieischeiJodeler" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="TheRob-1756-400d-8f9c-JoMeieischeiJodeler" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Jo Mei, ei schei Jodeler</de>
 				<en>Jo Mei, a fu'ing yodeler</en>
@@ -418,7 +418,7 @@
 			<ratings critics="32" speed="9" outcome="0" />
 		</programme>
 
-		<programme id="c4be7d64-35e9-4e56-8e6e-TheRobTest06" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="c4be7d64-35e9-4e56-8e6e-TheRobTest06" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 			<title>
 				<de>Jag den Meringo</de>
 				<en>Chasing Meringo</en>
@@ -439,7 +439,7 @@
 			<ratings critics="67" speed="66" outcome="65" />
 		</programme>
 
-		<programme id="therob-programme-elefantengedaechtnis" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="therob-programme-elefantengedaechtnis" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<de>Elefantengedächtnis</de>
 				<en>An elephant memory</en>
@@ -456,7 +456,7 @@
 			<data country="D" year="1975" distribution="2" maingenre="9" subgenre="" flags="0" blocks="1" price_mod="1.00" />
 			<ratings critics="67" speed="25" outcome="0" />
 			<children>
-				<programme id="therob-programme-elefantengedaechtnis-ep101" product="5" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="therob-programme-elefantengedaechtnis-ep101" product="5" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Zahnpasta</de>
 						<en>Toothpaste</en>
@@ -467,7 +467,7 @@
 					</description>
 					<ratings critics="73" speed="24" />
 				</programme>
-				<programme id="therob-programme-elefantengedaechtnis-ep102" product="5" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="therob-programme-elefantengedaechtnis-ep102" product="5" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Limonade</de>
 						<en>Lemonade</en>
@@ -478,7 +478,7 @@
 					</description>
 					<ratings critics="65" speed="26" />
 				</programme>
-				<programme id="therob-programme-elefantengedaechtnis-ep103" product="5" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="therob-programme-elefantengedaechtnis-ep103" product="5" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Bleistifte</de>
 						<en>pencil</en>
@@ -489,7 +489,7 @@
 					</description>
 					<ratings critics="66" speed="25" />
 				</programme>
-				<programme id="therob-programme-elefantengedaechtnis-ep104" product="5" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-elefantengedaechtnis-ep104" product="5" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Moderator ohne Kontrolle</de>
 						<en>Moderator without control</en>
@@ -500,7 +500,7 @@
 					</description>
 					<ratings critics="74" speed="49" />
 				</programme>
-				<programme id="therob-programme-elefantengedaechtnis-ep105" product="5" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-elefantengedaechtnis-ep105" product="5" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Namentanzen</de>
 						<en>Dancing names</en>
@@ -514,7 +514,7 @@
 			</children>
 		</programme>
 
-		<programme id="631f722f-b5dc-4663-bd81-TheRobHist01" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="631f722f-b5dc-4663-bd81-TheRobHist01" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<de>Die Tempelritter</de>
 				<en>The Templars</en>
@@ -534,7 +534,7 @@
 			<ratings critics="75" speed="31" outcome="0" />
 		</programme>
 
-		<programme id="e61018ba-b0db-439c-a852-TheRobTest13" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="e61018ba-b0db-439c-a852-TheRobTest13" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Dudu ist die Grundidee, aber da das Setting in meinen Augen so verändert ist, dass man noch DuDu und Herbie anlegen kann, ohne das es stört, ist Baba auf fictional gesetzt. -->
 				<de>Baba der Trabbi</de>
@@ -555,7 +555,7 @@
 			<ratings critics="27" speed="34" outcome="46" />
 		</programme>
 
-		<programme id="TheRob-b0db-439c-a852-WilhelmTell" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="tt0102798" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-439c-a852-WilhelmTell" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="tt0102798" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Wilhelm Tell als Fiktion. Basiert auf keinem existierendem Film, von daher benutze ich mal den Klarnamen -->
 				<de>Wilhelm Tell</de>
@@ -576,7 +576,7 @@
 			<ratings critics="36" speed="32" outcome="31" />
 		</programme>
 
-		<programme id="TheRob-b0db-439c-a852-Janosik" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-439c-a852-Janosik" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Janosik als Fiktion. Basiert auf keinem existierendem Film, von daher benutze ich mal den Klar Namen -->
 				<de>Janosik</de>
@@ -597,7 +597,7 @@
 			<ratings critics="56" speed="42" outcome="41" />
 		</programme>
 
-		<programme id="therob-programme-trash-skandale" product="7" licence_type="3" fictional="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="therob-programme-trash-skandale" product="7" licence_type="3" fictional="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<de>Skandale</de>
 				<en>Scandals</en>
@@ -614,7 +614,7 @@
 			<data country="D" year="1979" distribution="2" maingenre="11" subgenre="6" flags="92" blocks="2" price_mod="1.00" />
 			<ratings critics="65" speed="35" outcome="60" />
 			<children>
-				<programme id="therob-programme-trash-skandale-ep101" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="therob-programme-trash-skandale-ep101" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>[1|Full] qualmt die Bude zu</de>
 						<en>[1|Full] smokes the place down</en>
@@ -625,7 +625,7 @@
 					</description>
 					<ratings critics="60" speed="30" />
 				</programme>
-				<programme id="therob-programme-trash-skandale-ep102" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-trash-skandale-ep102" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>[1|Full] beleidigt die Interviewerin</de>
 						<en>[1|Full] insults the interviewer</en>
@@ -636,7 +636,7 @@
 					</description>
 					<ratings critics="65" speed="35" />
 				</programme>
-				<programme id="therob-programme-trash-skandale-ep103" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-trash-skandale-ep103" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>[1|Full] im Dschungel</de>
 						<en>[1|Full] in the jungle</en>
@@ -650,7 +650,7 @@
 			</children>
 		</programme>
 
-		<programme id="therob-programme-adv-Sinbadsreisen" product="7" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="therob-programme-adv-Sinbadsreisen" product="7" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<!-- Abteuerserie  -->
 			<title>
 				<de>Sinbads Reisen</de>
@@ -669,7 +669,7 @@
 			<data country="JPN" year="1978" distribution="2" maingenre="1" subgenre="2" flags="0" blocks="1" price_mod="1.00" />
 			<ratings critics="38" speed="43" outcome="0" />
 			<children>
-				<programme id="therob-programme-adv-sinbadsreisen-ep101" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="therob-programme-adv-sinbadsreisen-ep101" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Sinbad und die Insel</de>
 						<en>Sinbad and the isle</en>
@@ -680,7 +680,7 @@
 					</description>
 					<ratings critics="34" speed="41" />
 				</programme>
-				<programme id="therob-programme-adv-sinbadsreisen-ep102" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-adv-sinbadsreisen-ep102" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Sinbad und das Diamantental</de>
 						<en>Sinbad and the diamant valley</en>
@@ -691,7 +691,7 @@
 					</description>
 					<ratings critics="34" speed="42" />
 				</programme>
-				<programme id="therob-programme-adv-sinbadsreisen-ep103" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-adv-sinbadsreisen-ep103" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Sinbad und der Riese</de>
 						<en>Sinbad and the giant</en>
@@ -702,7 +702,7 @@
 					</description>
 					<ratings critics="37" speed="47" />
 				</programme>
-				<programme id="therob-programme-adv-sinbadsreisen-ep104" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-adv-sinbadsreisen-ep104" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Sinbad heiratet</de>
 						<en>The marriage of Sinbad</en>
@@ -713,7 +713,7 @@
 					</description>
 					<ratings critics="35" speed="29" />
 				</programme>
-				<programme id="therob-programme-adv-sinbadreisen-ep105" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-adv-sinbadreisen-ep105" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Sinbad und der Riesenvogel</de>
 						<en>Sinbad and the giant bird</en>
@@ -724,7 +724,7 @@
 					</description>
 					<ratings critics="33" speed="51" />
 				</programme>
-				<programme id="therob-programme-adv-sinbadreisen-ep106" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-adv-sinbadreisen-ep106" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Sinbad und das karge Land</de>
 						<en>Sinbad and the desert land</en>
@@ -735,7 +735,7 @@
 					</description>
 					<ratings critics="42" speed="39" />
 				</programme>
-				<programme id="therob-programme-adv-sinbadsreisen-ep107" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-adv-sinbadsreisen-ep107" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Sinbad geht in Rente</de>
 						<en>Sinbads retires</en>
@@ -750,7 +750,7 @@
 			</children>
 		</programme>
 
-		<programme id="therob-programme-mng-firmengruendungen" product="7" licence_type="3" fictional="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="therob-programme-mng-firmengruendungen" product="7" licence_type="3" fictional="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<!-- Zielgruppe Manager, geflagt als Kultur -->
 			<title>
 				<de>Firmengründungen</de>
@@ -768,7 +768,7 @@
 			<data country="D" year="1984" distribution="2" maingenre="300" subgenre="4" flags="4" blocks="2" price_mod="1.00" />
 			<ratings critics="45" speed="23" outcome="0" />
 			<children>
-				<programme id="therob-programme-mng-firmengruendungen-ep101" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="therob-programme-mng-firmengruendungen-ep101" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Firmenstudio in Nollywood</de>
 						<en>Movie studio in Nollywood</en>
@@ -779,7 +779,7 @@
 					</description>
 					<ratings critics="43" speed="22" />
 				</programme>
-				<programme id="therob-programme-mng-firmengruendungen-epp102" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-mng-firmengruendungen-epp102" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Erotikshop im Jemen</de>
 						<en>Erotic shop in Yemen</en>
@@ -790,7 +790,7 @@
 					</description>
 					<ratings critics="48" speed="27" />
 				</programme>
-				<programme id="therob-programme-mng-firmengruendungen-ep103" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-mng-firmengruendungen-ep103" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Kühlschrankfachladen in Grönland</de>
 						<en>Refrigerators in Iceland</en>
@@ -804,7 +804,7 @@
 			</children>
 		</programme>
 
-		<programme id="b528cab3-ec3d-43fc-TheRobCallInTest01" product="3" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="b528cab3-ec3d-43fc-TheRobCallInTest01" product="3" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<de>Schach gegen den Meister</de>
 				<en>Chess against the masters</en>
@@ -825,7 +825,7 @@
 				<modifier name="price" value="1.2" />
 			</modifiers>
 			<children>
-				<programme id="8aedcc43-c63d-4ab3-TheRobCallInTestEp101" product="3" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="8aedcc43-c63d-4ab3-TheRobCallInTestEp101" product="3" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>2 Türme, 3 Bauern</de>
 						<en>2 rooks, 3 pawns</en>
@@ -836,7 +836,7 @@
 					</description>
 					<ratings critics="30" speed="4" />
 				</programme>
-				<programme id="a2ac67b0-6689-4c50-9489-TheRobCallInTestEp102" product="3" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="a2ac67b0-6689-4c50-9489-TheRobCallInTestEp102" product="3" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Springer und Pferde</de>
 						<en>Knights and bishops</en>
@@ -847,7 +847,7 @@
 					</description>
 					<ratings critics="32" speed="4" />
 				</programme>
-				<programme id="82a377c0-4950-40cb-9813-TheRobCallInTestEp103" product="3" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="82a377c0-4950-40cb-9813-TheRobCallInTestEp103" product="3" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Nur noch Bauern</de>
 						<en>Only pawns left</en>
@@ -858,7 +858,7 @@
 					</description>
 					<ratings critics="24" speed="4" />
 				</programme>
-				<programme id="81800e30-c387-4a29-9c21-TheRobCallInTestEp104" product="3" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="81800e30-c387-4a29-9c21-TheRobCallInTestEp104" product="3" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Damen</de>
 						<en>Queens</en>
@@ -872,7 +872,7 @@
 			</children>
 		</programme>
 
-		<programme id="TheRob-b5dc-4663-bd81-DerOsten" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b5dc-4663-bd81-DerOsten" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<!-- Zielgruppe Rentner -->
 			<title>
 				<de>Der Osten - der wahre Horror</de>
@@ -891,7 +891,7 @@
 			<ratings critics="25" speed="40" outcome="0" />
 		</programme>
 
-		<programme id="TheRob-b5dc-4663-bd81-DerWesten" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b5dc-4663-bd81-DerWesten" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<!-- Zielgruppe Rentner -->
 			<title>
 				<de>Der Westen - der wahre Horror</de>
@@ -910,7 +910,7 @@
 			<ratings critics="25" speed="40" outcome="0" />
 		</programme>
 
-		<programme id="TheRob-CallIn-TopundTeuer-KurvenderWelt" product="7" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-CallIn-TopundTeuer-KurvenderWelt" product="7" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<de>Kurven der Welt - Erkenne sie alle</de>
 				<en>curves of the world - guess them all</en>
@@ -921,7 +921,7 @@
 			</description>
 			<staff>
 				<member index="0" function="1">Per_custom_Freddy_42</member>
-				<member index="0" function="2">Per_custom_Freddy_45</member>
+				<member index="1" function="2">Per_custom_Freddy_45</member>
 			</staff>
 			<groups target_groups="256" pro_pressure_groups="0" contra_pressure_groups="0" />
 			<data country="SWE" year="2006" distribution="2" maingenre="8" subgenre="" flags="192" blocks="2" price_mod="1.00" />
@@ -933,7 +933,7 @@
 				<modifier name="price" value="0.4" />
 			</modifiers>
 			<children>
-				<programme id="TheRob-CallIn-TopundTeuer-KurvenderWelt01" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="TheRob-CallIn-TopundTeuer-KurvenderWelt01" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Jamaika</de>
 						<en>Jamaica</en>
@@ -944,7 +944,7 @@
 					</description>
 					<ratings critics="20" speed="38" />
 				</programme>
-				<programme id="TheRob-CallIn-TopundTeuer-KurvenderWelt02" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="TheRob-CallIn-TopundTeuer-KurvenderWelt02" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Kambodscha</de>
 						<en>Cambodia</en>
@@ -955,7 +955,7 @@
 					</description>
 					<ratings critics="29" speed="33" />
 				</programme>
-				<programme id="TheRob-CallIn-TopundTeuer-KurvenderWelt03" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="TheRob-CallIn-TopundTeuer-KurvenderWelt03" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Bulgarien</de>
 						<en>Bulgaria</en>
@@ -966,7 +966,7 @@
 					</description>
 					<ratings critics="21" speed="43" />
 				</programme>
-				<programme id="TheRob-CallIn-TopundTeuer-KurvenderWelt04" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="TheRob-CallIn-TopundTeuer-KurvenderWelt04" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<!-- Zielgruppe Damen -->
 						<de>Tunesien</de>
@@ -982,7 +982,7 @@
 			</children>
 		</programme>
 
-		<programme id="TheRob-99bf-Rep-KampfderPlaneten-" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-99bf-Rep-KampfderPlaneten-" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Reportage, Fiktion die auf einer wahren Begebenheit basiert, geflagt als culture und cult. Bezieht sich auf die Radioshow Krieg der Welten von Orson Welles -->
 				<de>Kampf der Planeten - die wahre Geschichte</de>
@@ -1002,7 +1002,7 @@
 			<ratings critics="79" speed="45" outcome="0" />
 		</programme>
 
-		<programme id="therob-programme-HaFr-Marmeladenselbermachen" product="7" licence_type="3" fictional="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="therob-programme-HaFr-Marmeladenselbermachen" product="7" licence_type="3" fictional="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Zielgruppe Hausfrauen -->
 				<de>Marmeladen selber machen</de>
@@ -1020,7 +1020,7 @@
 			<data country="Aut" year="1951" distribution="2" maingenre="9" subgenre="" flags="0" blocks="2" price_mod="1.00" />
 			<ratings critics="35" speed="9" outcome="0" />
 			<children>
-				<programme id="therob-programme-HaFr-Marmeladenselbermachen-ep101" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="therob-programme-HaFr-Marmeladenselbermachen-ep101" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Erdbeermarmelade</de>
 						<en>Strawberry jelly</en>
@@ -1031,7 +1031,7 @@
 					</description>
 					<ratings critics="34" speed="10" />
 				</programme>
-				<programme id="therob-programme-HaFr-Marmeladenselbermachen-ep102" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-HaFr-Marmeladenselbermachen-ep102" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Pflaumenmarmelade</de>
 						<en>Plum jelly</en>
@@ -1042,7 +1042,7 @@
 					</description>
 					<ratings critics="35" speed="9" />
 				</programme>
-				<programme id="therob-programme-HaFr-Marmeladenselbermachen-ep103" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-HaFr-Marmeladenselbermachen-ep103" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Kirschmarmelade</de>
 						<en>Cherry jelly</en>
@@ -1056,7 +1056,7 @@
 			</children>
 		</programme>
 
-		<programme id="TheRob-b0db-myst-Wardaswahr" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-myst-Wardaswahr" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- War das wahr? Fictional, Mystery -->
 				<de>War das wahr?</de>
@@ -1076,7 +1076,7 @@
 			<ratings critics="49" speed="37" outcome="12" />
 		</programme>
 
-		<programme id="TheRob-b0db-cri-Derschwarzmarkt" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-cri-Derschwarzmarkt" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Der Schwarzmarkt, Fictional, Krimi -->
 				<de>Der Schwarzmarkt</de>
@@ -1096,7 +1096,7 @@
 			<ratings critics="46" speed="43" outcome="21" />
 		</programme>
 
-		<programme id="TheRob-b0db-cri-Werwares" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-cri-Werwares" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Wer war es?, Fictional, Krimi -->
 				<de>Wer war es?</de>
@@ -1116,7 +1116,7 @@
 			<ratings critics="6" speed="32" outcome="7" />
 		</programme>
 
-		<programme id="TheRob-b0db-dok-UeberlebenwirdieLAF" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b0db-dok-UeberlebenwirdieLAF" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Überleben wir die LAF?, Fictional, Dokumentation -->
 				<de>Überleben wir die L.A.F.?</de>
@@ -1129,14 +1129,14 @@
 			<staff>
 				<member index="0" function="1">TheRob-TowerTV-RednackRoot</member>
 				<member index="1" function="8">Per_custom_Freddy_631</member>
-				<member index="1" function="128">Per_custom_Freddy_404</member>
+				<member index="2" function="128">Per_custom_Freddy_404</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
 			<data country="D" year="1971" distribution="2" maingenre="6" subgenre="300" flags="16" blocks="1" price_mod="1.00" />
 			<ratings critics="7" speed="16" outcome="0" />
 		</programme>
 
-		<programme id="therob-programme-GrafRuccola01" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="therob-programme-GrafRuccola01" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Kinderserie, geflagt als Animation -->
 				<de>Graf Ruccola und das Gemüse</de>
@@ -1155,7 +1155,7 @@
 			<data country="F" year="1971" distribution="2" maingenre="3" subgenre="5" flags="2" blocks="1" price_mod="1.00" />
 			<ratings critics="54" speed="34" outcome="0" />
 			<children>
-				<programme id="therob-programme-GrafRuccola-ep101" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="therob-programme-GrafRuccola-ep101" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Graf Ruccola trifft Spargel</de>
 						<en>Count Ruccola meets asparagus</en>
@@ -1166,7 +1166,7 @@
 					</description>
 					<ratings critics="57" speed="35" />
 				</programme>
-				<programme id="therob-programme-GrafRuccola-ep102" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="therob-programme-GrafRuccola-ep102" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Graf Ruccola trifft Spinat</de>
 						<en>Count Ruccola meets spinach</en>
@@ -1177,7 +1177,7 @@
 					</description>
 					<ratings critics="54" speed="35" />
 				</programme>
-				<programme id="therob-programme-GrafRuccola-ep103" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="therob-programme-GrafRuccola-ep103" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Graf Ruccola trifft Blumenkohl</de>
 						<en>Count Ruccola meets cauliflower</en>
@@ -1188,7 +1188,7 @@
 					</description>
 					<ratings critics="50" speed="30" />
 				</programme>
-				<programme id="therob-programme-GrafRuccola-ep104" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-GrafRuccola-ep104" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Graf Ruccola trifft Rosenkohl</de>
 						<en>Count Ruccola meets Brussels sprouts</en>
@@ -1199,7 +1199,7 @@
 					</description>
 					<ratings critics="49" speed="34" />
 				</programme>
-				<programme id="therob-programme-GrafRuccola-ep105" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-GrafRuccola-ep105" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Graf Ruccola trifft Bohnen</de>
 						<en>Count Ruccola meets beans</en>
@@ -1213,7 +1213,7 @@
 			</children>
 		</programme>
 
-		<programme id="therob-programme-GrafRuccola02" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="therob-programme-GrafRuccola02" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Kinderserie, geflagt als Animation -->
 				<de>Graf Ruccola und das Obst</de>
@@ -1232,7 +1232,7 @@
 			<data country="F" year="1989" distribution="2" maingenre="3" subgenre="5" flags="2" blocks="1" price_mod="1.00" />
 			<ratings critics="47" speed="42" outcome="0" />
 			<children>
-				<programme id="therob-programme-GrafRuccola-ep201" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="therob-programme-GrafRuccola-ep201" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Graf Ruccola trifft Kirschen</de>
 						<en>Count Ruccola meets cherries</en>
@@ -1243,7 +1243,7 @@
 					</description>
 					<ratings critics="49" speed="45" />
 				</programme>
-				<programme id="therob-programme-GrafRuccola-ep202" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="therob-programme-GrafRuccola-ep202" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Graf Ruccola trifft Birnen</de>
 						<en>Count Ruccola meets pears</en>
@@ -1254,7 +1254,7 @@
 					</description>
 					<ratings critics="45" speed="40" />
 				</programme>
-				<programme id="therob-programme-GrafRuccola-ep203" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="therob-programme-GrafRuccola-ep203" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Graf Ruccola trifft Erdbeeren</de>
 						<en>Count Ruccola meets strawberries</en>
@@ -1265,7 +1265,7 @@
 					</description>
 					<ratings critics="46" speed="37" />
 				</programme>
-				<programme id="therob-programme-GrafRuccola-ep204" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-GrafRuccola-ep204" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Graf Ruccola trifft Äpfel</de>
 						<en>Count Ruccola meets apples</en>
@@ -1276,7 +1276,7 @@
 					</description>
 					<ratings critics="47" speed="39" />
 				</programme>
-				<programme id="therob-programme-GrafRuccola-ep205" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-GrafRuccola-ep205" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Graf Ruccola trifft Orangen</de>
 						<en>Count Ruccola meets oranges</en>
@@ -1287,7 +1287,7 @@
 					</description>
 					<ratings critics="45" speed="41" />
 				</programme>
-				 <programme id="therob-programme-GrafRuccola-ep206" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				 <programme id="therob-programme-GrafRuccola-ep206" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Graf Ruccola trifft Himbeeren</de>
 						<en>Count Ruccola meets raspberries</en>
@@ -1298,7 +1298,7 @@
 					</description>
 					<ratings critics="42" speed="44" />
 				</programme>
-				 <programme id="therob-programme-GrafRuccola-ep207" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				 <programme id="therob-programme-GrafRuccola-ep207" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Graf Ruccola trifft Trauben</de>
 						<en>Count Ruccola meets grapes</en>
@@ -1309,7 +1309,7 @@
 					</description>
 					<ratings critics="45" speed="41" />
 				</programme>
-				<programme id="therob-programme-GrafRuccola-ep208" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-GrafRuccola-ep208" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Graf Ruccola trifft Brombeeren</de>
 						<en>Count Ruccola meets blackberries</en>
@@ -1320,7 +1320,7 @@
 					</description>
 					<ratings critics="50" speed="45" />
 				</programme>
-				<programme id="therob-programme-GrafRuccola-ep209" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-GrafRuccola-ep209" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Graf Ruccola trifft Bananen</de>
 						<en>Count Ruccola meets bananas</en>
@@ -1334,7 +1334,7 @@
 			</children>
 		</programme>
 
-		<programme id="therob-programme-GrafRuccola03" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="therob-programme-GrafRuccola03" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Serie für Jugendliche, geflagt als Animation -->
 				<de>Graf Ruccola und die Nachtschattengewächse</de>
@@ -1353,7 +1353,7 @@
 			<data country="F" year="2001" distribution="2" maingenre="3" subgenre="5" flags="2" blocks="1" price_mod="1.00" />
 			<ratings critics="56" speed="38" outcome="0" />
 			<children>
-				<programme id="therob-programme-GrafRuccola-ep301" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="therob-programme-GrafRuccola-ep301" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Graf Ruccola und die Tomate</de>
 						<en>Count Ruccola and the tomato</en>
@@ -1364,7 +1364,7 @@
 					</description>
 					<ratings critics="59" speed="39" />
 				</programme>
-				<programme id="therob-programme-GrafRuccola-ep302" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="therob-programme-GrafRuccola-ep302" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Graf Ruccola und die Kartoffel</de>
 						<en>Count Ruccola and the potato</en>
@@ -1375,7 +1375,7 @@
 					</description>
 					<ratings critics="56" speed="39" />
 				</programme>
-				<programme id="therob-programme-GrafRuccola-ep303" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="therob-programme-GrafRuccola-ep303" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Graf Ruccola und die Aubergine</de>
 						<en>Count Ruccola and the aubergine</en>
@@ -1386,7 +1386,7 @@
 					</description>
 					<ratings critics="52" speed="34" />
 				</programme>
-				<programme id="therob-programme-GrafRuccola-ep304" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-GrafRuccola-ep304" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Graf Ruccola und die Paprika</de>
 						<en>Count Ruccola and the bell peppers</en>
@@ -1397,7 +1397,7 @@
 					</description>
 					<ratings critics="51" speed="38" />
 				</programme>
-				<programme id="therob-programme-GrafRuccola-ep305" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-GrafRuccola-ep305" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Graf Ruccola und der Stechapfel</de>
 						<en>Count Ruccola and the jimsonweed</en>
@@ -1411,7 +1411,7 @@
 			</children>
 		</programme>
 
-		<programme id="TheRob-serie-crime-DieZwillinge" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-crime-DieZwillinge" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Die Zwillinge, Crime mit Flag Mystery, letzte Folge mit subgenre Drama und Comedy -->
 				<de>Die Zwillinge</de>
@@ -1430,7 +1430,7 @@
 			<data country="DDR" year="1980" distribution="2" maingenre="4" subgenre="14" flags="0" blocks="1" price_mod="1.00" />
 			<ratings critics="40" speed="40" outcome="" />
 			<children>
-				<programme id="TheRob-serie-DieZwillinge-Ep001" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DieZwillinge-Ep001" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Rolle jagt den Ladendieb</de>
 						<en>Rolle chases the shoplifter</en>
@@ -1441,7 +1441,7 @@
 					</description>
 					<ratings critics="50" speed="30" />
 				</programme>
-				<programme id="TheRob-serie-DieZwillinge-Ep002" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DieZwillinge-Ep002" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Ralle wird die Ware nicht los</de>
 						<en>Ralle could not sell the hot stuff</en>
@@ -1452,7 +1452,7 @@
 					</description>
 					<ratings critics="30" speed="50" />
 				</programme>
-				<programme id="TheRob-serie-DieZwillinge-Ep003" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DieZwillinge-Ep003" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Rolle schöpft Verdacht</de>
 						<en>Rolle got a suspicion</en>
@@ -1463,7 +1463,7 @@
 					</description>
 					<ratings critics="42" speed="38" />
 				</programme>
-				<programme id="TheRob-serie-DieZwillinge-Ep004" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DieZwillinge-Ep004" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Ralle schöpft Verdacht</de>
 						<en>Ralle got a suspicion</en>
@@ -1474,7 +1474,7 @@
 					</description>
 					<ratings critics="38" speed="42" />
 				</programme>
-				<programme id="TheRob-serie-DieZwillinge-Ep005" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DieZwillinge-Ep005" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Das große Kennenlernen</de>
 						<en>The big get to know each other</en>
@@ -1489,7 +1489,7 @@
 			</children>
 		</programme>
 
-		<programme id="TheRob-serie-myst-DasUnbekannte" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-myst-DasUnbekannte" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Das Unbekannte, Mystery und Subgenre Horror plus FSK18 -->
 				<de>Das Unbekannte</de>
@@ -1508,7 +1508,7 @@
 			<data country="USA" year="1940" distribution="2" maingenre="14" subgenre="12" flags="64" blocks="1" price_mod="1.00" />
 			<ratings critics="65" speed="40" outcome="" />
 			<children>
-				<programme id="TheRob-serie-DasUnbekannte-Ep001" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DasUnbekannte-Ep001" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Ich klopfe, wenn Du schläfst!</de>
 						<en>I will knock, when you sleep!</en>
@@ -1519,7 +1519,7 @@
 					</description>
 					<ratings critics="67" speed="42" />
 				</programme>
-				<programme id="TheRob-serie-DasUnbekannte-Ep002" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DasUnbekannte-Ep002" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Der See</de>
 						<en>The Lake</en>
@@ -1530,7 +1530,7 @@
 					</description>
 					<ratings critics="65" speed="38" />
 				</programme>
-				<programme id="TheRob-serie-DasUnbekannte-Ep003" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DasUnbekannte-Ep003" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Der fremde Planet</de>
 						<en>Unknown planet</en>
@@ -1541,7 +1541,7 @@
 					</description>
 					<ratings critics="61" speed="44" />
 				</programme>
-				<programme id="TheRob-serie-DasUbekannte-Ep004" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DasUbekannte-Ep004" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Die unsichtbare Bedrohung</de>
 						<en>The unvisible threat</en>
@@ -1555,7 +1555,7 @@
 			</children>
 		</programme>
 
-		<programme id="TheRob-1756-Musik-Show-MusikderBerge" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-1756-Musik-Show-MusikderBerge" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 				<!-- Musik der Berge, Musikshow 102, Zielgruppe Kinder -->
 			<title>
 				<de>Musik der Berge</de>
@@ -1576,7 +1576,7 @@
 			<ratings critics="25" speed="12" outcome="0" />
 		</programme>
 
-		<programme id="TheRob-1756-Polit-Show-WasistSache" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="TheRob-1756-Polit-Show-WasistSache" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 				<!-- Was ist Sache, Politshow 102, Zielgruppe Arbeitnehmer -->
 			<title>
 				<de>Was ist Sache</de>
@@ -1596,7 +1596,7 @@
 			<ratings critics="35" speed="21" outcome="0" />
 		</programme>
 
-		<programme id="TheRob-1756-Yellow-Press-DasLebenderGrace" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="TheRob-1756-Yellow-Press-DasLebenderGrace" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 				<!-- Das Leben der Grace, YellowPress 301, Zielgruppe Frauen -->
 			<title>
 				<de>Das Leben der [2|Full]</de>
@@ -1616,7 +1616,7 @@
 			<ratings critics="35" speed="31" outcome="0" />
 		</programme>
 
-		<programme id="TheRob-1756-polit-event-AnalysederReden" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="TheRob-1756-polit-event-AnalysederReden" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 				<!-- Analyse der Reden, Polit Event 201, Zielgruppe Manager -->
 			<title>
 				<de>Analyse der Reden</de>
@@ -1637,7 +1637,7 @@
 			<ratings critics="65" speed="21" outcome="0" />
 		</programme>
 
-		<programme id="TheRob-serie-Sonst-TrendfuerMaenner" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="tt0192937" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-Sonst-TrendfuerMaenner" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="tt0192937" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Trend fuer Maenner, Sostiges -->
 				<de>Trend für Männer</de>
@@ -1655,7 +1655,7 @@
 			<data country="D" year="1952" distribution="2" maingenre="0" subgenre="" flags="0" blocks="1" price_mod="1.00" />
 			<ratings critics="28" speed="44" outcome="" />
 			<children>
-				<programme id="TheRob-serie-TrendfuerMaenner-Ep001" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-TrendfuerMaenner-Ep001" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Urangrill</de>
 						<en>Uranium barbecue</en>
@@ -1666,7 +1666,7 @@
 					</description>
 					<ratings critics="29" speed="43" />
 				</programme>
-				<programme id="TheRob-serie-TrendfuerMaenner-Ep002" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-TrendfuerMaenner-Ep002" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>0 auf 1000 kmh in 3 Sekunden</de>
 						<en>0 on 764 mph in 3 seconds</en>
@@ -1677,7 +1677,7 @@
 					</description>
 					<ratings critics="26" speed="43" />
 				</programme>
-				<programme id="TheRob-serie-TrendfuerMaenner-Ep003" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-TrendfuerMaenner-Ep003" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Kellerbunker</de>
 						<en>Cellar shelter</en>
@@ -1688,7 +1688,7 @@
 					</description>
 					<ratings critics="29" speed="46" />
 				</programme>
-				<programme id="TheRob-serie-TrendfuerMaenner-Ep004" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-TrendfuerMaenner-Ep004" product="7" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Frittenbike</de>
 						<en>French fries bike</en>
@@ -1702,7 +1702,7 @@
 			</children>
 		</programme>
 
-		<programme id="therob-programme-ser-RonnyunddasBytekehrenzurueck" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="therob-programme-ser-RonnyunddasBytekehrenzurueck" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 				<!-- Serie Horror-->
 			<title>
 				<de>Die Rückkehr von Ronny und das Byte</de>
@@ -1721,7 +1721,7 @@
 			<data country="SCO" year="1979" distribution="2" maingenre="12" subgenre="" flags="64" blocks="2" price_mod="1.00" />
 			<ratings critics="17" speed="55" outcome="0" />
 			<children>
-				<programme id="therob-programme-ser-RonnyunddasBytekehrenzurueck-ep01" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="therob-programme-ser-RonnyunddasBytekehrenzurueck-ep01" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Das Byte beißt den Wärter</de>
 						<en>The Byte bites the guardian</en>
@@ -1732,7 +1732,7 @@
 					</description>
 					<ratings critics="13" speed="59" />
 				</programme>
-				<programme id="therob-programme-ser-RonnyunddasBytekehrenzurueck-ep02" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="therob-programme-ser-RonnyunddasBytekehrenzurueck-ep02" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Ronny sucht das Fliwatüt</de>
 						<en>Ronny searches the Fliwatuet</en>
@@ -1743,7 +1743,7 @@
 					</description>
 					<ratings critics="14" speed="54" />
 				</programme>
-				<programme id="therob-programme-ser-RonnyunddasBytekehrenzurueck-ep03" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="therob-programme-ser-RonnyunddasBytekehrenzurueck-ep03" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Die Bank</de>
 						<en>The bank</en>
@@ -1754,7 +1754,7 @@
 					</description>
 					<ratings critics="17" speed="47" />
 				</programme>
-				<programme id="therob-programme-ser-RonnyunddasBytekehrenzurueck-ep04" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-ser-RonnyunddasBytekehrenzurueck-ep04" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Vernichte das Bit</de>
 						<en>Destroy the Bit</en>
@@ -1765,7 +1765,7 @@
 					</description>
 					<ratings critics="12" speed="59" />
 				</programme>
-				<programme id="therob-programme-ser-RonnyunddasBytekehrenzurueck-ep05" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+				<programme id="therob-programme-ser-RonnyunddasBytekehrenzurueck-ep05" product="5" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
 						<de>Der Anfang</de>
 						<en>The Beginning</en>
@@ -1779,7 +1779,7 @@
 			</children>
 		</programme>
 
-		<programme id="TheRob-serie-Moumental-BestofTVTower" product="5" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-Moumental-BestofTVTower" product="5" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Best of TVTower, Show 204 Wieder gleiche Wertung für alle Folgen. -->
 				<de>Best of TVTower</de>
@@ -1797,7 +1797,7 @@
 			<data country="D" year="1980" distribution="2" maingenre="204" subgenre="" flags="8" blocks="4" price_mod="1.00" />
 			<ratings critics="89" speed="38" outcome="" />
 			<children>
-				<programme id="TheRob-serie-BestofTVTower-Ep001" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-BestofTVTower-Ep001" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Tiefsee Dinoschrecken, Banzai</de>
 						<en>Dino deep sea terror, banzai</en>
@@ -1815,7 +1815,7 @@
 					<groups target_groups="0" />
 					<data country="D" year="1980" distribution="0" maingenre="204" subgenre="" flags="8" blocks="4" price_mod="1.0" />
 				</programme>
-				<programme id="TheRob-serie-BestofTVTower-Ep002" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-BestofTVTower-Ep002" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Der Osten - der Westen</de>
 						<en>The east - the west</en>
@@ -1833,7 +1833,7 @@
 					</staff>
 					<data country="D" year="1980" distribution="0" maingenre="204" subgenre="" flags="8" blocks="4" price_mod="1.00" />
 				</programme>
-				<programme id="TheRob-serie-BestofTVTower-Ep003" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-BestofTVTower-Ep003" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Iris entdeckt die Alm</de>
 						<en>Iris explores the alp</en>
@@ -1851,7 +1851,7 @@
 					</staff>
 					<data country="D" year="1980" distribution="0" maingenre="204" subgenre="" flags="8" blocks="4" price_mod="1.00" />
 				</programme>
-				<programme id="TheRob-serie-BestofTVTower-Ep004" product="7" licence_type="2" tmdb_id="0" imdb_id="tt0072443" rt_id="0" creator="Sjaele/TheRob">
+				<programme id="TheRob-serie-BestofTVTower-Ep004" product="7" licence_type="2" tmdb_id="0" imdb_id="tt0072443" creator="Sjaele/TheRob">
 					<title>
 						<de>Picknick am Wegesrand</de>
 						<en>Picknick on a sidewalk</en>
@@ -1877,7 +1877,7 @@
 			</children>
 		</programme>
 
-		<programme id="TheRob-dda6-mov-ero-LolitasimHeu" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-dda6-mov-ero-LolitasimHeu" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<de>Lolitas im Heu</de>
 				<en>Lolitas in the hay</en>
@@ -1896,7 +1896,7 @@
 			<ratings critics="29" speed="49" outcome="89" />
 		</programme>
 
-		<programme id="TheRob-serie-DieStraendederWelt" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-DieStraendederWelt" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Die Strände der Welt, fictional, Dok mit Sub Erotik, keine individuellen Werte -->
 				<de>Die Strände der Welt</de>
@@ -1914,7 +1914,7 @@
 			<data country="CSSR" year="1980" distribution="2" maingenre="6" subgenre="8" flags="0" blocks="1" price_mod="1.00" />
 			<ratings critics="29" speed="59" outcome="" />
 			<children>
-				<programme id="TheRob-serie-DieStraendederWelt-Episode001" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DieStraendederWelt-Episode001" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Walvis Bucht</de>
 						<en>Walvis Bay</en>
@@ -1924,7 +1924,7 @@
 						<en>Namibia. Vera hops happily around the beach. The sand and animals are shown. And you could also learn a little bit about the country.</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-DieStraendederWelt-Episode002" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DieStraendederWelt-Episode002" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Oak Beach</de>
 						<en>Oak beach</en>
@@ -1934,7 +1934,7 @@
 						<en>Australia with direct view on the Great Barrier Reef. Vera hops happily around the beach. The sand and animals are shown. And you could also learn a little bit about the country.</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-DieStraendederWelt-Episode003" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DieStraendederWelt-Episode003" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Vallvik</de>
 						<en>Vallvik</en>
@@ -1944,7 +1944,7 @@
 						<en>Sweden. Should anybody tell the moderater, that everybody sees clearly, she is freezing? Vera hops happily around the beach. The sand and animals are shown. And you could also learn a little bit about the country.</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-DieStraendederWelt-Episode004" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DieStraendederWelt-Episode004" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Playa Corcovado</de>
 						<en>Playa Corcovador</en>
@@ -1954,7 +1954,7 @@
 						<en>Costa Rica. Vera hops happily around the beach. The sand and animals are shown. And you could also learn a little bit about the country.</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-DieStraendederWelt-Episode005" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DieStraendederWelt-Episode005" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Koh Thas</de>
 						<en>Koh Thas</en>
@@ -1964,7 +1964,7 @@
 						<en>Cambodia. Who's holding coconuts? Vera hops happily around the beach. The sand and animals are shown. And you could also learn a little bit about the country.</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-DieStraendederWelt-Episode006" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-DieStraendederWelt-Episode006" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Vyshka</de>
 						<en>Vyshka</en>
@@ -1977,7 +1977,7 @@
 			</children>
 		</programme>
 
-		<programme id="TheRob-serie-Wirstellenvor" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-Wirstellenvor" product="5" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Wir stellen vor, Music show -->
 				<de>Wir stellen vor</de>
@@ -1995,7 +1995,7 @@
 			<data country="I" year="1959" distribution="2" maingenre="102" subgenre="" flags="0" blocks="1" price_mod="1.00" />
 			<ratings critics="30" speed="59" outcome="" />
 			<children>
-				<programme id="TheRob-serie-Wirstellenvor-Episode001" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-Wirstellenvor-Episode001" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Buddy Holly</de>
 						<en>Buddy Holly</en>
@@ -2006,7 +2006,7 @@
 					</description>
 					<ratings critics="41" speed="59" />
 				</programme>
-				<programme id="TheRob-serie-Wirstellenvor-Episode002" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-Wirstellenvor-Episode002" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Ritchie Valens</de>
 						<en>Ritchie Valens</en>
@@ -2017,7 +2017,7 @@
 					</description>
 					<ratings critics="28" speed="59" />
 				</programme>
-				<programme id="TheRob-serie-Wirstellenvor-Episode003" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-Wirstellenvor-Episode003" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Monotones</de>
 						<en>Monotones</en>
@@ -2028,7 +2028,7 @@
 					</description>
 					<ratings critics="28" speed="59" />
 				</programme>
-				<programme id="TheRob-serie-Wirstellenvor-Episode004" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-Wirstellenvor-Episode004" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Little Richard</de>
 						<en>Little Richard</en>
@@ -2039,7 +2039,7 @@
 					</description>
 					<ratings critics="30" speed="58" />
 				</programme>
-				<programme id="TheRob-serie-Wirstellenvor-Episode005" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-Wirstellenvor-Episode005" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Eddie Cochran</de>
 						<en>Eddie Cochran</en>
@@ -2050,7 +2050,7 @@
 					</description>
 					<ratings critics="27" speed="60" />
 				</programme>
-				<programme id="TheRob-serie-Wirstellenvor-Episode006" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-Wirstellenvor-Episode006" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Chuck Berry</de>
 						<en>Chuck Berry</en>
@@ -2061,7 +2061,7 @@
 					</description>
 					<ratings critics="32" speed="59" />
 				</programme>
-				<programme id="TheRob-serie-Wirstellenvor-Episode007" product="7" licence_type="2" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-Wirstellenvor-Episode007" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Elvis Presley</de>
 						<en>Elvis Presley</en>
@@ -2075,7 +2075,7 @@
 			</children>
 		</programme>
 
-		<programme id="TheRob-b5dc-4663-hist-DieWikinger" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-b5dc-4663-hist-DieWikinger" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<de>Die Wikinger</de>
 				<en>The Vikings</en>
@@ -2096,7 +2096,7 @@
 		</programme>
 
 		<!--
-		<programme id="TheRob-Mon-TvTower-EinmonumentalerVersuch" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="8751" created_by="TheRob">
+		<programme id="TheRob-Mon-TvTower-EinmonumentalerVersuch" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<de>Ein Monumentaler Versuch</de>
 				<en>A monumental Try</en>
@@ -2118,7 +2118,7 @@
 		</programme>
 		-->
 
-		<programme id="TheRob-1757-Polit-Show-UndJetzt?" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" rt_id="0" creator="">
+		<programme id="TheRob-1757-Polit-Show-UndJetzt?" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="">
 				<!-- Und Jetzt?, Politshow 102, Zielgruppe Arbeitnehmer -->
 			<title>
 				<de>Und Jetzt?</de>
@@ -3111,4 +3111,4 @@
 			<speed min="5" max="20" slope="12" />
 		</scripttemplate>
 	</scripttemplates>
-</tvgdb>
+</tvtdb>

--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -463,15 +463,6 @@ Type TDatabaseLoader
 				person.SetPersonalityData( new TPersonPersonalityData.CopyFromBase( person.GetPersonalityData() ) )
 				pd = TPersonPersonalityData(person.GetPersonalityData())
 			EndIf
-		
-			'=== IMAGES ===
-			Local nodeImages:TxmlNode = xml.FindChild(node, "images")
-			data = New TData
-			'contains custom fictional overriding the base one
-			xml.LoadValuesToData(nodeImages, data, [..
-				"face_code" ..
-			])
-			person.faceCode = data.GetString("face_code", person.faceCode)
 
 
 			'=== DETAILS ===
@@ -686,15 +677,6 @@ Type TDatabaseLoader
 		EndIf
 
 
-
-		'=== CONDITIONS ===
-		Local nodeConditions:TxmlNode = xml.FindChild(node, "conditions")
-		data = New TData
-		xml.LoadValuesToData(nodeConditions, data, [..
-			"year_range_from", "year_range_to" ..
-		])
-		newsEventTemplate.availableYearRangeFrom = data.GetInt("year_range_from", newsEventTemplate.availableYearRangeFrom)
-		newsEventTemplate.availableYearRangeTo = data.GetInt("year_range_to", newsEventTemplate.availableYearRangeTo)
 
 		'=== AVAILABILITY ===
 		xml.LoadValuesToData(xml.FindChild(node, "availability"), data, [..
@@ -1244,7 +1226,7 @@ Type TDatabaseLoader
 		Local timeFields:String[] = [..
 			"year", "year_relative", "year_relative_min", "year_relative_max", ..
 			"day", "day_random_min", "day_random_max", "day_random_slope", ..
-			"hour", "hour_random_min", "hour_random_max", "day_random_slope" ..
+			"hour", "hour_random_min", "hour_random_max", "hour_random_slope" ..
 		]
 		'try to load it from the "<data>" block
 		'(this is done to allow the old v3-"year" definition)

--- a/source/game.gamescriptexpression.bmx
+++ b/source/game.gamescriptexpression.bmx
@@ -15,6 +15,7 @@ GetGameScriptExpression().RegisterHandler("TIME_DAYSPLAYED", GameScriptExpressio
 GetGameScriptExpression().RegisterHandler("TIME_YEARSPLAYED", GameScriptExpression_Handle_Time)
 GetGameScriptExpression().RegisterHandler("TIME_DAYOFMONTH", GameScriptExpression_Handle_Time)
 GetGameScriptExpression().RegisterHandler("TIME_DAYOFYEAR", GameScriptExpression_Handle_Time)
+GetGameScriptExpression().RegisterHandler("TIME_MONTH", GameScriptExpression_Handle_Time)
 GetGameScriptExpression().RegisterHandler("TIME_ISNIGHT", GameScriptExpression_Handle_Time)
 GetGameScriptExpression().RegisterHandler("TIME_ISDAWN", GameScriptExpression_Handle_Time)
 GetGameScriptExpression().RegisterHandler("TIME_ISDAY", GameScriptExpression_Handle_Time)
@@ -61,6 +62,8 @@ Function GameScriptExpression_Handle_Time:string(variable:string, params:string[
 			return string( GetWorldTime().GetDayOfMonth() )
 		case "time_dayofyear"
 			return string( GetWorldTime().GetDayOfYear() )
+		case "time_month"
+			return string( GetWorldTime().GetMonth() )
 		case "time_isnight"
 			return string( GetWorldTime().IsNight() )
 		case "time_isdawn"


### PR DESCRIPTION
Hier schonmal vorgeschlagene Anpassungen an den News-Datenbankeinträgen. Einige Sachen dürften echte Fehler sein, andere Geschmackssache. Ich habe die Commits getrennt gelassen, so dass es leichter ist Teile der Anpassungen rauszulassen.

Die Änderungen an den Genres lassen sich im DB-Editor ganz gut prüfen (weiteres Review wäre hier auch nötig), da nun im Outline das Icon für das News-Genre angezeigt wird.

@jukey - gern auch drüberschauen; Neugenerierung beim Editor ist nötig, da es Grammatik-Änderungen gab.