### PR TITLE
Feat chooseable amateurs

### DIFF
--- a/res/lang/production/production_de.txt
+++ b/res/lang/production/production_de.txt
@@ -43,6 +43,7 @@ JOB_AMATEUR_MUSICIANS        = Freizeitmusiker
 
 JOB_POSITION_UNASSIGNED = Unbesetzt
 
+CAST_TRAINING         = Ausbildung
 CAST_EXPERIENCE       = Erfahrung
 CAST_FAME             = Bekanntheit
 CAST_AFFINITY         = Affinität

--- a/res/lang/production/production_en.txt
+++ b/res/lang/production/production_en.txt
@@ -43,6 +43,7 @@ JOB_AMATEUR_MUSICIANS        = Amateur musicians
 
 JOB_POSITION_UNASSIGNED = Unassigned
 
+CAST_TRAINING         = Training
 CAST_EXPERIENCE       = Experience
 CAST_FAME             = Fame
 CAST_AFFINITY         = Affinity

--- a/res/lang/production/production_es.txt
+++ b/res/lang/production/production_es.txt
@@ -43,6 +43,7 @@ JOB_MUSICIANS        = Músico
 
 #JOB_POSITION_UNASSIGNED = 
 
+#CAST_TRAINING         =
 #CAST_EXPERIENCE       = 
 #CAST_FAME             = 
 #CAST_AFFINITY         = 

--- a/res/lang/production/production_fr.txt
+++ b/res/lang/production/production_fr.txt
@@ -43,6 +43,7 @@ JOB_MUSICIANS        = Musiciens
 
 #JOB_POSITION_UNASSIGNED = 
 
+#CAST_TRAINING         =
 #CAST_EXPERIENCE       = 
 #CAST_FAME             = 
 #CAST_AFFINITY         = 

--- a/res/lang/production/production_pt-br.txt
+++ b/res/lang/production/production_pt-br.txt
@@ -43,6 +43,7 @@ JOB_AMATEUR_MUSICIANS        = Músicos amadores
 
 JOB_POSITION_UNASSIGNED = Não atribuído
 
+#CAST_TRAINING         =
 CAST_EXPERIENCE       = Experiência
 CAST_FAME             = Fama
 #CAST_AFFINITY         = 

--- a/res/lang/production/production_tr.txt
+++ b/res/lang/production/production_tr.txt
@@ -43,6 +43,7 @@ JOB_MUSICIANS        = Müzisyenler
 
 #JOB_POSITION_UNASSIGNED = 
 
+#CAST_TRAINING         =
 #CAST_EXPERIENCE       = 
 #CAST_FAME             = 
 #CAST_AFFINITY         = 

--- a/source/game.game.bmx
+++ b/source/game.game.bmx
@@ -229,6 +229,10 @@ Type TGame Extends TGameBase {_exposeToLua="selected"}
 			'done which programme yet)
 			TLogger.Log("TGame", "Refreshing production/cinema states of programmes (refreshing cast-information)", LOG_DEBUG)
 			GetProgrammeDataCollection().UpdateAll()
+			
+			TLogger.Log("TGame", "Ensure enough castable amateurs exist.", LOG_DEBUG)
+			GetProductionManager().UpdateCurrentlyAvailableAmateurs()
+
 
 			'Begin Game - fire Events
 			'so we start at day "1"
@@ -236,6 +240,11 @@ Type TGame Extends TGameBase {_exposeToLua="selected"}
 			'time after day
 			TriggerBaseEvent(GameEventKeys.Game_OnMinute, timeData)
 			TriggerBaseEvent(GameEventKeys.Game_OnHour, timeData) 
+		Else
+			if not GetProductionManager().currentAvailableAmateurs or GetProductionManager().currentAvailableAmateurs.length = 0
+				TLogger.Log("TGame", "Ensure enough castable amateurs exist (old savegame).", LOG_DEBUG)
+				GetProductionManager().UpdateCurrentlyAvailableAmateurs()
+			endif
 		EndIf
 
 		'so we could add news etc.

--- a/source/game.gamerules.bmx
+++ b/source/game.gamerules.bmx
@@ -81,6 +81,10 @@ Type TGameRules {_exposeToLua}
 	Field InRoomTimeSlowDownMod:Float = 1.0
 
 	Field startProgrammeAmount:int = 0
+	
+	'how many productions (jobs, so theoretically less productions)
+	'are required to make a person a celebrity
+	Field UpgradeInsignificantOnProductionJobsCount:Int = 3
 
 	'penalty to pay if a player sends an xrated movie at the wrong time
 	Field sentXRatedPenalty:int = 25000

--- a/source/game.person.base.bmx
+++ b/source/game.person.base.bmx
@@ -922,6 +922,14 @@ Type TPersonBase Extends TGameObject
 
 
 	Method FinishProduction:Int(programmeDataID:Int, job:Int)
+		'make sure the person can store at least basic production data from now on
+		'(this else is only ensured on "UpgradeInsignificantToCelebrity"
+		If Not GetProductionData()
+			If IsFictional() and CanLevelUp() 
+				SetProductionData(new TPersonProductionBaseData)
+			EndIf
+		EndIf
+
 		If GetProductionData()
 			_productionData.FinishProduction(programmeDataID, job)
 		EndIf

--- a/source/game.person.bmx
+++ b/source/game.person.bmx
@@ -67,7 +67,7 @@ Function UpgradeInsignificantToCelebrity:Int(p:TPersonBase var, ignoreProduction
 	'jobsDone is increased _after_ finishing the production,
 	'so "jobsDone <= 2" will be true until the 3rd production is finishing
 	If Not ignoreProductionJobs
-		If p.GetTotalProductionJobsDone() <= 2 Then Return False
+		If p.GetTotalProductionJobsDone() <= GameRules.UpgradeInsignificantOnProductionJobsCount Then Return False
 	EndIf
 
 	'remove from previous prefiltered lists

--- a/source/game.person.bmx
+++ b/source/game.person.bmx
@@ -67,7 +67,18 @@ Function UpgradeInsignificantToCelebrity:Int(p:TPersonBase var, ignoreProduction
 	'jobsDone is increased _after_ finishing the production,
 	'so "jobsDone <= 2" will be true until the 3rd production is finishing
 	If Not ignoreProductionJobs
-		If p.GetTotalProductionJobsDone() <= GameRules.UpgradeInsignificantOnProductionJobsCount Then Return False
+		'check if one job reached the limit ?
+		'if total is already below then we can skip the detailed check
+		If p.GetTotalProductionJobsDone() < GameRules.UpgradeInsignificantOnProductionJobsCount Then Return False
+
+		local doUpgrade:Int = False
+		For local jobID:int = EachIn TVTPersonJob.CAST_IDs
+			If p.GetProductionJobsDone(jobID) >= GameRules.UpgradeInsignificantOnProductionJobsCount
+				doUpgrade = True
+				exit
+			EndIf
+		Next
+		if not doUpgrade Then Return False
 	EndIf
 
 	'remove from previous prefiltered lists
@@ -317,8 +328,6 @@ Type TPersonProductionData Extends TPersonProductionBaseData
 	Field calculatedTopGenreCache:Int = 0 {nosave}
 	'array containing GUIDs of all produced programmes
 	Field producedProgrammes:String[] {nosave}
-	'array containing IDs of all produced programmes
-	Field producedProgrammeIDs:Int[] {nosave}
 	Field producedProgrammesCached:Int = False {nosave}
 
 	Global PersonsGainExperienceForProgrammes:Int = True
@@ -331,6 +340,7 @@ Type TPersonProductionData Extends TPersonProductionBaseData
 		self._person = base._person
 
 		self.jobsDone = base.jobsDone[ .. ]
+		self.producedProgrammeIDs = base.producedProgrammeIDs[ .. ]
 		self.producingIDs = base.producingIDs[ .. ]
 		self.priceModifier = base.priceModifier
 
@@ -604,7 +614,7 @@ Type TPersonProductionData Extends TPersonProductionBaseData
 
 
 	'refresh cache (for newly converted "insignifants" or after a savegame)
-	Method GetProducedProgrammeIDs:Int[]()
+	Method GetProducedProgrammeIDs:Int[]() override
 		If Not producedProgrammesCached
 			_GenerateProducedProgrammesCache()
 		EndIf

--- a/source/game.production.bmx
+++ b/source/game.production.bmx
@@ -512,14 +512,16 @@ Type TProduction Extends TOwnedGameObject
 			EndIf
 		Next
 
+		'fix release time (non live) now
+		'fix BEFORE AddProgrammeLicence() so that series headers can
+		'adjust their releaseTime accordingly
+		if not productionConcept.script.IsLive()
+			_designatedProgrammeLicence.data.releaseTime = GetWorldTime().GetTimeGone()
+		endif
+
 		'non-live gets added after finishing the production
 		if not productionConcept.script.IsLive()
 			AddProgrammeLicence()
-		endif
-
-		'fix release time (non live) now
-		if not productionConcept.script.IsLive()
-			_designatedProgrammeLicence.data.releaseTime = GetWorldTime().GetTimeGone()
 		endif
 
 		'update programme data so it releases to cinema etc (if needed)

--- a/source/game.production.bmx
+++ b/source/game.production.bmx
@@ -349,7 +349,7 @@ Type TProduction Extends TOwnedGameObject
 		startTime = GetWorldTime().GetTimeGone()
 		'modify production time by mod (TODO: add random plus minus?)
 		endTime = startTime + productionTime * GetProductionTimeMod()
-print "Produktionszeit = " + productionTime+" * "+GetProductionTimeMod()
+		'print "Produktionszeit = " + productionTime+" * "+GetProductionTimeMod()
 		'round end time to next xx:x5 to avoid people entering
 		'the studio before next production starts (production
 		'manager checks in 5 minute interval)
@@ -371,7 +371,6 @@ print "Produktionszeit = " + productionTime+" * "+GetProductionTimeMod()
 		'emit an event so eg. network can recognize the change
 		TriggerBaseEvent(GameEventKeys.Production_Start, Null, Self)
 
-
 		if isLiveProduction
 			BeginPreProduction()
 		else
@@ -389,6 +388,9 @@ print "Produktionszeit = " + productionTime+" * "+GetProductionTimeMod()
 		BlockStudio(True)
 
 		productionStep = TVTProductionStep.PREPRODUCTION
+		
+		_designatedProgrammeLicence.data.SetState(TVTProgrammeState.IN_PRODUCTION)
+		_designatedProgrammeLicence.data.Update()
 
 		TLogger.Log("TProduction.BeginPreProduction()", "Beginning preproduction: ~q" + productionConcept.GetTitle() +"~q", LOG_DEBUG)
 		Return True
@@ -442,6 +444,9 @@ print "Produktionszeit = " + productionTime+" * "+GetProductionTimeMod()
 			productionConcept.script.lastLiveTime = endTime
 		EndIf
 
+		_designatedProgrammeLicence.data.SetState(TVTProgrammeState.IN_PRODUCTION)
+		_designatedProgrammeLicence.data.Update()
+
 		'set studio blocked / update block state
 		BlockStudio(True)
 
@@ -454,7 +459,7 @@ print "Produktionszeit = " + productionTime+" * "+GetProductionTimeMod()
 
 		'define speed, critics ... based on current cast values, script ...
 		FixProgrammeDataValues()
-		
+
 		TLogger.Log("TProduction.BeginShooting()", "Beginning shooting: ~q" + productionConcept.GetTitle() +"~q. Production: "+ GetWorldTime().GetFormattedDate(startTime) + "  -  " + GetWorldTime().GetFormattedDate(endTime), LOG_DEBUG)
 		Return True
 	End Method
@@ -507,14 +512,17 @@ print "Produktionszeit = " + productionTime+" * "+GetProductionTimeMod()
 			EndIf
 		Next
 
-
 		'non-live gets added after finishing the production
 		if not productionConcept.script.IsLive()
 			AddProgrammeLicence()
 		endif
 
+		'fix release time (non live) now
+		if not productionConcept.script.IsLive()
+			_designatedProgrammeLicence.data.releaseTime = GetWorldTime().GetTimeGone()
+		endif
 
-		'update programme data so it releases to cinema etc
+		'update programme data so it releases to cinema etc (if needed)
 		_designatedProgrammeLicence.data.Update()
 
 
@@ -598,7 +606,7 @@ print "Produktionszeit = " + productionTime+" * "+GetProductionTimeMod()
 		FillProgrammeData(programmeData, productionConcept)
 		programmeData.country = GetStationMapCollection().config.GetString("nameShort", "UNK")
 		programmeData.distributionChannel = TVTProgrammeDistributionChannel.TV
-		programmeData.releaseTime = GetWorldTime().GetTimeGone()
+		programmeData.releaseTime = -1 'release time is on "finish"
 		If productionConcept.script.IsLive()
 			programmeData.releaseTime = productionConcept.GetLiveTime()
 		EndIf
@@ -657,9 +665,6 @@ print "Produktionszeit = " + productionTime+" * "+GetProductionTimeMod()
 			programmeData.AddCast(New TPersonProductionJob.Init(p.GetID(), job.job))
 		Next
 
-		'update programme data so releases to cinema etc (if needed)
-		programmeData.Update()
-		
 		Return programmeData
 	End Method
 
@@ -765,10 +770,6 @@ print "Produktionszeit = " + productionTime+" * "+GetProductionTimeMod()
 			pd.SetModifier("price", productionPriceMod)
 		EndIf
 		
-		'fix release time now
-		pd.releaseTime = GetWorldTime().GetTimeGone()
-
-
 		'=== 3.2 PROGRAMME PRODUCTION PROPERTIES ===
 		pd.review = MathHelper.Clamp(productionValueMod * productionConcept.script.review *scriptPotentialMod, 0, 1.0)
 		pd.speed = MathHelper.Clamp(productionValueMod * productionConcept.script.speed *scriptPotentialMod, 0, 1.0)

--- a/source/game.production.productionmanager.bmx
+++ b/source/game.production.productionmanager.bmx
@@ -10,6 +10,9 @@ Type TProductionManager
 	'once one starts productions in a studio
 	Field productionsToProduce:TList = CreateList()
 	Field liveProductions:TList = CreateList()
+	
+	'all amateurs currently available in castings
+	Field currentAvailableAmateurs:TPersonBase[]
 
 	Global _instance:TProductionManager
 	Global _eventListeners:TEventListenerBase[]
@@ -98,6 +101,11 @@ Type TProductionManager
 
 	Function onGameMinute:Int(triggerEvent:TEventBase)
 		'TODO: (selten und) zufaellig laufende Produktionen unterbrechen ?
+
+		'update every 4 hours at x:10
+		If triggerEvent.GetData().GetInt("minute") = 10 and triggerEvent.GetData().GetInt("hour") mod 4 = 0
+			GetInstance().UpdateCurrentlyAvailableAmateurs()
+		EndIf
 	End Function
 
 
@@ -390,6 +398,163 @@ Type TProductionManager
 	End Function
 
 
+	'returns amateurs interested in the given job
+	'- uses "currentAvailableAmateurs" not from "all amateurs"
+	'- persons are returned "in order" (top to bottom)
+	'- no randomness is used
+	'- call UpdateCurrentlyAvailableAmateurs() to randomize
+	Method GetCurrentAvailableAmateurs:TPersonBase[](filterToJobID:Int, filterToGenderID:Int, minAge:Int, amateursToInclude:Int, minAmountUninterestedAmateurs:Int = 0)
+		'load up to X persons with interest in the given job
+		'additionally load X persons without interest in the given job
+		Local amateursInterested:TPersonBase[] = new TPersonBase[amateursToInclude]
+		Local amateursUninterested:TPersonBase[] = new TPersonBase[amateursToInclude]
+		Local amateursInterestedAdded:Int = 0
+		Local amateursUninterestedAdded:Int = 0
+		Local result:TPersonBase[] = new TPersonBase[amateursToInclude]
+
+		For Local i:int = 0 Until currentAvailableAmateurs.length
+			if filterToGenderID > 0 and currentAvailableAmateurs[i].gender <> filterToGenderID then continue
+			'amateurs do not have any "age" yet
+			'if minAge > 0 and currentAvailableAmateurs[i].GetAge() < minAge then continue
+
+			If currentAvailableAmateurs[i].HasPreferredJob(filterToJobID)
+				if amateursInterestedAdded < amateursToInclude
+					amateursInterested[amateursInterestedAdded] = currentAvailableAmateurs[i]
+					amateursInterestedAdded :+ 1
+				endif
+			Else
+				if amateursUninterestedAdded < amateursToInclude
+					amateursUninterested[amateursUninterestedAdded] = currentAvailableAmateurs[i]
+					amateursUninterestedAdded :+ 1
+				endif
+			EndIf
+			if amateursUninterestedAdded > amateursToInclude and amateursInterestedAdded > amateursToInclude
+				exit
+			endif
+		Next
+		
+
+		'iterate through interested until "toInclude - minimumUninterested"
+		'is reached (or not enough interested are existing
+		local addInterestedCount:Int = Min(amateursInterestedAdded, amateursToInclude - minAmountUninterestedAmateurs)
+		Local added:Int
+		For local i:int = 0 until addInterestedCount
+			'print "adding: interested " + amateursInterested[i].GetFullName() + "  " + bin(amateursInterested[i]._preferredJobs) + "   has="+amateursInterested[i].HasPreferredJob(filterToJobID)
+			result[added] = amateursInterested[i]
+			added :+ 1
+		Next
+
+		'add uninterested (as much as needed to fill "amateursToinclude")
+		Local addUninterestedCount:Int = Min(amateursUninterestedAdded, amateursToInclude - addInterestedCount)
+		For local i:int = 0 until addUninterestedCount
+			'print "adding: uninterested " + amateursUninterested[i].GetFullName() + "  " + bin(amateursUninterested[i]._preferredJobs) + "   has="+amateursUninterested[i].HasPreferredJob(filterToJobID)
+			result[added] = amateursUninterested[i]
+			added :+ 1
+		Next
+		
+		Return result
+	End Method
+
+
+	Method GetCastAmateurCandidates:TPersonBase[](filterToJobID:Int, filterToGenderID:Int, minAge:Int, amateursToInclude:Int)
+		Local persons:TPersonBase[] = new TPersonBase[amateursToInclude]
+		Local personsAdded:Int = 0
+
+
+		Local amountWithoutJob:Int = (amateursToInclude * 3) / 10
+		if amateursToInclude > 1 then amountWithoutJob :+ 1
+
+		local amateursWithJob:TPersonBase[] = GetPersonBaseCollection().GetRandomInsignificants(currentAvailableAmateurs, amateursToInclude - amountWithoutJob, True, True, filtertoJobID, filterToGenderID, True, "", null)
+		local amateursWithJobIDs:Int[] = new Int[amateursWithJob.length]
+		For local i:int = 0 until amateursWithJob.length
+			amateursWithJobIDs[i] = amateursWithJob[i].id
+		Next
+		'no job restrictions but other persons than the ones with job
+		local amateursWithoutJob:TPersonBase[] = GetPersonBaseCollection().GetRandomInsignificants(currentAvailableAmateurs, amountWithoutJob, True, True, 0, filterToGenderID, True, "", null, amateursWithJobIDs)
+
+
+		For local i:int = 0 until amateursWithJob.length + amateursWithoutJob.length
+			Local amateur:TPersonBase
+			if i < amateursWithJob.length
+				amateur = amateursWithJob[i]
+			else
+				amateur = amateursWithoutJob[i - amateursWithJob.length]
+			endif
+			
+			If amateur
+				'custom production not possible with real persons...
+				'also the person must be bookable for productions (maybe retired?)
+				If Not amateur.IsAlive() Then continue
+				If Not amateur.IsFictional() Then continue
+				if Not amateur.IsBookable() Then continue
+
+				if not amateur.HasJob(filterToJobID) and amateur.GetJobCount() >= 4 then continue 
+
+				amateur.SetJob(filterToJobID, True)
+
+				persons[personsAdded] = amateur
+				personsAdded :+ 1
+			EndIf
+		Next
+
+		Return persons
+	End Method
+	
+
+	Method GetCastCelebrityCandidates:TPersonBase[](filterToJobID:Int, filterToGenderID:Int, minAge:Int)
+		Local persons:TPersonBase[10]
+		Local personsAdded:Int = 0
+		
+		Local personsList:TObjectList = GetPersonBaseCollection().GetCastableCelebritiesList()
+		For Local person:TPersonBase = EachIn personsList
+			'custom production not possible with real persons...
+			If Not person.IsFictional() Then Continue
+			'also the person must be bookable for productions (maybe retired?)
+			If Not person.IsBookable() Then Continue
+			If Not person.IsAlive() Then Continue
+
+
+			If filterToGenderID > 0 And person.gender <> filterToGenderID Then Continue
+
+			'we also want to avoid "children" (only available for celebs)
+			If minAge >= 0 and person.GetAge() < minAge And person.GetAge() <> -1 Then Continue
+
+			If filterToJobID = 0 Or person.HasJob(filterToJobID)
+				if personsAdded = persons.length then persons = persons[.. persons.length + 10]
+
+				persons[personsAdded] = person
+				personsAdded :+ 1
+			EndIf
+		Next
+		
+		if persons.length = personsAdded
+			Return persons
+		Else
+			Return persons[.. personsAdded]
+		EndIf
+	End Method
+	
+
+	Method GetCastCandidates:TPersonBase[](filterToJobID:Int, filterToGenderID:Int, minAge:Int, amateursToInclude:Int = 0, minAmountUninterestedAmateurs:Int = 0, prependAmateurs:Int = True)
+		Local persons:TPersonBase[]
+
+		'fill in available celebs
+		persons = GetCastCelebrityCandidates(filterToJobID, filterToGenderID, minAge)
+
+		'add amateurs/laymen at the top/bottom 
+		if amateursToInclude > 0
+			Local amateurs:TPersonBase[] = GetCurrentAvailableAmateurs(filterToJobID, filterToGenderID, minAge, amateursToInclude, minAmountUninterestedAmateurs)
+			if prependAmateurs
+				persons = amateurs + persons
+			else
+				persons = persons + amateurs
+			endif
+		endif
+
+		Return persons
+	End Method
+	
+
 	Method UpdateLiveProductions:Int()
 		local removeProductions:TProduction[]
 
@@ -405,6 +570,154 @@ Type TProductionManager
 			liveProductions.Remove(production)
 		Next
 	End Method
+	
+	
+	
+	'ensure that for each job + gender enough insignificants/amateurs
+	'are available ("interested" in the jobs)
+	Method UpdateCurrentlyAvailableAmateurs()
+		'- fetch all amateurs
+		'- count existing per preferred job/gender (and repair if needed
+		'- ensure minimum of X per job/gender exist (create if needed)
+		'- shuffle the array so any "fetch from top to down" results
+		'  in a varying result (but the same until the next "shuffle")
+
+		Local desiredAmountPerJobGender:int = 5
+		
+
+		'1.) fetch all amateurs
+		'    all fictional, bookable, no job restriction, no gender restriction, alive, no country restriction
+		currentAvailableAmateurs = GetPersonBaseCollection().GetFilteredInsignificantsArray(True, True, 0, -1, True, "", null, null)
+		'remove celebs? -> should not be needed
+
+
+		'2.) count existing and repair missing preferences
+		'done a bit more "complicated" to allow a more dynamic amount of
+		'genders, not just undefined/male/female 
+		Local preferredJobCount:Int[] = new Int[ TVTPersonJob.CAST_IDs.length * (TVTPersonGender.count + 1)]
+		For Local p:TPersonBase = EachIn currentAvailableAmateurs
+			local jobIndex:Int = 0
+
+			'repair missing preferences - and add 1 up to 3 of them
+			if p._preferredJobs = 0 
+				p.SetPreferredJob(TVTPersonJob.CAST_IDs[RandRange(0, TVTPersonJob.CAST_IDs.length-1)], True)
+				Local chance:Int = RandRange(0, 100)
+				If chance < 10 Then p.SetPreferredJob(TVTPersonJob.CAST_IDs[RandRange(0, TVTPersonJob.CAST_IDs.length-1)], True)
+				If chance < 20 Then	p.SetPreferredJob(TVTPersonJob.CAST_IDs[RandRange(0, TVTPersonJob.CAST_IDs.length-1)], True)
+			endif
+			
+			
+			For Local jobID:int = EachIn TVTPersonJob.CAST_IDs
+				if p.HasPreferredJob(jobID)
+					'all genders for the "generic" count
+					preferredJobCount[jobIndex] :+ 1
+					'also store count for each gender
+					if p.gender >= 1 and p.gender <= TVTPersonGender.count
+						preferredJobCount[jobIndex + p.gender*TVTPersonJob.CAST_IDs.length] :+ 1
+					endif
+				endif
+				jobIndex :+ 1
+			Next
+		Next
+		'debug output
+		rem
+		print "amateurs: " + currentAvailableAmateurs.length
+		print "cast jobs: " + TVTPersonJob.CAST_IDs.length
+		print "preferredJobCount.length = " + preferredJobCount.length
+		For local jobIndex:int = 0 to TVTPersonJob.CAST_IDs.length - 1
+			local jobID:int = TVTPersonJob.CAST_IDs[jobIndex]
+			Local countDetails:String
+			For local genderIndex:Int = 1 to TVTPersonGender.count
+				if countDetails then countDetails :+ ", "
+				countDetails :+ TVTPersonGender.GetAsString( genderIndex ) + "=" + preferredJobCount[jobIndex + genderIndex*TVTPersonJob.CAST_IDs.length]
+			Next
+			print "job="+TVTPersonJob.GetAsString(jobID) + "  count=" + preferredJobCount[jobIndex] + " (" + countDetails + ")"
+		Next
+		endrem
+
+
+		'3.) fill up missing / ensure enough persons prefer a job
+		Local countryCode:String = GetStationMapCollection().config.GetString("nameShort", "Unk")
+		Local newAmateurs:TPersonBase[10]
+		Local newAmateursIndex:Int = 0
+		If GetPersonGenerator().HasProvider(countryCode)
+			countryCode = GetPersonGenerator().GetRandomCountryCode()
+		EndIf
+		rem
+		For Local jobIndex:int = 0 until TVTPersonJob.CAST_IDs.length
+			If preferredJobCount[jobIndex] < desiredAmountPerJobGender
+				For local addCount:int = 0 until (desiredAmountPerJobGender - preferredJobCount[jobIndex])
+					local useCountryCode:String = countryCode
+					'try to use "map specific names"
+					If RandRange(0,100) < 20
+						useCountryCode = GetPersonGenerator().GetRandomCountryCode()
+					EndIf
+
+					local amateur:TPersonBase = GetPersonBaseCollection().CreateRandom(countryCode, -1)
+					Local jobID:int = TVTPersonJob.CAST_IDs[jobIndex]
+					amateur.SetPreferredJob(jobID, True)
+					'enable 1-2 other (or the same again) randomly
+					Local chance:Int = RandRange(0, 100)
+					If chance < 10 Then amateur.SetPreferredJob(TVTPersonJob.CAST_IDs[RandRange(0, TVTPersonJob.CAST_IDs.length-1)], True)
+					If chance < 20 Then	amateur.SetPreferredJob(TVTPersonJob.CAST_IDs[RandRange(0, TVTPersonJob.CAST_IDs.length-1)], True)
+					
+					if newAmateursIndex >= newAmateurs.length then newAmateurs = newAmateurs[.. newAmateursIndex + 10]
+					newAmateurs[newAmateursIndex] = amateur
+					newAmateursIndex :+ 1
+
+					'also increase count for the gender specific count now
+					preferredJobCount[jobIndex + amateur.gender * (TVTPersonJob.CAST_IDs.length)] :+ 1
+				Next
+			EndIf
+		Next
+		endrem
+		
+		For Local genderIndex:Int = 1 to TVTPersonGender.count
+			For Local jobIndex:int = 0 until TVTPersonJob.CAST_IDs.length
+				local index:int = jobIndex + genderIndex * TVTPersonJob.CAST_IDs.length
+				If preferredJobCount[index] < desiredAmountPerJobGender
+					For local addCount:int = 0 until (desiredAmountPerJobGender - preferredJobCount[index])
+						local useCountryCode:String = countryCode
+						'try to use "map specific names"
+						If RandRange(0,100) < 20
+							useCountryCode = GetPersonGenerator().GetRandomCountryCode()
+						EndIf
+
+						local amateur:TPersonBase = GetPersonBaseCollection().CreateRandom(countryCode, TVTPersonGender.GetAtIndex(genderIndex))
+						Local jobID:int = TVTPersonJob.CAST_IDs[jobIndex]
+						amateur.SetPreferredJob(jobID, True)
+						'enable 1-2 other (or the same again) randomly
+						Local chance:Int = RandRange(0, 100)
+						If chance < 10 Then amateur.SetPreferredJob(TVTPersonJob.CAST_IDs[RandRange(0, TVTPersonJob.CAST_IDs.length-1)], True)
+						If chance < 20 Then	amateur.SetPreferredJob(TVTPersonJob.CAST_IDs[RandRange(0, TVTPersonJob.CAST_IDs.length-1)], True)
+
+						if newAmateursIndex >= newAmateurs.length then newAmateurs = newAmateurs[.. newAmateursIndex + 10]
+						newAmateurs[newAmateursIndex] = amateur
+						newAmateursIndex :+ 1
+					Next
+				EndIf
+			Next
+		Next
+
+		'add new amateurs to the existing ones
+		'no "+ 1" as newAmateursIndex is "nextAmateursIndex" already 
+		'currentAvailableAmateurs :+ newAmateurs[.. newAmateursIndex + 1]
+		currentAvailableAmateurs :+ newAmateurs[.. newAmateursIndex]
+
+		For Local i:int = 0 Until currentAvailableAmateurs.length
+			if not currentAvailableAmateurs[i] then throw "empty " + i
+		Next
+
+
+		'4.) Shuffle entries to allow a bit variation in top-down
+		'    retrievals (iterating through array)
+		For Local a:int = 0 To currentAvailableAmateurs.length - 2
+			Local b:int = RandRange( a, currentAvailableAmateurs.length - 1)
+			Local p:TPersonBase = currentAvailableAmateurs[a]
+			currentAvailableAmateurs[a] = currentAvailableAmateurs[b]
+			currentAvailableAmateurs[b] = p
+		Next
+	End Method		
 
 	
 	Method UpdateProductions:int()

--- a/source/game.production.productionmanager.bmx
+++ b/source/game.production.productionmanager.bmx
@@ -103,7 +103,8 @@ Type TProductionManager
 		'TODO: (selten und) zufaellig laufende Produktionen unterbrechen ?
 
 		'update every 4 hours at x:10
-		If triggerEvent.GetData().GetInt("minute") = 10 and triggerEvent.GetData().GetInt("hour") mod 4 = 0
+		Local time:Long = triggerEvent.GetData().GetLong("time")
+		If GetWorldTime().GetDayMinute(time) = 10 and GetWorldTime().GetDayHour(time) mod 4 = 0
 			GetInstance().UpdateCurrentlyAvailableAmateurs()
 		EndIf
 	End Function

--- a/source/game.production.productionmanager.bmx
+++ b/source/game.production.productionmanager.bmx
@@ -641,7 +641,7 @@ Type TProductionManager
 		Local countryCode:String = GetStationMapCollection().config.GetString("nameShort", "Unk")
 		Local newAmateurs:TPersonBase[10]
 		Local newAmateursIndex:Int = 0
-		If GetPersonGenerator().HasProvider(countryCode)
+		If not GetPersonGenerator().HasProvider(countryCode)
 			countryCode = GetPersonGenerator().GetRandomCountryCode()
 		EndIf
 		rem
@@ -684,7 +684,7 @@ Type TProductionManager
 							useCountryCode = GetPersonGenerator().GetRandomCountryCode()
 						EndIf
 
-						local amateur:TPersonBase = GetPersonBaseCollection().CreateRandom(countryCode, TVTPersonGender.GetAtIndex(genderIndex))
+						local amateur:TPersonBase = GetPersonBaseCollection().CreateRandom(useCountryCode, TVTPersonGender.GetAtIndex(genderIndex))
 						Local jobID:int = TVTPersonJob.CAST_IDs[jobIndex]
 						amateur.SetPreferredJob(jobID, True)
 						'enable 1-2 other (or the same again) randomly
@@ -699,7 +699,6 @@ Type TProductionManager
 				EndIf
 			Next
 		Next
-
 		'add new amateurs to the existing ones
 		'no "+ 1" as newAmateursIndex is "nextAmateursIndex" already 
 		'currentAvailableAmateurs :+ newAmateurs[.. newAmateursIndex + 1]

--- a/source/game.screen.supermarket.production.bmx
+++ b/source/game.screen.supermarket.production.bmx
@@ -1947,8 +1947,9 @@ Type TGUICastSelectList Extends TGUISelectList
 	Function SortCastByName:Int(o1:Object, o2:Object)
 		Local a1:TGUICastListItem = TGUICastListItem(o1)
 		Local a2:TGUICastListItem = TGUICastListItem(o2)
-		If Not a1 or a1.isAmateur Then Return -1
-		If Not a2 or a2.isAmateur Then Return 1
+		'sort amateurs "on top"
+		If Not a1 or a1.isAmateur and (not a2 or not a2.isAmateur) Then Return -1
+		If Not a2 or a2.isAmateur and (not a1 or not a1.isAmateur) Then Return 1
 
 		If a1.person.GetLastName().ToLower() = a2.person.GetLastName().ToLower()
 			Return a1.person.GetFirstName().ToLower() > a2.person.GetFirstName().ToLower()
@@ -1962,11 +1963,20 @@ Type TGUICastSelectList Extends TGUISelectList
 	Function SortCastByJobXP:Int(o1:Object, o2:Object)
 		Local a1:TGUICastListItem = TGUICastListItem(o1)
 		Local a2:TGUICastListItem = TGUICastListItem(o2)
-		If Not a1 or a1.isAmateur Then Return -1
-		If Not a2 or a2.isAmateur Then Return 1
-
-		Local xp1:float=a1.person.GetEffectiveJobExperiencePercentage(a1.selectJobID)
-		Local xp2:float=a2.person.GetEffectiveJobExperiencePercentage(a2.selectJobID)
+		'sort amateurs "on top"
+		If Not a1 or a1.isAmateur and (not a2 or not a2.isAmateur) Then Return -1
+		If Not a2 or a2.isAmateur and (not a1 or not a1.isAmateur) Then Return 1
+		
+		Local xp1:float
+		Local xp2:float
+		'for amateurs we order by production job count (when to "upgrade")
+		If a1 And a1.isAmateur And a2 And a2.isAmateur
+			xp1 = a1.person.GetProductionJobsDone(a1.selectJobID)
+			xp2 = a2.person.GetProductionJobsDone(a2.selectJobID)
+		Else
+			xp1 = a1.person.GetEffectiveJobExperiencePercentage(a1.selectJobID)
+			xp2 = a2.person.GetEffectiveJobExperiencePercentage(a2.selectJobID)
+		EndIf
 
 		If xp1 = xp2 Then Return SortCastByName(o1, o2)
 		Return xp1 < xp2
@@ -1975,13 +1985,24 @@ Type TGUICastSelectList Extends TGUISelectList
 	Function SortCastByGenreXP:Int(o1:Object, o2:Object)
 		Local a1:TGUICastListItem = TGUICastListItem(o1)
 		Local a2:TGUICastListItem = TGUICastListItem(o2)
-		If Not a1 or a1.isAmateur Then Return -1
-		If Not a2 or a2.isAmateur Then Return 1
+		'sort amateurs "on top"
+		If Not a1 or a1.isAmateur and (not a2 or not a2.isAmateur) Then Return -1
+		If Not a2 or a2.isAmateur and (not a1 or not a1.isAmateur) Then Return 1
 
 		Local genre:Int = TScreenHandler_SupermarketProduction.GetInstance().currentProductionConcept.script.mainGenre
 
-		Local xp1:float=TPersonProductionData(a1.person.getProductionData()).GetEffectiveGenreExperiencePercentage(genre)
-		Local xp2:float=TPersonProductionData(a2.person.getProductionData()).GetEffectiveGenreExperiencePercentage(genre)
+		Local xp1:float
+		Local xp2:float
+		'for amateurs we order by production job count (when to "upgrade")
+		If a1 And a1.isAmateur And a2 And a2.isAmateur
+			xp1 = a1.person.GetProductionJobsDone(a1.selectJobID)
+			xp2 = a2.person.GetProductionJobsDone(a2.selectJobID)
+		Else
+			Local pd1:TPersonProductionData = TPersonProductionData(a1.person.getProductionData())
+			Local pd2:TPersonProductionData = TPersonProductionData(a2.person.getProductionData())
+			If pd1 Then xp1 = pd1.GetEffectiveGenreExperiencePercentage(genre)
+			If pd2 Then xp2 = pd2.GetEffectiveGenreExperiencePercentage(genre)
+		EndIf
 
 		If xp1 = xp2 Then Return SortCastByName(o1, o2)
 		Return xp1 < xp2
@@ -1990,8 +2011,9 @@ Type TGUICastSelectList Extends TGUISelectList
 	Function SortCastByFee:Int(o1:Object, o2:Object)
 		Local a1:TGUICastListItem = TGUICastListItem(o1)
 		Local a2:TGUICastListItem = TGUICastListItem(o2)
-		If Not a1 or a1.isAmateur Then Return -1
-		If Not a2 or a2.isAmateur Then Return 1
+		'sort amateurs "on top"
+		If Not a1 or a1.isAmateur and (not a2 or not a2.isAmateur) Then Return -1
+		If Not a2 or a2.isAmateur and (not a1 or not a1.isAmateur) Then Return 1
 
 		local playerID:Int = 0
 		local blocks:Int = 1
@@ -2685,12 +2707,11 @@ Type TGUICastListItem Extends TGUISelectListItem
 		'maybe "TPersonBase.GetFace()" ?
 		If TSprite(face)
 			TSprite(face).Draw(x+5, y+3)
-		Else
-			If TImage(face)
-				DrawImageArea(TImage(face), x+1, y+3, 2, 4, 34, 33)
-				'DrawImage(TProgrammePerson(person).GetFigureImage(), GetScreenRect().GetX(), GetScreenRect().GetY())
-			EndIf
+		ElseIf TImage(face)
+			DrawImageArea(TImage(face), x+1, y+3, 2, 4, 34, 33)
+			'DrawImage(TProgrammePerson(person).GetFigureImage(), GetScreenRect().GetX(), GetScreenRect().GetY())
 		EndIf
+
 
 		If name Or nameHint
 			Local border:SRect = nameSprite.GetNinePatchInformation().contentBorder

--- a/source/game.screen.supermarket.production.bmx
+++ b/source/game.screen.supermarket.production.bmx
@@ -1948,8 +1948,8 @@ Type TGUICastSelectList Extends TGUISelectList
 		Local a1:TGUICastListItem = TGUICastListItem(o1)
 		Local a2:TGUICastListItem = TGUICastListItem(o2)
 		'sort amateurs "at bottom"
-		If Not a1 or a1.isAmateur and (not a2 or not a2.isAmateur) Then Return 1
-		If Not a2 or a2.isAmateur and (not a1 or not a1.isAmateur) Then Return -1
+		'If Not a1 or a1.isAmateur and (not a2 or not a2.isAmateur) Then Return 1
+		'If Not a2 or a2.isAmateur and (not a1 or not a1.isAmateur) Then Return -1
 
 		If a1.person.GetLastName().ToLower() = a2.person.GetLastName().ToLower()
 			Return a1.person.GetFirstName().ToLower() > a2.person.GetFirstName().ToLower()
@@ -2012,8 +2012,8 @@ Type TGUICastSelectList Extends TGUISelectList
 		Local a1:TGUICastListItem = TGUICastListItem(o1)
 		Local a2:TGUICastListItem = TGUICastListItem(o2)
 		'sort amateurs "at bottom"
-		If Not a1 or a1.isAmateur and (not a2 or not a2.isAmateur) Then Return 1
-		If Not a2 or a2.isAmateur and (not a1 or not a1.isAmateur) Then Return -1
+		'If Not a1 or a1.isAmateur and (not a2 or not a2.isAmateur) Then Return 1
+		'If Not a2 or a2.isAmateur and (not a1 or not a1.isAmateur) Then Return -1
 
 		local playerID:Int = 0
 		local blocks:Int = 1

--- a/source/game.screen.supermarket.production.bmx
+++ b/source/game.screen.supermarket.production.bmx
@@ -1947,9 +1947,9 @@ Type TGUICastSelectList Extends TGUISelectList
 	Function SortCastByName:Int(o1:Object, o2:Object)
 		Local a1:TGUICastListItem = TGUICastListItem(o1)
 		Local a2:TGUICastListItem = TGUICastListItem(o2)
-		'sort amateurs "on top"
-		If Not a1 or a1.isAmateur and (not a2 or not a2.isAmateur) Then Return -1
-		If Not a2 or a2.isAmateur and (not a1 or not a1.isAmateur) Then Return 1
+		'sort amateurs "at bottom"
+		If Not a1 or a1.isAmateur and (not a2 or not a2.isAmateur) Then Return 1
+		If Not a2 or a2.isAmateur and (not a1 or not a1.isAmateur) Then Return -1
 
 		If a1.person.GetLastName().ToLower() = a2.person.GetLastName().ToLower()
 			Return a1.person.GetFirstName().ToLower() > a2.person.GetFirstName().ToLower()
@@ -1963,9 +1963,9 @@ Type TGUICastSelectList Extends TGUISelectList
 	Function SortCastByJobXP:Int(o1:Object, o2:Object)
 		Local a1:TGUICastListItem = TGUICastListItem(o1)
 		Local a2:TGUICastListItem = TGUICastListItem(o2)
-		'sort amateurs "on top"
-		If Not a1 or a1.isAmateur and (not a2 or not a2.isAmateur) Then Return -1
-		If Not a2 or a2.isAmateur and (not a1 or not a1.isAmateur) Then Return 1
+		'sort amateurs "at bottom"
+		If Not a1 or a1.isAmateur and (not a2 or not a2.isAmateur) Then Return 1
+		If Not a2 or a2.isAmateur and (not a1 or not a1.isAmateur) Then Return -1
 		
 		Local xp1:float
 		Local xp2:float
@@ -1985,9 +1985,9 @@ Type TGUICastSelectList Extends TGUISelectList
 	Function SortCastByGenreXP:Int(o1:Object, o2:Object)
 		Local a1:TGUICastListItem = TGUICastListItem(o1)
 		Local a2:TGUICastListItem = TGUICastListItem(o2)
-		'sort amateurs "on top"
-		If Not a1 or a1.isAmateur and (not a2 or not a2.isAmateur) Then Return -1
-		If Not a2 or a2.isAmateur and (not a1 or not a1.isAmateur) Then Return 1
+		'sort amateurs "at bottom"
+		If Not a1 or a1.isAmateur and (not a2 or not a2.isAmateur) Then Return 1
+		If Not a2 or a2.isAmateur and (not a1 or not a1.isAmateur) Then Return -1
 
 		Local genre:Int = TScreenHandler_SupermarketProduction.GetInstance().currentProductionConcept.script.mainGenre
 
@@ -2011,9 +2011,9 @@ Type TGUICastSelectList Extends TGUISelectList
 	Function SortCastByFee:Int(o1:Object, o2:Object)
 		Local a1:TGUICastListItem = TGUICastListItem(o1)
 		Local a2:TGUICastListItem = TGUICastListItem(o2)
-		'sort amateurs "on top"
-		If Not a1 or a1.isAmateur and (not a2 or not a2.isAmateur) Then Return -1
-		If Not a2 or a2.isAmateur and (not a1 or not a1.isAmateur) Then Return 1
+		'sort amateurs "at bottom"
+		If Not a1 or a1.isAmateur and (not a2 or not a2.isAmateur) Then Return 1
+		If Not a2 or a2.isAmateur and (not a1 or not a1.isAmateur) Then Return -1
 
 		local playerID:Int = 0
 		local blocks:Int = 1

--- a/source/game.screen.supermarket.production.bmx
+++ b/source/game.screen.supermarket.production.bmx
@@ -2487,6 +2487,9 @@ Type TGUICastListItem Extends TGUISelectListItem
 		Local overlayIntensity:Float = 0.35	
 		Local name:String = displayName
 		local nameHint:String 
+		
+		'update isAmateur state?
+		if isAmateur and person.IsCelebrity() then isAmateur = False
 
 		If isAmateur And Not isDragged()
 			If GetDisplayJobID() > 0 and TVTPersonJob.IsCastJob( GetDisplayJobID() )

--- a/source/game.screen.supermarket.production.bmx
+++ b/source/game.screen.supermarket.production.bmx
@@ -264,7 +264,8 @@ Type TScreenHandler_SupermarketProduction Extends TScreenHandler
 
 
 		'=== TAKE OVER OLD CONCEPT VALUES ===
-		If currentProductionConcept
+		'only take over if not already "finished planning"
+		If currentProductionConcept and not currentProductionConcept.IsProduceable()
 			'=== CAST ===
 			'loop over all jobs and try to take over as much of them as
 			'possible.

--- a/source/game.screen.supermarket.production.bmx
+++ b/source/game.screen.supermarket.production.bmx
@@ -2738,12 +2738,9 @@ Type TGUICastListItem Extends TGUISelectListItem
 		Local boxAreaPaddingY:Int = 4, barAreaPaddingY:Int = 4
 
 		If showAmateurInformation
-			jobDescriptionH = 0
+'			jobDescriptionH = 0
 			lifeDataH = 0
-			lastProductionsH = 0
-
-			'bereich fuer hinweis einfuehren -- dass  es sich um einen
-			'non-celeb handelt der "Erfahrung" sammelt
+'			lastProductionsH = 0
 		EndIf
 
 		boxH = skin.GetBoxSize(89, -1, "", "spotsPlanned", "neutral").GetY()
@@ -2754,6 +2751,9 @@ Type TGUICastListItem Extends TGUISelectListItem
 		'also contains 8 bars
 		If person.IsCelebrity() And Not showAmateurInformation
 			barAreaH = 2 * barAreaPaddingY + 7 * (barH + 2)
+		else
+			'"profession"
+			barAreaH = 1 * barAreaPaddingY + 1 * (barH + 2)
 		EndIf
 
 		'box area
@@ -2769,9 +2769,10 @@ Type TGUICastListItem Extends TGUISelectListItem
 		'=== TITLE AREA ===
 		skin.RenderContent(contentX, contentY, contentW, titleH, "1_top")
 			Local title:String = person.GetFullName()
-			If showAmateurInformation
-				title = GetLocale("JOB_AMATEUR")
-			EndIf
+			'If showAmateurInformation
+				'title = GetLocale("JOB_AMATEUR")
+				'title = person.GetFullName() + " ("+GetLocale("JOB_AMATEUR_" + TVTPersonJob.GetAsString(jobID)) + ")"
+			'EndIf
 
 			If titleH <= 18
 				GetBitmapFont("default", 13, BOLDFONT).DrawBox(title, contentX + 5, contentY +1, contentW - 10, titleH, sALIGN_LEFT_CENTER, skin.textColorNeutral)
@@ -2781,12 +2782,13 @@ Type TGUICastListItem Extends TGUISelectListItem
 		contentY :+ titleH
 
 
-		If Not showAmateurInformation
-			'=== JOB DESCRIPTION AREA ===
-			If jobDescriptionH > 0
-				skin.RenderContent(contentX, contentY, contentW, jobDescriptionH, "1")
+		'=== JOB DESCRIPTION AREA ===
+		If jobDescriptionH > 0
+			skin.RenderContent(contentX, contentY, contentW, jobDescriptionH, "1")
 
-				Local firstJobID:Int = -1
+			Local firstJobID:Int = -1
+			Local genreText:String = ""
+			If not showAmateurInformation
 				For Local jobIndex:Int = 1 To TVTPersonJob.Count
 					Local jobID:Int = TVTPersonJob.GetAtIndex(jobIndex)
 					If Not person.HasJob(jobID) Then Continue
@@ -2800,27 +2802,28 @@ Type TGUICastListItem Extends TGUISelectListItem
 					genre = person.GetProductionData().GetTopGenre()
 				endif
 
-				Local genreText:String = ""
 				If genre >= 0 Then genreText = GetLocale("PROGRAMME_GENRE_" + TVTProgrammeGenre.GetAsString(genre))
 				If genreText Then genreText = "~q" + genreText+"~q-"
-
-				If firstJobID >= 0
-					'add genre if you know the job
-					skin.fontNormal.DrawBox(genreText + GetLocale("JOB_"+TVTPersonJob.GetAsString(firstJobID)), contentX + 5, contentY, contentW - 10, jobDescriptionH, sALIGN_LEFT_CENTER, skin.textColorNeutral)
-				Else
-					'use the given jobID but declare as amateur
-					If jobID > 0
-						skin.fontNormal.DrawBox(GetLocale("JOB_AMATEUR_"+TVTPersonJob.GetAsString(jobID)), contentX + 5, contentY, contentW - 10, jobDescriptionH, sALIGN_LEFT_CENTER, skin.textColorNeutral)
-					Else
-						skin.fontNormal.DrawBox(GetLocale("JOB_AMATEUR"), contentX + 5, contentY, contentW - 10, jobDescriptionH, sALIGN_LEFT_CENTER, skin.textColorNeutral)
-					EndIf
-				EndIf
-
-				contentY :+ jobDescriptionH
 			EndIf
 
+			If firstJobID >= 0
+				'add genre if you know the job
+				skin.fontNormal.DrawBox(genreText + GetLocale("JOB_"+TVTPersonJob.GetAsString(firstJobID)), contentX + 5, contentY, contentW - 10, jobDescriptionH, sALIGN_LEFT_CENTER, skin.textColorNeutral)
+			Else
+				'use the given jobID but declare as amateur
+				If jobID > 0
+					skin.fontNormal.DrawBox(GetLocale("JOB_AMATEUR_"+TVTPersonJob.GetAsString(jobID)), contentX + 5, contentY, contentW - 10, jobDescriptionH, sALIGN_LEFT_CENTER, skin.textColorNeutral)
+				Else
+					skin.fontNormal.DrawBox(GetLocale("JOB_AMATEUR"), contentX + 5, contentY, contentW - 10, jobDescriptionH, sALIGN_LEFT_CENTER, skin.textColorNeutral)
+				EndIf
+			EndIf
 
-			'=== LIFE DATA AREA ===
+			contentY :+ jobDescriptionH
+		EndIf
+
+
+		'=== LIFE DATA AREA ===
+		If lifeDataH > 0
 			skin.RenderContent(contentX, contentY, contentW, lifeDataH, "1")
 			'splitter
 			GetSpriteFromRegistry("gfx_datasheet_content_splitterV").DrawArea(contentX + 5 + 165, contentY, 2, jobDescriptionH)
@@ -2835,15 +2838,17 @@ Type TGUICastListItem Extends TGUISelectListItem
 				skin.fontNormal.DrawSimple(person.GetCountryCode(), contentX + 170 + 5, contentY, skin.textColorNeutral)
 			EndIf
 			contentY :+ lifeDataH
+		EndIf
 
 
-			'=== LAST PRODUCTIONS AREA ===
+		'=== LAST PRODUCTIONS AREA ===
+		if lastProductionsH > 0
 			skin.RenderContent(contentX, contentY, contentW, lastProductionsH, "2")
-
-			If person.IsCelebrity() and person.GetProductionData()
+			'If person.IsCelebrity() and person.GetProductionData()
+			'If person.GetTotalProductionJobsDone() > 0 and 
+			If person.GetProductionData()
 				'last productions
 				Local productionIDs:Int[] = person.GetProductionData().GetProducedProgrammeIDs()
-
 				If productionIDs and productionIDs.length > 0
 					Local i:Int = 0
 					Local entryNum:Int = 0
@@ -2865,6 +2870,7 @@ Type TGUICastListItem Extends TGUISelectListItem
 			EndIf
 			contentY :+ lastProductionsH
 		EndIf
+
 
 		'=== BARS / BOXES AREA ===
 		'background for bars + boxes
@@ -2960,6 +2966,16 @@ Type TGUICastListItem Extends TGUISelectListItem
 				End Select
 				contentY :+ barH + 2
 			Next
+		Else
+			'bars have a top-padding
+			contentY :+ barAreaPaddingY
+
+			Local percentageUntilUpgrade:Float = person.GetProductionJobsDone(jobID) / float(GameRules.UpgradeInsignificantOnProductionJobsCount)
+
+			skin.RenderBar(contentX + 5, contentY, 100, 12, percentageUntilUpgrade)
+			skin.fontSmallCaption.DrawSimple(GetLocale("CAST_TRAINING"), contentX + 5 + 100 + 5, contentY - 2, skin.textColorLabel, EDrawTextEffect.Emboss, 0.3)
+			contentY :+ barH + 2
+
 		EndIf
 	'hidden?
 	Rem


### PR DESCRIPTION
- Verfuegbare Amateure in eigener Liste (damit immer die "gleichen" Leute statt immer Zufall pro "Listenaufruf")
- Liste wird aller 4 Stunden erneuert / durchgewuerfelt
- Amateure listen nun ihre Produktionen auf
- Upgrade von Amateur zu Profi/Promi nach Abschluss der dritten Produktion mit demselben Beruf (statt vorher "alle Berufe zusammen")
- Auswahllisten haben nun immer 5 Amateure mit zur Auswahl

![aufwertung](https://user-images.githubusercontent.com/2625226/129104666-7c1e4c0e-485b-4a25-becb-7b5b37e1068a.gif)
