### PR TITLE
Betty - Geschenkhistorie muss zurückgesetzt werden

### DIFF
--- a/source/game.betty.bmx
+++ b/source/game.betty.bmx
@@ -45,7 +45,7 @@ Type TBetty
 
 	Method Initialize:int()
 		inLove = new Int[4]
-
+		presentHistory = null
 		_inLoveSum = -1
 	End Method
 


### PR DESCRIPTION
Neben den Bettypunkten für die Spieler muss auch die Geschenkhistorie zurückgesetzt werden. Ansonsten werden im Laden nach einem Neustart die falschen Zahlen für bereits gekaufte Geschenke angezeigt. Und auch die Prüfung, ob ein Geschenk an dem Tag noch überreicht werden darf, geht sonst schief.