### PR TITLE
Dev-Kommando für Script-Ausführung

### DIFF
--- a/source/main.bmx
+++ b/source/main.bmx
@@ -4241,6 +4241,18 @@ Type GameEvents
 				RoomHandler_ScriptAgency.GetInstance().SellScriptToPlayer(script, player.playerID, True)
 				GetGame().SendSystemMessage("added script: "+script.GetTitle()+" ["+script.GetScriptTemplate().GetGUID()+"]")
 
+			Case "exec"
+				Local fileToLoad:String = payload.Trim()
+				If FileType(fileToLoad) = FILETYPE_FILE
+					Local content:string = LoadText(fileToLoad)
+					For Local line:String = EachIn content.Split(chr(10))
+						If line.startsWith("/dev")
+							Local event:TEventBase=TEventBase.create("execScript", new TData().add("text", line))
+							onChatAddEntry(event)
+						End If
+					Next
+				End If
+
 			Case "help"
 				SendHelp()
 
@@ -4270,6 +4282,7 @@ Type GameEvents
 			GetGame().SendSystemMessage("|b|playerai|/b| [player#] [on=1, off=0]")
 			GetGame().SendSystemMessage("|b|loaddb|/b| (dbname)")
 			GetGame().SendSystemMessage("|b|reloaddev|/b|")
+			GetGame().SendSystemMessage("|b|exec|/b| (scriptPath)")
 		End Function
 
 		'internal helper function


### PR DESCRIPTION
Mit dem /dev exec scriptFile kann man einfach mehrere Kommandos ausführen (oder ein "kompliziertes" mit kürzerer Eingabe). Das ist ganz nützlich, um Vorbedingungen für Testfälle zu schaffen (z.B. mehrere Drehbücher zur Verfügung stellen, oder Geld und Beliebtheit anpassen).
Nur mit "/dev" beginnende Zeilen werden verarbeitet, so dass man die Skripte gut kommentieren kann.

Damit könnte man sogar eine Art Testfallkatalog erstellen (Datei enthält /dev-Kommandos und lesbare Anweisungen, denen man für einen manuellen Test folgen kann). Dafür wäre es allerdings noch hilfreich, wenn man den Dateipfad bei Nichtexistenz nochmal manipuliert (suche Scriptdatei z.B. auch in tests/testcases: /dev exec t1 vs /dev exec tests/testcases/t1).