### PR TITLE
KI Logging

### DIFF
--- a/res/ai/CommonAI/AIEngine.lua
+++ b/res/ai/CommonAI/AIEngine.lua
@@ -37,6 +37,14 @@ JOB_STATUS_RUN		= "J_run"
 JOB_STATUS_DONE		= "J_done"
 JOB_STATUS_CANCEL	= "J_cancel"
 
+LOG_OFF				= 0
+LOG_ERROR			= 1
+LOG_INFO			= 2
+LOG_DEBUG			= 3
+LOG_TRACE			= 4
+LOG_TASK_DEF_LEVEL	= LOG_INFO
+LOG_JOB_START_LEVEL = LOG_DEBUG
+
 -- ##### CLASSES #####
 -- >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 _G["KIObjekt"] = class(SLFObject, function(c)		-- Erbt aus dem Basic-Objekt des Frameworks
@@ -100,9 +108,9 @@ function AIPlayer:ForceTask(taskID, priority)
 	if task ~= nil then
 		if self.CurrentTask ~= nil and self.CurrentTask.SituationPriority > priority then
 			priority = self.CurrentTask.SituationPriority + 10
-			debugMsg("ForceTask: " .. taskID .. " with adjusted priority " .. priority)
+			self:LogInfo("ForceTask: " .. taskID .. " with adjusted priority " .. priority)
 		else
-			debugMsg("ForceTask: " .. taskID .. " with priority " .. priority)
+			self:LogInfo("ForceTask: " .. taskID .. " with priority " .. priority)
 		end
 		task.SituationPriority = priority
 		player:ForceNextTask()
@@ -112,7 +120,7 @@ end
 
 --stop a current task and start the next one
 function AIPlayer:ForceNextTask()
-	debugMsg("ForceNextTask")
+	self:LogDebug("ForceNextTask")
 	if self.CurrentTask ~= nil then
 		local nextTask = self:SelectTask()
 		local nextTaskName = ""
@@ -142,7 +150,7 @@ function AIPlayer:ForceNextTask()
 			end
 			-- cancel old one
 			if cancelTask then
-				debugMsg("ForceNextTask: Cancel current task...")
+				self:LogDebug("ForceNextTask: Cancel current task...")
 				self.CurrentTask:SetAbort()
 			end
 
@@ -153,7 +161,7 @@ function AIPlayer:ForceNextTask()
 			--start the next job of the new task
 			self.CurrentTask:StartNextJob()
 		else
-			debugMsg("ForceNextTask() failed: no follow up task found...")
+			self:LogInfo("ForceNextTask() failed: no follow up task found...")
 		end
 	end
 end
@@ -352,6 +360,8 @@ _G["AITask"] = class(KIDataObjekt, function(c)
 	c.assignmentType = 0
 
 	c.FixedCosts = nil
+
+	c.LogLevel = LOG_TASK_DEF_LEVEL
 end)
 
 
@@ -383,7 +393,7 @@ end
 function AITask:getWorldTicks()
 	local player = _G["globalPlayer"]
 	if player == nil then
-		debugMsg("_G[\"globalPlayer\"] is NIL!")
+		self:LogError("_G[\"globalPlayer\"] is NIL!")
 		return 0
 	end
 	return player.WorldTicks
@@ -411,7 +421,7 @@ function AITask:resume()
 	-- its external objects in "TVT.*"
 	if self.InvalidDataObject then
 		if self.Status == TASK_STATUS_PREPARE or self.Status == TASK_STATUS_RUN then
-			debugMsg(type(self) .. ": InvalidDataObject resume => TASK_STATUS_OPEN")
+			self:LogError(type(self) .. ": InvalidDataObject resume => TASK_STATUS_OPEN")
 			self.Status = TASK_STATUS_OPEN
 		end
 		self.InvalidDataObject = false
@@ -424,7 +434,9 @@ function AITask:CallActivate()
 	self.TickCounter = 0
 	self.TicksTotalTime = 0
 	self:InitializeMaxTicks()
-	debugMsg("### Starting task '" .. self:typename() .. "'! (Prio: " .. self.CurrentPriority .."). MaxTicks: " .. self.MaxTicks)
+	debugMsgDepth(-10)
+	self:LogInfo("### Starting task '" .. self:typename() .. "'! (Prio: " .. self.CurrentPriority .."). MaxTicks: " .. self.MaxTicks)
+	debugMsgDepth(1)
 	self:Activate()
 end
 
@@ -436,7 +448,7 @@ end
 
 
 function AITask:Activate()
-	debugMsg("Please implement me... " .. type(self))
+	self:LogError("Please implement me... " .. type(self))
 end
 
 
@@ -452,10 +464,10 @@ end
 
 --Wird aufgerufen, wenn der Task zur Bearbeitung ausgewaehlt wurde (NICHT UEBERSCHREIBEN!)
 function AITask:StartNextJob()
-	--debugMsg("StartNextJob")
+	self:LogTrace("StartNextJob")
 
 	--local roomNumber = TVT.GetPlayerRoom()
-	--debugMsg("Player-Raum: " .. roomNumber .. " - Target-Raum: " .. self.TargetRoom)
+	--self:LogTrace("Player-Raum: " .. roomNumber .. " - Target-Raum: " .. self.TargetRoom)
 	if TVT.GetPlayerRoom() ~= self.TargetRoom then --sorgt dafür, dass der Spieler in den richtigen Raum geht!
 		self.Status = TASK_STATUS_PREPARE
 		self.CurrentJob = self:getGotoJob()
@@ -486,15 +498,14 @@ function AITask:Tick()
 	--sometimes a figure is stuck in the adagency... we cancel jobs in
 	--that case
 	if (self.Status == TASK_STATUS_OPEN) then
-		debugMsg("Status OPEN! Darf nicht sein!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-		debugMsg(self:typename())
+		self:LogError(self:typename()..": Status OPEN! Darf nicht sein!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
 		self:SetDone()
 	end
 
 	-- have to idle?
 	if (self.Status == TASK_STATUS_IDLE) then
 		self.idleTicks = self.idleTicks - 1
-		debugMsg("idling ... " .. self.idleTicks)
+		self:LogTrace("idling ... " .. self.idleTicks)
 		if (self.idleTicks < 0) then
 			self.idleTicks = 0
 			self.Status = TASK_STATUS_RUN
@@ -503,15 +514,15 @@ function AITask:Tick()
 
 	if ((self.Status == TASK_STATUS_RUN) or (self.Status == TASK_STATUS_WAIT)) then
 		self.TickCounter = self.TickCounter + 1
-		--debugMsg("MaxTickCount: " .. self.TickCounter .. " > " .. self.MaxTicks)
 		if (self.TickCounter > self.MaxTicks) then
+			self:LogTrace("MaxTickCount: " .. self.TickCounter .. " > " .. self.MaxTicks)
 			self:TooMuchTicks()
 		end
 	end
 
 	if ((self.Status == TASK_STATUS_RUN) or (self.Status == TASK_STATUS_PREPARE)) then
 		if (self.CurrentJob == nil) then
-			--debugMsg("----- Kein Job da - Neuen Starten")
+			self:LogTrace("----- Kein Job da - Neuen Starten")
 			self:StartNextJob() --Von vorne anfangen
 		else
 			if self.CurrentJob.Status == JOB_STATUS_CANCEL then
@@ -524,10 +535,9 @@ function AITask:Tick()
 				self.CurrentJob:OnDone()
 				self.CurrentJob:Stop()
 				self.CurrentJob = nil
-				--debugMsg("----- Alter Job ist fertig - Neuen Starten")
+				self:LogTrace("----- Alter Job ist fertig - Neuen Starten")
 				self:StartNextJob() --Von vorne anfangen
 			else
-				--debugMsg("----- Job-Tick")
 				self.CurrentJob:CallTick() --Fortsetzen
 			end
 		end
@@ -574,9 +584,10 @@ function AITask:RecalcPriority()
 	--  40 minutes or more being 80%
 	if self.TargetRoom > 0 then
 		local blockedMinutes = TVT.TimeToMinutes( TVT.GetRoomBlockedTimeString(self.TargetRoom) )
-		--debugMsg("PRIO: Target room ".. self.TargetRoom ..". blockedMinutes " .. blockedMinutes))
+		--TODO once the log level is changed for a task, these log messages would constantly appear
+		--self:LogTrace("PRIO: Target room ".. self.TargetRoom ..". blockedMinutes " .. blockedMinutes)
 		if blockedMinutes >= 1 then
-			--debugMsg("PRIO: Target room is blocked too long, reducing priority. " .. math.max(0.2, 1.0 - 0.02*blockedMinutes))
+			--self:LogDebug("PRIO: Target room is blocked too long, reducing priority. " .. math.max(0.2, 1.0 - 0.02*blockedMinutes))
 			self.CurrentPriority = math.max(0.2, 1.0 - 0.02*blockedMinutes)
 		end
 	end
@@ -587,26 +598,27 @@ end
 
 
 function AITask:TooMuchTicks()
-	debugMsg("... waited long enough.")
+	self:LogInfo("... waited long enough.")
 	self:SetDone()
 end
 
 
 function AITask:SetWait()
-	debugMsg("Waiting...")
+	self:LogDebug("Waiting...")
 	self.Status = TASK_STATUS_WAIT
 end
 
 
 function AITask:SetIdle(idleTicks)
 	idleTicks = idleTicks or 10 --default is 10 ticks
-	debugMsg("idling for " .. idleTicks .. " ticks")
+	self:LogDebug("idling for " .. idleTicks .. " ticks")
 	self.Status = TASK_STATUS_IDLE
 end
 
 
 function AITask:SetDone()
-	debugMsg("### Task finished!")
+	debugMsgDepth(-10)
+	self:LogInfo("### Task finished!")
 	local player = _G["globalPlayer"]
 	self.Status = TASK_STATUS_DONE
 	self.SituationPriority = 0
@@ -615,7 +627,7 @@ function AITask:SetDone()
 
 
 	if(TVT.doLeaveRoom(false) == TVT.RESULT_FAILED) then
-		debugMsg("Failed leaving room normally. Forcefully leaving the room now!")
+		self:LogDebug("Failed leaving room normally. Forcefully leaving the room now!")
 		TVT.doLeaveRoom(true)
 	end
 
@@ -625,7 +637,8 @@ end
 
 --no priority modification
 function AITask:SetAbort()
-	debugMsg("<<< Task aborted!")
+	debugMsgDepth(-10)
+	self:LogInfo("<<< Task aborted!")
 	self.Status = TASK_STATUS_CANCEL
 
 	-- reset back
@@ -634,7 +647,8 @@ end
 
 --with priority modification
 function AITask:SetCancel()
-	debugMsg("<<< Task cancelled!")
+	debugMsgDepth(-10)
+	self:LogInfo("<<< Task cancelled!")
 	self.Status = TASK_STATUS_CANCEL
 	self.SituationPriority = self.SituationPriority / 2
 
@@ -681,6 +695,32 @@ function AITask:OnMoneyChanged(value, reason, reference)
 	--Zum überschreiben
 end
 
+--convenience log methods for tasks
+function AITask:LogError(message)
+	self:Log(LOG_ERROR, message)
+end
+
+function AITask:LogInfo(message)
+	self:Log(LOG_INFO, message)
+end
+
+function AITask:LogDebug(message)
+	self:Log(LOG_DEBUG, message)
+end
+
+function AITask:LogTrace(message)
+	self:Log(LOG_TRACE, message)
+end
+
+--main log method - write message if given level should be logged
+function AITask:Log(level, message)
+	if level == nil then
+		debugMsg("Log level not defined for "..self:typename())
+		print(debug.traceback())
+	elseif level > LOG_OFF and level <= self.LogLevel then
+		debugMsg(message)
+	end
+end
 -- <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 -- >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
@@ -697,6 +737,9 @@ _G["AIJob"] = class(KIDataObjekt, function(c)
 	c.TickMaxTime = 0
 	c.StartParams = nil
 	c.jobStartTime = 0
+	c.LogStartLevel = LOG_JOB_START_LEVEL
+	c.LogDoneLevel = LOG_OFF -- actually also remove comment where used - too many calculations
+	c.LogLevel = nil
 end)
 
 function AIJob:typename()
@@ -713,7 +756,7 @@ end
 function AIJob:resume()
 	if self.InvalidDataObject then
 		if self.Status == JOB_STATUS_REDO or self.Status == JOB_STATUS_RUN then
-			debugMsg(self:typename() .. ": InvalidDataObject resume => JOB_STATUS_NEW")
+			self:LogError(self:typename() .. ": InvalidDataObject resume => JOB_STATUS_NEW")
 			self.Status = JOB_STATUS_NEW
 		end
 		self.InvalidDataObject = false
@@ -723,6 +766,8 @@ end
 
 
 function AIJob:Start(pParams)
+	self:Log(self.LogStartLevel, "Job " .. self:typename() .. " started.")
+	debugMsgDepth(1)
 	self:OnStart()
 
 	self.jobStartTime = os.clock()
@@ -745,7 +790,7 @@ end
 
 
 function AIJob:Prepare(pParams)
-	debugMsg("Implementiere mich: " .. type(self))
+	self:LogError("Implementiere mich: " .. type(self))
 end
 
 
@@ -767,11 +812,12 @@ end
 
 
 function AIJob:ReDoCheck(minutesWait, ticksWait)
-	if ((self.LastCheckWorldTicks + ticksWait) < self:getWorldTicks() or (self.LastCheck + minutesWait) < TVT.GetTimeGoneInMinutes()) then
-		--debugMsg("ReDoCheck: (time: " .. self.LastCheck .. " + " .. minutesWait .. " < " .. TVT.GetTimeGoneInMinutes() .."    ticks: " ..self.LastCheckWorldTicks .. " + " .. ticksWait .." < " .. self:getWorldTicks())
+	local timeGone = TVT.GetTimeGoneInMinutes()
+	if ((self.LastCheckWorldTicks + ticksWait) < self:getWorldTicks() or (self.LastCheck + minutesWait) < timeGone) then
+		self:LogDebug("ReDoCheck: (time: " .. self.LastCheck .. " + " .. minutesWait .. " < " .. timeGone .."    ticks: " ..self.LastCheckWorldTicks .. " + " .. ticksWait .." < " .. self:getWorldTicks())
 		self.Status = JOB_STATUS_REDO
 		self.LastCheckWorldTicks = self:getWorldTicks()
-		self.LastCheck = TVT.GetTimeGoneInMinutes()
+		self.LastCheck = timeGone
 		self:Prepare(self.StartParams)
 	end
 end
@@ -788,12 +834,14 @@ end
 
 
 function AIJob:OnDone()
-	debugMsg("Job " .. self:typename() .. " done. Duration=" .. string.format("%.4f", (1000 * (os.clock() - self.jobStartTime))) .. "ms  TickCount=" .. self.Ticks .. "  TickTime=" .. string.format("%.4f", 1000 * self.TicksTotalTime) .."ms  TickMax=" .. string.format("%.4f", 1000 * self.TickMaxTime))
+	debugMsgDepth(-1)
+	--self:Log(self.LogDoneLevel, "Job " .. self:typename() .. " done. Duration=" .. string.format("%.4f", (1000 * (os.clock() - self.jobStartTime))) .. "ms  TickCount=" .. self.Ticks .. "  TickTime=" .. string.format("%.4f", 1000 * self.TicksTotalTime) .."ms  TickMax=" .. string.format("%.4f", 1000 * self.TickMaxTime))
 end
 
 
 function AIJob:OnCancel()
-	debugMsg("Job " .. self:typename() .. " cancelled. Duration=" .. string.format("%.4f", (1000 * (os.clock() - self.jobStartTime))) .. "ms  TickCount=" .. self.Ticks .. "  TickTime=" .. string.format("%.4f", 1000 * self.TicksTotalTime) .."ms  TickMax=" .. string.format("%.4f", 1000 * self.TickMaxTime))
+	debugMsgDepth(-1)
+	self:LogInfo("Job " .. self:typename() .. " cancelled. Duration=" .. string.format("%.4f", (1000 * (os.clock() - self.jobStartTime))) .. "ms  TickCount=" .. self.Ticks .. "  TickTime=" .. string.format("%.4f", 1000 * self.TicksTotalTime) .."ms  TickMax=" .. string.format("%.4f", 1000 * self.TickMaxTime))
 end
 
 
@@ -818,7 +866,47 @@ end
 
 
 function AIJob:SetCancel()
-	debugMsg("SetCancel(): Implementiere mich: " .. type(self))
+	self:LogError("SetCancel(): Implementiere mich: " .. type(self))
+end
+
+--convenience log methods for jobs
+function AIJob:LogError(message)
+	self:Log(LOG_ERROR, message)
+end
+
+function AIJob:LogInfo(message)
+	self:Log(LOG_INFO, message)
+end
+
+function AIJob:LogDebug(message)
+	self:Log(LOG_DEBUG, message)
+end
+
+function AIJob:LogTrace(message)
+	self:Log(LOG_TRACE, message)
+end
+
+--main log method - write message if given level should be logged
+function AIJob:Log(level, message)
+	if level == nil then
+		debugMsg("Log level not defined for "..self:typename())
+		print(debug.traceback())
+	elseif level > LOG_OFF and level <= self:GetLogLevel() then
+		debugMsg(message)
+	end
+end
+
+--calculate inherited log level from task if job log level is not explicitly defined
+function AIJob:GetLogLevel()
+	if self.LogLevel == nil then
+		if self.Task ~= nil and self.Task.LogLevel ~=nil then
+			self.LogLevel = self.Task.LogLevel
+		else
+			debugMsg(self:typename().." log level undefined")
+			self.LogLevel = LOG_OFF
+		end
+	end
+	return self.LogLevel
 end
 -- <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
@@ -853,11 +941,11 @@ end
 function AIIdleJob:Start(pParams)
 	if (self.IdleTime ~= 0) then
 		self.IdleTill = TVT.GetTimeGoneInMinutes() + self.IdleTime
-		--debugMsg("Set self.IdleTill = " .. self.IdleTill)
+		self:LogDebug("Set self.IdleTill = " .. self.IdleTill)
 	end
 	if (self.IdleTicks ~= 0) then
 		self.IdleTillWorldTicks = self:getWorldTicks() + self.IdleTicks
-		--debugMsg("Set self.IdleTillWorldTicks = " .. self.IdleTillWorldTicks)
+		self:LogDebug("Set self.IdleTillWorldTicks = " .. self.IdleTillWorldTicks)
 	end
 end
 
@@ -887,18 +975,14 @@ function AIIdleJob:Tick()
 	end
 
 	if finishedIdling == true then
-		--debugMsg("Finished idling ...")
+		self:LogDebug("Finished idling ...")
 		self.Status = JOB_STATUS_DONE
 		return
 	else
-		--debugMsg("Idling ...")
+		self:LogTrace("Idling ...")
 	end
 end
 
---override to disable debugmsg
-function AIIdleJob:OnDone()
--- debugMsg("Job " .. self:typename() .. " done in " .. math.floor(1000 * (os.clock() - self.jobStartTime)) .. " ms.")
-end
 -- <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 
@@ -914,6 +998,7 @@ _G["AIJobGoToRoom"] = class(AIJob, function(c)
 	c.WaitSinceWorldTicks = -1
 	c.WaitTill = -1
 	c.WaitTillWorldTicks = -1
+	c.LogStartLevel = LOG_OFF
 end)
 
 function AIJobGoToRoom:typename()
@@ -925,7 +1010,7 @@ function AIJobGoToRoom:OnBeginEnterRoom(roomId, result)
 	local resultId = tonumber(result)
 	if (resultId == TVT.RESULT_INUSE) then
 		if (self.IsWaiting) then
-			-- debugMsg( TVT.ME .. " BeginEnterRoom: Room still in use. Will continue to wait...a bit. Waiting time: " .. self.WaitTill .. "/" .. TVT.GetTimeGoneInMinutes().."  ticks=" .. self.WaitTillWorldTicks .. "/" .. self:getWorldTicks() .. ")")
+			self:LogDebug( TVT.ME .. " BeginEnterRoom: Room still in use. Will continue to wait...a bit. Waiting time: " .. self.WaitTill .. "/" .. TVT.GetTimeGoneInMinutes().."  ticks=" .. self.WaitTillWorldTicks .. "/" .. self:getWorldTicks() .. ")")
 		elseif (self:ShouldIWait()) then
 			self.IsWaiting = true
 			self.WaitSince = TVT.GetTimeGoneInMinutes()
@@ -938,9 +1023,9 @@ function AIJobGoToRoom:OnBeginEnterRoom(roomId, result)
 			if ((self.WaitTillWorldTicks - self.WaitSinceWorldTicks) > 20) then
 				self.WaitTillWorldTicks = self.WaitSinceWorldTicks + 20
 			end
-			debugMsg("BeginEnterRoom: Room occupied! Will wait a bit. Waiting time: " .. self.WaitTill .. "/" .. TVT.GetTimeGoneInMinutes().."  /  ticks: " .. self.WaitTillWorldTicks .. "/" .. self:getWorldTicks() .. ")")
+			self:LogDebug("BeginEnterRoom: Room occupied! Will wait a bit. Waiting time: " .. self.WaitTill .. "/" .. TVT.GetTimeGoneInMinutes().."  /  ticks: " .. self.WaitTillWorldTicks .. "/" .. self:getWorldTicks() .. ")")
 		else
-			debugMsg("BeginEnterRoom: Room occupied! Won't wait this time.")
+			self:LogInfo("BeginEnterRoom: Room occupied! Won't wait this time.")
 			self.Status = JOB_STATUS_CANCEL
 			self.Task:SetCancel()
 		end
@@ -948,25 +1033,24 @@ function AIJobGoToRoom:OnBeginEnterRoom(roomId, result)
 		local blockedMinutes = TVT.TimeToMinutes( TVT.GetRoomBlockedTimeString(roomId) )
 		--if blocked shorter than 10 minutes, we will wait
 		if TVT.IsRoomBlocked(roomId) == 1 and blockedMinutes <= 10 then
-			debugMsg("BeginEnterRoom: Room blocked short enough! ... waiting a bit. Blocked for " .. blockedMinutes .. " minute(s).")
+			self:LogInfo("BeginEnterRoom: Room blocked short enough! ... waiting a bit. Blocked for " .. blockedMinutes .. " minute(s).")
 		else
-			debugMsg("BeginEnterRoom: Room enter forbidden or room blocked and waiting time too long: " .. blockedMinutes .. " minute(s).")
+			self:LogInfo("BeginEnterRoom: Room enter forbidden or room blocked and waiting time too long: " .. blockedMinutes .. " minute(s).")
 			self.Status = JOB_STATUS_CANCEL
 			self.Task:SetCancel()
 		end
 	elseif(resultId == TVT.RESULT_NOKEY) then
-		debugMsg("BeginEnterRoom: Room locked! Need a key to enter. Cancelled task.")
+		self:LogInfo("BeginEnterRoom: Room locked! Need a key to enter. Cancelled task.")
 		self.Status = JOB_STATUS_CANCEL
 		self.Task:SetCancel()
 	elseif(resultId == TVT.RESULT_OK) then
-		--debugMsg("BeginEnterRoom: Entering allowed. roomId: " .. roomId)
+		self:LogDebug("BeginEnterRoom: Entering allowed. roomId: " .. roomId)
 	end
 end
 
 
 function AIJobGoToRoom:OnEnterRoom(roomId)
-	--debugMsg("EnterRoom: Entering roomId: " .. roomId)
-	--debugMsg("AIJobGoToRoom DONE!")
+	self:LogInfo("AIJobGoToRoom: Entering roomId: " .. roomId)
 	self.Status = JOB_STATUS_DONE
 end
 
@@ -994,9 +1078,9 @@ function AIJobGoToRoom:OnReachTarget()
 	-- room as it was occupied
 	if (self.Status == JOB_STATUS_REDO) or (self.Status == JOB_STATUS_RUN) then
 		if TVT.isRoomUnused(self.TargetRoom) == TVT.RESULT_INUSE then
-			--debugMsg("OnReachTarget - Skip going in, still used")
+			self:LogTrace("OnReachTarget - Skip going in, still used")
 		else
-			--debugMsg("OnReachTarget - GoToRoom again")
+			self:LogTrace("OnReachTarget - GoToRoom again")
 			TVT.DoGoToRoom(self.TargetRoom)
 		end
 	end
@@ -1005,9 +1089,9 @@ end
 
 function AIJobGoToRoom:Prepare(pParams)
 	if ((self.Status == JOB_STATUS_NEW) or (self.Status == TASK_STATUS_PREPARE) or (self.Status == JOB_STATUS_REDO)) then
-		--debugMsg("DoGoToRoom: " .. self.TargetRoom .. " => " .. self.Status)
+		self:LogTrace("DoGoToRoom: " .. self.TargetRoom .. " => " .. self.Status)
 		if TVT.DoGoToRoom(self.TargetRoom) <= 0 then
-			--debugMsg("DoGoToRoom: failed, eg. not allowed to do so.")
+			self:LogTrace("DoGoToRoom: failed, eg. not allowed to do so.")
 		else
 			self.Status = JOB_STATUS_RUN
 		end
@@ -1017,27 +1101,27 @@ end
 
 function AIJobGoToRoom:Tick()
 	if (self.IsWaiting) then
-		--debugMsg("AIJobGoToRoom:Tick ... waiting")
+		self:LogTrace("AIJobGoToRoom:Tick ... waiting")
 		if (TVT.isRoomUnused(self.TargetRoom) == 1) then
-			--debugMsg("Room is unused now")
+			self:LogTrace("Room is unused now")
 			self.IsWaiting = false
 			TVT.DoGoToRoom(self.TargetRoom)
 		elseif ((self.WaitTill - TVT.GetTimeGoneInMinutes()) <= 0 or (self.WaitTillWorldTicks - self:getWorldTicks()) <= 0) then
-			debugMsg("Room is still used. I do not want to wait anylonger.")
+			self:LogInfo("Room is still used. I do not want to wait any longer.")
 			self.IsWaiting = false
 			self.Status = JOB_STATUS_CANCEL
 		else
-			--debugMsg("Waiting to enter the room. Waiting till time: " .. self.WaitTill .. "/" .. TVT.GetTimeGoneInMinutes() .. "  /  ticks: " .. self.WaitTillWorldTicks .. "/" .. self:getWorldTicks() .. ".")
+			self:LogTrace("Waiting to enter the room. Waiting till time: " .. self.WaitTill .. "/" .. TVT.GetTimeGoneInMinutes() .. "  /  ticks: " .. self.WaitTillWorldTicks .. "/" .. self:getWorldTicks() .. ".")
 		end
 	-- while walking / going by elevator
 	elseif (self.Status ~= JOB_STATUS_DONE) then
 		-- check if room is blocked - if so, abort task
 		if (self.TargetRoom >= 0) and TVT.IsRoomBlocked(self.TargetRoom) == 1 then
 			local blockedMinutes = TVT.TimeToMinutes( TVT.GetRoomBlockedTimeString(self.TargetRoom) )
-			if blockedMinutes <=  10 then
-				debugMsg("Target room is blocked but soon reopening.")
+			if blockedMinutes <= 10 then
+				self:LogInfo("Target room is blocked but soon reopening.")
 			else
-				debugMsg("Target room is blocked ... cancelling task.")
+				self:LogInfo("Target room is blocked ... cancelling task.")
 				self.Status = JOB_STATUS_CANCEL
 				self.Task:SetCancel()
 			end
@@ -1045,12 +1129,6 @@ function AIJobGoToRoom:Tick()
 
 		self:ReDoCheck(10, 10)
 	end
-end
-
-
---override to disable debugmsg
-function AIJobGoToRoom:OnDone()
--- debugMsg("Job " .. self:typename() .. " done in " .. math.floor(1000 * (os.clock() - self.jobStartTime)) .. " ms.")
 end
 -- <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 

--- a/res/ai/DefaultAIPlayer/CommonObjects.lua
+++ b/res/ai/DefaultAIPlayer/CommonObjects.lua
@@ -266,7 +266,7 @@ function BuyProgrammeLicencesRequisition:CheckActuality()
 	end
 	self.Count = table.count(self.licenceReqs)
 	if oldCount == self.Count and table.count(removeList) > 0 then
-		devMsg("!!!! FAILED to remove from self.licenceReqs")
+		logWithLevel(LOG_ERROR, LOG_ERROR, "!!!! FAILED to remove from self.licenceReqs")
 	end
 
 	if (self.Count > 0) then

--- a/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
+++ b/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
@@ -84,6 +84,7 @@ _G["DefaultAIPlayer"] = class(AIPlayer, function(c)
 	--c.Requisitions = nil  --darf nicht überschrieben werden
 
 	c.LastStationMapMarketAnalysis = 0
+	c.LogLevel = LOG_INFO
 end)
 
 function DefaultAIPlayer:typename()
@@ -91,11 +92,11 @@ function DefaultAIPlayer:typename()
 end
 
 function DefaultAIPlayer:LogInfo(message)
-	debugMsg(message)
+	logWithLevel(self.LogLevel, LOG_INFO, message)
 end
 
 function DefaultAIPlayer:LogDebug(message)
-	--debugMsg(message)
+	logWithLevel(self.LogLevel, LOG_DEBUG, message)
 end
 
 function DefaultAIPlayer:initParameters()
@@ -211,31 +212,19 @@ function DefaultAIPlayer:OnGameBegins()
 	end
 	--END LOAD COMPATIBILITY
 
-	if 1 == 2 then
+	if self.LogLevel >= LOG_DEBUG then
+		self:LogDebug("--------------------")
 		local se = StatisticEvaluator()
 		for j = 0, 3 do
 			self:LogInfo("run " .. j)
 			for i = 0, 2 do
 				se:AddValue(1 + i*2)
-				self:LogInfo("added " .. i .. ".  AverageValue=" .. se.AverageValue .. "  minValue=" .. se.MinValue .. "  maxValue=" .. se.MaxValue .. "  TotalSum=" .. se.TotalSum .. "  CurrentValue=" .. se.CurrentValue .. "  Values=" .. se.Values)
+				self:LogDebug("added " .. i .. ".  AverageValue=" .. se.AverageValue .. "  minValue=" .. se.MinValue .. "  maxValue=" .. se.MaxValue .. "  TotalSum=" .. se.TotalSum .. "  CurrentValue=" .. se.CurrentValue .. "  Values=" .. se.Values)
 			end
 			se:Adjust()
-			self:LogInfo("adjusted.  AverageValue=" .. se.AverageValue .. "  minValue=" .. se.MinValue .. "  maxValue=" .. se.MaxValue .. "  TotalSum=" .. se.TotalSum .. "  CurrentValue=" .. se.CurrentValue .. "  Values=" .. se.Values)
+			self:LogDebug("adjusted.  AverageValue=" .. se.AverageValue .. "  minValue=" .. se.MinValue .. "  maxValue=" .. se.MaxValue .. "  TotalSum=" .. se.TotalSum .. "  CurrentValue=" .. se.CurrentValue .. "  Values=" .. se.Values)
 		end
-	
-		self:LogInfo("--------------------")
-		self:LogInfo("--------------------")
-	
-		se = StatisticEvaluatorOld()
-		for j = 0, 3 do
-			debugMsg("run " .. j)
-			for i = 0, 2 do
-				se:AddValue(1 + i*2)
-				self:LogInfo("added " .. i .. ".  AverageValue=" .. se.AverageValue .. "  minValue=" .. se.MinValue .. "  maxValue=" .. se.MaxValue .. "  TotalSum=" .. se.TotalSum .. "  CurrentValue=" .. se.CurrentValue .. "  Values=" .. se.Values)
-			end
-			se:Adjust()
-			self:LogInfo("adjusted.  AverageValue=" .. se.AverageValue .. "  minValue=" .. se.MinValue .. "  maxValue=" .. se.MaxValue .. "  TotalSum=" .. se.TotalSum .. "  CurrentValue=" .. se.CurrentValue .. "  Values=" .. se.Values)
-		end
+		self:LogDebug("--------------------")
 	end
 end
 
@@ -382,7 +371,7 @@ function DefaultAIPlayer:GetNextEnemyId()
 end
 
 function DefaultAIPlayer:CleanUp()
-	self:LogInfo(self:typename() .. ": CleanUp")
+	self:LogDebug(self:typename() .. ": CleanUp")
 
 	self:LogDebug("Requisitions (before): " .. table.count(self.Requisitions))
 
@@ -750,11 +739,6 @@ end
 
 -- figure is now at the desired target
 function OnReachTarget(target, targetText)
-	--if target ~= nil then
-	--	devMsg("OnReachTarget: " .. targetText)
-	--else
-	--	devMsg("OnReachTarget: unknown")
-	--end
 	--debugMsg("OnReachTarget")
 	if (aiIsActive) then
 		getAIPlayer():OnReachTarget()

--- a/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
+++ b/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
@@ -90,6 +90,14 @@ function DefaultAIPlayer:typename()
 	return "DefaultAIPlayer"
 end
 
+function DefaultAIPlayer:LogInfo(message)
+	debugMsg(message)
+end
+
+function DefaultAIPlayer:LogDebug(message)
+	--debugMsg(message)
+end
+
 function DefaultAIPlayer:initParameters()
 	if (self.Ventruesome == nil or self.Ventruesome <= 0) then
 		--Waghalsigkeit 3-8
@@ -112,11 +120,11 @@ function DefaultAIPlayer:initParameters()
 	end
 
 	--for checking that the same parameters are still used after loading a saved game
-	--debugMsg("initializing ".. self.Ventruesome.. " ".. self.NewsPriority .." ".. self.ExpansionPriority .." " .. self.BrainSpeed)
+	self:LogDebug("initializing ".. self.Ventruesome.. " ".. self.NewsPriority .." ".. self.ExpansionPriority .." " .. self.BrainSpeed)
 end
 
 function DefaultAIPlayer:initializePlayer()
-	debugMsg("Initialisiere DefaultAIPlayer-KI ...")
+	self:LogInfo("Initialisiere DefaultAIPlayer-KI ...")
 	self.Stats = BusinessStats()
 	self.Stats:Initialize()
 	self.Budget = BudgetManager()
@@ -155,7 +163,7 @@ function DefaultAIPlayer:resume()
 	_G["globalPlayer"] = self
 
 	if (self.Strategy == nil) then
-		debugMsg(self:typename() .. ": Resume Strategy")
+		self:LogInfo(self:typename() .. ": Resume Strategy")
 		self.Strategy = DefaultStrategy()
 	end
 
@@ -202,33 +210,33 @@ function DefaultAIPlayer:OnGameBegins()
 		self.Stats.SpotPenaltyPerSpot = StatisticEvaluator()
 	end
 	--END LOAD COMPATIBILITY
+
+	if 1 == 2 then
+		local se = StatisticEvaluator()
+		for j = 0, 3 do
+			self:LogInfo("run " .. j)
+			for i = 0, 2 do
+				se:AddValue(1 + i*2)
+				self:LogInfo("added " .. i .. ".  AverageValue=" .. se.AverageValue .. "  minValue=" .. se.MinValue .. "  maxValue=" .. se.MaxValue .. "  TotalSum=" .. se.TotalSum .. "  CurrentValue=" .. se.CurrentValue .. "  Values=" .. se.Values)
+			end
+			se:Adjust()
+			self:LogInfo("adjusted.  AverageValue=" .. se.AverageValue .. "  minValue=" .. se.MinValue .. "  maxValue=" .. se.MaxValue .. "  TotalSum=" .. se.TotalSum .. "  CurrentValue=" .. se.CurrentValue .. "  Values=" .. se.Values)
+		end
 	
---[[
-	local se = StatisticEvaluator()
-	for j = 0, 3 do
-		debugMsg("run " .. j)
-		for i = 0, 2 do
-			se:AddValue(1 + i*2)
-			debugMsg("added " .. i .. ".  AverageValue=" .. se.AverageValue .. "  minValue=" .. se.MinValue .. "  maxValue=" .. se.MaxValue .. "  TotalSum=" .. se.TotalSum .. "  CurrentValue=" .. se.CurrentValue .. "  Values=" .. se.Values)
+		self:LogInfo("--------------------")
+		self:LogInfo("--------------------")
+	
+		se = StatisticEvaluatorOld()
+		for j = 0, 3 do
+			debugMsg("run " .. j)
+			for i = 0, 2 do
+				se:AddValue(1 + i*2)
+				self:LogInfo("added " .. i .. ".  AverageValue=" .. se.AverageValue .. "  minValue=" .. se.MinValue .. "  maxValue=" .. se.MaxValue .. "  TotalSum=" .. se.TotalSum .. "  CurrentValue=" .. se.CurrentValue .. "  Values=" .. se.Values)
+			end
+			se:Adjust()
+			self:LogInfo("adjusted.  AverageValue=" .. se.AverageValue .. "  minValue=" .. se.MinValue .. "  maxValue=" .. se.MaxValue .. "  TotalSum=" .. se.TotalSum .. "  CurrentValue=" .. se.CurrentValue .. "  Values=" .. se.Values)
 		end
-		se:Adjust()
-		debugMsg("adjusted.  AverageValue=" .. se.AverageValue .. "  minValue=" .. se.MinValue .. "  maxValue=" .. se.MaxValue .. "  TotalSum=" .. se.TotalSum .. "  CurrentValue=" .. se.CurrentValue .. "  Values=" .. se.Values)
 	end
-
-	debugMsg("--------------------")
-	debugMsg("--------------------")
-
-	se = StatisticEvaluatorOld()
-	for j = 0, 3 do
-		debugMsg("run " .. j)
-		for i = 0, 2 do
-			se:AddValue(1 + i*2)
-			debugMsg("added " .. i .. ".  AverageValue=" .. se.AverageValue .. "  minValue=" .. se.MinValue .. "  maxValue=" .. se.MaxValue .. "  TotalSum=" .. se.TotalSum .. "  CurrentValue=" .. se.CurrentValue .. "  Values=" .. se.Values)
-		end
-		se:Adjust()
-		debugMsg("adjusted.  AverageValue=" .. se.AverageValue .. "  minValue=" .. se.MinValue .. "  maxValue=" .. se.MaxValue .. "  TotalSum=" .. se.TotalSum .. "  CurrentValue=" .. se.CurrentValue .. "  Values=" .. se.Values)
-	end
-]]
 end
 
 
@@ -374,20 +382,20 @@ function DefaultAIPlayer:GetNextEnemyId()
 end
 
 function DefaultAIPlayer:CleanUp()
-	debugMsg(self:typename() .. ": CleanUp")
+	self:LogInfo(self:typename() .. ": CleanUp")
 
-	--debugMsg("Requisitions (before): " .. table.count(self.Requisitions))
+	self:LogDebug("Requisitions (before): " .. table.count(self.Requisitions))
 
 	local tempList = table.copy(self.Requisitions)
 
 	for k,v in pairs(tempList) do
 		if (not v:CheckActuality()) then
 			table.remove(self.Requisitions, index)
-			--debugMsg("Requisition removed")
+			self:LogDebug("Requisition removed")
 		end
 	end
 
-	--debugMsg("Requisitions (after): " .. table.count(self.Requisitions))
+	self:LogDebug("Requisitions (after): " .. table.count(self.Requisitions))
 end
 
 -- <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -719,7 +727,7 @@ function OnEnterRoom(roomId)
 
 		-- when visiting the boss or betty, update sammy information
 		if roomId == TVT.ROOM_BOSS_PLAYER_ME then
-			debugMsg("Visiting my boss", true)
+			--debugMsg("Visiting my boss", true)
 
 			getAIPlayer().currentAwardType = TVT.bo_GetCurrentAwardType()
 			getAIPlayer().currentAwardStartTime = tonumber(TVT.bo_GetCurrentAwardStartTimeString())

--- a/res/ai/DefaultAIPlayer/TaskArchive.lua
+++ b/res/ai/DefaultAIPlayer/TaskArchive.lua
@@ -147,7 +147,7 @@ function JobSellMovies:Tick()
 			self.Task.Player.programmeLicencesInArchiveCount = math.max(0, self.Task.Player.programmeLicencesInArchiveCount - 1)
 			self.Task.Player.programmeLicencesInSuitcaseCount = self.Task.Player.programmeLicencesInSuitcaseCount + 1
 		else
-			self:LogInfo("# put "..case[i].Title.." in suitcase, errorcode: "..ec)
+			self:LogError("# put "..case[i].Title.." in suitcase, errorcode: "..ec)
 		end
 	end
 

--- a/res/ai/DefaultAIPlayer/TaskArchive.lua
+++ b/res/ai/DefaultAIPlayer/TaskArchive.lua
@@ -25,15 +25,14 @@ function TaskArchive:Activate()
 
 	self.SellMoviesJob = JobSellMovies()
 	self.SellMoviesJob.Task = self
+	--self.LogLevel = LOG_TRACE
 end
 
 function TaskArchive:GetNextJobInTargetRoom()
 	--nur einmal am Tag verkaufen, ausser im Notfall
-	if self.latestSaleOnDay >= TVT.GetDay() and not self.emergencySale
-	then
-		debugMsg(timetostring().." archive Task, been here done that")
+	if self.latestSaleOnDay >= TVT.GetDay() and not self.emergencySale then
+		self:LogDebug("was here today, already")
 	elseif (self.SellMoviesJob.Status ~= JOB_STATUS_DONE) then
-		debugMsg("return SellMoviesJob")
 		return self.SellMoviesJob
 	end
 
@@ -90,7 +89,6 @@ function JobSellMovies:Tick()
 		return t;
 	end
 
-	debugMsg("archive: Sell movies job started")
 	--ins archiv wenn nach mitternacht (oben)
 
 	self.Task.latestSaleOnDay = TVT.GetDay()
@@ -98,7 +96,7 @@ function JobSellMovies:Tick()
 
 	--fetch licences
 	local nArchive = TVT.ar_GetProgrammeLicenceCount()
-	debugMsg ("# archived licences: "..nArchive)
+	self:LogDebug("# archived licences: "..nArchive)
 	local movies = {};
 	for i=0, (nArchive-1)
 	do
@@ -106,14 +104,14 @@ function JobSellMovies:Tick()
 		--ignore episodes/collection-elements
 		if m ~= nil and m.HasParentLicence()==0 and m.isAvailable() then
 			vm = newarchivedMovie(m)
-			debugMsg("# found "..vm.Title.." (guid="..vm.GUID.."  id="..vm.Id..") ".." "..vm.price..",  TopicalityLoss="..string.format("%.4f", vm.TopicalityLoss*100).."% (Max="..string.format("%.2f", vm.MaxTopicalityLoss*100).."%), planned: "..tostring(vm.planned))
+			self:LogTrace("# found "..vm.Title.." (guid="..vm.GUID.."  id="..vm.Id..") ".." "..vm.price..",  TopicalityLoss="..string.format("%.4f", vm.TopicalityLoss*100).."% (Max="..string.format("%.2f", vm.MaxTopicalityLoss*100).."%), planned: "..tostring(vm.planned))
 			table.insert(movies,vm)
 		end
 	end
 
 
 	-- check licences
-	debugMsg("# checking single/series licences: "..#movies)
+	self:LogDebug("# checking single/series licences: "..#movies)
 	-- filter by topicality, ignore planned
 	-- in emergency raise bar to keep programme
 	-- keep expensive ones (except their maximum topicality is too low)
@@ -121,7 +119,7 @@ function JobSellMovies:Tick()
 	if self.Task.emergencySale then useMaxTopicalityLossTreshold = self.emergencyMaxTopicalityLossTreshold end
 	local case = {}
 	for k,v in pairs (movies) do
-		if v == nil then debugMsg("# ERROR: movie #" .. k.." is nil") end
+		if v == nil then self:LogError("# ERROR: movie #" .. k.." is nil") end
 		local sellIt = false
 		-- sell when topicality will never raise enough again ("burned")
 		if v.MaxTopicalityLoss > useMaxTopicalityLossTreshold then sellIt = true end
@@ -133,23 +131,23 @@ function JobSellMovies:Tick()
 		if sellIt and v.planned > 0 then sellIt = false end
 
 		if sellIt then
-			debugMsg("# mark for suitcase: "..v.Title)
+			self:LogInfo("mark for suitcase (selling): "..v.Title)
 			table.insert(case,v)
 		end
 	end
 
 
-	debugMsg("# selected for suitcase: "..#case)
+	self:LogDebug("# selected for suitcase: "..#case)
 	-- move licences to suitcase
 	for i=1, #case do
 		ec = TVT.ar_AddProgrammeLicenceToSuitcaseByGUID(case[i].GUID)
 		if ec == TVT.RESULT_OK then
-			debugMsg("# put "..case[i].Title.." in suitcase, OK")
+			self:LogDebug("  put "..case[i].Title.." in suitcase, OK")
 
 			self.Task.Player.programmeLicencesInArchiveCount = math.max(0, self.Task.Player.programmeLicencesInArchiveCount - 1)
 			self.Task.Player.programmeLicencesInSuitcaseCount = self.Task.Player.programmeLicencesInSuitcaseCount + 1
 		else
-			debugMsg("# put "..case[i].Title.." in suitcase, errorcode: "..ec)
+			self:LogInfo("# put "..case[i].Title.." in suitcase, errorcode: "..ec)
 		end
 	end
 
@@ -160,12 +158,11 @@ function JobSellMovies:Tick()
 		if self.Task.Player ~= nil then
 			local t = self.Task.Player.TaskList[_G["TASK_MOVIEDISTRIBUTOR"]]
 			if t ~= nil then
-				debugMsg("# increasing SituationPriority for movie distributor task")
+				self:LogDebug("# increasing SituationPriority for movie distributor task")
 				t.SituationPriority = 150 --arbitrary value, maybe needs higher one
 			end
 		end
 	end
-	debugMsg("archive: Sell movies job done")
 end
 
 function timetostring()

--- a/res/ai/DefaultAIPlayer/TaskBoss.lua
+++ b/res/ai/DefaultAIPlayer/TaskBoss.lua
@@ -134,7 +134,7 @@ function JobCheckCredit:Tick()
 			self.Task.NeededInvestmentBudget = self.Task.NeededInvestmentBudget - repay
 			self:LogDebug("Repaid " .. repay .. " from credit to boss.")
 		else
-			self:LogInfo("FAILED to repay " .. repay .. " from credit to boss.")
+			self:LogError("FAILED to repay " .. repay .. " from credit to boss.")
 		end
 
 	-- TAKE credit
@@ -148,7 +148,7 @@ function JobCheckCredit:Tick()
 			if TVT.bo_doTakeCredit(credit) == TVT.RESULT_OK then
 				self:LogInfo("Took a credit of " .. credit .." from boss.")
 			else
-				self:LogInfo("FAILED to get credit of " .. credit .." from boss.")
+				self:LogError("FAILED to get credit of " .. credit .." from boss.")
 			end
 
 			self.Task.TryToGetCredit = math.max(0, self.Task.TryToGetCredit - credit)

--- a/res/ai/DefaultAIPlayer/TaskBoss.lua
+++ b/res/ai/DefaultAIPlayer/TaskBoss.lua
@@ -25,6 +25,7 @@ function TaskBoss:Activate()
 	-- Was getan werden soll:
 	self.CheckCreditJob = JobCheckCredit()
 	self.CheckCreditJob.Task = self
+	--self.LogLevel = LOG_TRACE
 end
 
 
@@ -131,9 +132,9 @@ function JobCheckCredit:Tick()
 			self.Task.TryToRepayCredit = self.Task.TryToRepayCredit - repay
 			-- adjust budget
 			self.Task.NeededInvestmentBudget = self.Task.NeededInvestmentBudget - repay
---			debugMsg("Repaid " .. repay .. " from credit to boss.")
+			self:LogDebug("Repaid " .. repay .. " from credit to boss.")
 		else
-			debugMsg("FAILED to repay " .. repay .. " from credit to boss.")
+			self:LogInfo("FAILED to repay " .. repay .. " from credit to boss.")
 		end
 
 	-- TAKE credit
@@ -145,9 +146,9 @@ function JobCheckCredit:Tick()
 
 		if credit > 0 then
 			if TVT.bo_doTakeCredit(credit) == TVT.RESULT_OK then
---				debugMsg("Took a credit of " .. credit .." from boss.")
+				self:LogInfo("Took a credit of " .. credit .." from boss.")
 			else
-				debugMsg("FAILED to get credit of " .. credit .." from boss.")
+				self:LogInfo("FAILED to get credit of " .. credit .." from boss.")
 			end
 
 			self.Task.TryToGetCredit = math.max(0, self.Task.TryToGetCredit - credit)

--- a/res/ai/DefaultAIPlayer/TaskRoomBoard.lua
+++ b/res/ai/DefaultAIPlayer/TaskRoomBoard.lua
@@ -26,6 +26,7 @@ function TaskRoomBoard:Activate()
 	-- Was getan werden soll:
 	self.ChangeRoomSignsJob = JobChangeRoomSigns()
 	self.ChangeRoomSignsJob.Task = self
+	--self.LogLevel = LOG_TRACE
 end
 
 function TaskRoomBoard:GetNextJobInTargetRoom()
@@ -82,7 +83,7 @@ function JobChangeRoomSigns:typename()
 end
 
 function JobChangeRoomSigns:Prepare(pParams)
-	--debugMsg("Starte JobChangeRoomSigns")
+
 end
 
 function JobChangeRoomSigns:Tick()
@@ -93,7 +94,7 @@ function JobChangeRoomSigns:Tick()
 			if (sign ~= nil and sign.GetOwner() == TVT.ME) then
 				--Noch am richtigen Platz?
 				if sign.IsAtOriginalPosition() == 0 then
-					debugMsg("Haenge Raumschild (" .. sign.GetOwnerName() .. ") wieder an den richtigen Platz: " .. sign.GetSlot() .. "/" .. sign.GetFloor() .. " -> " .. sign.GetOriginalSlot() .. "/" .. sign.GetOriginalFloor())
+					self:LogInfo("Haenge Raumschild (" .. sign.GetOwnerName() .. ") wieder an den richtigen Platz: " .. sign.GetSlot() .. "/" .. sign.GetFloor() .. " -> " .. sign.GetOriginalSlot() .. "/" .. sign.GetOriginalFloor())
 					--wieder alles in Ordnung bringen
 					TVT.rb_SwitchSignPositions(sign.GetSlot(), sign.GetFloor(), sign.GetOriginalSlot(), sign.GetOriginalFloor())
 				end
@@ -112,7 +113,7 @@ function JobChangeRoomSigns:Tick()
 		local roomId = self:GetEnemyRoomId(enemyId)
 		local roomSign = TVT.rb_GetFirstSignOfRoom(roomId).data
 		TVT.rb_SwitchSigns(sign, roomSign)
-		debugMsg("Verschiebe FRDuban-Schild auf Raum " .. roomId .. " (" .. roomSign.GetOwnerName() ..") des Spielers " .. enemyId )
+		self:LogDebug("Verschiebe FRDuban-Schild auf Raum " .. roomId .. " (" .. roomSign.GetOwnerName() ..") des Spielers " .. enemyId )
 	end
 
 	if self.Task.VRDubanTerrorLevel >= 2 then
@@ -121,7 +122,7 @@ function JobChangeRoomSigns:Tick()
 		local roomId = self:GetEnemyRoomId(enemyId)
 		local roomSign = TVT.rb_GetFirstSignOfRoom(roomId).data
 		TVT.rb_SwitchSigns(sign, roomSign)
-		debugMsg("Verschiebe  VRDuban-Schild auf Raum " .. roomId .. " (" .. roomSign.GetOwnerName() ..") des Spielers " .. enemyId )
+		self:LogDebug("Verschiebe  VRDuban-Schild auf Raum " .. roomId .. " (" .. roomSign.GetOwnerName() ..") des Spielers " .. enemyId )
 	end
 
 	-- handled the situation "for now"

--- a/res/ai/DefaultAIPlayer/TaskStationMap.lua
+++ b/res/ai/DefaultAIPlayer/TaskStationMap.lua
@@ -37,6 +37,7 @@ function TaskStationMap:Activate()
 
 	self.BuyStationJob = JobBuyStation()
 	self.BuyStationJob.Task = self
+	--self.LogLevel = LOG_TRACE
 end
 
 
@@ -50,7 +51,7 @@ function TaskStationMap:GetNextJobInTargetRoom()
 	if (self.BuyStationJob.Status ~= JOB_STATUS_DONE) then
 		--buy only if there is no credit
 		if (MY.GetCredit(-1) <= self.maxAllowedCredit) then
-			--debugMsg("considering station buy")
+			self:LogTrace("considering station buy")
 			return self.BuyStationJob
 		else
 			self.BuyStationJob.Status = JOB_STATUS_DONE
@@ -81,7 +82,7 @@ end
 
 function TaskStationMap:BudgetSetup()
 	if self.UseInvestment then
-		debugMsg("+++ Investition in TaskStationMap!")
+		self:LogInfo("+++ Investition in TaskStationMap!")
 		self.SituationPriority = 15
 	end
 end
@@ -111,8 +112,8 @@ function TaskStationMap:GetAverageStationRunningCostPerPerson()
 	local totalReach = 0
 	local stationCount = TVT.of_getStationCount(TVT.ME)
 
-	debugMsg("TaskStationMapJob.GetAverageStationRunningCostPerPerson")
-	debugMsg("Owning " .. stationCount .. " stations.")
+	self:LogTrace("TaskStationMapJob.GetAverageStationRunningCostPerPerson")
+	self:LogTrace("Owning " .. stationCount .. " stations.")
 	if stationCount > 0 then
 		for stationIndex = 0, stationCount-1 do
 			local station = TVT.of_getStationAtIndex(i, stationIndex)
@@ -144,8 +145,6 @@ function JobAnalyseStationMarket:Prepare(pParams)
 end
 
 function JobAnalyseStationMarket:Tick()
-	debugMsg("JobAnalyseStationMarket: checking stations of other players")
-
 	local player = _G["globalPlayer"]
 
 	-- fetch positions of other players stations, cable network uplinks
@@ -159,7 +158,7 @@ function JobAnalyseStationMarket:Tick()
 		local satelliteUplinkProviders = {}
 		if i ~= TVT.ME then
 			local stationCount = TVT.of_getStationCount(i)
-			--debugMsg("JobAnalyseStationMarket: player " .. i .. " has " .. stationCount .. " stations.")
+			self:LogTrace("JobAnalyseStationMarket: player " .. i .. " has " .. stationCount .. " stations.")
 			if stationCount > 0 then
 				for stationIndex = 0, stationCount-1 do
 					local station = TVT.of_getStationAtIndex(i, stationIndex)
@@ -168,7 +167,7 @@ function JobAnalyseStationMarket:Tick()
 						if station.IsAntenna() == 1 then
 							--store x,y and owner
 							table.insert(positions, {station.pos.GetX(), station.pos.GetY(), i})
-							--debugMsg("JobAnalyseStationMarket: player " .. i .. " has an antenna at " .. station.pos.GetX() .."/".. station.pos.GetY())
+							self:LogTrace("JobAnalyseStationMarket: player " .. i .. " has an antenna at " .. station.pos.GetX() .."/".. station.pos.GetY())
 						elseif station.IsCableNetworkUplink() == 1 then
 							table.insert(cableNetworkUplinkProviders, {station.providerGUID})
 						elseif station.IsSatelliteUplink() == 1 then
@@ -176,7 +175,7 @@ function JobAnalyseStationMarket:Tick()
 						end
 					end
 				end
-				--debugMsg("JobAnalyseStationMarket: player " .. i .. " has " .. table.count(positions) .." antennas.")
+				self:LogDebug("JobAnalyseStationMarket: player " .. i .. " has " .. table.count(positions) .." antennas.")
 			end
 		end
 		table.insert(self.Task.knownAntennaPositions, positions)
@@ -210,7 +209,7 @@ function JobAdjustStationInvestment:Prepare(pParams)
 end
 
 function JobAdjustStationInvestment:Tick()
-	debugMsg("JobAdjustStationInvestment: currentBudget=" .. self.Task.CurrentBudget .. "  neededInvestmentBudget"..self.Task.NeededInvestmentBudget)
+	self:LogTrace("  before adjust: currentBudget=" .. self.Task.CurrentBudget .. "  neededInvestmentBudget"..self.Task.NeededInvestmentBudget)
 
 	-- lower needed value each time we check
 	if (self.Task.CurrentBudget < self.Task.NeededInvestmentBudget) then
@@ -220,6 +219,7 @@ function JobAdjustStationInvestment:Tick()
 	-- require a minimum investment
 	self.Task.NeededInvestmentBudget = math.max(300000, self.Task.NeededInvestmentBudget)
 
+	self:LogTrace("  after adjust: currentBudget=" .. self.Task.CurrentBudget .. "  neededInvestmentBudget"..self.Task.NeededInvestmentBudget)
 
 	self.Status = JOB_STATUS_DONE
 end
@@ -236,28 +236,27 @@ function JobBuyStation:typename()
 end
 
 function JobBuyStation:Prepare(pParams)
-	--debugMsg("JobBuyStation: Prepare checking stations! current budget:" .. self.Task.CurrentBudget)
 	-- ignore budgets and just buy a station if there is some need
 	-- the more stations we have, the less likely this is called
 	local player = _G["globalPlayer"]
 	local ignoreBudgetChance = 100 - (8-player.ExpansionPriority)*math.min(TVT.of_getStationCount(TVT.ME)-1,10)
-	--debugMsg("  ignoreBudgetChance: " ..ignoreBudgetChance)
+	self:LogTrace("  ignoreBudgetChance: " ..ignoreBudgetChance)
 
 	local moneyExcludingFixedCosts = TVT.GetMoney() - player.Budget.CurrentFixedCosts
 	--TODO make constant player character dependent
 	if moneyExcludingFixedCosts > 800000 and math.random(0,100) < ignoreBudgetChance then
 		self.Task.CurrentBudget = (0.4 + 0.06*player.ExpansionPriority) * moneyExcludingFixedCosts
-		--debugMsg("  raised current budget to " .. self.Task.CurrentBudget .." to buy a station because 'we want it'.")
+		self:LogDebug("  raised current budget to " .. self.Task.CurrentBudget .." to buy a station because 'we want it'.")
 	end
 
 	if (self.Task.CurrentBudget < self.Task.NeededInvestmentBudget) then
-		--debugMsg(" Cancel ... budget lower than needed investment budget")
+		self:LogDebug(" Cancel ... budget lower than needed investment budget")
 		self:SetCancel()
 	end
 
 	local hour= TVT.GetDayHour()
 	if (hour > 14 and hour < 23) then
-		--debugMsg(" Cancel ... no buying if too little of the day is left: ".. hour)
+		self:LogDebug(" Cancel ... no buying if too little of the day is left: ".. hour)
 		self:SetCancel()
 	end
 end
@@ -274,10 +273,12 @@ function JobBuyStation:GetBestCableNetworkOffer()
 	local bestAttraction = 0
 	local player = _G["globalPlayer"]
 
-	debugMsg("Cablenetworks to check: " .. TVT.of_getCableNetworkCount())
+	local networkCount = TVT.of_getCableNetworkCount()
 
-	if TVT.of_getCableNetworkCount() > 0 then
-		for i = 0, TVT.of_getCableNetworkCount()-1 do
+	self:LogDebug("Cablenetworks to check: " .. networkCount)
+
+	if networkCount > 0 then
+		for i = 0, networkCount-1 do
 			local cableNetwork = TVT.of_GetCableNetworkAtIndex(i)
 
 			-- ignore if we already are clients of this provider
@@ -301,9 +302,9 @@ function JobBuyStation:GetBestCableNetworkOffer()
 		end
 	end
 	if bestOffer then
-		debugMsg(" - best cable network " .. bestOffer.GetName() .."  reach: " .. bestOffer.GetReach(false) .. "  exclusive/increase: " .. bestOffer.GetExclusiveReach(false) .. "  price: " .. bestOffer.GetBuyPrice() .. " (incl.fees: " .. bestOffer.GetTotalBuyPrice() ..")  F: " .. (bestOffer.GetExclusiveReach(false) / bestOffer.GetPrice()) .. "  buyPrice: " .. bestOffer.GetBuyPrice() )
+		self:LogDebug(" - best cable network " .. bestOffer.GetName() .."  reach: " .. bestOffer.GetReach(false) .. "  exclusive/increase: " .. bestOffer.GetExclusiveReach(false) .. "  price: " .. bestOffer.GetBuyPrice() .. " (incl.fees: " .. bestOffer.GetTotalBuyPrice() ..")  F: " .. (bestOffer.GetExclusiveReach(false) / bestOffer.GetPrice()) .. "  buyPrice: " .. bestOffer.GetBuyPrice() )
 	else
-		debugMsg(" -> no best cable network found")
+		self:LogTrace(" - no best cable network found")
 	end
 
 	return bestOffer, bestAttraction
@@ -315,10 +316,11 @@ function JobBuyStation:GetBestSatelliteOffer()
 	local bestAttraction = 0
 	local player = _G["globalPlayer"]
 
-	debugMsg("Satellites to check: " .. TVT.of_getSatelliteCount())
+	local satCount = TVT.of_getSatelliteCount()
+	self:LogDebug("Satellites to check: " .. satCount)
 
-	if TVT.of_getSatelliteCount() > 0 then
-		for i = 0, TVT.of_getSatelliteCount()-1 do
+	if satCount > 0 then
+		for i = 0, satCount-1 do
 			local satellite = TVT.of_GetSatelliteAtIndex(i)
 			-- ignore if we already are clients of this provider
 			-- ignore non-launched and not available for player
@@ -336,17 +338,17 @@ function JobBuyStation:GetBestSatelliteOffer()
 						bestOffer = tempStation
 						bestAttraction = attraction
 
-						debugMsg(" - new best satellite " .. bestOffer.GetName() .."  reach: " .. bestOffer.GetReach(false) .. "  exclusive/increase: " .. bestOffer.GetExclusiveReach(false) .. "  price: " .. bestOffer.GetBuyPrice() .. " (incl.fees: " .. bestOffer.GetTotalBuyPrice() ..")  F: " .. (bestOffer.GetExclusiveReach(false) / bestOffer.GetPrice()) .. "  buyPrice: " .. bestOffer.GetBuyPrice() )
-						debugMsg("   -> attraction: " .. attraction .. "  |  ".. pricePerViewer .. " - (" .. priceDiff .. " / currentBudget: " .. self.Task.CurrentBudget)
+						self:LogTrace(" - new best satellite " .. bestOffer.GetName() .."  reach: " .. bestOffer.GetReach(false) .. "  exclusive/increase: " .. bestOffer.GetExclusiveReach(false) .. "  price: " .. bestOffer.GetBuyPrice() .. " (incl.fees: " .. bestOffer.GetTotalBuyPrice() ..")  F: " .. (bestOffer.GetExclusiveReach(false) / bestOffer.GetPrice()) .. "  buyPrice: " .. bestOffer.GetBuyPrice() )
+						self:LogTrace("   -> attraction: " .. attraction .. "  |  ".. pricePerViewer .. " - (" .. priceDiff .. " / currentBudget: " .. self.Task.CurrentBudget)
 					end
 				end
 			end
 		end
 	end
 	if bestOffer ~= nil then
-		debugMsg(" -> best satellite " .. bestOffer.GetName() .."  reach: " .. bestOffer.GetReach(false) .. "  exclusive/increase: " .. bestOffer.GetExclusiveReach(false) .. "  price: " .. bestOffer.GetBuyPrice() .. " (incl.fees: " .. bestOffer.GetTotalBuyPrice() ..")  F: " .. (bestOffer.GetExclusiveReach(false) / bestOffer.GetPrice()) .. "  buyPrice: " .. bestOffer.GetBuyPrice() )
+		self:LogDebug(" - best satellite " .. bestOffer.GetName() .."  reach: " .. bestOffer.GetReach(false) .. "  exclusive/increase: " .. bestOffer.GetExclusiveReach(false) .. "  price: " .. bestOffer.GetBuyPrice() .. " (incl.fees: " .. bestOffer.GetTotalBuyPrice() ..")  F: " .. (bestOffer.GetExclusiveReach(false) / bestOffer.GetPrice()) .. "  buyPrice: " .. bestOffer.GetBuyPrice() )
 	else
-		debugMsg(" -> no best satellite found")
+		self:LogTrace(" - no best satellite found")
 	end
 	return bestOffer, bestAttraction
 end
@@ -411,25 +413,29 @@ function JobBuyStation:GetBestAntennaOffer()
 		if table.count(value) > 2 then otherOwner = value[3] end
 		local tempStation = TVT.of_GetTemporaryAntennaStation(x, y)
 
+		local stationString = "tempStation is nil"
+		if tempStation ~= nil then
+			stationString = "Station " .. tablePos .. "  at " .. x .. "," .. y .. ".  owner: " .. otherOwner .. "  reach: " .. tempStation.GetReach(false) .. "  exclusive/increase: " .. tempStation.GetExclusiveReach(false) .. "  price: " .. tempStation.GetBuyPrice() .. " (incl.fees: " .. tempStation.GetTotalBuyPrice() ..")  F: " .. (tempStation.GetExclusiveReach(false) / tempStation.GetPrice()) .. "  buyPrice: " .. tempStation.GetBuyPrice()
+		end
 
 		--filter criterias
 		--0) skip checks if there is no tempstation
 		if tempStation == nil then
-			-- debugMsg("tempStation is nil!")
+			self:LogTrace(stationString)
 
 		--1) outside
 		elseif tempStation.GetPrice() < 0 then
---			debugMsg(" - Station " .. tablePos .. "  at " .. x .. "," .. y .. ".  owner: " .. otherOwner .. "  reach: " .. tempStation.GetReach(false) .. "  exclusive/increase: " .. tempStation.GetExclusiveReach(false) .. "  price: " .. tempStation.GetBuyPrice() .. " (incl.fees: " .. tempStation.GetTotalBuyPrice() ..")  F: " .. (tempStation.GetExclusiveReach(false) / tempStation.GetPrice()) .. "  buyPrice: " .. tempStation.GetBuyPrice() .. " -> outside of map!")
+			self:LogTrace(stationString .. " -> outside of map!")
 			tempStation = nil
 
 		--2) price to high
 		elseif tempStation.GetPrice() > self.Task.CurrentBudget then
-			debugMsg(" - Station " .. tablePos .. "  at " .. x .. "," .. y .. ".  owner: " .. otherOwner .. "  reach: " .. tempStation.GetReach(false) .. "  exclusive/increase: " .. tempStation.GetExclusiveReach(false) .. "  price: " .. tempStation.GetBuyPrice() .. " (incl.fees: " .. tempStation.GetTotalBuyPrice() ..")  F: " .. (tempStation.GetExclusiveReach(false) / tempStation.GetPrice()) .. "  buyPrice: " .. tempStation.GetBuyPrice() .. " -> too expensive!")
+			self:LogTrace(stationString .. " -> too expensive!")
 			tempStation = nil
 
 		--3) relative increase to low (at least 35% required)
 		elseif tempStation.GetRelativeExclusiveReach(false) < 0.35 then
-			debugMsg(" - Station " .. tablePos .. "  at " .. x .. "," .. y .. ".  owner: " .. otherOwner .. "  reach: " .. tempStation.GetReach(false) .. "  exclusive/increase: " .. tempStation.GetExclusiveReach(false) .. "(" .. tempStation.GetRelativeExclusiveReach(false)..")" .. "  price: " .. tempStation.GetBuyPrice() .. " (incl.fees: " .. tempStation.GetTotalBuyPrice() ..")  F: " .. (tempStation.GetExclusiveReach(false) / tempStation.GetPrice()) .. "  buyPrice: " .. tempStation.GetBuyPrice() .. " -> not enough reach increase!")
+			self:LogTrace(stationString .. " -> not enough relative reach increase!")
 			tempStation = nil
 
 		--4) absolute increase too low
@@ -438,11 +444,11 @@ function JobBuyStation:GetBestAntennaOffer()
 
 		--5)  reach to low (at least 75.000 required)
 		elseif tempStation.GetReach(false) < 75000 then
-			debugMsg(" - Station " .. tablePos .. "  at " .. x .. "," .. y .. ".  owner: " .. otherOwner .. "  reach: " .. tempStation.GetReach(false) .. "  exclusive/increase: " .. tempStation.GetExclusiveReach(false) .. "  price: " .. tempStation.GetBuyPrice() .. " (incl.fees: " .. tempStation.GetTotalBuyPrice() ..")  F: " .. (tempStation.GetExclusiveReach(false) / tempStation.GetPrice()) .. "  buyPrice: " .. tempStation.GetBuyPrice() .. " -> not enough absolute reach!")
+			self:LogTrace(stationString .. " -> not enough absolute reach!")
 			tempStation = nil
 
 		else
-			debugMsg(" - Station " .. tablePos .. "  at " .. x .. "," .. y .. ".  owner: " .. otherOwner .. "  reach: " .. tempStation.GetReach(false) .. "  exclusive/increase: " .. tempStation.GetExclusiveReach(false) .. "  price: " .. tempStation.GetBuyPrice() .. " (incl.fees: " .. tempStation.GetTotalBuyPrice() ..")  F: " .. (tempStation.GetExclusiveReach(false) / tempStation.GetPrice()) .. "  buyPrice: " .. tempStation.GetBuyPrice() .. " -> OK!")
+			self:LogTrace(stationString .. " -> OK!")
 		end
 
 
@@ -462,7 +468,7 @@ function JobBuyStation:GetBestAntennaOffer()
 			-- raise attraction (even further) if AI's enemy is there
 			if otherOwner == player:GetArchEnemyId() then attraction = attraction * 1.06 end
 
-			debugMsg("    -> attraction: " .. attraction .. "  |  ".. pricePerViewer .. " - (" .. priceDiff .. " / currentBudget: " .. self.Task.CurrentBudget .. ")")
+			self:LogTrace("    -> attraction: " .. attraction .. "  |  ".. pricePerViewer .. " - (" .. priceDiff .. " / currentBudget: " .. self.Task.CurrentBudget .. ")")
 
 			if bestOffer == nil then
 				bestOffer = tempStation
@@ -479,8 +485,6 @@ end
 
 
 function JobBuyStation:Tick()
-	debugMsg("JobBuyStation: Checking stations! current budget:" .. self.Task.CurrentBudget)
-
 	local player = _G["globalPlayer"]
 
 	local bestAntennaOffer, bestAntennaAttraction = self:GetBestAntennaOffer()
@@ -492,13 +496,15 @@ function JobBuyStation:Tick()
 	if bestOffer ~= nil then
 		local price = bestOffer.GetTotalBuyPrice()
 		if bestOffer == bestAntennaOffer then
-			debugMsg(" Buying antenna station in " .. bestOffer.GetSectionName(false) .. " at " .. bestOffer.pos.GetIntX() .. "," .. bestOffer.pos.GetIntY() .. ".  exclusive/increase: " .. bestOffer.GetExclusiveReach(false) .. "  price: " .. price)
+			self:LogInfo("Buying antenna station in " .. bestOffer.GetSectionName(false) .. " at " .. bestOffer.pos.GetIntX() .. "," .. bestOffer.pos.GetIntY() .. ".  exclusive/increase: " .. bestOffer.GetExclusiveReach(false) .. "  price: " .. price)
 			TVT.of_buyAntennaStation(bestOffer.pos.GetIntX(), bestOffer.pos.GetIntY())
 		elseif bestOffer == bestSatelliteOffer then
-			debugMsg(" Contracting satellite uplink " .. bestOffer.GetLongName() .. ".  exclusive/increase: " .. bestOffer.GetExclusiveReach(false) .. "  price: " .. price)
+			self:LogInfo("Contracting satellite uplink " .. bestOffer.GetLongName() .. ".  exclusive/increase: " .. bestOffer.GetExclusiveReach(false) .. "  price: " .. price)
+			--TODO Vertrag abschließen!!
 			--TVT.of_buyAntennaStation(bestOffer.pos.GetIntX(), bestOffer.pos.GetIntY())
 		elseif bestOffer == bestCableNetworkOffer then
-			debugMsg(" Contracting cable network uplink " .. bestOffer.GetLongName() .. ".  exclusive/increase: " .. bestOffer.GetExclusiveReach(false) .. "  price: " .. price)
+			self:LogInfo("Contracting cable network uplink " .. bestOffer.GetLongName() .. ".  exclusive/increase: " .. bestOffer.GetExclusiveReach(false) .. "  price: " .. price)
+			--TODO Vertrag abschließen!!
 			--TVT.of_buyAntennaStation(bestOffer.pos.GetIntX(), bestOffer.pos.GetIntY())
 		end
 
@@ -513,7 +519,7 @@ function JobBuyStation:Tick()
 		else
 			self.Task.NeededInvestmentBudget = newBudget
 		end
-		debugMsg(" Next channel buy when reaching investment budget of " .. self.Task.NeededInvestmentBudget)
+		self:LogDebug(" Next channel buy when reaching investment budget of " .. self.Task.NeededInvestmentBudget)
 	end
 
 	self.Status = JOB_STATUS_DONE

--- a/tst
+++ b/tst
@@ -1,0 +1,38 @@
+'/dev exec tst
+/dev money 1 10000000
+
+'Programme
+'Ariane-Programm
+'/dev givelicence 1 rakete 
+'/dev givelicence 1 papierflieger
+
+'/dev givelicence 1 Wirsch
+
+'Morgenshow
+/dev givescript 1 morning
+'/dev givescript 1 TVTintern
+
+'Kasinachtshow
+'/dev givescript 1 UnterhaltungNachts
+
+'LiveKonzert
+/dev givescript 1 LiveKonzert
+/dev givescript 1 musiksterne
+
+'Abgezockt
+'animalseries01
+'averagedayseries01
+'ser-dram-TVTintern
+'karprachd
+'typentausch
+'/dev givescript 1 typentausch
+/dev givescript 1 DerFahnder
+'/dev givescript 1 Abgezockt
+
+'Spendengala
+'/dev givescript 1 Spenden
+
+'TED 6cab2c62
+'Kochshow 50b89ce5
+
+'/dev givelicence 1 6cab2c62


### PR DESCRIPTION
Erster Vorschlag für die Logging-API. Das meiste "Debug-Logging" dürfte ja in den Jobs erfolgen. Daher bekommt die Basisklasse unterschiedliche Log-Methoden. 
* Das Log-Level kann entweder am Job direkt gesetzt werden oder wird vom Task geerbt
* Es wird nicht das Ende sondern der Start eines Jobs geloggt (wenn man was an den Ausführungszeiten prüfen will, kann man das Ende-Logging in der Engine wieder einschalten)
* Das meiste Logging ist erst einmal deaktiviert und muss nach und nach an die neue API angepasst werden. Das kann im Zuge der weiteren Optimierung der KI-Performance erfolgen

Interessant wäre noch API für das kurzzeitge Ändern von Log-Levels. Anwendungsfall wäre, dass man das Logging unter bestimmten Nebenbedingungen feiner machen will. Z.B. Vergleichen der Werbung, wenn eine Requisition für Level 5 bearbeitet wird.
Auch weiß ich nicht, wie "teuer" Lua-Berechnugnen sind. Dein Beispiel für unterschiedlichen Detailierungsgrad je Level ist ja sinnvoll, aber man möchte ja nicht unnötig teuer Strings zusammenbauen, um sie dann nicht zu verwenden. Und im KI-Code möchte man ja auch nicht haufenweise Code-Blöcke für unterschiedliche Log-Level haben...