### PR TITLE
Gagenberechnung

### DIFF
--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -503,7 +503,7 @@ Type TDatabaseLoader
 			
 			'0 would mean: cuts price to 0
 			If person.GetProductionData().priceModifier = 0 Then person.GetProductionData().priceModifier = 1.0
-			person.GetProductionData().priceModifier = 0.01 * data.GetFloat("price_mod", 100*person.GetProductionData().priceModifier)
+			person.GetProductionData().priceModifier = data.GetFloat("price_mod", person.GetProductionData().priceModifier)
 
 			if TPersonProductionData(person.GetProductionData())
 				TPersonProductionData(person.GetProductionData()).topGenre = data.GetInt("topgenre", TPersonProductionData(person.GetProductionData()).topGenre)

--- a/source/game.person.bmx
+++ b/source/game.person.bmx
@@ -552,9 +552,7 @@ Type TPersonProductionData Extends TPersonProductionBaseData
 				dynamicFee = 7000 * attributeMod
 		End Select
 
-		Local fee:Float = baseFee
-		'incorporate the dynamic fee amount
-		fee :+ dynamicFee * xpMod * sympathyMod * priceModifier
+		Local fee:Float = feeByExperience(baseFee, dynamicFee * xpMod * sympathyMod * priceModifier, GetEffectiveJobExperiencePercentage(jobID))
 		'incorporate the block amount modifier
 		fee :* blocksMod
 		'round to next "1000" block
@@ -562,6 +560,24 @@ Type TPersonProductionData Extends TPersonProductionBaseData
 		'round to "beautiful" (100, ..., 1000, 1250, 1500, ..., 2500)
 		fee = TFunctions.RoundToBeautifulValue(fee)
 		Return fee
+
+		'goal - production early in the game attractive, but later in the game not too cheap
+		'increase the fee heavily based on the experience
+		'what is the intended growth?
+		Function feeByExperience:Float(fee:Float, dynamicFee:Float, xpPercent:Float)
+			'Local factor:Float = 1.0045^(300*xpPercent + 30 ) - 1
+
+			'0-1 growing fast, slow
+			'Local factor:Float = Sin(xpPercent * 90)
+
+			'0-1 growing slow, fast, slow
+			'Local factor:Float = (Sin(xpPercent * 180 - 90) + 1) * 0.5
+
+			'0-2 growing slow, fast, slow
+			Local factor:Float = (Sin(xpPercent * 180 - 90) + 1)
+			'print xpPercent +" "+factor
+			Return fee + dynamicFee * factor
+		EndFunction
 	End Method
 	
 

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -2502,6 +2502,13 @@ Type TSaveGame Extends TGameState
 				print "RepairData: Create (new) programme producers (savegame did not contain them)"
 				GetGame().GenerateStartProgrammeProducers()
 			EndIf
+			For Local person:TPersonBase = EachIn GetPersonBaseCollection().GetCastablesList()
+				Local prodData:TPersonProductionBaseData = person.GetProductionData()
+				If prodData And prodData.priceModifier < 0.011
+					prodData.priceModifier = 1.0
+					print "RepairData: Fix price modifier from 1% to intended 100% for "+person.getFullName()
+				EndIF
+			Next
 		EndIf
 		if savegameVersion < 15
 			'ensure consistent broadcast slots


### PR DESCRIPTION
Die "normalen" Gagen zu Beginn des Spiels (um 30000 statt 150000) wurden durch einen Datenbankeinlesefehler erreicht (Faktor für dynamischen Anteil 1% statt 100%).
Ich schlage vor, den Faktor für den dynamischen Anteil stark von der Erfahrung abhängig zu machen. Dadurch werden zu Beginn des Spiels vernünftige Preise erreicht, wenn die Erfahrung aber steigt und man davon profitieren will, muss man mehr Geld in die Hand nehmen.

Allererster Vorschlag ist ein sinus-mäßiges Anwachsen 0%->Faktor 0, 100% Faktor 2). Als Nebeneffekt erledigt sich auch das Problem mit den Amateur-Gagen.

closes #391