### PR TITLE
KI-Vorspulen

### DIFF
--- a/source/main.bmx
+++ b/source/main.bmx
@@ -869,7 +869,7 @@ Type TApp
 
 
 			If KeyManager.IsHit(KEY_Y)
-				DebugScreen.Dev_FastForwardToTime(GetWorldTime().GetTimeGone() + 1*TWorldTime.DAYLENGTH, DebugScreen.GetShownPlayerID())
+				'DebugScreen.Dev_FastForwardToTime(GetWorldTime().GetTimeGone() + 1*TWorldTime.DAYLENGTH, DebugScreen.GetShownPlayerID())
 				'print some debug for stationmap
 				rem
 				For local pID:Int = 1 to 4
@@ -1398,7 +1398,7 @@ endrem
 		SetColor(oldCol)
 		SetAlpha(oldA)
 
-		textX:+ Max(75, bf.DrawSimple("Speed:" + Int(GetWorldTime().GetVirtualMinutesPerSecond() * 100), textX , 0).x)
+		textX:+ Max(75, bf.DrawSimple("Speed:" + Int(GetWorldTime().GetTimeFactor()), textX , 0).x)
 		textX:+ Max(50, bf.DrawSimple("FPS: "+GetDeltaTimer().currentFps, textX, 0).x)
 		textX:+ Max(50, bf.DrawSimple("UPS: " + Int(GetDeltaTimer().currentUps), textX,0).x)
 	'ron|gc


### PR DESCRIPTION
Rausgezogen aus #465.
Um die KI über längere Spielstände bewerten zu können, sollte es neben dem "Vorspulen um einen Tag" ein allgemeines Vorspulen geben. Die Aktion könnte in der Debug-Ansicht untergebracht werden (KI-Aktionen oder Misc).

Aktuell sehe ich diese Funktion weniger für den ausgelieferten Zustand als für die Entwicklung (wo ich ohnehin immer vor dem Start compiliere). Insofern sind die Paramter Geschwindigkeit/Anzahl der Tage, die vorgespult werden etc. nicht so kritisch.

Das Tastenkürzel "y" würde ich lieber rausnehmen und die Funktion direkt in den Debug-Screen integrieren. Der Eingriff ist zu drastisch, wenn man aus Versehen y drückt.

Das Speichern der Spielstände würde ich zumindest auskommentiert drinlassen. Auf diese Weise kann man von einem späteren Stand (Sendernetz schon weiter ausgebaut) mit unterschiedlichen KI-Implementierungen weiterspielen und die Ergebnisse vergleichen.