### PR TITLE
fix outage localization

### DIFF
--- a/source/game.broadcast.base.bmx
+++ b/source/game.broadcast.base.bmx
@@ -657,7 +657,7 @@ Type TBroadcast
 		Else 'dann Sendeausfall! TODO: Chef muss böse werden!
 			TLogger.Log("TBroadcast.ComputeAndSetPlayersProgrammeAttraction()", "Player '" + playerId + "': Malfunction!", LOG_DEBUG)
 			'outage
-			GetAudienceResult(playerId).Title = "Malfunction!"
+			GetAudienceResult(playerId).Title =  GetLocale("BROADCASTING_OUTAGE")
 			GetAudienceResult(playerId).broadcastOutage = True
 			attraction = CalculateMalfunction(lastProgrammeAttraction)
 		End If

--- a/source/game.broadcastmaterial.news.bmx
+++ b/source/game.broadcastmaterial.news.bmx
@@ -1,4 +1,4 @@
-﻿﻿﻿SuperStrict
+﻿SuperStrict
 'for TBroadcastSequence
 Import "game.broadcast.base.bmx"
 Import "game.broadcast.genredefinition.news.bmx"


### PR DESCRIPTION
Sendeausfall in der Statistik-Übersicht. Außerdem war bei den Nachrichten wieder so ein Dateistartzeichen reingerutscht.