### PR TITLE
Fix: [Scriptagency] no selling preproductions

### DIFF
--- a/source/game.production.productionconcept.bmx
+++ b/source/game.production.productionconcept.bmx
@@ -106,6 +106,20 @@ Type TProductionConceptCollection Extends TGameObjectCollection
 			Return script.CanGetProducedCount()
 		endIf
 	End Method
+
+
+	Method getProductionsIncludingPreProductionsCount:Int(script:TScript)
+		'finished productions
+		Local producedConceptCount:Int = script.GetProductionsCount()
+		Local productionConcepts:TProductionConcept[] = GetProductionConceptsByScript(script, True)
+		'add preproductions
+		For Local concept:TProductionConcept = EachIn productionConcepts
+			If concept.IsProductionStarted()
+				producedConceptCount :+ 1
+			EndIF
+		Next
+		return producedConceptCount
+	EndMethod
 End Type
 
 

--- a/source/game.roomhandler.scriptagency.bmx
+++ b/source/game.roomhandler.scriptagency.bmx
@@ -374,12 +374,15 @@ Type RoomHandler_ScriptAgency extends TRoomHandler
 		return TRUE
 	End Method
 
+	Method CanBuyScriptFromPlayer:Int(script:TScript)
+		Return GetProductionConceptCollection().getProductionsIncludingPreproductionsCount(script) <= 0
+	EndMethod
 
 	Method BuyScriptFromPlayer:int(script:TScript)
 		'remove from player (lists and suitcase) - and give him money
 		if GetPlayerBaseCollection().IsPlayer(script.owner)
 			'TODO remove when implementing Dialogue for scripts
-			If script.getProductionsCount() > 0 Then Return False
+			If Not CanBuyScriptFromPlayer(script) Then Return False
 			local pc:TPlayerProgrammeCollection = GetPlayerProgrammeCollection(script.owner)
 			'try to remove it from the suitcase
 			if pc.RemoveScriptFromSuitcase(script)
@@ -883,6 +886,12 @@ endrem
 				Return FALSE
 			EndIf
 		EndIf
+
+		If guiScript.script.owner > 0 And Not GetInstance().CanBuyScriptFromPlayer(guiScript.script)
+			triggerEvent.SetVeto(True)
+			Return FALSE
+		EndIf
+
 		Return True
 	End Function
 	
@@ -996,7 +1005,7 @@ endrem
 			if hoveredGuiScript.IsDragged()
 				GetGameBase().SetCursor(TGameBase.CURSOR_HOLD)
 '			elseif hoveredGuiScript.script.owner = GetPlayerBase().playerID or (GetPlayerBase().GetFinance().canAfford(hoveredGuiScript.script.GetPrice()) and GetPlayerProgrammeCollection(GetPlayerBase().playerID).CanMoveScriptToSuitcase())
-			elseif hoveredGuiScript.IsDragable()
+			elseif hoveredGuiScript.IsDragable() And CanBuyScriptFromPlayer(hoveredGuiScript.script)
 				GetGameBase().SetCursor(TGameBase.CURSOR_PICK_VERTICAL)
 			else
 				GetGameBase().SetCursor(TGameBase.CURSOR_PICK_VERTICAL, TGameBase.CURSOR_EXTRA_FORBIDDEN)

--- a/source/game.roomhandler.studio.bmx
+++ b/source/game.roomhandler.studio.bmx
@@ -603,9 +603,9 @@ Type RoomHandler_Studio Extends TRoomHandler
 			'adjust list limit
 			Local minConceptLimit:Int = 1
 			If studioScript.GetSubScriptCount() > 0
-				minConceptLimit = Min(GameRules.maxProductionConceptsPerScript, studioScript.GetSubScriptCount() - getProductionCount(studioScript))
+				minConceptLimit = Min(GameRules.maxProductionConceptsPerScript, studioScript.GetSubScriptCount() - GetProductionConceptCollection().getProductionsIncludingPreproductionsCount(studioScript))
 			Else
-				minConceptLimit = Min(GameRules.maxProductionConceptsPerScript, studioScript.GetProductionLimitMax() - getProductionCount(studioScript))
+				minConceptLimit = Min(GameRules.maxProductionConceptsPerScript, studioScript.GetProductionLimitMax() - GetProductionConceptCollection().getProductionsIncludingPreproductionsCount(studioScript))
 			EndIf
 
 			guiListDeskProductionConcepts.SetItemLimit( minConceptLimit )
@@ -887,19 +887,6 @@ Type RoomHandler_Studio Extends TRoomHandler
 		Return text
 	End Method
 
-	'get number of (pre)productions for a script for determining the number of possible concepts
-	Function getProductionCount:Int(script:TScript)
-		'finished productions
-		Local producedConceptCount:Int = script.GetProductionsCount()
-		Local productionConcepts:TProductionConcept[] = GetProductionConceptCollection().GetProductionConceptsByScript(script, True)
-		'add preproductions
-		For Local concept:TProductionConcept = EachIn productionConcepts
-			If concept.IsProductionStarted()
-				producedConceptCount :+ 1
-			EndIF
-		Next
-		return producedConceptCount
-	EndFunction
 
 	Method GenerateStudioManagerDialogue(dialogueType:Int = 0)
 		If Not TFigure(GetPlayerBase().GetFigure()).inRoom Then Return
@@ -929,7 +916,7 @@ Type RoomHandler_Studio Extends TRoomHandler
 
 		If script
 			'=== PRODUCED CONCEPT COUNT ===
-			producedCount = getProductionCount(script)
+			producedCount = GetProductionConceptCollection().getProductionsIncludingPreproductionsCount(script)
 
 			'=== COLLECT PRODUCEABLE CONCEPTS ===
 			productionConcepts = GetProductionConceptCollection().GetProductionConceptsByScript(script, True)


### PR DESCRIPTION
Aktuell kann man noch Drehbücher für Live-Produktionen verkaufen, nachdem die Vorproduktion schon stattgefunden hat (tatsächlich kann man sie auch wegwerfen und die Sendung dann trotzdem noch senden).
Statt den Studio-Handler zu importieren, wäre es vermutlich sauberer, den "ProductionCountIncludingPreproduction" in der ProductionConceptCollection unterzubringen.
Ich wollte aber zunächst kurz Feedback einholen.