### PR TITLE
[Debug] Programmansicht bei Tageswechsel

### DIFF
--- a/source/gamefunctions_debug.bmx
+++ b/source/gamefunctions_debug.bmx
@@ -3379,6 +3379,7 @@ Type TDebugProgrammePlanInfos
 
 
 	Method Update(playerID:Int, x:Int, y:Int)
+		If showCurrent > 0 Then dayShown = GetWorldTime().GetDay()
 	End Method
 
 


### PR DESCRIPTION
Der Last-Minute-Fix zum Verhindern des Flackerns beim Zurückblättern hat einen anderen Bug verursacht. Beim ersten Öffnen wird der falsche Tag angezeigt und beim Tageswechsel wird die Ansicht auch nicht aktualisiert.