### PR TITLE
Image bei Betty sollte höher sein können als das Senderimage

### DIFF
--- a/source/game.betty.bmx
+++ b/source/game.betty.bmx
@@ -178,7 +178,8 @@ Type TBetty
 		if not ignorePublicImage
 			local playerImage:TPublicImage = GetPublicImage(PlayerID)
 			if playerImage
-				local maxAmountImageLimit:int = int(ceil(0.01*playerImage.GetAverageImage()  * LOVE_MAXIMUM))
+				local maxAmountImageLimit:int = int(ceil(1.5 * 0.01 * playerImage.GetAverageImage() * LOVE_MAXIMUM))
+				maxAmountImageLimit = Min(maxAmountImageLimit, LOVE_MAXIMUM)
 				If Self.InLove[PlayerID-1] + amount > maxAmountImageLimit
 					amount = Min(amount, maxAmountImageLimit - Self.InLove[PlayerID-1])
 				Endif


### PR DESCRIPTION
Der Kommentar impliziert, dass das Image bei Betty 150% des Senderimage betragen kann. Der Code erlaubte allerdings maximal das Senderimage. Mit der Änderung kann es nun wirklich entsprechend mehr Bettypunkte geben.

Die Frage wäre, ob man das nicht sogar auf das Doppelte oder Dreifache erhöhen sollte. Aktuell spielt es vermutlich noch keine Rolle, wenn man aber Missionen einführt, in denen es darum geht, möglichst schnell bei Betty im Ansehen zu steigen, könnte es eine Strategie sein, mit möglichst vielen Geschenken und Kulturprogrammen ans Ziel zu kommen, dabei aber das Senderimage (etwas) zu vernachlässigen (geringere Einschaltquoten).