### PR TITLE
Antennenreichweite vom Startjahr abhängig

### DIFF
--- a/config/DEV.xml
+++ b/config/DEV.xml
@@ -163,6 +163,10 @@
 			<!-- maximal waiting time in hours between finishing one production and starting the next one-->
 			<DEV_PRODUCERS_MAX_WAIT_HOURS value="96" />
 
+			<!-- intended reach of the first antenna;
+				due to min/max values for the radius the actual reach may differ -->
+			<!-- DEV_STATION_INITIAL_INTENDED_REACH value="950000" /> -->
+
 			<!-- enable/disable station map daily running cost increase -->
 			<!-- <DEV_STATION_INCREASE_DAILY_MAINTENANCE_COSTS value="FALSE" /> -->
 

--- a/source/game.game.bmx
+++ b/source/game.game.bmx
@@ -1210,6 +1210,8 @@ Type TGame Extends TGameBase {_exposeToLua="selected"}
 
 
 		'=== STATION MAP ===
+		'set marker for initializing antenna radius on new game
+		GetStationMapCollection().antennaStationRadius = TStationMapCollection.ANTENNA_RADIUS_NOT_INITIALIZED
 		'load the used map
 		GetStationMapCollection().LoadMapFromXML("res/maps/germany/germany.xml")
 '		GetStationMapCollection().LoadMapFromXML("res/maps/germany.xml")

--- a/source/game.gamerules.bmx
+++ b/source/game.gamerules.bmx
@@ -117,6 +117,7 @@ Type TGameRules {_exposeToLua}
 	Field newsStudioSortNewsBy:string = "age"
 
 	'=== STATIONMAP ===
+	Field stationInitialIntendedReach:int = 950000
 	'time a station needs to get constructed
 	'value in hours
 	'set to default (0) on start (game.game.bmx prepareNewGame())
@@ -184,6 +185,7 @@ Type TGameRules {_exposeToLua}
 
 
 		'=== STATION(MAP) ===
+		stationInitialIntendedReach = data.GetInt("DEV_STATION_INITIAL_INTENDED_REACH", stationInitialIntendedReach)
 		stationConstructionTime = data.GetInt("DEV_STATION_CONSTRUCTION_TIME", 0)
 		stationIncreaseDailyMaintenanceCosts = data.GetBool("DEV_STATION_INCREASE_DAILY_MAINTENANCE_COSTS", stationIncreaseDailyMaintenanceCosts)
 		stationDailyMaintenanceCostsPercentage = data.GetFloat("DEV_STATION_DAILY_MAINTENANCE_COSTS_PERCENTAGE", stationDailyMaintenanceCostsPercentage)


### PR DESCRIPTION
Der im PR verfolgte Ansatz ist, möglichst eine Startreichweite von knapp über 1 Mio zu haben. Erster Ansatz war, feste Größen für bestimmte Jahresabschnitte zu vergeben. Implementiert ist aber eine automatische Radiusermittlung.

Ab 1997 ist der Radius so groß, dass man kaum im Startsendegebiet so viele Zuschauer zusammenbekommt, um die Sendelizenzen bezahlen zu können. Deshalb ist das Antennensenden dann ohne zusätzliche Lizenz möglich. Das könnte man aber auch vom Radius statt vom Jahr abhängig machen.

Die Koordinaten der temporären Antenne ist aus den Spielersetup entnommen. Langfristig könnte diese Startposition aber auch in der Karte stehen.

Siehe #518 