### PR TITLE
KI-Stationsausbau

### DIFF
--- a/res/ai/DefaultAIPlayer/TaskStationMap.lua
+++ b/res/ai/DefaultAIPlayer/TaskStationMap.lua
@@ -316,7 +316,7 @@ function JobBuyStation:GetAttraction(tempStation)
 	--to avoid buying too many stations (upkeep!)
 	local attraction = 1 / pricePerViewer * (0.9 + 0.1 * math.max(0, (price / self.Task.CurrentBudget)))
 	--TODO do not buy if reach increase is too small
-	if exclusiveReach < 100000 then
+	if exclusiveReach < 100000 or tempStation:CanSignContract(-1) == 0 then
 		attraction = 0
 	end
 	self:LogTrace("    -> attraction: " .. attraction .. "  |  ".. pricePerViewer .. " - (" .. priceDiff .. " / currentBudget: " .. self.Task.CurrentBudget .. ")")

--- a/source/game.stationmap.bmx
+++ b/source/game.stationmap.bmx
@@ -3706,7 +3706,7 @@ Type TStationCableNetworkUplink extends TStationBase {_exposeToLua="selected"}
 
 
 	'override to check if already subscribed
-	Method CanSignContract:int(duration:Long)
+	Method CanSignContract:int(duration:Long)  {_exposeToLua}
 		if not Super.CanSignContract(duration) then return False
 
 		if CanSubscribeToProvider(duration) <= 0 then return False
@@ -4123,7 +4123,7 @@ Type TStationSatelliteUplink extends TStationBase {_exposeToLua="selected"}
 
 
 	'override to check if already subscribed
-	Method CanSignContract:int(duration:Long)
+	Method CanSignContract:int(duration:Long) {_exposeToLua}
 		if not Super.CanSignContract(duration) then return False
 
 		if CanSubscribeToProvider(duration) <= 0 then return False


### PR DESCRIPTION
Bei der Ermittlung der Attraktivität von Kabel- und Satellitenverträgen muss in Betracht gezogen werden, ob diese überhaupt abgeschlossen werden können (Mindest-Image). Ansonsten kann es vorkommen, dass eine KI, die mit dem Image nicht vom Fleck kommt, überhaupt nicht mehr ausbaut. (Kabelvertrag gewinnt wegen Attraktivität, Buy schlägt fehl und das immer wieder.)