### PR TITLE
FIX: weekday-script

### DIFF
--- a/source/game.gamescriptexpression.bmx
+++ b/source/game.gamescriptexpression.bmx
@@ -51,11 +51,11 @@ Function GameScriptExpression_Handle_Time:string(variable:string, params:string[
 			return string( floor(GetWorldTime().GetDaysRun() / GetWorldTime().GetDaysPerYear()) )
 		case "time_weekday"
 			'attention, use the weekday depending on game start (day 1
-			'of a game is always a monday)
-			return string( GetWorldTime().GetWeekdayByDay( GetWorldTime().GetDaysRun() ) )
+			'of a game is always a monday... ani: no it is not)
+			'return string( GetWorldTime().GetWeekdayByDay( GetWorldTime().GetDaysRun() ) )
 			'this would return weekday of the exact start date
 			'so 1985/1/1 is a different weekday than 1986/1/1
-			'return string( GetWorldTime().GetWeekday() )
+			return string( GetWorldTime().GetWeekday() )
 		case "time_season"
 			return string( GetWorldTime().GetSeason() )
 		case "time_dayofmonth"


### PR DESCRIPTION
Ich glaube, die Script-Auswertung des Wochentages muss auf die Alternative umgestellt werden. Das Spiel beginnt nicht immer am Montag.

Wie komme ich gerade jetzt darauf? Eine Möglichkeit eine Reihe von Samstagabendshows Live (am Samstagabedn) zu erzwingen, wäre mit den aktuellen Optionen auch möglich, wenn man ein Script per Availability am Donnerstag verfügbar macht und dann als Livezeit für die Kinder "in 2 Tagen", "in 9 Tagen" etc. zu definieren. Einfacher wäre natürlich eine Erweiterung der Zeit-Codes.