### PR TITLE
Fallback für Serienfolgengenre

### DIFF
--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -1501,7 +1501,7 @@ Type TDatabaseLoader
 		nodeData = xml.FindChild(node, "genres")
 		data = New TData
 		xml.LoadValuesToData(nodeData, data, ["mainGenre", "subGenres"])
-		scriptTemplate.mainGenre = data.GetInt("mainGenre", 0)
+		scriptTemplate.mainGenre = data.GetInt("mainGenre", scriptTemplate.mainGenre)
 		For Local sg:String = EachIn data.GetString("subGenres", "").split(",")
 			'skip empty or "undefined" genres
 			If Int(sg) = 0 Then Continue


### PR DESCRIPTION
Folgen definieren typischerweise das Genre nicht neu. Beim Einlesen der Daten darf daher nicht 0 als Fallback verwendet werden, sondern das schon beim Clonen gesetzte Genre.

closes #374