### PR TITLE
Debug Programmübersicht

### DIFF
--- a/source/main.bmx
+++ b/source/main.bmx
@@ -1193,10 +1193,10 @@ Type TApp
 					If KeyManager.IsHit(KEY_3) Then GameConfig.SetObservedObject( GetPlayer(3).GetFigure() )
 					If KeyManager.IsHit(KEY_4) Then GameConfig.SetObservedObject( GetPlayer(4).GetFigure() )
 				Else
-					If KeyManager.IsHit(KEY_1) Then GetGame().SetActivePlayer(1)
-					If KeyManager.IsHit(KEY_2) Then GetGame().SetActivePlayer(2)
-					If KeyManager.IsHit(KEY_3) Then GetGame().SetActivePlayer(3)
-					If KeyManager.IsHit(KEY_4) Then GetGame().SetActivePlayer(4)
+					If KeyManager.IsHit(KEY_1) Then GetGame().SetActivePlayer(1); TInGameInterface.GetInstance().showChannel=1
+					If KeyManager.IsHit(KEY_2) Then GetGame().SetActivePlayer(2); TInGameInterface.GetInstance().showChannel=2
+					If KeyManager.IsHit(KEY_3) Then GetGame().SetActivePlayer(3); TInGameInterface.GetInstance().showChannel=3
+					If KeyManager.IsHit(KEY_4) Then GetGame().SetActivePlayer(4); TInGameInterface.GetInstance().showChannel=4
 				EndIf
 
 


### PR DESCRIPTION
Bei vielen Programmen gibt es einen Überlauf nach unten, so dass man die Zuschauerstatistik nicht mehr gut sehen kann.

* Serienfolgen nicht einzeln anzeigen (die Aktualität der Einzelfolgen könnte man ja im Notfall auch im Büro direkt anschauen)
* Überlauf verhindern und den Platz unter der Werbung nutzen; selbst wenn es da zum Überlauf kommt, sieht man in der Zuschauerstatistik zumindest noch die Zuschauerzahlen besser)
* Beim Wechsel des aktiven Spielers auch den Kanal wechseln (erleichtert schnelle Wechsel in der Debug-Ansicht; um die KI an- und auszuschalten müssen beide Werte übereinstimmen, damit es verlässlich klappt)

closes #467 