### PR TITLE
KI Logging aufräumen, Werbevertragsauswahl

### DIFF
--- a/res/ai/CommonAI/AIEngine.lua
+++ b/res/ai/CommonAI/AIEngine.lua
@@ -256,7 +256,7 @@ function AIPlayer:BeginNewTask()
 	--TODO: Warte-Task einfügen, wenn sich ein Task wiederholt
 	self.CurrentTask = self:SelectTask()
 	if self.CurrentTask == nil then
-		debugMsg("AIPlayer:BeginNewTask - task is nil... " )
+		logWithLevel(LOG_ERROR, LOG_ERROR, "AIPlayer:BeginNewTask - task is nil... " )
 	else
 		self.CurrentTask:CallActivate()
 		self.CurrentTask:StartNextJob()
@@ -1184,6 +1184,7 @@ function BroadcastStatistics:AddBroadcast(day, hour, broadcastTypeID, attraction
 end
 
 
+--TODO is it really the type that is interesting for the attraction, genre instead? ??
 function BroadcastStatistics:GetAttraction(day, hour, broadcastType)
 	local currentI = tostring(day) .. string.format("%02d", hour)
 	if broadcastType == TVT.Constants.BroadcastMaterialType.NEWSSHOW then
@@ -1408,12 +1409,10 @@ function logWithLevel(currentLogLevel, messageLogLevel, message)
 				end
 			end
 		else
-			debugMsg("Error: message log level not defined")
-			print(debug.traceback())
+			debugMsg("Error: message log level not defined " .. debug.traceback())
 		end
 	else
-		debugMsg("Error: current log level not defined")
-		print(debug.traceback())
+		debugMsg("Error: current log level not defined " .. debug.traceback())
 	end
 end
 

--- a/res/ai/DefaultAIPlayer/CommonObjects.lua
+++ b/res/ai/DefaultAIPlayer/CommonObjects.lua
@@ -372,7 +372,7 @@ function AIToolsClass:GetAverageBroadcastQualityByLevel(level)
 	return 0.00
 end
 
-
+--TODO Problem der Überlappung der MinAudience bei Level 4 und 5 (z.T. gleiche Anforderungen - doppelte Verträge)
 function AIToolsClass:GetAudienceQualityLevel(day, hour)
 	local maxAudience = self:GetMaxAudiencePercentage(day, hour)
 	if (maxAudience <= 0.04) then
@@ -397,6 +397,7 @@ end
 
 function AIToolsClass:GetBroadcastQualityLevel(broadcastMaterial)
 	if broadcastMaterial == nil then return 0 end
+	--TODO raw-QualityLevel!! also consider number of licences und average quality!!
 	local quality = broadcastMaterial:GetQuality() * 100
 
 	if quality > 20 then
@@ -466,7 +467,16 @@ function AIToolsClass:GetBroadcastAttraction(broadcastMaterialSource, day, hour,
 	-- "GetQuality()" already contains topicality-influence for infomercials
 	-- and programmes
 	-- return playerMod * timeMod * audienceMod * (broadcastMaterialSource.GetQuality() * broadcastMaterialSource.GetProgrammeTopicality())
-	return playerMod * timeMod * audienceMod * broadcastMaterialSource.GetQuality()
+	local result = playerMod * timeMod * audienceMod * broadcastMaterialSource.GetQuality()
+
+	--TODO Anzahl Lizenzen und Durchschnittsqualität berücksichtigen
+
+	local relTop = broadcastMaterialSource:GetRelativeTopicality()
+	result = result * relTop
+	if hour < 2 or hour > 16 then
+		result = result * relTop
+	end
+	return result
 end
 
 --[[

--- a/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
+++ b/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
@@ -52,6 +52,8 @@ if (unitTestMode) then
 end
 --]]
 
+--TODO log levels for "global" functions in this file, replace debugMsg
+
 -- ##### GLOBALS #####
 aiIsActive = true
 


### PR DESCRIPTION
Hier ein weiterer Aufräum-PR. Vorrangig habe ich aus den Tasks die debugMsg-Aufrufe entfernt. Im AIPlayer gibt es noch eine Reihe von "globalen" Funktionen, bei denen ein Umbau auf das Logging mit zwei zusätzlichen Parametern die Lesbarkeit verschlechtern würde. Aber diese Stellen dürften auch weniger interessant für Änderungen oder schnelles An- und Ausschalten sein.

Die andere wichtige Änderung ist ein Umbau der Entscheidung, ob ein Werbevertrag abgeschlossen wird oder nicht. Statt anhand der Level zu entscheiden (Morgens, Mittags, Abends) finde ich, dass die geforderte Zuschauerzahl entscheiden muss, wie viele überschüssige Spots es geben darf. Es kann ja durchaus zur Primetime mal einen Film geben, der deutlich weniger Zuschauer hat als mit dem besten Film erreichbar sind. Da können es dann auch mehr "Surplus-Spots" sein.
Da kann noch optimiert werden, aber zum Testspielen sollte es schon gehen.

An anderes Problem war der Abschluss "guter" Verträge. Ich hatte mich gewundert, warum da manchmal ein meiner Ansicht nach guter weggelassen wurde. Des Rätsels Lösung war der Tick-Iterier-Mechanismus. Beim ersten null-Vertrag wurde abgebrochen. Das kann auch schon mal nach dreien der Fall sein, wenn nämlich wegen Requisition-Vertragsabschluss Slot 4 nicht mehr belegt war, alle anderen aber schon...

Und dann bin ich beim Testspielen über einen langen Zeitraum (wieder) über das Problem gestoßen, dass eine KI auch nach 60 Tagen noch bei 13% Image verharrt. Beim Beobachten ist mir dann aufgefallen, dass praktisch jeden Tag dasselbe Vormittagsprogramm gesendet wurde (schlechte Filme oder solche mit geringer Topicality), obwohl 35 Filme zur Auswahl stehen. Mit Logausgaben habe ich dann gesehen, dass es eine Reihe von Filmen mit fast 100 Ausstrahlungen gab und ein Großteil nur selten oder sogar noch gar nicht gesendet wurde. Die KI hat also haufenweise Lizenzen gekauft ohne sie jemals zu senden. Und hier sehe ich einen riesigen Umbau vor mir. Denn das *fixe* Einstufen von Filmen nach Qualität für die unterschiedlichen Sendezeiten funktioniert nicht. Man kann eigentlich nicht sagen: gib mir mal mögliche Filme für Stunde X (komplett unabhängig vom Rest). Man muss eigentlich fragen: welche Filme möche ich heute senden und wie ordne ich die dann an (nehme ich nur welche mit maximaler Topicality oder wenn das nicht geht, welche guten hebe ich mir noch für morgen auf, um sie dann bei voller Topicality zu senden).

Dieser Umbau ist mir aber zu groß für die aktuelle Optimierungsrunde. Deshalb dieser PR als nächster Zwischenschritt.