### PR TITLE
DB und Zeitaufräumen

### DIFF
--- a/res/database/Default/database_news.xml
+++ b/res/database/Default/database_news.xml
@@ -1689,7 +1689,7 @@ Demonstrations are expected again this year.</en>
 				<en>Our scientists are puzzling. The prognosis: tonight a great darkness overshadows our country. The problem: It is unclear if it will ever be light again.</en>
 			</description>
 			<effects>
-				<effect trigger="happen" type="triggernews" news="920616c0-05b7-4078-a253-d070e58b7b98" time="2,1,1,7-9" />
+				<effect trigger="happen" type="triggernews" news="920616c0-05b7-4078-a253-d070e58b7b98" time="2,1,1,7,9" />
 			</effects>
 			<data genre="4" price="1.0" quality="58" />
 			<availability year_range_from="-1" year_range_to="-1" />
@@ -2310,7 +2310,7 @@ Demonstrations are expected again this year.</en>
 				<en>Soccer star Bollock is tired of Bavarian veal sausage and beer. Manager Hochness says: "Michel can leave if the transfer fee is right".</en>
 			</description>
 			<effects>
-				<effect trigger="happen" type="triggernews" news="571543da-edcb-48c5-866d-e978491be0b9" time="2,1,1,7-15" />
+				<effect trigger="happen" type="triggernews" news="571543da-edcb-48c5-866d-e978491be0b9" time="2,1,1,7,15" />
 			</effects>
 			<data genre="2" price="1.0" quality="29" />
 			<availability year_range_from="-1" year_range_to="-1" />

--- a/res/database/Default/user/jorgaeff.xml
+++ b/res/database/Default/user/jorgaeff.xml
@@ -443,7 +443,7 @@
 			<effects>
 				<!-- "übermorgen 10-16 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,2,2,10,16" news="news-jorgaeff-drops-08" />
-				<effect trigger="happen" type="modifyPersonPopularity" referenceGUID="ronny-programmeperson-bennyjameson" valueMin="-0.03" valueMax="-0.07" />
+				<effect trigger="happen" type="modifyPersonPopularity" referenceGUID="ronny-programmeperson-bennyjameson" valueMin="-0.07" valueMax="-0.03" />
 			</effects>
 		</news>
 

--- a/res/database/Default/user/kieferer.xml
+++ b/res/database/Default/user/kieferer.xml
@@ -114,7 +114,14 @@ All means are right for them.</en>
 	</scripttemplates>
 
 	<allnews>
-		<news id="news-stockexchange-generic" type="0" thread_id="news-stockexchange-thread" creator="" created_by="Kieferer">
+		<!-- flags: 1,2,4,256 - now, unique, unskippable, invisible (effect only); trigger news only-->
+		<news id="news-stockexchange-trigger" type="0" thread_id="news-stockexchange-thread" creator="" created_by="nittka">
+			<effects>
+				<effect trigger="happen" type="triggernews" time="8,0,9,11" news="news-stockexchange-generic" />
+			</effects>
+			<data genre="0" flags="263" happen_time="0" quality="0" price="1" />
+		</news>
+		<news id="news-stockexchange-generic" type="2" thread_id="news-stockexchange-thread" creator="" created_by="Kieferer">
 			<title>
 				<de>Börsennachrichten für Tag %WORLDTIME:GAMEDAY%</de>
 				<en>Stock Exchange News for day %WORLDTIME:GAMEDAY%</en>
@@ -217,8 +224,8 @@ All means are right for them.</en>
 				<!-- triggers itself again for next weekday (at 9-11) -->
 				<effect trigger="happen" type="triggernews" time="8,1,9,11" news="news-stockexchange-generic" />
 			</effects>
-			<!-- 8: "next +1 weekday" at 9-11 -->
-			<data genre="0" flags="145" happen_time="8,1,9,11" quality_min="30" quality_max="40" quality_slope="50" price="0.9" />
+			<!-- flags: 4, 128 unskippable, especial -->
+			<data genre="0" flags="132" quality_min="30" quality_max="40" quality_slope="50" price="0.9" />
 		</news>
 	</allnews>
 </tvtdb>

--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -2076,7 +2076,7 @@ Type TDatabaseLoader
 
 		'= TIME =
 		'local releaseTime:String = ":".Join([string(releaseYear), string(releaseYearRelative), string(releaseYearMin), string(releaseYearMax), string(releaseDay), string(releaseHour)])
-		Return GetWorldTime().MakeTime(releaseYear, releaseDay, releaseHour, 0, 0)
+		Return GetWorldTime().MakeTime(releaseYear, releaseDay-1, releaseHour, 0, 0)
 	End Function
 
 

--- a/source/game.game.bmx
+++ b/source/game.game.bmx
@@ -221,7 +221,7 @@ Type TGame Extends TGameBase {_exposeToLua="selected"}
 			'=== CREATE / INIT SPORTS ("life outside")===
 			TLogger.Log("TGame", "Starting all sports (and their leagues) -1 year before now.", LOG_DEBUG)
 			GetNewsEventSportCollection().CreateAllLeagues()
-			GetNewsEventSportCollection().StartAll( Long(GetWorldTime().MakeRealTime(GetWorldTime().GetYear()-1,0,0,0,0)) )
+			GetNewsEventSportCollection().StartAll( Long(GetWorldTime().MakeRealTime(GetWorldTime().GetYear()-1,1,1)) )
 			
 
 			'refresh states of old programme productions (now we now

--- a/source/game.newsagency.sports.bmx
+++ b/source/game.newsagency.sports.bmx
@@ -1239,11 +1239,11 @@ Type TNewsEventSportLeague Extends TGameObject
 				'next match starts in february
 				'take time of 2 months later (either february or march - so
 				'guaranteed to be the "next" year - when still in december)
-				t = matchTime + GetWorldTime().MakeRealTime(0, 2, 0, 0, 0)
+				t = matchTime + GetWorldTime().MakeRealTime(0, 2, 1)
 				'set time to "next year" begin of february - use "MakeRealTime"
 				'to get the time of the ingame "5th february" (or the next
 				'possible day)
-				t = GetWorldTime().MakeRealTime(GetWorldTime().GetYear(t), 2, 5, 0, 0)
+				t = GetWorldTime().MakeRealTime(GetWorldTime().GetYear(t), 2, 5)
 				'calculate next possible match time (after winter break)
 				matchTime = GetNextMatchStartTime(t)
 'If name = "Regionalliga" Then Print "   -> winterbreak delay"

--- a/source/game.newsagency.sports.icehockey.bmx
+++ b/source/game.newsagency.sports.icehockey.bmx
@@ -252,7 +252,7 @@ Type TNewsEventSportLeague_IceHockey extends TNewsEventSportLeague
 		'take year of the given time and use the defined months for a
 		'hockey season
 		'match time: 16. 9. - 26.2. (1. Liga)
-		Return GetWorldTime().MakeRealTime(GetWorldTime().GetYear(time), seasonStartMonth, seasonStartDay, 0, 0)
+		Return GetWorldTime().MakeRealTime(GetWorldTime().GetYear(time), seasonStartMonth, seasonStartDay)
 	End Method
 
 

--- a/source/game.newsagency.sports.soccer.bmx
+++ b/source/game.newsagency.sports.soccer.bmx
@@ -221,7 +221,7 @@ Type TNewsEventSportLeague_Soccer Extends TNewsEventSportLeague
 		'soccer season
 		'match time: 14. 8. - 14.5. (1. Liga)
 		'match time: 29. 7. -       (3. Liga)
-		Return GetWorldTime().MakeRealTime(GetWorldTime().GetYear(time), seasonStartMonth, seasonStartDay, 0, 0)
+		Return GetWorldTime().MakeRealTime(GetWorldTime().GetYear(time), seasonStartMonth, seasonStartDay)
 	End Method
 
 

--- a/source/game.world.worldtime.bmx
+++ b/source/game.world.worldtime.bmx
@@ -80,9 +80,12 @@ Type TWorldTime Extends TWorldTimeBase {_exposeToLua="selected"}
 
 
 	'create a time in seconds
-	'attention: month and day use real world values (12m and 365d)
-	Method MakeRealTime:Long(year:int, month:int, day:int, hour:Long, minute:Long, second:Long = 0, millisecond:Long = 0) {_exposeToLua}
-		Return (((((Long(30 * month + day) * GetDaysPerYear()) / 360 + year * GetDaysPerYear()) * 24 + hour) * 60 + minute) * 60 + second) * SECONDLENGTH + millisecond
+	'attention: month and day use real world values (12m and 365d), i.e. parameters represent a real date
+	Method MakeRealTime:Long(year:int, month:int, day:int) {_exposeToLua}
+		if day > 30 then day = 30
+		local result:long = year * GetYearLength() + ((Long(30 * (month-1) + (day-1)) * GetDaysPerYear() * DAYLENGTH ) / 360)
+		'print "TIME:" +year+"-"+month+"-"+day +"   "+ result +"   "+ GetFormattedGameDate(result)
+		return result 
 	End Method
 
 
@@ -1088,7 +1091,7 @@ Type TWorldTime Extends TWorldTimeBase {_exposeToLua="selected"}
 	End Method
 
 
-	Method CalcTime_ExactDate:Long(nowTime:Long=-1, yearMin:int=0, yearMax:int=-1000000, monthMin:int=0, monthMax:int=-1000000, dayMin:int=0, dayMax:int=-1000000, hourMin:int=0, hourMax:int=-1000000, minuteMin:int=0, minuteMax:int=-1000000)
+	Method CalcTime_ExactDate:Long(nowTime:Long=-1, yearMin:int=0, yearMax:int=-1000000, monthMin:int=0, monthMax:int=-1000000, dayMin:int=0, dayMax:int=-1000000)
 		If nowTime = -1 Then nowTime = _timeGone
 
 		'print "IN nowTime="+nowTime+"  yearMin="+yearMin+"  yearMax="+yearMax+"  monthMin="+monthMin+"  monthMax="+monthMax+"  dayMin="+dayMin+"  dayMax="+dayMax+"  hourMin="+hourMin+"  hourMax="+hourMax+"  minuteMin="+minuteMin+"  minuteMax="+minuteMax
@@ -1102,21 +1105,14 @@ Type TWorldTime Extends TWorldTimeBase {_exposeToLua="selected"}
 		if dayMin = -1 then dayMin = RandRange(1, 30) 'Sorry february!
 		if dayMax <> dayMin and dayMax > -1000000 then dayMin = RandRange(dayMin, dayMax)
 
-		if hourMin = -1 then hourMin = RandRange(0, 23)
-		if hourMax <> hourMin and hourMax > -1000000 then hourMin = RandRange(hourMin, hourMax)
-
-		if minuteMin = -1 then minuteMin = RandRange(0, 59)
-		if minuteMax <> minuteMin and minuteMax > -1000000 then minuteMin = RandRange(minuteMin, minuteMax)
-
-
 		'relative mode, there wont be an time entry before 1000 AD.
 		if yearMin < 1000
 			'print "nowTime="+nowTime+"  yearMin="+yearMin+"  yearMax="+yearMax+"  monthMin="+monthMin+"  monthMax="+monthMax+"  dayMin="+dayMin+"  dayMax="+dayMax+"  hourMin="+hourMin+"  hourMax="+hourMax+"  minuteMin="+minuteMin+"  minuteMax="+minuteMax
 			'print "time = " + GetFormattedGameDate(MakeRealTime(GetYear(nowTime) + yearMin, monthMin, dayMin, hourMin, minuteMin))
 			'print "now year = " + GetYear(nowTime)
-			return MakeRealTime(GetYear(nowTime) + yearMin, monthMin, dayMin, hourMin, minuteMin)
+			return MakeRealTime(GetYear(nowTime) + yearMin, monthMin, dayMin)
 		else
-			return MakeRealTime(yearMin, monthMin, dayMin, hourMin, minuteMin)
+			return MakeRealTime(yearMin, monthMin, dayMin)
 		endif
 	End Method
 
@@ -1181,7 +1177,7 @@ Type TWorldTime Extends TWorldTimeBase {_exposeToLua="selected"}
 				elseif timeValues.length >= 3
 					return CalcTime_WeekdayAtHour(nowTime, timeValues[0], timeValues[1], timeValues[2])
 				endif
-			'4 = next year Y, month M, day D, hour H, minute I
+			'4 = next year Y, month M, day D
 			case 4
 				if timeValues.length < 1
 					return -1
@@ -1189,12 +1185,10 @@ Type TWorldTime Extends TWorldTimeBase {_exposeToLua="selected"}
 					Select timeValues.length
 						Case 1   return CalcTime_ExactDate(nowTime, timeValues[0])
 						Case 2   return CalcTime_ExactDate(nowTime, timeValues[0], , timeValues[1])
-						Case 3   return CalcTime_ExactDate(nowTime, timeValues[0], , timeValues[1], , timeValues[2])
-						Case 4   return CalcTime_ExactDate(nowTime, timeValues[0], , timeValues[1], , timeValues[2], , timeValues[3])
-						Default  return CalcTime_ExactDate(nowTime, timeValues[0], , timeValues[1], , timeValues[2], , timeValues[3], , timeValues[4])
+						Default  return CalcTime_ExactDate(nowTime, timeValues[0], , timeValues[1], , timeValues[2])
 					End Select
 				endif
-			'5 = next year Y-Y2, month M-M2, day D-D2, hour H-H2, minute I-I2
+			'5 = next year Y-Y2, month M-M2, day D-D2
 			case 5
 				if timeValues.length < 1
 					return -1
@@ -1205,11 +1199,7 @@ Type TWorldTime Extends TWorldTimeBase {_exposeToLua="selected"}
 						Case 3   return CalcTime_ExactDate(nowTime, timeValues[0], timeValues[1], timeValues[2], timeValues[2])
 						Case 4   return CalcTime_ExactDate(nowTime, timeValues[0], timeValues[1], timeValues[2], timeValues[3])
 						Case 5   return CalcTime_ExactDate(nowTime, timeValues[0], timeValues[1], timeValues[2], timeValues[3], timeValues[4], timeValues[4])
-						Case 6   return CalcTime_ExactDate(nowTime, timeValues[0], timeValues[1], timeValues[2], timeValues[3], timeValues[4], timeValues[5])
-						Case 7   return CalcTime_ExactDate(nowTime, timeValues[0], timeValues[1], timeValues[2], timeValues[3], timeValues[4], timeValues[5], timeValues[6], timeValues[6])
-						Case 8   return CalcTime_ExactDate(nowTime, timeValues[0], timeValues[1], timeValues[2], timeValues[3], timeValues[4], timeValues[5], timeValues[6], timeValues[7])
-						Case 9   return CalcTime_ExactDate(nowTime, timeValues[0], timeValues[1], timeValues[2], timeValues[3], timeValues[4], timeValues[5], timeValues[6], timeValues[7], timeValues[8], timeValues[8])
-						Default  return CalcTime_ExactDate(nowTime, timeValues[0], timeValues[1], timeValues[2], timeValues[3], timeValues[4], timeValues[5], timeValues[6], timeValues[7], timeValues[8], timeValues[9])
+						Default  return CalcTime_ExactDate(nowTime, timeValues[0], timeValues[1], timeValues[2], timeValues[3], timeValues[4], timeValues[5])
 					End Select
 				endif
 			'6 = next year Y, gameday GD, hour H, minute I

--- a/source/game.world.worldtime.bmx
+++ b/source/game.world.worldtime.bmx
@@ -1135,7 +1135,7 @@ Type TWorldTime Extends TWorldTimeBase {_exposeToLua="selected"}
 		if minuteMax <> minuteMin and minuteMax > -1000000 then minuteMin = RandRange(minuteMin, minuteMax)
 
 
-		return MakeTime(yearMin, gameDayMin, hourMin, minuteMin)
+		return MakeTime(yearMin, gameDayMin -1, hourMin, minuteMin)
 	End Method
 
 


### PR DESCRIPTION
Weitere Aufräumarebeiten in Datenbank und Zeitermittlung.
* DB-Zeitdefinitionen und min-max-Vertauschung
* Börsennachrichten mit sauberer Initial- und Folgenachricht (solange es keine "regelmäßige happen_time" gibt)
* Zeit aus Zeittyp 4 und 5 entfernt, Ermittlung der Zeit aus dem vorgegebenen Datum
* One-Off-Fehler bei Tag des Jahres