### PR TITLE
Geschwindigkeitsberechnung Vorspulen

### DIFF
--- a/docs/manual_de.md
+++ b/docs/manual_de.md
@@ -54,7 +54,7 @@ Desweiteren gibt es die Möglichkeit zum Schnellspeichern bzw. -laden. Dazu einf
 Spielgeschwindigkeit
 ====================
 
-Ihr könnt die Spielgeschwindigkeit mit den Pfeiltasten „hoch“ und „runter“ verändern. Es gibt auch noch voreingestellte Geschwindigkeiten. Dazu siehe am Ende die „Tastenkürzel der Enwicklerversion“. Über die Pfeiltasten „links“ und „rechts“ ändert Ihr die Spielgeschwindigkeit und die Bewegungsgeschwindigkeit der Spielfiguren.
+Es gibt drei voreingestellte Geschwindigkeiten, die über Knöpfe unter der Uhrzeit ausgewählt werden können. Möglichkeiten zum schnellen Vorspulen können dem Abschitt „Tastenkürzel der Enwicklerversion“ entnommen werden..
 
 
 Bewegung der Spielfigur
@@ -283,15 +283,15 @@ Tastenkürzel für die Entwicklerversion
 
 Spielgeschwindigkeit
 --------------------
-* Cursor Hoch/Runter : Spielgeschwindigkeit +/-
-* Cursor Links/Rechts : Laufgeschwindigkeit und Spielgeschwindigkeit +/-
+* Cursor Links/Rechts : Spielgeschwindigkeit -/+
 * Strg Links + Cursor Rechts: Schnellvorlauf Stufe 1
 * Strg Rechts + Cursor Rechts: Schnellvorlauf Stufe 2
-* 5 : Spielgeschwindigkeit 60 Spielminuten/s
-* 6 : Spielgeschwindigkeit 120 Spielminuten/s
-* 7 : Spielgeschwindigkeit 180 Spielminuten/s
+* 5 : Spielgeschwindigkeit 30 Spielminuten/s
+* 6 : Spielgeschwindigkeit 60 Spielminuten/s
+* 7 : Spielgeschwindigkeit 120 Spielminuten/s
 * 8 : Spielgeschwindigkeit 240 Spielminuten/s
-* 9 : Spielgeschwindigkeit 1 Spielminute/s (Standard)
+* 9 : Spielgeschwindigkeit 0,5 Spielminuten/s (Standard)
+* 0 : Spielgeschwindigkeit 0 ("Pause")
 
 Raeume
 ------

--- a/docs/manual_en.md
+++ b/docs/manual_en.md
@@ -57,7 +57,7 @@ On the other hand, there's also the possibility of quick-saving and -loading. Si
 Game Speed
 ==========
 
-You can change the game's speed with the "up" and "down" arrow keys. There are also preset speeds. For this, see the end of the "Keyboard Shortcuts for the Developer Version". The "left" and "right" arrow keys alter the game speed and the movement speed of the in-game characters.
+There are three preset speeds that can be selected via the buttons below the clock. The section "Keyboard Shortcuts for the Developer Version" contains further options for fast-forwarding.
 
 Movement of In-Game Characters
 ==============================
@@ -285,15 +285,15 @@ Keyboard Shortcuts for the Developer Version
 
 Game Speed
 ----------
-* Up/down arrow keys : Game speed +/-
-* Left/right arrow keys : Running speed and game speed +/-
+* Left/right arrow keys : game speed -/+
 * Left-Ctrl + right arrow key : Fast forward level 1
 * Right-Ctrl + right arrow key: Fast forward level 2
-* 5 : Speed 60 game minutes/s
-* 6 : Speed 120 game minutes/s
-* 7 : Speed 180 game minutes/s
+* 5 : Speed 30 game minutes/s
+* 6 : Speed 60 game minutes/s
+* 7 : Speed 120 game minutes/s
 * 8 : Speed 240 game minutes/s
-* 9 : Speed 1 game minute/s (standard)
+* 9 : Speed 0.5 game minutes/s (standard)
+* 0 : Speed 0 ("pause")
 
 Rooms
 -----

--- a/source/game.game.bmx
+++ b/source/game.game.bmx
@@ -113,23 +113,26 @@ Type TGame Extends TGameBase {_exposeToLua="selected"}
 
 	Method SetGameSpeedPreset(preset:Int)
 		preset = Max(Min(GameRules.worldTimeSpeedPresets.length-1, preset), 0)
-		SetGameSpeed(GameRules.worldTimeSpeedPresets[preset])
+		SetGameSpeed(GameRules.worldTimeSpeedPresets[preset], True)
 	End Method
 
-
-	Method SetGameSpeed(timeFactor:Int = 15)
-		Local modifier:Float = Float(timeFactor) / GameRules.worldTimeSpeedPresets[0]
-
+	Method SetGameSpeed(timeFactor:Int = 15, reducedBuildingTimeFactor:Int = False)
 		GetWorldTime().SetTimeFactor( timeFactor ) 'same as "modifier * GameRules.worldTimeSpeedPresets[0]"
-'15 30 180 600
-'1 2 12 40
-		TEntity.globalWorldSpeedFactor = GameRules.globalEntityWorldSpeedFactor + 0.005 * modifier
-		'also move slightly faster with higher speed...
-		'speed preset 1 (modifier = 2) is default
-		'normally a "modifier" as factor would be a direct translation
-		'but this does not look nice for the normal presets where you do
-		'not expect "speed 3" to look so "fast forward"
-		GetBuildingTime().SetTimeFactor( 0.75 + 0.5 * (modifier-1) )
+		'15 30 180 600
+		'1  2  12  40
+		Local modifier:Float = Float(timeFactor) / GameRules.worldTimeSpeedPresets[0]
+		If reducedBuildingTimeFactor Then
+			TEntity.globalWorldSpeedFactor = GameRules.globalEntityWorldSpeedFactor + 0.005 * modifier
+			'also move slightly faster with higher speed...
+			'speed preset 1 (modifier = 2) is default
+			'normally a "modifier" as factor would be a direct translation
+			'but this does not look nice for the normal presets where you do
+			'not expect "speed 3" to look so "fast forward"
+			GetBuildingTime().SetTimeFactor( 0.75 + 0.5 * (modifier-1) )
+		Else
+			GetBuildingTime().SetTimeFactor( modifier )
+			TEntity.globalWorldSpeedFactor = modifier
+		EndIf
 
 '		TEntity.globalWorldSpeedFactor = GameRules.globalEntityWorldSpeedFactor + 0.005 * modifier
 		'move as fast as on level 2 (to avoid odd looking figures)

--- a/source/gamefunctions_debug.bmx
+++ b/source/gamefunctions_debug.bmx
@@ -2292,9 +2292,7 @@ endrem
 			FastForward_TimeFactorBackup = GetWorldTime()._timeFactor
 			FastForward_BuildingTimeSpeedFactorBackup = GetBuildingTime()._timeFactor
 
-			TEntity.globalWorldSpeedFactor = 500/4
-			GetWorldTime().SetTimeFactor(16000/4 + 60)
-			GetBuildingTime().SetTimeFactor(400/4 + 60)
+			GetGame().SetGameSpeed( 150 * 60 )
 		EndIf
 	End Method
 

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -826,15 +826,13 @@ Type TApp
 		'in game and not gameover
 		If GetGame().gamestate = TGame.STATE_RUNNING And Not GetGame().IsGameOver()
 			If not TGUIListBase(GUIManager.GetFocus()) or not TGUIListBase(GUIManager.GetFocus()).IsHandlingKeyBoardScrolling() 
-				If KeyManager.IsDown(KEY_UP) Then GetWorldTime().AdjustTimeFactor(+5)
-				If KeyManager.IsDown(KEY_DOWN) Then GetWorldTime().AdjustTimeFactor(-5)
+				'If KeyManager.IsDown(KEY_UP) Then 
+				'If KeyManager.IsDown(KEY_DOWN) Then 
 			EndIf
 
 			If KeyManager.IsDown(KEY_RIGHT)
 				If Not KeyManager.IsDown(KEY_LCONTROL) And Not KeyManager.Isdown(KEY_RCONTROL)
-					TEntity.globalWorldSpeedFactor :+ 0.05
-					GetWorldTime().AdjustTimeFactor(+10)
-					GetBuildingTime().AdjustTimeFactor(+0.05)
+					GetGame().SetGameSpeed( Int(GetWorldTime().getTimeFactor) + 10 )
 				Else
 					'fast forward
 					If Not DEV_FastForward
@@ -843,14 +841,14 @@ Type TApp
 						DEV_FastForward_TimeFactorBackup = GetWorldTime()._timeFactor
 						DEV_FastForward_BuildingTimeSpeedFactorBackup = GetBuildingTime()._timeFactor
 
+						'set fixed speed instead of adding to the current
 						If KeyManager.IsDown(KEY_RCONTROL)
-							TEntity.globalWorldSpeedFactor :+ 200
-							GetWorldTime().AdjustTimeFactor(+8000)
-							GetBuildingTime().AdjustTimeFactor(+200)
+							GetGame().SetGameSpeed( 150 * 60 )
+'							TEntity.globalWorldSpeedFactor :+ 200
+'							GetWorldTime().AdjustTimeFactor(+8000)
+'							GetBuildingTime().AdjustTimeFactor(+200)
 						ElseIf KeyManager.IsDown(KEY_LCONTROL)
-							TEntity.globalWorldSpeedFactor :+ 50
-							GetWorldTime().AdjustTimeFactor(+2000)
-							GetBuildingTime().AdjustTimeFactor(+50)
+							GetGame().SetGameSpeed( 60 * 60 )
 						EndIf
 					EndIf
 				EndIf
@@ -866,9 +864,7 @@ Type TApp
 
 
 			If KeyManager.IsDown(KEY_LEFT) Then
-				TEntity.globalWorldSpeedFactor = Max( TEntity.globalWorldSpeedFactor - 0.05, 0)
-				GetWorldTime().AdjustTimeFactor(-10)
-				GetBuildingTime().AdjustTimeFactor(-0.05)
+				GetGame().SetGameSpeed( Max(Int(GetWorldTime().getTimeFactor) - 10, 0) )
 			EndIf
 
 
@@ -1265,11 +1261,12 @@ endrem
 				EndIf
 			EndIf
 		EndIf
-		If KeyManager.IsHit(KEY_5) Then GetGame().SetGameSpeed( 60*15 )  '60 virtual minutes per realtime second
-		If KeyManager.IsHit(KEY_6) Then GetGame().SetGameSpeed( 120*15 ) '120 minutes per second
-		If KeyManager.IsHit(KEY_7) Then GetGame().SetGameSpeed( 180*15 ) '180 minutes per second
-		If KeyManager.IsHit(KEY_8) Then GetGame().SetGameSpeed( 240*15 ) '240 minute per second
-		If KeyManager.IsHit(KEY_9) Then GetGame().SetGameSpeed( 1*15 )   '1 minute per second
+		If KeyManager.IsHit(KEY_5) Then GetGame().SetGameSpeed( 30 * 60 ) '30 game minutes per realtime second
+		If KeyManager.IsHit(KEY_6) Then GetGame().SetGameSpeed( 60 * 60 ) '60 game minutes per realtime second
+		If KeyManager.IsHit(KEY_7) Then GetGame().SetGameSpeed( 120 * 60 )
+		If KeyManager.IsHit(KEY_8) Then GetGame().SetGameSpeed( 240 * 60 )
+		If KeyManager.IsHit(KEY_9) Then GetGame().SetGameSpeedPreset( 1 )
+		If KeyManager.IsHit(KEY_0) Then GetGame().SetGameSpeed( 0 ) 'pause
 		If KeyManager.IsHit(KEY_Q) Then TVTDebugQuoteInfos = 1 - TVTDebugQuoteInfos
 
 		If KeyManager.IsHit(KEY_TAB)
@@ -1363,9 +1360,7 @@ endrem
 				DEV_FastForward_TimeFactorBackup = GetWorldTime()._timeFactor
 				DEV_FastForward_BuildingTimeSpeedFactorBackup = GetBuildingTime()._timeFactor
 
-				TEntity.globalWorldSpeedFactor :+ 25
-				GetWorldTime().AdjustTimeFactor(+1000)
-				GetBuildingTime().AdjustTimeFactor(+25)
+				GetGame().SetGameSpeed( 30 * 60 )
 			EndIf
 		Else
 			'stop fast forward
@@ -4343,6 +4338,7 @@ Type GameEvents
 			GetGame().SendSystemMessage("|b|loaddb|/b| (dbname)")
 			GetGame().SendSystemMessage("|b|reloaddev|/b|")
 			GetGame().SendSystemMessage("|b|exec|/b| (scriptPath)")
+			GetGame().SendSystemMessage("|b|devkeys|/b| [enable 0 or 1]")
 		End Function
 
 		'internal helper function


### PR DESCRIPTION
Keine Reaktion auf Hoch/Runter (nur Weltgeschwindigkeit aber nicht Gebäude). Verlangsamte Personen/Fahrstuhl nur in "Presets" 1-3, bei Vorspulen (5,6,7,8 und Pfeiltasten) werden alle Geschwindigkeiten gleichermaßen behandelt.

Das Setzen der Geschwindigkeite erfolgt über eine einheitliche API (nicht Setzen aller drei Werte einzeln).

Zunächst Review. Falls OK würde ich noch das Handbuch entsprechend anpassen. Außerdem könnte man sich für die Presets nochmal den Faktor für die Entitäten anschauen. Der Fahrstuhl öffnet sich im Level 3 verglichen mit den restlichen Geschwindigkeiten ziemlich langsam. Vielleicht kann das noch etwas erhöht werden.

closes #437