### PR TITLE
Behandlung optionaler Flags bei Serie

### DIFF
--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -1484,6 +1484,8 @@ Type TDatabaseLoader
 			'try to clone the parent, if that fails, create a new instance
 			If parentScriptTemplate
 				scriptTemplate = TScriptTemplate(THelper.CloneObject(parentScriptTemplate, "id"))
+				'#440 optional flags are not propagated to episode templates
+				scriptTemplate.flagsOptional = 0
 			EndIf
 			If Not scriptTemplate
 				scriptTemplate = New TScriptTemplate


### PR DESCRIPTION
Für Serien werden die optionalen Flags des Haupteintrags nicht an die Kinddrehbuchvorlagen weitergegeben. Stattdessen werden bei der Drehbucherstellung die Flags ermittelt und dann an die Folgen vererbt (so sind dann z.B. alle Folgen live). Einzelfolgen können weiterhin eigene optionale Flags haben.

Die Berechnung der Live-Zeit und das Deaktivieren von X-Rated kann infolgedessen erst nach dem Propagieren der Elternflags erfolgen.