### PR TITLE
[DB] mehr Variablen in Drehbuchtiteln

### DIFF
--- a/res/database/Default/user/kieferer.xml
+++ b/res/database/Default/user/kieferer.xml
@@ -4,9 +4,15 @@
 	<scripttemplates>
 		<scripttemplate product="1" licence_type="1" guid="scripttemplate-random-kieferer-mysteriousisland">
 			<title>
-				<de>Mysteriöse Insel</de>
-				<en>Mysterious Island</en>
+				<de>%ADJECTIVE% Insel</de>
+				<en>%ADJECTIVE% Island</en>
 			</title>
+			<variables>
+				<adjective>
+					<de>Mysteriöse|Gefährliche|Unheimliche|Abgelegene|Ferne</de>
+					<en>Mysterious|Dangerous|Uncanny|Secluded|Remote</en>
+				</adjective>
+			</variables>
 			<description>
 				<de>Nach einem Bootsunfall stranden Jill und Frank auf einer Insel, die doch nicht so einsam
 ist wie gedacht. Bald kämpfen sie um Leben und Tod.</de>
@@ -31,14 +37,31 @@ ist wie gedacht. Bald kämpfen sie um Leben und Tod.</de>
 
 		<scripttemplate product="1" licence_type="1" guid="scripttemplate-random-kieferer-mummyattack">
 			<title>
-				<de>Mumien greifen an</de>
-				<en>Mummy Attack</en>
+				<de>%TITLE%</de>
+				<en>%TITLE%</en>
 			</title>
 			<description>
 				<de>Ein ganz normaler Teenagerausflug endet in einem Besäufnis und einem Wald voller Untoter.</de>
 				<en>A normal teenage trip ends in drunkenness and a forest full of undead.</en>
 			</description>
-
+			<variables>
+				<title>
+					<de>%WHO% greifen an|Angriff der %WHO%|Rache der %WHO%|Umzingelt von %WHOD%|Wald der %WHO%</de>
+					<en>%WHO% Attack|Assault of the %WHO%|Revenge of the %WHO%|Surrounded by %WHOD%|Forest of the %WHO%</en>
+				</title>
+				<whoi>
+					<de>Mumien|Zombies</de>
+					<en>Mummies|Zombies</en>
+				</whoi>
+				<who>
+					<de>%WHOI%|Vampire|Geister|Monster|Werwölfe</de>
+					<en>%WHOI%|Vampires|Ghosts|Monsters|Werewolves</en>
+				</who>
+				<whod>
+					<de>%WHOI%|Vampiren|Geistern|Monstern|Werwölfen</de>
+					<en>%WHOI%|Vampires|Ghosts|Monsters|Werewolves</en>
+				</whod>
+			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" />
 				<job index="1" function="2" required="1" gender="1" />
@@ -59,8 +82,8 @@ ist wie gedacht. Bald kämpfen sie um Leben und Tod.</de>
 
 		<scripttemplate product="1" licence_type="1" guid="scripttemplate-random-kieferer-daytrip">
 			<title>
-				<de>Kaffeefahrt</de>
-				<en>Day Trip</en>
+				<de>Kaffeefahrt%MODIFIER%</de>
+				<en>Day Trip%MODIFIER%</en>
 			</title>
 			<description>
 				<de>Eine Rentnergruppe probt den Aufstand. Sie wollen eine Kaffeefahrt ohne Heizdecken.
@@ -68,6 +91,16 @@ Doch der Reiseveranstalter trickst sie aus.</de>
 				<en>A group of pensioners is rehearsing the uprising. They want a day trip without buying electric blankets.
 But the tour operator tricks them.</en>
 			</description>
+			<variables>
+				<modifier>
+					<de>| nach %RANDOMCITY%</de>
+					<en>| to %RANDOMCITY%</en>
+				</modifier>
+				<randomcity>
+					<de>%STATIONMAP:RANDOMCITY%</de>
+					<en>%STATIONMAP:RANDOMCITY%</en>
+				</randomcity>
+			</variables>
 
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -86,16 +119,25 @@ But the tour operator tricks them.</en>
 
 		<scripttemplate product="1" licence_type="1" guid="scripttemplate-random-kieferer-goldrush">
 			<title>
-				<de>Goldrausch</de>
-				<en>Gold Rush</en>
+				<de>Goldrausch%MODIFIER%</de>
+				<en>Gold Rush%MODIFIER%</en>
 			</title>
 			<description>
-				<de>Rivalisierende Goldschürfer wetteifern in Prosperous Creek um die größten Goldfunde.
+				<de>Rivalisierende Goldschürfer wetteifern in %RANDOMCITY% um die größten Goldfunde.
 Dabei sind ihnen alle Mittel recht.</de>
-				<en>Rival gold prospectors compete for the largest gold finds in Prosperous Creek.
+				<en>Rival gold prospectors compete for the largest gold finds in %RANDOMCITY%.
 All means are right for them.</en>
 			</description>
-
+			<variables>
+				<modifier>
+					<de>| in %RANDOMCITY%</de>
+					<en>| in %RANDOMCITY%</en>
+				</modifier>
+				<randomcity>
+					<de>%STATIONMAP:RANDOMCITY%|Prosperous Creek</de>
+					<en>%STATIONMAP:RANDOMCITY%|Prosperous Creek</en>
+				</randomcity>
+			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" />
 				<job index="1" function="2" required="1" gender="1" />

--- a/res/database/Default/user/ronny.xml
+++ b/res/database/Default/user/ronny.xml
@@ -841,12 +841,19 @@ Illustrious guests and music by [3|Nick].</en>
 		<!-- product="3" => "Show" -->
 		<scripttemplate product="3" licence_type="1" guid="scripttemplate-ron-musiksterneamabend">
 			<title>
-				<de>Musiksterne am Abend</de>
+				<de>%WHAT% %WHEN%</de>
 			</title>
 			<description>
-				<de>Fetzige Popmusik für Jung und Alt. Von gefüllten Fussballstadien auf die Showbühne. Unterhaltung pur</de>
+				<de>Fetzige Musik für Jung und Alt. Von gefüllten Fussballstadien auf die Showbühne. Unterhaltung pur</de>
 			</description>
-
+			<variables>
+				<what>
+					<de>Musiksterne|Talente|Pop|Unterhaltung|Musikgenuss|Klassik|Rock|Metal|Jazz|Folk|Blues|Hip-Hop</de>
+				</what>
+				<when>
+					<de>am Abend|zur besten Sendezeit|in der Dämmerung|im Mondschein|unterm Sternenzelt|zur guten Nacht|zum Sonnenuntergang</de>
+				</when>
+			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" />
 				<job index="1" function="8" required="1" gender="2" />
@@ -870,11 +877,17 @@ Illustrious guests and music by [3|Nick].</en>
 
 		<scripttemplate product="3" licence_type="1" guid="scripttemplate-ron-morningshow">
 			<title>
-				<de>Goldene Morgenstunden</de>
+				<de>%SHOWNAME%</de>
 			</title>
 			<description>
 				<de>Aufgewacht das Bettchen kracht. Lockere Morgenunterhaltung für alle - vom Frühaufsteher bis zum arbeitslosen Langschläfer.</de>
 			</description>
+
+			<variables>
+				<showname>
+					<de>Goldene Morgenstunden|Guten Morgen %STATIONMAP:RANDOMCITY%|Die Frühaufsteher|Start in den Tag</de>
+				</showname>
+			</variables>
 
 			<jobs>
 				<job index="0" function="1" required="1" />

--- a/res/database/Default/user/therob.xml
+++ b/res/database/Default/user/therob.xml
@@ -2177,13 +2177,24 @@
 	<scripttemplates>
 		<scripttemplate product="3" licence_type="1" guid="TheRob-Script-Rep-Drehbuecher">
 			<title>
-				<de>Drehbücher für Anfänger</de>
-				<en>Moviescripts fo beginners</en>
+				<de>%WHAT% für %WHO%</de>
+				<en>%WHAT% for %WHO%</en>
 			</title>
 			<description>
-				<de>Wie schreibe ich Drehbücher für TowerTV? Eine Reportage, die die erfolgreichsten Autoren besucht, sie genau durchleuchtet und in Interviews spannende Tipps entlockt.</de>
-				<en>How do I write TowerTV scripts? A report that visits the most successful authors, examines them in detail and elicits exciting tips in interviews.</en>
+				<de>Wie schreibe ich %WHAT% für TVTower? Eine Reportage, die die erfolgreichsten Autoren besucht, sie genau durchleuchtet und in Interviews spannende Tipps entlockt.</de>
+				<en>How do I write %WHAT% for TVTower? A report that visits the most successful authors, examines them in detail and elicits exciting tips in interviews.</en>
 			</description>
+			<variables>
+				<what>
+					<de>Drehbücher|Nachrichten|Serien|Filme</de>
+					<en>Movie scripts|News|Series|Movies</en>
+				</what>
+				<who>
+					<de>Anfänger|Neulinge|Fortgeschrittene|Profis|Neugierige</de>
+					<en>beginners|newcomers|the advanced|professionals|the curious</en>
+				</who>
+			</variables>
+			
 			<jobs>
 				<job index="0" function="1" required="1" />
 				<job index="1" function="128" required="1" gender="2" />
@@ -2202,12 +2213,23 @@
 		</scripttemplate>
 		<scripttemplate product="4" licence_type="1" guid="TheRob-Script-Rep-AusmeinemGebiet">
 			<title>
-				<de>Reportagen aus dem Sendegebiet</de>
-				<en>Local report</en>
+				<de>%TITLE%</de>
+				<en>%TITLE%</en>
 			</title>
+			<variables>
+				<title>
+					<de>Reportagen aus dem Sendegebiet|Neues aus %RANDOMCITY%|Reportagen aus %RANDOMCITY%|Was ist los in %RANDOMCITY%?</de>
+					<en>Local report|News from %RANDOMCITY%|Report from  %RANDOMCITY%|What's up in %RANDOMCITY%?</en>
+				</title>
+				<randomcity>
+					<de>%STATIONMAP:RANDOMCITY%</de>
+					<en>%STATIONMAP:RANDOMCITY%</en>
+				</randomcity>
+			</variables>
+			
 			<description>
-				<de>Reporter durchreisen das Sendegebiet um ausführlich über lokale Sendegebietsereignisse zu berichten. Die neueste Ausstellung, ein Jubiläum? Alles wird entdeckt.</de>
-				<en>Reporters travel through the broadcast area to report in detail on local broadcast area events. The latest exhibition, an anniversary? Everything will be discovered.</en>
+				<de>Reporter durchreisen das Sendegebiet um ausführlich über lokale Ereignisse zu berichten. Die neueste Ausstellung, ein Jubiläum? Alles wird entdeckt.</de>
+				<en>Reporters travel through the broadcast area to report in detail on local events. The latest exhibition, an anniversary? Everything will be discovered.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -2226,12 +2248,31 @@
 		</scripttemplate>
 		<scripttemplate product="3" licence_type="1" guid="TheRob-Script-Talk-DieNeuestenFilme">
 			<title>
-				<de>Die neusten Filme</de>
+				<de>%TITLE%</de>
 				<en>Upcoming movies</en>
 			</title>
+			<variables>
+				<title>
+					<de>%ADJECTIVE% %SUBJECT%%MODIFIER%</de>
+					<en>%ADJECTIVE% %SUBJECT%%MODIFIER%</en>
+				</title>
+				<subject>
+					<de>Filme|Serien|Shows|Produktionen</de>
+					<en>movies|series|shows|productions</en>
+				</subject>
+				<adjective>
+					<de>Die neusten|Herausragende|Die spannendsten</de>
+					<en>Upcoming|Outstanding|Exciting</en>
+				</adjective>
+				<modifier>
+					<de>|| %WORLDTIME:YEAR%</de>
+					<en>|| %WORLDTIME:YEAR%</en>
+				</modifier>
+			</variables>
+			
 			<description>
-				<de>Talkrunde in der die Filme des nächsten Jahres besprochen werden. Was muss man sehen, was kann man sich sparen?</de>
-				<en>A Review about the upcoming movies with guests. What should you see, what could you miss?</en>
+				<de>Besprechung der Neuerscheinungen. Was muss man sehen, was kann man sich sparen?</de>
+				<en>Review of new releases. What should you see, what could you miss?</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -2339,13 +2380,23 @@
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="TheRob-Script-Com-EngeloderBengel">
 			<title>
-				<de>Engel oder Bengel</de>
-				<en>Our Son Is No Angel</en>
+				<de>%TITLE%</de>
+				<en>%TITLE%</en>
 			</title>
 			<description>
 				<de>Familienkomödie über das Leben mit einem frechen Sohnemann. Das Drehbuch wird von dem Stardrehbuchschreiber Don Ron geschrieben.</de>
 				<en>Familycomedy about the life with a cheeky son. The script is written by the starwriter Don Ron.</en>
 			</description>
+			<variables>
+				<title>
+					<de>Engel oder Bengel|%NAME% dreht durch|%NAME% außer Rand und Band</de>
+					<en>Our Son Is No Angel|%NAME% goes berserk|%NAME% goes haywire</en>
+				</title>
+				<name>
+					<de>%PERSONGENERATOR_FIRSTNAME(de,1)%|%PERSONGENERATOR_FIRSTNAME(es,1)%|Tim</de>
+				</name>
+			</variables>
+			
 			<jobs>
 				<job index="0" function="1" required="1" />
 				<job index="1" function="2" required="1" gender="1" />


### PR DESCRIPTION
Ich habe bei einem Teil der Drehbuchtitel ohne Variablen mal welche eingefügt. Vielleicht hast Du noch ein paar Ideen. Das generische <Produzent>s "Titel" habe ich noch nicht berücksichtigt. Da sollten wohl auch keine generierten Namen verwendet werden.

Ich hatte auch schon mal überlegt, ob es nicht sinnvoll wäre, bei den Jobs auch vordefinierte, nicht änderbare Personen (per Referenz) zu unterstützen. Dann könnte man nämlich erzwingen, dass ein bestimmter Regisseur oder Hauptdarsteller dabei ist, der dann auch im Titel oder der Beschreibung auftaucht. Das wäre aber eine größere Erweiterung.