### PR TITLE
konfigurierbare Anzahl von Produzenten

### DIFF
--- a/config/DEV.xml
+++ b/config/DEV.xml
@@ -156,6 +156,13 @@
 			<!-- TRUE/1   FALSE/0 -->
 			<DEV_ROUND_TO_BEAUTIFUL_VALUES value="TRUE" />
 
+			<!-- number of in game producers shooting movies etc. based on script templates from database-->
+			<DEV_PRODUCERS_COUNT value="4" />
+			<!-- minimal waiting time in hours between finishing one production and starting the next one-->
+			<DEV_PRODUCERS_MIN_WAIT_HOURS value="36" />
+			<!-- maximal waiting time in hours between finishing one production and starting the next one-->
+			<DEV_PRODUCERS_MAX_WAIT_HOURS value="96" />
+
 			<!-- enable/disable station map daily running cost increase -->
 			<!-- <DEV_STATION_INCREASE_DAILY_MAINTENANCE_COSTS value="FALSE" /> -->
 

--- a/source/game.game.bmx
+++ b/source/game.game.bmx
@@ -1464,7 +1464,7 @@ Type TGame Extends TGameBase {_exposeToLua="selected"}
 		'TLogger.Log("PrepareNewGame()", "Generated morning show programme producer.", LOG_DEBUG)
 
 		'movie/series producers exist with different characteristics/budgets
-		For local i:int = 0 to 3
+		For local i:int = 0 to (GameRules.devConfig.GetInt("DEV_PRODUCERS_COUNT", 4) - 1)
 			Local p:TProgrammeProducer = new TProgrammeProducer
 			p.countryCode = GetProgrammeProducerCollection().GenerateRandomCountryCode()
 			p.name = GetProgrammeProducerCollection().GenerateRandomName()

--- a/source/game.programmeproducer.bmx
+++ b/source/game.programmeproducer.bmx
@@ -67,7 +67,7 @@ Type TProgrammeProducer Extends TProgrammeProducerBase
 		Super.RandomizeCharacteristics()
 
 		budgetIncrease = RandRange(3, 8) * 250
-		nextProductionTime = GetWorldTime().GetTimeGone() + RandRange(12, 48) * TWorldTime.HOURLENGTH
+		nextProductionTime = GetWorldTime().GetTimeGone() + RandRange(12, 96) * TWorldTime.HOURLENGTH
 		
 		'TODO: greed, favorite genres...
 	End Method
@@ -77,7 +77,6 @@ Type TProgrammeProducer Extends TProgrammeProducerBase
 		'remove instance specific event listeners...
 	End Method	
 
-	
 	Method Update:Int()
 		budget :+ budgetIncrease 'update every 15minutes = 96x a day ...
 		
@@ -85,8 +84,9 @@ Type TProgrammeProducer Extends TProgrammeProducerBase
 
 		If nextProductionTime < GetWorldTime().GetTimeGone()
 			ScheduleNextProduction(Null)
-
-			nextProductionTime = GetWorldTime().GetTimeGone() + TWorldTime.HOURLENGTH * RandRange(32, 72)
+			Local minWaitHours:Int = GameRules.devConfig.GetInt("DEV_PRODUCERS_MIN_WAIT_HOURS", 36)
+			Local maxWaitHours:Int = GameRules.devConfig.GetInt("DEV_PRODUCERS_MAX_WAIT_HOURS", 96)
+			nextProductionTime = GetWorldTime().GetTimeGone() + TWorldTime.HOURLENGTH * RandRange(minWaitHours, maxWaitHours)
 		EndIf
 		
 		'is one of the running/scheduled productions finished now?


### PR DESCRIPTION
Zur Steuerung der Anzahl vom Spiel produzierter Programme kann die Anzahl der Produzenten und die minimale Wartezeit zwischen zwei Produktionen konfiguriert werden.

closes #459