### PR TITLE
Fix: [DB] script title

### DIFF
--- a/res/database/Default/database_scripts.xml
+++ b/res/database/Default/database_scripts.xml
@@ -360,7 +360,7 @@
 				<title>
 					<!-- twice ... to select it more often -->
 					<de>%NAME% %TITLEACTION%|%NAME% %TITLEACTION%|%NAME%|%QUESTION%|%DISEASE% und ich|Ich bin %NAME%</de>
-					<en>%NAME% %TITLEACTION%|%NAME% %TITLEACTION%|%NAME%|%QUESTION%|%DISEASE% and me|I am %NAME%|I'm %NAME%</en>
+					<en>%NAME% %TITLEACTION%|%NAME% %TITLEACTION%|%NAME%|%QUESTION%|%DISEASE% and me|I am %NAME%</en>
 				</title>
 				<name>
 					<de>%PERSONGENERATOR_FIRSTNAME(de,1)%|%PERSONGENERATOR_FIRSTNAME(aut,1)%</de>


### PR DESCRIPTION
Wegen der unterschiedlichen Anzahl von Optionen für den Titel konnte es dazu kommen, dass er in einer Sprache "MISSING" war.