### PR TITLE
Weniger strenger Available-Filter

### DIFF
--- a/source/game.programme.programmelicence.bmx
+++ b/source/game.programme.programmelicence.bmx
@@ -3081,7 +3081,12 @@ Type TProgrammeLicenceFilter
 	Method DoesFilter:Int(licence:TProgrammeLicence)
 		if not licence then return False
 
-		if checkAvailability and not licence.isAvailable() then return False
+		'if a licence is exceeding the broadcast limit it is not available
+		'in the movie agency it will have lost tradeability, 
+		'if owned by a player it should be visible in the archive for potential selling
+		if not licence.isExceedingBroadCastLimit()
+			if checkAvailability and not licence.isAvailable() then return False
+		endif
 		if checkTradeability and not licence.isTradeable() then return False
 		if checkVisibility and not licence.isVisible() then return False
 


### PR DESCRIPTION
#409: Statt unterschiedliche Filter zu verwenden, könnte der Availability-Filter etwas abgeschwächt werden. Programme im eigenen Besitz würden dann trotz Erreichen des Ausstrahlungslimits angezeigt werden (könnten aber nicht im Programm platziert werden).

Typischerweise sollte es ja ein Datenbankfehler sein, wenn sich ein Programm nach Erreichen des Limits noch im eigenen Besitz befindet - außer eben bei Serienfolgen, die nicht einzeln zurückgegeben werden sollten. Und selbst wenn es gewollt ist (Limit erreicht, aber Warten bis Aktualität wieder hoch bevor man verkauft), muss man das Programm sehen können!

Da die Filter aber auch an anderen Stellen verwendet werden, kann ich gerade schlecht einschätzen, ob diese Änderung andere ungewünsche Nebeneffekte hat.