### PR TITLE
Pool refills limits

### DIFF
--- a/source/game.player.programmecollection.bmx
+++ b/source/game.player.programmecollection.bmx
@@ -810,6 +810,14 @@ Type TPlayerProgrammeCollection extends TOwnedGameObject {_exposeToLua="selected
 		'sold or "destroyed" script, so destroy its production concepts too
 		DestroyProductionConceptsByScript(script)
 
+		'a series becomes tradeable only if it is completely produced (or the script is thrown away)
+		if script.isSeries()
+			local licence:TProgrammeLicence = GetPlayerProgrammeCollection(script.owner).GetProgrammeLicence(script.usedInProgrammeID)
+			if licence and not licence.hasLicenceFlag(TVTProgrammeLicenceFlag.TRADEABLE)
+				licence.setLicenceFlag(TVTProgrammeLicenceFlag.TRADEABLE, True)
+			end if
+		endif
+
 		scripts.remove(script)
 		studioScripts.remove(script)
 		'remove from suitcase too!

--- a/source/game.production.bmx
+++ b/source/game.production.bmx
@@ -538,6 +538,13 @@ Type TProduction Extends TOwnedGameObject
 			If productionConcept.script.HasParentScript()
 				Local parentScript:TScript = productionConcept.script.GetParentScript()
 				If parentScript.IsProduced()
+					If parentScript.isSeries()
+						'make the programme tradeable as well
+						local licence:TProgrammeLicence = GetPlayerProgrammeCollection(owner).GetProgrammeLicence(parentScript.usedInProgrammeID)
+						if licence
+							licence.setLicenceFlag(TVTProgrammeLicenceFlag.TRADEABLE, True)
+						end if
+					EndIf
 					GetPlayerProgrammeCollection(owner).RemoveScript(parentscript, False)
 				EndIf
 			EndIf
@@ -914,6 +921,10 @@ Type TProduction Extends TOwnedGameObject
 			'parentLicence.GetData().productionID = - self.GetID() 
 			parentLicence.GetData().SetFlag(TVTProgrammeDataFlag.CUSTOMPRODUCTION, True)
 
+			'if the template header does not define all licence flags, the ones
+			'set for the header heavily depend on the production order of episodes!
+			parentLicence.licenceFlags = programmeLicence.licenceFlags
+
 			'fill with basic data (title, description, ...)
 			FillProgrammeData(parentLicence.GetData(), productionConcept, productionConcept.script.GetParentScript(), True)
 
@@ -928,6 +939,8 @@ Type TProduction Extends TOwnedGameObject
 				parentLicence.licenceType = TVTProgrammeLicenceType.SERIES
 				parentLicence.data.dataType = TVTProgrammeDataType.SERIES
 			EndIf
+			'a series is not tradeable until shooting is finished
+			if parentLicence.isSeries() Then parentLicence.setLicenceFlag(TVTProgrammeLicenceFlag.TRADEABLE, False)
 		Else
 			'we already created the parental licence before
 


### PR DESCRIPTION
Ziel ist, dass das Refill-Flag (#400) nicht nur für Einzellizenzen sondern auch für Serien korrekt ausgewertet wird. Es ist von der Datenbank her möglich, dass die Folgen jeweils einzelne Limits haben (Pilot 1x, alle anderen Folgen 2x).
Der aktuelle Ansatz ist, dass das Remove/Sell-Flag als gesetzt angesehen wird, wenn es im Header oder in einer der Folgen definiert ist. Es ist nämlich wenig sinnvoll, dass nur eine Einzelfolge zurückgegeben wird.
Das Refill-Flag wird aktuell pro Folge einzeln interpretiert (wenn es nicht schon für den Header gesetzt ist).

Mit dem aktuellen Stand funktionieren bei mir explizit definierte Filme und Serien (Test und Anpassung für Eigenproduktionen steht noch aus. Hier ist insb. auf die korrekte Übernahme der Lizenzflags aus den Vorlagen zu achten).

Je mehr ich darüber nachdenke, desto intuitiver finde ich eigentlich die Variante (als Standard), dass "Refill" in jedem Fall bei Rückgabe die Limits wieder auffrischt, nicht nur wenn alle Limits erschöpft sind. Beispiel Serie mit 12 Folgen und jeweils zwei Ausstrahlungen  - alle außer einer Folge 2x gesendet. Der nächste, der die Serie kauft kann eine Folge einmal senden...

PR zunächst als Draft.