### PR TITLE
Einkaufszettel Serienproduktion im Supermarkt

### DIFF
--- a/source/game.production.productionconcept.gui.bmx
+++ b/source/game.production.productionconcept.gui.bmx
@@ -822,7 +822,7 @@ endrem
 		local bgColor:TColor
 
 		'ready for production
-		if productionConcept.IsProduceable()
+		if productionConcept.IsProduceable() or productionConcept.IsProductionStarted() or productionConcept.IsProductionFinished()
 			bgColor = colorProduceableBG
 		'planned but not paid
 		elseif productionConcept.isPlanned()
@@ -892,7 +892,7 @@ endrem
 		GetAsset().draw(Self.GetScreenRect().GetX(), Self.GetScreenRect().GetY(), -1, null, scaleAsset)
 
 		'ready for production
-		if productionConcept.IsProduceable()
+		if productionConcept.IsProduceable() or productionConcept.isProductionStarted() or productionConcept.isProductionFinished
 			GetSpriteFromRegistry("gfx_datasheet_icon_ok").Draw(Self.GetScreenRect().GetX()-2, Self.GetScreenRect().GetY() + GetAsset().GetHeight() * scaleAsset -1)
 		'finished planning
 		elseif productionConcept.IsPlanned()
@@ -927,7 +927,7 @@ endrem
 
 
 		'finished
-		if productionConcept.IsProduceable()
+		if productionConcept.IsProduceable() or productionConcept.IsProductionStarted() or productionConcept.IsProductionFinished()
 			titleColor = colorProduceable
 			genreColor = colorHint
 		'all slots filled, just not paid

--- a/source/game.screen.supermarket.production.bmx
+++ b/source/game.screen.supermarket.production.bmx
@@ -176,6 +176,13 @@ Type TScreenHandler_SupermarketProduction Extends TScreenHandler
 			Return
 		EndIf
 
+		'remove current concept if its produciton has started
+		If currentProductionConcept.isProductionStarted() or currentProductionConcept.isProductionFinished()
+			SetCurrentProductionConcept (Null, Null)
+			GetInstance().ReloadProductionConceptContent()
+			Return
+		EndIf
+
 		editTextsButton.Enable()
 		If currentProductionConcept.IsProduceable()
 			editTextsButton.Disable()


### PR DESCRIPTION
Für Serien/Drehbücher mit mehreren möglichen Produktionen kann man mehrere Einkaufslisten fertigstellen und alle Produktionen auf einmal starten.
Wenn man dann in den Supermarkt geht, sieht man nur den Einkaufszettel der unmittelbar gestarteten Produktion nicht mehr. Die anderen sind noch sichtbar. Wenn man aber abwartet, bis die zweite Produktion startet, sollte sich die Farbe des Einkaufszettels nich auf "in Planung" zurückändern.

Außerdem wurde umgesetzt, dass der Einkaufszettel (wenn bereits in Produktion) verschwindet, wenn er angeklickt wird.

Closes #449