### PR TITLE
SegFault in news event

### DIFF
--- a/source/game.broadcastmaterial.news.bmx
+++ b/source/game.broadcastmaterial.news.bmx
@@ -1,4 +1,4 @@
-﻿SuperStrict
+﻿﻿﻿SuperStrict
 'for TBroadcastSequence
 Import "game.broadcast.base.bmx"
 Import "game.broadcast.genredefinition.news.bmx"
@@ -472,13 +472,14 @@ endrem
 
 	Method GetNewsEvent:TNewsEvent() {_exposeToLua}
 		if newsEventID = 0 and newsEvent then return newsEvent
-		if not GetNewsEventCollection().GetByID(newsEventID)
+		Local result:TNewsEvent = GetNewsEventCollection().GetByID(newsEventID)
+		if not result
 			for local ik:TIntKey = EachIn GetNewsEventCollection().allNewsEvents.Keys()
 				print "known: " + ik.value + "   " + GetNewsEventCollection().GetByID(ik.value).GetTitle()
 			Next
-			end
+			Throw "Unknown Event id "+ newsEventID
 		endif
-		return GetNewsEventCollection().GetByID(newsEventID)
+		return result
 	End Method
 
 


### PR DESCRIPTION
Bei einem Hyperschnellspiel (Producer-Lizenz-Titel) kam es bei mir gerade einen Seg-Fault mit voriger Event-ID-Listen-Ausgabe im modifizierten Code.
Es gab wohl gerade kein Event und selbst nach der Ausgabe aller News hat nicht das "end" gezogen, sondern es gab einen SegFault (kein Event trotz ID, kein Titel?). Jedenfalls gibt es auch an der Stelle noch Verbesserungspotential.