### PR TITLE
Fix: [DB] make string option count match

### DIFF
--- a/res/database/Default/database_scripts.xml
+++ b/res/database/Default/database_scripts.xml
@@ -391,8 +391,8 @@
 					<en>support him|help him|leave no stone unturned|assist him</en>
 				</environmentaction>
 				<feeling>
-					<de>~nGefühle hautnah!|~nGefühlskino!|||~nDa fühlt jeder mit!|~nEndlich mal ohne Klischees erzählt!</de>
-					<en>~nFeelings up close!|||~nFeeling cinema!||~nEveryone feels it!||~nFinally told without clichés!</en>
+					<de>|||~nGefühle hautnah!|~nGefühlskino!|~nDa fühlt jeder mit!|~nEndlich mal ohne Klischees erzählt!</de>
+					<en>|||~nFeelings up close!|~nFeeling cinema!|~nEveryone feels it!|~nFinally told without clichés!</en>
 				</feeling>
 			</variables>
 
@@ -501,7 +501,7 @@
 			<variables>
 				<attribute>
 					<de>Ein Haufen|Die Hillbillie-|Verrückte|Die Wahnsinns-|Bayrische|Tugendhafte|Durchgedrehte|Fromme|Zankende</de>
-					<en>A bunch of|The hillbillie-|Crazy|The frenzy|Bavarian|Virtuous|Pious|Brawly</en>
+					<en>A bunch of|The hillbillie-|Crazy|The frenzy|Bavarian|Virtuous|Nutty|Pious|Brawly</en>
 				</attribute>
 				<object>
 					<de>Waschweiber|Drag-Queens|Schwerenöter|Polizisten|Rettungsschwimmer|Clowns|Krankenpfleger|Stripper|Feuerwehrmänner|Nonnen</de>

--- a/res/database/Default/user/therob.xml
+++ b/res/database/Default/user/therob.xml
@@ -797,7 +797,7 @@
 					</title>
 					<description>
 						<de>[1|Full] reist mit Mia Issukalt nach Grönland und begleitet den Aufbau ihres Kühlschrankfachhandels. Ein etwas kühle Sache.</de>
-						<en>|1|Full] travels to Greenland with Mee Isfreezy and accompanies the development of her refrigerator business. A bit of a cool thing.</en>
+						<en>[1|Full] travels to Greenland with Mee Isfreezy and accompanies the development of her refrigerator business. A bit of a cool thing.</en>
 					</description>
 					<ratings critics="44" speed="19" />
 				</programme>


### PR DESCRIPTION
Wenn bei den "Feelings" leere Werte erlaubt sein sollen, kann man diese alle an den Anfang stellen