### PR TITLE
KI weitere Verbesserungen

### DIFF
--- a/res/ai/DefaultAIPlayer/TaskBoss.lua
+++ b/res/ai/DefaultAIPlayer/TaskBoss.lua
@@ -101,8 +101,9 @@ function JobCheckCredit:Prepare(pParams)
 		-- ATTENTION: money might change until "tick()", we could handle
 		-- it but this behaviour seems more "natural" (to not see the
 		-- money change in time)
-		-- try to at least become "positive" again
-		self.Task.TryToGetCredit = math.min( math.abs(TVT.GetMoney()), TVT.bo_getCreditAvailable() )
+		-- negative balance typically when the day begins (fixed costs, failed contracts);
+		-- try to achieve positive balance with minimal budget for buying news items
+		self.Task.TryToGetCredit = math.min( math.abs(TVT.GetMoney()) + 100000, TVT.bo_getCreditAvailable() )
 	end
 	if self.Task.NeededInvestmentBudget > 0 then
 		self.Task.TryToRepayCredit = math.max(0, math.min(TVT.GetMoney(), self.Task.NeededInvestmentBudget))

--- a/res/ai/DefaultAIPlayer/TaskRoomBoard.lua
+++ b/res/ai/DefaultAIPlayer/TaskRoomBoard.lua
@@ -15,6 +15,7 @@ _G["TaskRoomBoard"] = class(AITask, function(c)
 	c.RecognizedTerrorLevel = false
 	c.FRDubanTerrorLevel = 0 --FR Duban Terroristen
 	c.VRDubanTerrorLevel = 0 --VR Duban Terroristen
+	c.lastTaskHour = -1
 end)
 
 function TaskRoomBoard:typename()
@@ -28,6 +29,7 @@ function TaskRoomBoard:Activate()
 end
 
 function TaskRoomBoard:GetNextJobInTargetRoom()
+	self.lastTaskHour = TVT.GetDayHour()
 	if (self.ChangeRoomSignsJob.Status ~= JOB_STATUS_DONE) then
 		return self.ChangeRoomSignsJob
 	end
@@ -51,6 +53,17 @@ function TaskRoomBoard:getSituationPriority()
 	local maxTerrorLevel = math.max(self.FRDubanTerrorLevel, self.VRDubanTerrorLevel)
 	if maxTerrorLevel >= 3 then
 		self.SituationPriority = math.max(self.SituationPriority, maxTerrorLevel * 8)
+	end
+
+	--TODO do not permanently go to the room board
+	--TODO call getDayHour less often
+	--TODO modify strategic priority insead?
+	local now = TVT.GetDayHour()
+	if now > 17 or now < 2 then
+		return 0
+	end
+	if self.lastTaskHour >= 0 and math.abs((now - self.lastTaskHour)% 24)<3 then
+		return 0
 	end
 
 	return self.SituationPriority


### PR DESCRIPTION
Hier eine weitere Liste kleinerer Verbesserungen an der KI. Die Commits sind wieder erstmal einzeln zur besseren Übersicht. Ein Bug gibt es beim onMinute-Aufruf. Der liefert die falsche Zeit. Das kann mit der int-Long-Umstellung der Zeit zu tun haben. Kannst Du da mal draufschauen (dass das Event sofort die richtige Zeit bekommt).

* Budgetberechnung berücksichtigt Zeit (Fixkostenanteile über den Tag verteilt)
* um X:06 wird nicht die eigentliche Programmkorrektur gemacht, sondern die Schedule-Prio hochgesetzt (funktioniert besser, wenn man nicht sowieso im Büro ist)
* etwas vorsichtigere Werbungsschätzung für Prime-Time (Vertragsstrafen verhindern) und weniger überzählige Spots - kann noch optimiert werden, je geringer die Anforderungen des Spots sind, desto mehr überzählige Spots wären OK
* weniger unnötige Kategorieumbuchugen bei der Werbung (Fixkosten für schon gebuchte Abos sollten nicht wirklich zum Tagesbudget zählen)
* weitere Stellschrauben beim Filmkauf
* Senderkauf nicht zu kurz vor Tagesende (Fixkosten vermeiden), bei Budget-Override die Fixkosten nicht ignorieren
* Versuch, weniger häufig zum Raumplan zu gehen (lange Wege, suboptimale Werbeplanung verringern)
* nicht so häufig kompletten Programmplan umschmeißen (Performance, Werbung anfordern, die nichts mit Plan zu tun hat)