### PR TITLE
Randomisierung Lizenzen

### DIFF
--- a/config/DEV.xml
+++ b/config/DEV.xml
@@ -172,6 +172,14 @@
 			<!-- maximum total percentage of fixed running costs added -->
 			<!-- <DEV_STATION_DAILY_MAINTENANCE_COSTS_PERCENTAGE_TOTAL_MAX value="0.30" /> -->
 
+			<!-- parameters for randomizing licence attributes from the database
+			     when starting a new game: 
+			     +/- x% (max deviation - getting smaller when approaching extreme values; except for price)
+			     0 = no randomization -->
+			<DEV_DATABASE_LICENCE_RANDOM_REVIEW value="20" />
+			<DEV_DATABASE_LICENCE_RANDOM_SPEED value="20" />
+			<DEV_DATABASE_LICENCE_RANDOM_OUTCOME value="20" />
+			<DEV_DATABASE_LICENCE_RANDOM_PRICE value="20" />
 
 			<!-- example:
 				"LOAD"-values:

--- a/res/lang/gen_settings/genSettings_de.txt
+++ b/res/lang/gen_settings/genSettings_de.txt
@@ -27,6 +27,7 @@ EXIT_TO_MAINMENU                           = Zum Hauptmenü zurückkehren
 ALLOW_TRAILERS_AND_INFOMERCIALS                               = Trailer/Werbesendungen ermöglichen
 ALLOW_MOVIES_WITH_YEAR_OF_PRODUCTION_GT_GAMEYEAR              = Erlaube Filme mit Drehjahr > Spieljahr
 START_GAME_WITH_CREDIT                                        = Starte mit Kredit
+START_GAME_RANDOMIZE_PROGRAMME                                = Filmwerte bei Spielstart leicht ändern
 OPTION_ON                                                     = Option an
 OPTION_OFF                                                    = Option aus
 AVAILABLE_GAMES                                               = Verfügbare Spiele

--- a/res/lang/gen_settings/genSettings_en.txt
+++ b/res/lang/gen_settings/genSettings_en.txt
@@ -27,6 +27,7 @@ EXIT_TO_MAINMENU                           = Exit to main menu
 ALLOW_TRAILERS_AND_INFOMERCIALS                               = Allow trailers/infomercials
 ALLOW_MOVIES_WITH_YEAR_OF_PRODUCTION_GT_GAMEYEAR              = Allow movies with year of production > game year
 START_GAME_WITH_CREDIT                                        = Start with credit
+START_GAME_RANDOMIZE_PROGRAMME                                = Modify movie attributes a bit when starting
 OPTION_ON                                                     = Option on
 OPTION_OFF                                                    = Option off
 AVAILABLE_GAMES                                               = Available games

--- a/res/lang/gen_settings/genSettings_es.txt
+++ b/res/lang/gen_settings/genSettings_es.txt
@@ -27,6 +27,7 @@ EXIT_TO_MAINMENU                           = Salir al menú principal
 ALLOW_TRAILERS_AND_INFOMERCIALS                               = Permitir trailers/infomerciaales
 ALLOW_MOVIES_WITH_YEAR_OF_PRODUCTION_GT_GAMEYEAR              = Permitir las películas con año de fabricación > game year
 #START_GAME_WITH_CREDIT                                        = 
+#START_GAME_RANDOMIZE_PROGRAMME                                = 
 OPTION_ON                                                     = Option selecionada
 OPTION_OFF                                                    = Option deseleccionada
 AVAILABLE_GAMES                                               = Juegos disponibles

--- a/res/lang/gen_settings/genSettings_fr.txt
+++ b/res/lang/gen_settings/genSettings_fr.txt
@@ -27,6 +27,7 @@ EXIT_TO_MAINMENU                           = Exit to main menu
 ALLOW_TRAILERS_AND_INFOMERCIALS                               = Autoriser bande annonce /Publireportage
 ALLOW_MOVIES_WITH_YEAR_OF_PRODUCTION_GT_GAMEYEAR              = Autoriser les films avec année de production > année de jeu
 #START_GAME_WITH_CREDIT                                        = 
+#START_GAME_RANDOMIZE_PROGRAMME                                = 
 OPTION_ON                                                     = Option on
 OPTION_OFF                                                    = Option off
 AVAILABLE_GAMES                                               = Jeux disponibles

--- a/res/lang/gen_settings/genSettings_pt-br.txt
+++ b/res/lang/gen_settings/genSettings_pt-br.txt
@@ -27,6 +27,7 @@ EXIT_TO_MAINMENU                           = Sair para tela inicial
 ALLOW_TRAILERS_AND_INFOMERCIALS                               = Permitir trailers/infomerciais
 ALLOW_MOVIES_WITH_YEAR_OF_PRODUCTION_GT_GAMEYEAR              = Permitir filmes com o ano de produção > ano do jogo
 #START_GAME_WITH_CREDIT                                        = 
+#START_GAME_RANDOMIZE_PROGRAMME                                = 
 OPTION_ON                                                     = Opção ligada
 OPTION_OFF                                                    = Opção desligada
 AVAILABLE_GAMES                                               = Jogos disponíveis

--- a/res/lang/gen_settings/genSettings_tr.txt
+++ b/res/lang/gen_settings/genSettings_tr.txt
@@ -27,6 +27,7 @@ EXIT_TO_MAINMENU                           = Ana Menüye Çıkış
 ALLOW_TRAILERS_AND_INFOMERCIALS                               = Fragman ve Ödemeli Programlar Açık
 ALLOW_MOVIES_WITH_YEAR_OF_PRODUCTION_GT_GAMEYEAR              = Oyun yılından sonra üretilmiş filmlere İzin ver.
 #START_GAME_WITH_CREDIT                                        = 
+#START_GAME_RANDOMIZE_PROGRAMME                                = 
 OPTION_ON                                                     = Seçenek AÇIK
 OPTION_OFF                                                    = Seçenek KAPALI
 AVAILABLE_GAMES                                               = Mevcut Oyunlar

--- a/source/game.gamerules.bmx
+++ b/source/game.gamerules.bmx
@@ -11,6 +11,8 @@ Type TGameRules {_exposeToLua}
 	Field startAdAmount:Int = 3
 	'should a game start with a credit already given
 	Field startGameWithCredit:Int = True
+	'should licence attributes from the database be randomized
+	Field randomizeLicenceAttributes:Int = False
 
 	'if a player goes bankrupt does the restarting one get stations
 	'and money according to the average of other players?

--- a/source/game.screen.menu.bmx
+++ b/source/game.screen.menu.bmx
@@ -17,6 +17,7 @@ Type TScreen_GameSettings Extends TGameScreen
 	Field guiSpecialFormats:TGUICheckBox
 	Field guiFilterUnreleased:TGUICheckBox
 	Field guiStartWithCredit:TGUICheckBox
+	Field guiRandomizeLicence:TGUICheckBox
 	Field guiGameTitleLabel:TGuiLabel
 	Field guiGameTitle:TGuiInput
 	Field guiStartYearLabel:TGuiLabel
@@ -74,39 +75,47 @@ Type TScreen_GameSettings Extends TGameScreen
 		Local col:SColor8 = New SColor8(90, 90, 90)
 		Local labelH:Int = GetBitmapFontManager().Get("DefaultThin", 14, BOLDFONT).GetHeight("Title")
 		guiGameTitleLabel = New TGUILabel.Create(New TVec2D.Init(0, 0), "", col, name)
-		guiGameTitle = New TGUIinput.Create(New TVec2D.Init(0, labelH), New TVec2D.Init(250, -1), "", 32, name)
-		guiStartYearLabel = New TGUILabel.Create(New TVec2D.Init(255, 0), "", col, name)
-		guiStartYear = New TGUIinput.Create(New TVec2D.Init(255, labelH), New TVec2D.Init(70, -1), "", 4, name)
-		guiGameSeedLabel = New TGUILabel.Create(New TVec2D.Init(330, 0), "", col, name)
-		guiGameSeed = New TGUIinput.Create(New TVec2D.Init(330, labelH), New TVec2D.Init(75, -1), "", 9, name)
+		guiGameTitle = New TGUIinput.Create(New TVec2D.Init(0, labelH), New TVec2D.Init(150, -1), "", 32, name)
+		guiStartYearLabel = New TGUILabel.Create(New TVec2D.Init(0, 50), "", col, name)
+		guiStartYear = New TGUIinput.Create(New TVec2D.Init(0, 50 + labelH), New TVec2D.Init(60, -1), "", 4, name)
+		guiGameSeedLabel = New TGUILabel.Create(New TVec2D.Init(75, 50), "", col, name)
+		guiGameSeed = New TGUIinput.Create(New TVec2D.Init(75, 50 +labelH), New TVec2D.Init(75, -1), "", 9, name)
 
-		guiGameTitleLabel.SetFont( GetBitmapFontManager().Get("DefaultThin", 14, BOLDFONT) )
-		guiStartYearLabel.SetFont( GetBitmapFontManager().Get("DefaultThin", 14, BOLDFONT) )
-		guiGameSeedLabel.SetFont( GetBitmapFontManager().Get("DefaultThin", 14, BOLDFONT) )
+		guiGameTitleLabel.SetFont( GetBitmapFontManager().Get("DefaultThin", 13, BOLDFONT) )
+		guiStartYearLabel.SetFont( GetBitmapFontManager().Get("DefaultThin", 13, BOLDFONT) )
+		guiGameSeedLabel.SetFont( GetBitmapFontManager().Get("DefaultThin", 13, BOLDFONT) )
+		guiGameSeedLabel.SetContentAlignment(ALIGN_RIGHT, ALIGN_CENTER)
+		guiGameSeedLabel.SetSize(75, -1)
 
-
+		Local xCol1:Int = 160
 		Local checkboxHeight:Int = 0
-		gui24HoursDay = New TGUICheckBox.Create(New TVec2D.Init(430, 0), New TVec2D.Init(300), "", name)
+		gui24HoursDay = New TGUICheckBox.Create(New TVec2D.Init(xCol1, 0), New TVec2D.Init(280), "", name)
 		gui24HoursDay.SetChecked(True, False)
 		gui24HoursDay.disable() 'option not implemented
 		checkboxHeight :+ gui24HoursDay.GetScreenRect().GetH()
 
-		guiSpecialFormats = New TGUICheckBox.Create(New TVec2D.Init(430, 0 + checkboxHeight), New TVec2D.Init(300), "", name)
+		guiSpecialFormats = New TGUICheckBox.Create(New TVec2D.Init(xCol1, 0 + checkboxHeight), New TVec2D.Init(280), "", name)
 		guiSpecialFormats.SetChecked(True, False)
 		guiSpecialFormats.disable() 'option not implemented
 		checkboxHeight :+ guiSpecialFormats.GetScreenRect().GetH()
 
-		guiFilterUnreleased = New TGUICheckBox.Create(New TVec2D.Init(430, 0 + checkboxHeight), New TVec2D.Init(300), "", name)
+		guiFilterUnreleased = New TGUICheckBox.Create(New TVec2D.Init(xCol1, 0 + checkboxHeight), New TVec2D.Init(280), "", name)
 		guiFilterUnreleased.SetChecked(False, False)
 		checkboxHeight :+ guiFilterUnreleased.GetScreenRect().GetH()
 
-		guiStartWithCredit = New TGUICheckBox.Create(New TVec2D.Init(430, 0 + checkboxHeight), New TVec2D.Init(300), "", name)
+		guiStartWithCredit = New TGUICheckBox.Create(New TVec2D.Init(xCol1, 0 + checkboxHeight), New TVec2D.Init(280), "", name)
 		guiStartWithCredit.SetChecked(GameRules.startGameWithCredit, False)
 		checkboxHeight :+ guiStartWithCredit.GetScreenRect().GetH()
 
-		guiAnnounce = New TGUICheckBox.Create(New TVec2D.Init(430, 0 + checkboxHeight), New TVec2D.Init(300), "", name)
+		guiAnnounce = New TGUICheckBox.Create(New TVec2D.Init(xCol1, 0 + checkboxHeight), New TVec2D.Init(280), "", name)
 		guiAnnounce.SetChecked(True, False)
 
+		Local xCol2:Int = 445
+		checkboxHeight:Int = 0
+
+		guiRandomizeLicence = New TGUICheckBox.Create(New TVec2D.Init(xCol2, 0 + checkboxHeight), New TVec2D.Init(285), "", name)
+		guiRandomizeLicence.SetChecked(GameRules.randomizeLicenceAttributes, False)
+		checkboxHeight :+ guiRandomizeLicence.GetScreenRect().GetH()
 
 		guiSettingsPanel.AddChild(guiGameTitleLabel)
 		guiSettingsPanel.AddChild(guiGameTitle)
@@ -119,6 +128,7 @@ Type TScreen_GameSettings Extends TGameScreen
 		guiSettingsPanel.AddChild(guiSpecialFormats)
 		guiSettingsPanel.AddChild(guiFilterUnreleased)
 		guiSettingsPanel.AddChild(guiStartWithCredit)
+		guiSettingsPanel.AddChild(guiRandomizeLicence)
 
 
 		Local guiButtonsWindow:TGUIGameWindow
@@ -225,6 +235,7 @@ Type TScreen_GameSettings Extends TGameScreen
 		guiWidgets.AddLast(guiSpecialFormats)
 		guiWidgets.AddLast(guiFilterUnreleased)
 		guiWidgets.AddLast(guiStartWithCredit)
+		guiWidgets.AddLast(guiRandomizeLicence)
 		'guiWidgets.AddLast(guiGameTitleLabel)
 		guiWidgets.AddLast(guiGameTitle)
 		'guiWidgets.AddLast(guiStartYearLabel)
@@ -453,6 +464,8 @@ Type TScreen_GameSettings Extends TGameScreen
 					TProgrammeData.setIgnoreUnreleasedProgrammes( Not sender.isChecked() )
 			Case guiStartWithCredit
 					GameRules.startGameWithCredit = sender.isChecked()
+			Case guiRandomizeLicence
+					GameRules.randomizeLicenceAttributes = sender.isChecked()
 		End Select
 
 		'only inform when in settings menu
@@ -530,14 +543,15 @@ Rem
 			endif
 		Next
 endrem
-		guiGameTitleLabel.SetValue(GetLocale("GAME_TITLE")+":")
-		guiStartYearLabel.SetValue(GetLocale("START_YEAR")+":")
-		guiGameSeedLabel.SetValue(GetLocale("GAME")+" #:")
+		guiGameTitleLabel.SetValue(GetLocale("GAME_TITLE"))
+		guiStartYearLabel.SetValue(GetLocale("START_YEAR"))
+		guiGameSeedLabel.SetValue(GetLocale("GAME")+" #")
 
 		gui24HoursDay.SetCaption(GetLocale("24_HOURS_GAMEDAY"), True, True)
 		guiSpecialFormats.SetCaption(GetLocale("ALLOW_TRAILERS_AND_INFOMERCIALS"), True, True)
 		guiFilterUnreleased.SetCaption(GetLocale("ALLOW_MOVIES_WITH_YEAR_OF_PRODUCTION_GT_GAMEYEAR"), True, True)
 		guiStartWithCredit.SetCaption(GetLocale("START_GAME_WITH_CREDIT"), True, True)
+		guiRandomizeLicence.SetCaption(GetLocale("START_GAME_RANDOMIZE_PROGRAMME"), True, True)
 
 		guiAnnounce.SetValue("Nach weiteren Spielern suchen")
 


### PR DESCRIPTION
Prototyp für die Randomisierung von Tempo, Kritikerbewertung, Zuschauererfolg und Preis von Lizenzen beim Start eines neuen Spiels.
Die in der Datenbank hinterlegten Werte werden zufällig und ohne Wichtung um +/-20% (absolut, nicht vom Ausgangswert) geändert. Durch den Ausgangswert (20% oder 80%) ist die Tendenz meiner Ansicht nach hinreichend festgelegt, so dass es nicht nötigt ist, auf dieser Basis noch eine Verschiebung eher nach oben oder eher nach unten zu erzwingen.
Die Höhe der möglichen Abweichung könnte noch pro Attribut konfigurierbar gemacht werden (dev.xml). Im Gespräch war aber auch eine neuen gameconfig.xml, in der Z.B. Parameter für die Schwierigkeitslevel oder andere Spielparamter zusammengefasst werden.

Im Draft-PR geht es zunächst um die Position und den Ansatz für die Randomisierung.

see #475