### PR TITLE
Generalschlüsselaktionen

### DIFF
--- a/source/game.roomhandler.archive.bmx
+++ b/source/game.roomhandler.archive.bmx
@@ -403,22 +403,25 @@ Type RoomHandler_Archive extends TRoomHandler
 	Method onDrawRoom:int( triggerEvent:TEventBase )
 		'only draw custom elements for players room
 		local room:TRoom = TRoom(triggerEvent._sender)
-		if room.owner <> GetPlayerBaseCollection().playerID then return FALSE
+		local playerIsOwner:Int = room.owner = GetPlayerBaseCollection().playerID
+		if NOT playerIsOwner AND NOT GetCurrentPlayer().HasMasterKey() then return FALSE
 
 		programmeList.owner = room.owner
 		programmeList.Draw(TgfxProgrammelist.MODE_ARCHIVE)
-
-		'draw suitcase - make suitcase/vendor glow if needed
-		spriteSuitcase.Draw(suitcasePos.GetX(), suitcasePos.GetY())
-		If draggedGuiProgrammeLicence
-			Local oldColA:Float = GetAlpha()
-			SetBlend LightBlend
-			SetAlpha oldColA * Float(0.4 + 0.2 * Sin(Time.GetAppTimeGone() / 5))
-
+		
+		If playerIsOwner
+			'draw suitcase - make suitcase/vendor glow if needed
 			spriteSuitcase.Draw(suitcasePos.GetX(), suitcasePos.GetY())
-
-			SetAlpha(oldColA)
-			SetBlend AlphaBlend
+			If draggedGuiProgrammeLicence
+				Local oldColA:Float = GetAlpha()
+				SetBlend LightBlend
+				SetAlpha oldColA * Float(0.4 + 0.2 * Sin(Time.GetAppTimeGone() / 5))
+	
+				spriteSuitcase.Draw(suitcasePos.GetX(), suitcasePos.GetY())
+	
+				SetAlpha(oldColA)
+				SetBlend AlphaBlend
+			EndIf
 		EndIf
 
 		GUIManager.Draw( LS_archive )
@@ -453,7 +456,8 @@ Type RoomHandler_Archive extends TRoomHandler
 	Method onUpdateRoom:int( triggerEvent:TEventBase )
 		'only handle custom elements for players room
 		local room:TRoom = TRoom(triggerEvent._sender)
-		if room.owner <> GetPlayerBaseCollection().playerID then return FALSE
+		local playerIsOwner:Int = room.owner = GetPlayerBaseCollection().playerID
+		if NOT playerIsOwner AND NOT GetCurrentPlayer().HasMasterKey() then return FALSE
 
 		'open list when clicking dude
 		if not draggedGuiProgrammeLicence
@@ -486,11 +490,13 @@ Type RoomHandler_Archive extends TRoomHandler
 		If openCollectionTooltip Then openCollectionTooltip.Update()
 
 
-		'create missing gui elements for the current suitcase
-		For local licence:TProgrammeLicence = eachin GetPlayerProgrammeCollection( GetPlayerBase().playerID ).suitcaseProgrammeLicences
-			if guiListSuitcase.ContainsLicence(licence) then continue
-			guiListSuitcase.addItem( new TGuiProgrammeLicence.CreateWithLicence(licence),"-1" )
-		Next
+		If playerIsOwner
+			'create missing gui elements for the current suitcase
+			For local licence:TProgrammeLicence = eachin GetPlayerProgrammeCollection( GetPlayerBase().playerID ).suitcaseProgrammeLicences
+				if guiListSuitcase.ContainsLicence(licence) then continue
+				guiListSuitcase.addItem( new TGuiProgrammeLicence.CreateWithLicence(licence),"-1" )
+			Next
+		EndIf
 
 		'delete unused and create new gui elements
 		if haveToRefreshGuiElements then RefreshGUIElements()

--- a/source/game.roomhandler.news.bmx
+++ b/source/game.roomhandler.news.bmx
@@ -313,14 +313,14 @@ Type RoomHandler_News extends TRoomHandler
 		GUIManager.Draw( LS_newsroom )
 
 		'no further interaction for other players newsrooms
-		'local room:TRoom = TRoom( triggerEvent.GetData().get("room") )
+		local room:TRoom = TRoom( triggerEvent.GetData().get("room") )
 		'if not IsPlayersRoom(room) then return False
 
 		If PlannerToolTip Then PlannerToolTip.Render()
 		If NewsGenreTooltip then NewsGenreTooltip.Render()
 
 		'pinwall
-		If THelper.MouseIn(167,60,240,160)
+		If THelper.MouseIn(167,60,240,160) AND IsPlayersRoom(room)
 			GetGameBase().SetCursor(TGameBase.CURSOR_INTERACT)
 		EndIf
 
@@ -510,7 +510,7 @@ Type RoomHandler_News extends TRoomHandler
 
 
 		For local i:int = 0 until NewsGenreButtons.length
-			If NewsGenreButtons[i].IsHovered()
+			If NewsGenreButtons[i].IsHovered() AND IsPlayersRoom(room)
 				GetGameBase().SetCursor(TGameBase.CURSOR_INTERACT)
 				exit
 			EndIf

--- a/source/game.roomhandler.office.bmx
+++ b/source/game.roomhandler.office.bmx
@@ -193,7 +193,7 @@ Type RoomHandler_Office extends TRoomHandler
 			ElseIf THelper.MouseIn(395,210,195,65)
 				GetGameBase().SetCursor(TGameBase.CURSOR_INTERACT)
 			'stationmap
-			ElseIf THelper.MouseIn(732,45,160,170)
+			ElseIf THelper.MouseIn(732,45,160,170) AND IsPlayersRoom(room)
 				GetGameBase().SetCursor(TGameBase.CURSOR_INTERACT)
 			EndIf
 		EndIf
@@ -275,7 +275,7 @@ Type RoomHandler_Office extends TRoomHandler
 					StationsToolTip.enabled = 1
 					StationsToolTip.Hover()
 
-					If MouseManager.IsClicked(1) and not GetPlayer().GetFigure().IsChangingRoom()
+					If MouseManager.IsClicked(1) and not GetPlayer().GetFigure().IsChangingRoom() AND IsPlayersRoom(room)
 						'handled click
 						MouseManager.SetClickHandled(1)
 						ScreenCollection.GoToSubScreen("screen_office_stationmap")


### PR DESCRIPTION
Anpassungen bei Generalschlüsselbesitz: kein Zugriff auf die Karte, kein interaktiver Cursor in anderen Nachrichtenstudios, Filmstöbern in anderen Archiven.
Es gibt bei den Nachrichten allerdings noch eine optische Reaktion der Buttons wenn man draufklickt...

closes #339