### PR TITLE
erste Verbesserung KI

### DIFF
--- a/res/ai/CommonAI/AIEngine.lua
+++ b/res/ai/CommonAI/AIEngine.lua
@@ -224,10 +224,10 @@ function AIPlayer:TickProcessTask()
 		self:BeginNewTask()
 	else
 		if self.CurrentTask.Status == TASK_STATUS_DONE or self.CurrentTask.Status == TASK_STATUS_CANCEL then
-			-- wait until the NEXT task has a priority > 35 (idle a bit)
+			-- wait until the NEXT task has a certain priority (idle a bit)
 			local tasksPrioOrdered = SortTasksByPrio(self.TaskList)
 			local nextTask = tasksPrioOrdered[1] -- 0 = current, 1 = next
-			if nextTask ~= nil and nextTask.CurrentPriority > 35 then
+			if nextTask ~= nil and nextTask.CurrentPriority >= self.startTaskAtPriority then
 				self:BeginNewTask()
 			end
 		else
@@ -613,7 +613,11 @@ function AITask:SetDone()
 	self.LastDone = TVT.GetTimeGoneInMinutes()
 	self.LastDoneWorldTicks = self:getWorldTicks()
 
-	TVT.doLeaveRoom()
+
+	if(TVT.doLeaveRoom(false) == TVT.RESULT_FAILED) then
+		debugMsg("Failed leaving room normally. Forcefully leaving the room now!")
+		TVT.doLeaveRoom(true)
+	end
 
 	-- reset back
 	self.assignmentType = 0

--- a/res/ai/DefaultAIPlayer/BudgetManager.lua
+++ b/res/ai/DefaultAIPlayer/BudgetManager.lua
@@ -42,7 +42,7 @@ function BudgetManager:Initialize()
 	-- Right at start there are no empirical values for required budgets
 	-- so assume the same for all of them. Budget equals to XX% of
 	-- capital at begin of the game
-	local playerMoney = MY.GetMoney()
+	local playerMoney = TVT.GetMoney()
 	local startBudget = math.round(playerMoney * 0.90)
 
 
@@ -71,7 +71,7 @@ end
 -- Method is run at the begin of each day
 function BudgetManager:CalculateNewDayBudget()
 	debugMsg("=== Budget day " .. TVT.GetDaysRun() .. " ===")
-	debugMsg(string.left("Account balance:", 25, true) .. string.right(MY.GetMoney(), 10, true))
+	debugMsg(string.left("Account balance:", 25, true) .. string.right(TVT.GetMoney(), 10, true))
 
 	-- postpone empirical budget values one day backwards (new one incoming)
 	self.BudgetHistory[TIME_OLDDAY_3] = self.BudgetHistory[TIME_OLDDAY_2]
@@ -84,7 +84,7 @@ function BudgetManager:CalculateNewDayBudget()
 	self.AccountBalanceHistory[TIME_OLDDAY_1] = self.AccountBalanceHistory[TIME_TODAY]
 
 	-- update current values
-	self.AccountBalanceHistory[TIME_TODAY] = MY.GetMoney()
+	self.AccountBalanceHistory[TIME_TODAY] = TVT.GetMoney()
 	self.BudgetMinimum = self.BudgetMinimum * 1.01
 	self.BudgetMaximum = self.AccountBalanceHistory[TIME_TODAY] * 0.95
 
@@ -109,9 +109,9 @@ function BudgetManager:UpdateBudget(pBudget)
 	local player = _G["globalPlayer"]
 	local bossTask = player.TaskList[TASK_BOSS]
 	if bossTask ~= nil and bossTask.GuessCreditAvailable > 0 then
-		if MY.GetMoney() < 100000 then
+		if TVT.GetMoney() < 100000 then
 			bossTask.SituationPriority = 5
-		elseif MY.GetMoney() < 0 then
+		elseif TVT.GetMoney() < 0 then
 			bossTask.SituationPriority = 15
 		end
 	end
@@ -304,7 +304,7 @@ function BudgetManager:OnMoneyChanged(value, reason, reference)
 	if renewBudget == true then
 		-- do not allow a negative profit
 		local todaysProfit = math.max(0, MY.GetFinance(-1).GetCurrentProfit())
-		local budgetNow = self:CalculateAverageBudget(MY.GetMoney(), todaysProfit)
+		local budgetNow = self:CalculateAverageBudget(TVT.GetMoney(), todaysProfit)
 
 		--update budget when at least 15.000 Euro difference since last
 		--adjustment

--- a/res/ai/DefaultAIPlayer/CommonObjects.lua
+++ b/res/ai/DefaultAIPlayer/CommonObjects.lua
@@ -193,12 +193,14 @@ function SpotSlotRequisition:CheckActuality()
 	if (self.Done) then return false end
 	-- a requisition gets invalid as soon as the corresponding broadcast-
 	-- material changed (eg. licence vanished somehow)
-	if self.broadcastMaterialGUID ~= nil and self.broadcastMaterialGUID ~= "" then
-		if TVT.IsBroadcastMaterialInProgrammePlan(self.broadcastMaterialGUID, self.Day, self.Hour) == 0 then
-			self:Complete()
-			return false
-		end
-	end
+	--TODO this code needs to refactored; requisitions are modified while scheduling; they are not really bound to a single programme slot
+	--after lua engine refactoring, all requisitions were cancelled by this snippet
+	--	if self.broadcastMaterialGUID ~= nil and self.broadcastMaterialGUID ~= "" then
+	--		if TVT.IsBroadcastMaterialInProgrammePlan(self.broadcastMaterialGUID, self.Day, self.Hour) == 0 then
+	--			self:Complete()
+	--			return false
+	--		end
+	--	end
 
 	-- spot slot requisitions get outdated 2 hours after their "planned" time
 	if (self.Day >= TVT.GetDay() or ( self.Day == TVT.GetDay() and self.Hour + 2 > TVT.GetDayHour())) then

--- a/res/ai/DefaultAIPlayer/CommonObjects.lua
+++ b/res/ai/DefaultAIPlayer/CommonObjects.lua
@@ -3,7 +3,7 @@
 -- Movie ist jetzt nur noch ein Wrapper
 
 function CheckMovieBuyConditions(licence, maxPrice, minQuality)
-	if maxPrice ~= nil and (licence.GetPrice() > maxPrice) then return false; end
+	if maxPrice ~= nil and (licence.GetPrice(-1) > maxPrice) then return false; end
 	if (minQuality ~= nil) and (licence.GetQuality() < minQuality) then return false; end
 	return true
 end
@@ -54,11 +54,11 @@ function FilterAdContractsByMinAudience(contractList, minAudienceMin, minAudienc
 
 			-- adjust guessed audience if only specific target groups count
 			if (v.GetLimitedToTargetGroup() > 0) then
-				if addIt and v.GetMinAudience() < minAudienceMin.GetTotalValue( v.GetLimitedToTargetGroup() ) then addIt = false end
-				if addIt and v.GetMinAudience() > minAudienceMax.GetTotalValue( v.GetLimitedToTargetGroup() ) then addIt = false end
+				if addIt and v.GetMinAudience(TVT.ME) < minAudienceMin.GetTotalValue( v.GetLimitedToTargetGroup() ) then addIt = false end
+				if addIt and v.GetMinAudience(TVT.ME) > minAudienceMax.GetTotalValue( v.GetLimitedToTargetGroup() ) then addIt = false end
 			else
---debugMsg("  - " .. v.GetTitle() .. ": " .. v.GetMinAudience() .. " < " .. minAudienceMinSum .." or " .. v.GetMinAudience() .." > " .. minAudienceMaxSum .. "   ?")
-				if addIt and v.GetMinAudience() < minAudienceMinSum or v.GetMinAudience() > minAudienceMaxSum then addIt = false end
+--debugMsg("  - " .. v.GetTitle() .. ": " .. v.GetMinAudience(TVT.ME) .. " < " .. minAudienceMinSum .." or " .. v.GetMinAudience() .." > " .. minAudienceMaxSum .. "   ?")
+				if addIt and v.GetMinAudience(TVT.ME) < minAudienceMinSum or v.GetMinAudience(TVT.ME) > minAudienceMaxSum then addIt = false end
 			end
 
 			if addIt and table.contains(forbiddenIDs, v.GetID()) then addIt = false end

--- a/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
+++ b/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
@@ -489,15 +489,15 @@ end
 
 
 function BusinessStats:AddSpot(spot)
-	local profitCPM = 1000 * spot.GetProfit() / spot.GetMinAudience()
-	local penaltyCPM = 1000 * spot.GetPenalty() / spot.GetMinAudience()
+	local profitCPM = 1000 * spot.GetProfit(TVT.ME) / spot.GetMinAudience(TVT.ME)
+	local penaltyCPM = 1000 * spot.GetPenalty(TVT.ME) / spot.GetMinAudience(TVT.ME)
 
 	self.SpotProfitCPM:AddValue(profitCPM)
 	self.SpotProfitCPMPerSpot:AddValue(profitCPM / spot.GetSpotCount())
 
 	-- only add simple spots for now (without target groups / limits)
 	if (spot.GetLimitedToTargetGroup() <= 0) and (spot.GetLimitedToProgrammeGenre() <= 0) and (spot.GetLimitedToProgrammeFlag() <= 0) then
-		if (spot.GetMinAudience() < globalPlayer.Stats.Audience.MaxValue) then
+		if (spot.GetMinAudience(TVT.ME) < globalPlayer.Stats.Audience.MaxValue) then
 			self.SpotProfitCPMPerSpotAcceptable:AddValue(profitCPM / spot.GetSpotCount())
 			self.SpotPenaltyCPMPerSpotAcceptable:AddValue(penaltyCPM / spot.GetSpotCount())
 		end

--- a/res/ai/DefaultAIPlayer/TaskAdAgency.lua
+++ b/res/ai/DefaultAIPlayer/TaskAdAgency.lua
@@ -107,7 +107,7 @@ function TaskAdAgency.SortAdContractsByAttraction(list)
 		-- precache complex weight calculation
 		local weights = {}
 		for k,v in pairs(list) do
-			weights[ v.GetID() ] = (0.5 + 0.5*(0.9^v.GetSpotCount())) * v.GetProfitCPM() * (0.8 + 0.2 * 1.0/v.GetPenaltyCPM())
+			weights[ v.GetID() ] = (0.5 + 0.5*(0.9^v.GetSpotCount())) * v.GetProfitCPM(TVT.ME) * (0.8 + 0.2 * 1.0/v.GetPenaltyCPM(TVT.ME))
 		end
 
 		-- sort
@@ -372,7 +372,7 @@ function SignRequisitedContracts:SignMatchingContracts(requisition, guessedAudie
 --[[
 debugMsg("sort contractlist for " .. math.floor(minGuessedAudience.GetTotalSum()) .. " - " .. math.floor(guessedAudience.GetTotalSum()) .. "  entries=" .. table.count(filteredList))
 for key, adContract in pairs(filteredList) do
-	debugMsg(" - " .. adContract.GetTitle() .. "   minAudience=" .. adContract.GetMinAudience() .. "  spots=" .. adContract.GetSpotCount() .. "  profit=" .. adContract.GetProfit(TVT.ME))
+	debugMsg(" - " .. adContract.GetTitle() .. "   minAudience=" .. adContract.GetMinAudience(TVT.ME) .. "  spots=" .. adContract.GetSpotCount() .. "  profit=" .. adContract.GetProfit(TVT.ME))
 end
 --]]
 	for key, adContract in pairs(filteredList) do
@@ -490,9 +490,9 @@ function SignContracts:Tick()
 				openSpots = openSpots - contract.GetSpotCount()
 				contractsAllowed = contractsAllowed - 1
 
-				debugMsg("Signed an \"low audience\" contract: " .. contract.GetTitle() .. " (" .. contract.GetID() .. "). MinAudience: " .. contract.GetMinAudience())
+				debugMsg("Signed an \"low audience\" contract: " .. contract.GetTitle() .. " (" .. contract.GetID() .. "). MinAudience: " .. contract.GetMinAudience(TVT.ME))
 			else
-				debugMsg("FAILED signing an \"low audience\" contract: " .. contract.GetTitle() .. " (" .. contract.GetID() .. "). MinAudience: " .. contract.GetMinAudience() .. ". Failure code: " .. result)
+				debugMsg("FAILED signing an \"low audience\" contract: " .. contract.GetTitle() .. " (" .. contract.GetID() .. "). MinAudience: " .. contract.GetMinAudience(TVT.ME) .. ". Failure code: " .. result)
 			end
 
 
@@ -522,11 +522,11 @@ function SignContracts:Tick()
 				openSpots = openSpots - contract.GetSpotCount()
 				contractsAllowed = contractsAllowed - 1
 
-				debugMsg("Signed a \"good\" contract: " .. contract.GetTitle() .. " (" .. contract.GetID() .. "). MinAudience: " .. contract.GetMinAudience())
+				debugMsg("Signed a \"good\" contract: " .. contract.GetTitle() .. " (" .. contract.GetID() .. "). MinAudience: " .. contract.GetMinAudience(TVT.ME))
 
 				if openSpots <= 0 or contractsAllowed <= 0 then break end
 			else
-				debugMsg("FAILED signing a \"good\" contract: " .. contract.GetTitle() .. " (" .. contract.GetID() .. "). MinAudience: " .. contract.GetMinAudience() .. ". Failure code: " .. result)
+				debugMsg("FAILED signing a \"good\" contract: " .. contract.GetTitle() .. " (" .. contract.GetID() .. "). MinAudience: " .. contract.GetMinAudience(TVT.ME) .. ". Failure code: " .. result)
 			end
 		end
 	end

--- a/res/ai/DefaultAIPlayer/TaskArchive.lua
+++ b/res/ai/DefaultAIPlayer/TaskArchive.lua
@@ -38,7 +38,8 @@ function TaskArchive:GetNextJobInTargetRoom()
 	end
 
 	self.emergencySale = false
-	self:SetWait()
+	--self:SetWait()
+	self:SetDone()
 end
 
 
@@ -103,7 +104,7 @@ function JobSellMovies:Tick()
 	do
 		m = TVT.convertToProgrammeLicence(TVT.ar_GetProgrammeLicence(i).data)
 		--ignore episodes/collection-elements
-		if m ~= nil and m.HasParentLicence()==0 then
+		if m ~= nil and m.HasParentLicence()==0 and m.isAvailable() then
 			vm = newarchivedMovie(m)
 			debugMsg("# found "..vm.Title.." (guid="..vm.GUID.."  id="..vm.Id..") ".." "..vm.price..",  TopicalityLoss="..string.format("%.4f", vm.TopicalityLoss*100).."% (Max="..string.format("%.2f", vm.MaxTopicalityLoss*100).."%), planned: "..tostring(vm.planned))
 			table.insert(movies,vm)
@@ -142,7 +143,7 @@ function JobSellMovies:Tick()
 	-- move licences to suitcase
 	for i=1, #case do
 		ec = TVT.ar_AddProgrammeLicenceToSuitcaseByGUID(case[i].GUID)
-		if ec == 1 then
+		if ec == TVT.RESULT_OK then
 			debugMsg("# put "..case[i].Title.." in suitcase, OK")
 
 			self.Task.Player.programmeLicencesInArchiveCount = math.max(0, self.Task.Player.programmeLicencesInArchiveCount - 1)

--- a/res/ai/DefaultAIPlayer/TaskBoss.lua
+++ b/res/ai/DefaultAIPlayer/TaskBoss.lua
@@ -39,24 +39,28 @@ end
 
 function TaskBoss:BeforeBudgetSetup()
 	self:CalculateFixedCosts()
+	self.InvestmentPriority = 0
 
 	local money = TVT.GetMoney()
 	local credit = MY.GetCredit(-1)
 	if (money - credit) > 350000 then
 		if credit > 100000 then
-			self.NeededInvestmentBudget = 100000
+			self.NeededInvestmentBudget = credit / 5
 			self.InvestmentPriority = 1
 		elseif credit > 0 then
 			self.NeededInvestmentBudget = credit
 			self.InvestmentPriority = 1
 		else
 			self.NeededInvestmentBudget = 0
-			self.InvestmentPriority = 0
 			self.CurrentInvestmentPriority = 0
 		end
+	elseif (money - credit) > 100000 then
+		self.NeededInvestmentBudget = credit / 10
+		self.InvestmentPriority = 1
+	elseif (credit > 0) then
+		self.NeededInvestmentBudget = 10000
 	else
 		self.NeededInvestmentBudget = 0
-		self.InvestmentPriority = 0
 	end
 end
 

--- a/res/ai/DefaultAIPlayer/TaskBoss.lua
+++ b/res/ai/DefaultAIPlayer/TaskBoss.lua
@@ -40,8 +40,8 @@ end
 function TaskBoss:BeforeBudgetSetup()
 	self:CalculateFixedCosts()
 
-	local money = MY.GetMoney()
-	local credit = MY.GetCredit()
+	local money = TVT.GetMoney()
+	local credit = MY.GetCredit(-1)
 	if (money - credit) > 350000 then
 		if credit > 100000 then
 			self.NeededInvestmentBudget = 100000
@@ -93,15 +93,15 @@ end
 
 
 function JobCheckCredit:Prepare(pParams)
-	if MY.GetMoney() < 0 then
+	if TVT.GetMoney() < 0 then
 		-- ATTENTION: money might change until "tick()", we could handle
 		-- it but this behaviour seems more "natural" (to not see the
 		-- money change in time)
 		-- try to at least become "positive" again
-		self.Task.TryToGetCredit = math.min( math.abs(MY.GetMoney()), TVT.bo_getCreditAvailable() )
+		self.Task.TryToGetCredit = math.min( math.abs(TVT.GetMoney()), TVT.bo_getCreditAvailable() )
 	end
 	if self.Task.NeededInvestmentBudget > 0 then
-		self.Task.TryToRepayCredit = math.max(0, math.min(MY.GetMoney(), self.Task.NeededInvestmentBudget))
+		self.Task.TryToRepayCredit = math.max(0, math.min(TVT.GetMoney(), self.Task.NeededInvestmentBudget))
 	end
 
 
@@ -118,8 +118,8 @@ function JobCheckCredit:Tick()
 	-- REPAY credit
 	if self.Task.TryToRepayCredit > 0 then
 		local repay = self.Task.TryToRepayCredit
-		if repay > MY.GetCredit() then
-			repay = MY.GetCredit()
+		if repay > MY.GetCredit(-1) then
+			repay = MY.GetCredit(-1)
 		end
 
 		if TVT.bo_doRepayCredit(repay) == TVT.RESULT_OK then

--- a/res/ai/DefaultAIPlayer/TaskMovieDistributor.lua
+++ b/res/ai/DefaultAIPlayer/TaskMovieDistributor.lua
@@ -519,7 +519,7 @@ function JobAppraiseMovies:AppraiseMovie(licence)
 			pricePerBlockStats = stats.MoviePricePerBlockAcceptable
 			qualityStats = stats.MovieQualityAcceptable
 		else
-			debugMsg("CheckMovieBuyConditions (single licence) not met.  price: " .. licence.GetPrice() .. " > " .. self.MovieMaxPrice .."   quality: " .. string.format("%.4f", licence.GetQuality()) .. " < " .. string.format("%.4f", self.DayMovieMinQuality) )
+			debugMsg("CheckMovieBuyConditions (single licence) not met.  price: " .. licence.GetPrice(TVT.ME) .. " > " .. self.MovieMaxPrice .."   quality: " .. string.format("%.4f", licence.GetQuality()) .. " < " .. string.format("%.4f", self.DayMovieMinQuality) )
 			debugMsgDepth(-1)
 			return
 		end
@@ -528,7 +528,7 @@ function JobAppraiseMovies:AppraiseMovie(licence)
 			pricePerBlockStats = stats.SeriesPricePerBlockAcceptable
 			qualityStats = stats.SeriesQualityAcceptable
 		else
-			debugMsg("CheckMovieBuyConditions (series) not met.  price: " .. licence.GetPrice() .. " > " .. self.SeriesMaxPrice .."   quality: " .. string.format("%.4f", licence.GetQuality()) .. " < " .. string.format("%.4f", self.DaySeriesMinQuality) )
+			debugMsg("CheckMovieBuyConditions (series) not met.  price: " .. licence.GetPrice(TVT.ME) .. " > " .. self.SeriesMaxPrice .."   quality: " .. string.format("%.4f", licence.GetQuality()) .. " < " .. string.format("%.4f", self.DaySeriesMinQuality) )
 
 			debugMsgDepth(-1)
 			return

--- a/res/ai/DefaultAIPlayer/TaskNewsAgency.lua
+++ b/res/ai/DefaultAIPlayer/TaskNewsAgency.lua
@@ -144,7 +144,7 @@ end
 
 
 function TaskNewsAgency:BudgetMaximum()
-	local money = MY.GetMoney(-1)
+	local money = TVT.GetMoney()
 	if money <= 500000 then
 		return math.max(50000, math.floor(money / 10))
 	elseif money < 1000000 then

--- a/res/ai/DefaultAIPlayer/TaskNewsAgency.lua
+++ b/res/ai/DefaultAIPlayer/TaskNewsAgency.lua
@@ -60,8 +60,8 @@ function TaskNewsAgency:GetNextJobInTargetRoom()
 	end
 	if (self.NewsAgencyJob.Status ~= JOB_STATUS_DONE) then
 		return self.NewsAgencyJob
-	elseif (self.IdleJob ~= nil and self.IdleJob.Status ~= JOB_STATUS_DONE) then
-		return self.IdleJob
+	--elseif (self.IdleJob ~= nil and self.IdleJob.Status ~= JOB_STATUS_DONE) then
+	--	return self.IdleJob
 	end
 
 	self:SetDone()

--- a/res/ai/DefaultAIPlayer/TaskStationMap.lua
+++ b/res/ai/DefaultAIPlayer/TaskStationMap.lua
@@ -97,8 +97,8 @@ function TaskStationMap:GetAverageStationRunningCostPerPerson()
 			local station = TVT.of_getStationAtIndex(i, stationIndex)
 			if station ~= nil then
 				totalCost = totalCost + station.GetRunningCosts()
-				totalReach = totalReach + station.GetExclusiveReach()
-				--totalReach = totalReach + station.GetReach()
+				totalReach = totalReach + station.GetExclusiveReach(false)
+				--totalReach = totalReach + station.GetReach(false)
 			end
 		end
 	end
@@ -221,8 +221,8 @@ function JobBuyStation:Prepare(pParams)
 	local player = _G["globalPlayer"]
 	local ignoreBudgetChance = 100 - (8-player.ExpansionPriority)*math.min(TVT.of_getStationCount(TVT.ME)-1,10)
 	debugMsg("  ignoreBudgetChance: " ..ignoreBudgetChance)
-	if MY.GetMoney() > 1000000 and math.random(0,100) < ignoreBudgetChance then
-		self.Task.CurrentBudget = (0.35 + 0.06*player.ExpansionPriority) * MY.GetMoney()
+	if TVT.GetMoney() > 1000000 and math.random(0,100) < ignoreBudgetChance then
+		self.Task.CurrentBudget = (0.35 + 0.06*player.ExpansionPriority) * TVT.GetMoney()
 		debugMsg("  raised current budget to " .. self.Task.CurrentBudget .." to buy a station because 'we want it'.")
 	end
 
@@ -256,7 +256,7 @@ function JobBuyStation:GetBestCableNetworkOffer()
 				local tempStation = TVT.of_GetTemporaryCableNetworkUplinkStation(i)
 				if tempStation then
 					local price = tempStation.GetTotalBuyPrice()
-					local pricePerViewer = tempStation.GetExclusiveReach() / price
+					local pricePerViewer = tempStation.GetExclusiveReach(false) / price
 					local priceDiff = self.Task.CurrentBudget - price
 					--little influence by the amount of how well the budget is "used"
 					--to avoid buying too many stations (upkeep!)
@@ -271,7 +271,7 @@ function JobBuyStation:GetBestCableNetworkOffer()
 		end
 	end
 	if bestOffer then
-		debugMsg(" - best cable network " .. bestOffer.GetName() .."  reach: " .. bestOffer.GetReach() .. "  exclusive/increase: " .. bestOffer.GetExclusiveReach() .. "  price: " .. bestOffer.GetBuyPrice() .. " (incl.fees: " .. bestOffer.GetTotalBuyPrice() ..")  F: " .. (bestOffer.GetExclusiveReach() / bestOffer.GetPrice()) .. "  buyPrice: " .. bestOffer.GetBuyPrice() )
+		debugMsg(" - best cable network " .. bestOffer.GetName() .."  reach: " .. bestOffer.GetReach(false) .. "  exclusive/increase: " .. bestOffer.GetExclusiveReach(false) .. "  price: " .. bestOffer.GetBuyPrice() .. " (incl.fees: " .. bestOffer.GetTotalBuyPrice() ..")  F: " .. (bestOffer.GetExclusiveReach(false) / bestOffer.GetPrice()) .. "  buyPrice: " .. bestOffer.GetBuyPrice() )
 	else
 		debugMsg(" -> no best cable network found")
 	end
@@ -296,7 +296,7 @@ function JobBuyStation:GetBestSatelliteOffer()
 				local tempStation = TVT.of_GetTemporarySatelliteUplinkStation(i)
 				if tempStation then
 					local price = tempStation.GetTotalBuyPrice()
-					local pricePerViewer = tempStation.GetExclusiveReach() / price
+					local pricePerViewer = tempStation.GetExclusiveReach(false) / price
 					local priceDiff = self.Task.CurrentBudget - price
 					--little influence by the amount of how well the budget is "used"
 					--to avoid buying too many stations (upkeep!)
@@ -306,7 +306,7 @@ function JobBuyStation:GetBestSatelliteOffer()
 						bestOffer = tempStation
 						bestAttraction = attraction
 
-						debugMsg(" - new best satellite " .. bestOffer.GetName() .."  reach: " .. bestOffer.GetReach() .. "  exclusive/increase: " .. bestOffer.GetExclusiveReach() .. "  price: " .. bestOffer.GetBuyPrice() .. " (incl.fees: " .. bestOffer.GetTotalBuyPrice() ..")  F: " .. (bestOffer.GetExclusiveReach() / bestOffer.GetPrice()) .. "  buyPrice: " .. bestOffer.GetBuyPrice() )
+						debugMsg(" - new best satellite " .. bestOffer.GetName() .."  reach: " .. bestOffer.GetReach(false) .. "  exclusive/increase: " .. bestOffer.GetExclusiveReach(false) .. "  price: " .. bestOffer.GetBuyPrice() .. " (incl.fees: " .. bestOffer.GetTotalBuyPrice() ..")  F: " .. (bestOffer.GetExclusiveReach(false) / bestOffer.GetPrice()) .. "  buyPrice: " .. bestOffer.GetBuyPrice() )
 						debugMsg("   -> attraction: " .. attraction .. "  |  ".. pricePerViewer .. " - (" .. priceDiff .. " / currentBudget: " .. self.Task.CurrentBudget)
 					end
 				end
@@ -314,7 +314,7 @@ function JobBuyStation:GetBestSatelliteOffer()
 		end
 	end
 	if bestOffer ~= nil then
-		debugMsg(" -> best satellite " .. bestOffer.GetName() .."  reach: " .. bestOffer.GetReach() .. "  exclusive/increase: " .. bestOffer.GetExclusiveReach() .. "  price: " .. bestOffer.GetBuyPrice() .. " (incl.fees: " .. bestOffer.GetTotalBuyPrice() ..")  F: " .. (bestOffer.GetExclusiveReach() / bestOffer.GetPrice()) .. "  buyPrice: " .. bestOffer.GetBuyPrice() )
+		debugMsg(" -> best satellite " .. bestOffer.GetName() .."  reach: " .. bestOffer.GetReach(false) .. "  exclusive/increase: " .. bestOffer.GetExclusiveReach(false) .. "  price: " .. bestOffer.GetBuyPrice() .. " (incl.fees: " .. bestOffer.GetTotalBuyPrice() ..")  F: " .. (bestOffer.GetExclusiveReach(false) / bestOffer.GetPrice()) .. "  buyPrice: " .. bestOffer.GetBuyPrice() )
 	else
 		debugMsg(" -> no best satellite found")
 	end
@@ -389,30 +389,30 @@ function JobBuyStation:GetBestAntennaOffer()
 
 		--1) outside
 		elseif tempStation.GetPrice() < 0 then
---			debugMsg(" - Station " .. tablePos .. "  at " .. x .. "," .. y .. ".  owner: " .. otherOwner .. "  reach: " .. tempStation.GetReach() .. "  exclusive/increase: " .. tempStation.GetExclusiveReach() .. "  price: " .. tempStation.GetBuyPrice() .. " (incl.fees: " .. tempStation.GetTotalBuyPrice() ..")  F: " .. (tempStation.GetExclusiveReach() / tempStation.GetPrice()) .. "  buyPrice: " .. tempStation.GetBuyPrice() .. " -> outside of map!")
+--			debugMsg(" - Station " .. tablePos .. "  at " .. x .. "," .. y .. ".  owner: " .. otherOwner .. "  reach: " .. tempStation.GetReach(false) .. "  exclusive/increase: " .. tempStation.GetExclusiveReach(false) .. "  price: " .. tempStation.GetBuyPrice() .. " (incl.fees: " .. tempStation.GetTotalBuyPrice() ..")  F: " .. (tempStation.GetExclusiveReach(false) / tempStation.GetPrice()) .. "  buyPrice: " .. tempStation.GetBuyPrice() .. " -> outside of map!")
 			tempStation = nil
 
 		--2) price to high
 		elseif tempStation.GetPrice() > self.Task.CurrentBudget then
-			debugMsg(" - Station " .. tablePos .. "  at " .. x .. "," .. y .. ".  owner: " .. otherOwner .. "  reach: " .. tempStation.GetReach() .. "  exclusive/increase: " .. tempStation.GetExclusiveReach() .. "  price: " .. tempStation.GetBuyPrice() .. " (incl.fees: " .. tempStation.GetTotalBuyPrice() ..")  F: " .. (tempStation.GetExclusiveReach() / tempStation.GetPrice()) .. "  buyPrice: " .. tempStation.GetBuyPrice() .. " -> too expensive!")
+			debugMsg(" - Station " .. tablePos .. "  at " .. x .. "," .. y .. ".  owner: " .. otherOwner .. "  reach: " .. tempStation.GetReach(false) .. "  exclusive/increase: " .. tempStation.GetExclusiveReach(false) .. "  price: " .. tempStation.GetBuyPrice() .. " (incl.fees: " .. tempStation.GetTotalBuyPrice() ..")  F: " .. (tempStation.GetExclusiveReach(false) / tempStation.GetPrice()) .. "  buyPrice: " .. tempStation.GetBuyPrice() .. " -> too expensive!")
 			tempStation = nil
 
 		--3) relative increase to low (at least 35% required)
-		elseif tempStation.GetRelativeExclusiveReach() < 0.35 then
-			debugMsg(" - Station " .. tablePos .. "  at " .. x .. "," .. y .. ".  owner: " .. otherOwner .. "  reach: " .. tempStation.GetReach() .. "  exclusive/increase: " .. tempStation.GetExclusiveReach() .. "(" .. tempStation.GetRelativeExclusiveReach()..")" .. "  price: " .. tempStation.GetBuyPrice() .. " (incl.fees: " .. tempStation.GetTotalBuyPrice() ..")  F: " .. (tempStation.GetExclusiveReach() / tempStation.GetPrice()) .. "  buyPrice: " .. tempStation.GetBuyPrice() .. " -> not enough reach increase!")
+		elseif tempStation.GetRelativeExclusiveReach(false) < 0.35 then
+			debugMsg(" - Station " .. tablePos .. "  at " .. x .. "," .. y .. ".  owner: " .. otherOwner .. "  reach: " .. tempStation.GetReach(false) .. "  exclusive/increase: " .. tempStation.GetExclusiveReach(false) .. "(" .. tempStation.GetRelativeExclusiveReach(false)..")" .. "  price: " .. tempStation.GetBuyPrice() .. " (incl.fees: " .. tempStation.GetTotalBuyPrice() ..")  F: " .. (tempStation.GetExclusiveReach(false) / tempStation.GetPrice()) .. "  buyPrice: " .. tempStation.GetBuyPrice() .. " -> not enough reach increase!")
 			tempStation = nil
 
 		--4) absolute increase too low
-		--elseif tempStation.GetExclusiveReach() < 1500 then
+		--elseif tempStation.GetExclusiveReach(false) < 1500 then
 		--	tempStation = nil
 
 		--5)  reach to low (at least 75.000 required)
-		elseif tempStation.GetReach() < 75000 then
-			debugMsg(" - Station " .. tablePos .. "  at " .. x .. "," .. y .. ".  owner: " .. otherOwner .. "  reach: " .. tempStation.GetReach() .. "  exclusive/increase: " .. tempStation.GetExclusiveReach() .. "  price: " .. tempStation.GetBuyPrice() .. " (incl.fees: " .. tempStation.GetTotalBuyPrice() ..")  F: " .. (tempStation.GetExclusiveReach() / tempStation.GetPrice()) .. "  buyPrice: " .. tempStation.GetBuyPrice() .. " -> not enough absolute reach!")
+		elseif tempStation.GetReach(false) < 75000 then
+			debugMsg(" - Station " .. tablePos .. "  at " .. x .. "," .. y .. ".  owner: " .. otherOwner .. "  reach: " .. tempStation.GetReach(false) .. "  exclusive/increase: " .. tempStation.GetExclusiveReach(false) .. "  price: " .. tempStation.GetBuyPrice() .. " (incl.fees: " .. tempStation.GetTotalBuyPrice() ..")  F: " .. (tempStation.GetExclusiveReach(false) / tempStation.GetPrice()) .. "  buyPrice: " .. tempStation.GetBuyPrice() .. " -> not enough absolute reach!")
 			tempStation = nil
 
 		else
-			debugMsg(" - Station " .. tablePos .. "  at " .. x .. "," .. y .. ".  owner: " .. otherOwner .. "  reach: " .. tempStation.GetReach() .. "  exclusive/increase: " .. tempStation.GetExclusiveReach() .. "  price: " .. tempStation.GetBuyPrice() .. " (incl.fees: " .. tempStation.GetTotalBuyPrice() ..")  F: " .. (tempStation.GetExclusiveReach() / tempStation.GetPrice()) .. "  buyPrice: " .. tempStation.GetBuyPrice() .. " -> OK!")
+			debugMsg(" - Station " .. tablePos .. "  at " .. x .. "," .. y .. ".  owner: " .. otherOwner .. "  reach: " .. tempStation.GetReach(false) .. "  exclusive/increase: " .. tempStation.GetExclusiveReach(false) .. "  price: " .. tempStation.GetBuyPrice() .. " (incl.fees: " .. tempStation.GetTotalBuyPrice() ..")  F: " .. (tempStation.GetExclusiveReach(false) / tempStation.GetPrice()) .. "  buyPrice: " .. tempStation.GetBuyPrice() .. " -> OK!")
 		end
 
 
@@ -421,7 +421,7 @@ function JobBuyStation:GetBestAntennaOffer()
 			-- GetTotalBuyPrice() includes potential fees for a required
 			-- permission.
 			local price = tempStation.GetTotalBuyPrice()
-			local pricePerViewer = tempStation.GetExclusiveReach() / price
+			local pricePerViewer = tempStation.GetExclusiveReach(false) / price
 			local priceDiff = self.Task.CurrentBudget - price
 			--little influence by the amount of how well the budget is "used"
 			--to avoid buying too many stations (upkeep!)
@@ -462,13 +462,13 @@ function JobBuyStation:Tick()
 	if bestOffer ~= nil then
 		local price = bestOffer.GetTotalBuyPrice()
 		if bestOffer == bestAntennaOffer then
-			debugMsg(" Buying antenna station in " .. bestOffer.GetSectionName() .. " at " .. bestOffer.pos.GetIntX() .. "," .. bestOffer.pos.GetIntY() .. ".  exclusive/increase: " .. bestOffer.GetExclusiveReach() .. "  price: " .. price)
+			debugMsg(" Buying antenna station in " .. bestOffer.GetSectionName(false) .. " at " .. bestOffer.pos.GetIntX() .. "," .. bestOffer.pos.GetIntY() .. ".  exclusive/increase: " .. bestOffer.GetExclusiveReach(false) .. "  price: " .. price)
 			TVT.of_buyAntennaStation(bestOffer.pos.GetIntX(), bestOffer.pos.GetIntY())
 		elseif bestOffer == bestSatelliteOffer then
-			debugMsg(" Contracting satellite uplink " .. bestOffer.GetLongName() .. ".  exclusive/increase: " .. bestOffer.GetExclusiveReach() .. "  price: " .. price)
+			debugMsg(" Contracting satellite uplink " .. bestOffer.GetLongName() .. ".  exclusive/increase: " .. bestOffer.GetExclusiveReach(false) .. "  price: " .. price)
 			--TVT.of_buyAntennaStation(bestOffer.pos.GetIntX(), bestOffer.pos.GetIntY())
 		elseif bestOffer == bestCableNetworkOffer then
-			debugMsg(" Contracting cable network uplink " .. bestOffer.GetLongName() .. ".  exclusive/increase: " .. bestOffer.GetExclusiveReach() .. "  price: " .. price)
+			debugMsg(" Contracting cable network uplink " .. bestOffer.GetLongName() .. ".  exclusive/increase: " .. bestOffer.GetExclusiveReach(false) .. "  price: " .. price)
 			--TVT.of_buyAntennaStation(bestOffer.pos.GetIntX(), bestOffer.pos.GetIntY())
 		end
 

--- a/source/game.ai.bmx
+++ b/source/game.ai.bmx
@@ -453,9 +453,25 @@ Type TLuaFunctions Extends TLuaFunctionsBase {_exposeToLua}
 	End Method
 
 
-	Method doLeaveRoom:Int()
-		TFigure(GetPlayerBase(Self.ME).GetFigure()).leaveRoom(True)
-		Return Self.RESULT_OK
+	'set forceLeave to "True" to forcefully leave the room
+	Method doLeaveRoom:Int(forceLeave:Int)
+		If TFigure(GetPlayerBase(Self.ME).GetFigure()).LeaveRoom(forceLeave)
+			Return Self.RESULT_OK
+		Else
+			Return Self.RESULT_FAILED
+		EndIf
+	End Method
+
+
+	Method canLeaveRoom:Int()
+		Local f:TFigure = TFigure(GetPlayerBase(Self.ME).GetFigure())
+		If f.inRoom = Null Then Return Self.RESULT_WRONGROOM
+		
+		If f.CanLeaveRoom(f.inRoom)
+			Return Self.RESULT_OK
+		Else
+			Return Self.RESULT_NOTALLOWED
+		EndIf
 	End Method
 
 
@@ -733,6 +749,12 @@ Type TLuaFunctions Extends TLuaFunctionsBase {_exposeToLua}
 
 	Method GetProgrammeLicenceCount:Int()
 		Return GetPlayerProgrammeCollection(Self.ME).GetProgrammeLicenceCount()
+	End Method
+
+
+	Method GetProgrammeLicenceAtIndex:TProgrammeLicence(arrayIndex:Int=-1)
+		Local obj:TProgrammeLicence = GetPlayerProgrammeCollection(Self.ME).GetProgrammeLicenceAtIndex(arrayIndex)
+		If obj Then Return obj Else Return Null
 	End Method
 
 
@@ -1154,8 +1176,7 @@ endrem
 	Method of_getProgrammeLicenceAtIndex:TProgrammeLicence(arrayIndex:Int=-1)
 		If Not _PlayerInRoom("office") Then Return Null
 
-		Local obj:TProgrammeLicence = GetPlayerProgrammeCollection(Self.ME).GetProgrammeLicenceAtIndex(arrayIndex)
-		If obj Then Return obj Else Return Null
+		Return GetProgrammeLicenceAtIndex(arrayIndex)
 	End Method
 
 
@@ -1833,7 +1854,11 @@ endrem
 		'Skip series episodes or collection elements
 		If licence.HasParentLicence() Then Return Self.RESULT_NOTALLOWED
 
-		Return GetPlayerProgrammeCollection(Self.ME).AddProgrammeLicenceToSuitcase(licence)
+		If GetPlayerProgrammeCollection(Self.ME).AddProgrammeLicenceToSuitcase(licence)
+			Return Self.RESULT_OK
+		Else
+			Return Self.RESULT_FAILED
+		EndIf
 	End Method
 
 
@@ -1846,7 +1871,11 @@ endrem
 		'Skip series episodes or collection elements
 		If licence.HasParentLicence() Then Return Self.RESULT_NOTALLOWED
 
-		Return GetPlayerProgrammeCollection(Self.ME).AddProgrammeLicenceToSuitcase(licence)
+		If GetPlayerProgrammeCollection(Self.ME).AddProgrammeLicenceToSuitcase(licence)
+			Return Self.RESULT_OK
+		Else
+			Return Self.RESULT_FAILED
+		EndIf
 	End Method
 
 
@@ -1877,7 +1906,7 @@ endrem
 	Method ar_GetProgrammeLicenceCount:Int()
 		If Not _PlayerInRoom("archive") Then Return Self.RESULT_WRONGROOM
 
-		Return GetPlayerProgrammeCollection(Self.ME).GetProgrammeLicenceCount()
+		Return GetProgrammeLicenceCount()
 	End Method
 
 
@@ -1885,7 +1914,7 @@ endrem
 	Method ar_GetProgrammeLicence:TLuaFunctionResult(position:Int = -1)
 		If Not _PlayerInRoom("archive") Then Return TLuaFunctionResult.Create(Self.RESULT_WRONGROOM, Null)
 
-		Local licence:TProgrammeLicence = GetPlayerProgrammeCollection(Self.ME).GetProgrammeLicenceAtIndex(position)
+		Local licence:TProgrammeLicence = GetProgrammeLicenceAtIndex(position)
 		If licence
 			Return TLuaFunctionResult.Create(Self.RESULT_OK, licence)
 		Else

--- a/source/game.programme.adcontract.bmx
+++ b/source/game.programme.adcontract.bmx
@@ -2020,13 +2020,27 @@ price :* Max(1, minAudience/1000)
 		'no "acuteness" for obsolete contracts
 		If Self.getDaysLeft() < 0 Then Return 0
 
-		'multiply by spot count (the more to send in total, the more acute)
-'		Return self.GetSpotsToSend() * GetSpotsToSendPercentage() * GetTimeGonePercentage()^2
-		'0 days = 1
-		'1 day  = 0.25
-		'2      = 0.125
-		'3      = 0.0725
-		Return Self.GetSpotsToSend() * GetSpotsToSendPercentage() * (0.25 ^ GetDaysLeft())
+		'base value is audience which typically corrensponds to profit
+		Local result:Float = getMinAudiencePercentage() * 100
+		'min audience for target groups needs to be scaled 
+		If IsLimitedToTargetGroup(TVTTargetGroup.CHILDREN) Then result:* 6
+		If IsLimitedToTargetGroup(TVTTargetGroup.TEENAGERS) Then result:* 5
+		If IsLimitedToTargetGroup(TVTTargetGroup.HOUSEWIVES) Then result:* 4
+		If IsLimitedToTargetGroup(TVTTargetGroup.EMPLOYEES) Then result:* 4
+		If IsLimitedToTargetGroup(TVTTargetGroup.UNEMPLOYED) Then result:* 3
+		If IsLimitedToTargetGroup(TVTTargetGroup.MANAGER) Then result:* 7
+		If IsLimitedToTargetGroup(TVTTargetGroup.PENSIONERS) Then result:* 4
+		If IsLimitedToTargetGroup(TVTTargetGroup.WOMEN) Then result:* 2
+		If IsLimitedToTargetGroup(TVTTargetGroup.MEN) Then result:* 2
+		'aim at one spot per day left
+		If Self.getDaysLeft() < Self.getSpotsToSend() Then result:* 2
+		'big effort on last day
+		If Self.getDaysLeft() = 0 And GetWorldTime().getHour() > 5 Then result:* 4
+		'the more spots sent the worse failing will be (other spots wasted)
+		If GetSpotsToSendPercentage() < 1 Then result:/ (1-GetSpotsToSendPercentage())
+		'TODO consider profit/penalty more directly?
+		'TODO acuteness really as bmx function or rather part of player strategy (fast money vs best audience)
+		Return result
 	End Method
 
 

--- a/source/game.roomhandler.archive.bmx
+++ b/source/game.roomhandler.archive.bmx
@@ -241,7 +241,7 @@ Type RoomHandler_Archive extends TRoomHandler
 
 		'=== FOR ALL PLAYERS ===
 		'
-		print "room owner forcefully leaves archive: roomID="+TRoom(triggerEvent.GetReceiver()).id+"  figure="+figure.name
+		'print "room owner forcefully leaves archive: roomID="+TRoom(triggerEvent.GetReceiver()).id+"  figure="+figure.name
 
 		'instead of leaving the room and accidentially removing programmes
 		'from the plan we readd all licences from the suitcase back to


### PR DESCRIPTION
[EDIT] Im Laufe des PR sind noch Anpassungen dazugekommen

Es ist ein erster Schritt in Richtung stärkere Gegenspieler. 
* Informercials unterbinden (zunächst komplett - sie machen das Image kaputt)
* Versuch Wartezeit zureduzieren
* weniger "schlechte" Verträge schließen
* weniger Verträge schließen, die schon vorhandenen ähneln
* Versuch der Minimierung gefährlicher Werbung (Bugfix überzählige Spots, keine Werbung für Kinder/Manager, restriktiver bei Zielgruppenwerbung)
* keine Call-In-Shows (Image)
* Fix für #477 (Bestimmung der Mindestzuschauerzahl immer mit TVT.ME)
* Programmplanung macht zunächst Optimierung der nächsten Stunden (aktuelle Werbung)
* Es werden nur Lizenzen erworben, deren Qualität oberhalb des aktuellen Durchschnitts liegt
* Vereinfachung BudgetManager (die Mittelung der letzten Budgets hat nicht wirklich funktioniert, da Min-Max nie an den aktuellen Stand angepasst wurden)
* Senderausbau nur wenn Kredit klein genug ist (längere Anlaufphase, in der der Fundus aufgebaut wird)