### PR TITLE
Kultur-Flag bei Drehbüchern anzeigen

### DIFF
--- a/source/game.production.script.bmx
+++ b/source/game.production.script.bmx
@@ -1213,6 +1213,9 @@ Type TScript Extends TScriptBase {_exposeToLua="selected"}
 				genreString :+ " / " +GetProductionTypeString()
 			EndIf
 		EndIf
+		if IsCulture()
+			genreString :+ ", |i|" + GetLocale("PROGRAMME_FLAG_CULTURE") +"|/i|"
+		endif
 		If IsSeries()
 			genreString :+ " / " + GetLocale("SERIES_WITH_X_EPISODES").Replace("%EPISODESCOUNT%", GetSubScriptCount())
 		EndIf


### PR DESCRIPTION
Besonders bei frühem Spielstart gibt es vergleichsweise wenige Kultursendungen. Da können Eigenproduktionen helfen. Analog zu den Programmen sollte daher erkennbar sein, ob es das Flag gesetzt ist.