### PR TITLE
Verhalten Koffer im Archiv

### DIFF
--- a/source/game.roomhandler.archive.bmx
+++ b/source/game.roomhandler.archive.bmx
@@ -57,6 +57,7 @@ Type RoomHandler_Archive extends TRoomHandler
 			GuiListSuitcase.SetOrientation( GUI_OBJECT_ORIENTATION_HORIZONTAL )
 			GuiListSuitcase.acceptType = TGUIProgrammeLicenceSlotList.acceptAll
 			GuiListSuitcase.SetItemLimit(GameRules.maxProgrammeLicencesInSuitcase)
+			GuiListSuitcase.SetAutofillSlots(True)
 			GuiListSuitcase.SetSlotMinDimension(baseSprite.area.GetW(), baseSprite.area.GetH())
 			GuiListSuitcase.SetAcceptDrop("TGUIProgrammeLicence")
 


### PR DESCRIPTION
Der Koffer solle sich analog zu anderen Räumen verhalten. Bislang konnte man einen Film an eine beliebige Stelle im Koffer stellen.