### PR TITLE
kein Absturz bei fehlendem KI-Skript

### DIFF
--- a/source/game.ai.base.bmx
+++ b/source/game.ai.base.bmx
@@ -293,6 +293,13 @@ endrem
 		if scriptFileName = "" then return FALSE
 
 		Local loadingStopWatch:TStopWatch = new TStopWatch.Init()
+		If FileType(scriptFileName) = 1
+			'file exists
+		Else
+			TLogger.Log("LoadScript", "File ~q" + luaScriptFileName + "~q does not exist. Using default script.", LOG_ERROR)
+			scriptFileName = "res/ai/DefaultAIPlayer/DefaultAIPlayer.lua"
+		EndIf
+
 		'load content
 		GetLuaEngine().SetSource(LoadText(scriptFileName), scriptFileName)
 


### PR DESCRIPTION
Wenn ein Spiel mit einer KI-Implementierung gestartet wurde, die es beim Laden des Spielstandes nicht mehr gibt, sollte es nicht zum Programmabsturz kommen. Stattdessen wird die Default-Implementierung geladen.