### PR TITLE
KI Änderung Budgetberechnung; Stationskauf

### DIFF
--- a/res/ai/DefaultAIPlayer/BudgetManager.lua
+++ b/res/ai/DefaultAIPlayer/BudgetManager.lua
@@ -1,6 +1,5 @@
 -- File: BudgetManager
 
---TODO cleanup saving and budget calculation
 -- >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 _G["BudgetManager"] = class(KIDataObjekt, function(c)
 	KIDataObjekt.init(c)	-- must init base!
@@ -38,6 +37,12 @@ end
 
 -- Method is run at the begin of each day
 function BudgetManager:CalculateNewDayBudget()
+	--reset obsolete fields
+	self.SavingParts = 0.0
+	self.ExtraFixedCostsSavingsPercentage = 0
+	self.InvestmentSavings = 0
+
+
 	self.IgnoreMoneyChange = true
 	self.CurrentLogLevel = LOG_INFO
 	self:Log("=== Budget day " .. (TVT.GetDaysRun() + 1) .. " ===")
@@ -62,33 +67,12 @@ function BudgetManager:UpdateBudget(pBudget)
 	end
 
 	self:Log(string.left("Planned budget:", 25, true) .. string.right(pBudget, 10, true))
-	self:CutInvestmentSavingIfNeeded(pBudget)
 
 	-- split budget across the different tasks
 	self:AllocateBudgetToTasks(pBudget)
 
 	self.BudgetOnLastUpdateBudget = pBudget
 end
-
---TODO sollte man das wirklich immer machen? Am Tagesanfang steht oft wenig Geld zur Verfügung
-function BudgetManager:CutInvestmentSavingIfNeeded(pBudget)
-	local player = _G["globalPlayer"]
-
-	-- saved too much? Use savings or take credit
-	if (pBudget * 0.8) < self.InvestmentSavings then
-		self:Log("$$Cutting investment savings: " .. self.InvestmentSavings .. ". Budget only at " .. pBudget .. ". Savings getting halved." )
-		self.InvestmentSavings = self.InvestmentSavings / 2
-	end
-
-	-- saved too much? Use savings or take credit
-	if (pBudget * 0.6) < self.InvestmentSavings or self.InvestmentSavings < 0 then
-		self:Log("$$Totally get rid of investment savings. Savings: " .. self.InvestmentSavings .. ". Budget only at " .. pBudget .. ".")
-		self.InvestmentSavings = 0
-	end
-
-	return savings
-end
-
 
 function BudgetManager:AllocateBudgetToTasks(pBudget)
 	local player = _G["globalPlayer"]
@@ -97,7 +81,6 @@ function BudgetManager:AllocateBudgetToTasks(pBudget)
 	for k,v in pairs(player.TaskList) do
 		v:BeforeBudgetSetup()
 	end
-
 
 	-- sum up amount of budget units and sum up fix costs
 	local budgetUnits = 0
@@ -112,25 +95,15 @@ function BudgetManager:AllocateBudgetToTasks(pBudget)
 	self.CurrentFixedCosts = allFixedCostsSavings
 
 	self:Log(string.left("Fixed costs:", 25, true) .. string.right(allFixedCostsSavings, 10, true))
-	--TODO: character riskyness defines how much to save "extra"
-	allFixedCostsSavings = allFixedCostsSavings * (1 + self.ExtraFixedCostsSavingsPercentage)
 
-	--TODO not all fixed costs savings at the beginning of the day, we also expect income
 	local hour = TVT:GetDayHour()
 	local hourPart = (math.min(24, 4 + hour)/24) 
 	allFixedCostsSavings = allFixedCostsSavings * hourPart
-	local thisHourSavings = self.InvestmentSavings * hourPart
 
 	self:Log(string.left("F.C.+reserve (for hour):", 25, true) .. string.right(allFixedCostsSavings, 10, true))
 
-	-- Increase savings and define real budget to spend.
-	local tempBudget = pBudget - thisHourSavings - allFixedCostsSavings
-	-- Save a bit
-	if tempBudget > 0 then
-		self.InvestmentSavings = self.InvestmentSavings + math.round(tempBudget * self.SavingParts)
-	end
 	-- define final budget
-	local realBudget = pBudget - thisHourSavings - allFixedCostsSavings
+	local realBudget = pBudget - allFixedCostsSavings
 	self:Log(string.left("Savings:", 25, true) .. string.right(self.InvestmentSavings, 10, true))
 	self:Log(string.left("Final budget:", 25, true) .. string.right(realBudget, 10, true))
 	self:Log(string.right("=======", 35, true))
@@ -150,16 +123,6 @@ function BudgetManager:AllocateBudgetToTasks(pBudget)
 		v.BudgetWholeDay = v.CurrentBudget
 	end
 
-
-	-- check for investments
-	local investTask = self:GetTaskForInvestment(player.TaskList)
-	if (investTask ~= nil) then
-		self:Log(investTask:typename() .. "- Use Investment: " .. self.InvestmentSavings)
-		investTask.CurrentBudget = investTask.CurrentBudget + self.InvestmentSavings
-		investTask.UseInvestment = true
-		investTask.CurrentInvestmentPriority = 0
-	end
-
 	-- inform tasks for final budgets
 	self:Log("Budget split:")
 	for k,v in pairs(player.TaskList) do
@@ -170,59 +133,6 @@ function BudgetManager:AllocateBudgetToTasks(pBudget)
 		end
 	end
 end
-
-
-function BudgetManager:GetTaskForInvestment(tasks)
-	local taskSorted = SortTasksByInvestmentPrio(tasks)
-	local rank = 1
-	local highestPrio = nil
-
-	for k,v in pairs(taskSorted) do
-		if highestPrio == nil then
-			highestPrio = v
-			if self:IsTaskReadyForInvestment(v, rank) then
-				return v
-			end
-		else
-			if self:IsTaskReadyForInvestment(v, rank, highestPrio) then
-				return v
-			end
-		end
-		rank = rank + 1
-		if rank > 3 then return nil end
-	end
-	return nil
-end
-
-
-function BudgetManager:IsTaskReadyForInvestment(task, rank, highestPrioTask)
-	if rank == nil then rank = 1 end
-
-	-- 1. condition: enough money saved for this task
-	if (self.InvestmentSavings + task.BudgetWholeDay) >= task.NeededInvestmentBudget then
-		-- 2. condition: priority is high enough
-		if task.CurrentInvestmentPriority >= rank * 10 then
-			-- 3. condition: Distance to top priority task isn't too big
-			local prioOfHighest = task.CurrentInvestmentPriority
-			if highestPrioTask ~= nil then
-				prioOfHighest = highestPrioTask.CurrentInvestmentPriority
-			end
-
-			if prioOfHighest - task.CurrentInvestmentPriority <= 30 then
-				-- 4. condition: Savings / required invest of the top task <= 0.8
-				if highestPrioTask ~= nil then
-					if (self.InvestmentSavings / highestPrioTask.NeededInvestmentBudget <= 0.8) then
-						return true
-					end
-				else
-					return true
-				end
-			end
-		end
-	end
-	return false
-end
-
 
 function BudgetManager:OnMoneyChanged(value, reason, reference)
 	if self.IgnoreMoneyChange == true then return end

--- a/res/ai/DefaultAIPlayer/BudgetManager.lua
+++ b/res/ai/DefaultAIPlayer/BudgetManager.lua
@@ -1,5 +1,6 @@
 -- File: BudgetManager
 
+--TODO cleanup saving and budget calculation
 -- >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 _G["BudgetManager"] = class(KIDataObjekt, function(c)
 	KIDataObjekt.init(c)	-- must init base!
@@ -23,7 +24,7 @@ end
 
 function BudgetManager:ResetDefaults()
 	-- Percentage of the budget to save for investments
-	self.SavingParts = 0.3
+	self.SavingParts = 0.0
 	-- Percentage to add on fixed costs "to make sure it is enough"
 	self.ExtraFixedCostsSavingsPercentage = 0
 	self.IgnoreMoneyChange = false

--- a/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
+++ b/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
@@ -143,9 +143,11 @@ function DefaultAIPlayer:initializePlayer()
 	--TODO if saving is too low, boss credit will not be repaid (budget for boss task?
 	--if it is too big, not enough money is available for movies (investment savings?) 
 	-- budget saving from 10-30%
-	self.Budget.SavingParts = 0.1 + 0.05 * math.random(0,4)
+	--self.Budget.SavingParts = 0.1 + 0.05 * math.random(0,4)
+	self.Budget.SavingParts = 0
 	-- extra safety add-to-fixed-costs from 40-70%
-	self.Budget.ExtraFixedCostsSavingsPercentage = 0.4 + 0.10 * math.random(0,3)
+	--self.Budget.ExtraFixedCostsSavingsPercentage = 0.4 + 0.10 * math.random(0,3)
+	self.Budget.ExtraFixedCostsSavingsPercentage = 0
 
 	self.archEnemyID = -1
 

--- a/res/ai/DefaultAIPlayer/Strategy.lua
+++ b/res/ai/DefaultAIPlayer/Strategy.lua
@@ -95,7 +95,8 @@ function BeginExpandStrategy:Start(playerAI)
 	playerAI.TaskList[TASK_MOVIEDISTRIBUTOR].InvestmentPriority = 0
 	playerAI.TaskList[TASK_STATIONMAP].BasePriority = 3
 	playerAI.TaskList[TASK_STATIONMAP].InvestmentPriority = 15
-	playerAI.Budget.SavingParts = 0.6
+	--handle differently
+	--playerAI.Budget.SavingParts = 0.6
 end
 
 

--- a/res/ai/DefaultAIPlayer/TaskAdAgency.lua
+++ b/res/ai/DefaultAIPlayer/TaskAdAgency.lua
@@ -11,8 +11,8 @@ _G["TaskAdAgency"] = class(AITask, function(c)
 	c.BasePriority = 3
 	c.BudgetWeight = 0
 
-	--no budget to spare
-	c.RequiresBudgetHandling = false
+	--budget handling for fixedCosts
+	c.RequiresBudgetHandling = true
 
 	-- zu Senden
 	-- Strafe
@@ -529,10 +529,20 @@ function SignContracts:Tick()
 	local contractsAllowed = TVT.Rules.adContractsPerPlayerMax - MY.GetProgrammeCollection().GetAdContractCount()
 	local haveLow = false
 
+	local signedContracts = TaskAdAgency.GetAllAdContracts()
+	--count penalty for failed contracts as fixed costs
+	local fixedCosts = 0
+	if TVT:GetDayHour() > 19 then
+		for key, contract in pairs(signedContracts) do
+			if contract ~= nil then
+				if contract:GetDaysLeft(-1) == 0 then fixedCosts = fixedCosts + contract.getPenalty(TVT.ME) end
+			end
+		end
+	end
+	self.Task.FixedCosts = fixedCosts
 
 	-- check if we have a low end contract
 	if contractsAllowed > 0 then
-		local signedContracts = TaskAdAgency.GetAllAdContracts()
 		local lowAudience = self.lowAudienceFactor * self.maxAudience
 		local lowUnsent = 0
 		for key, contract in pairs(signedContracts) do

--- a/res/ai/DefaultAIPlayer/TaskNewsAgency.lua
+++ b/res/ai/DefaultAIPlayer/TaskNewsAgency.lua
@@ -117,13 +117,13 @@ function TaskNewsAgency:BeforeBudgetSetup()
 	local player = _G["globalPlayer"]
 
 	if player.NewsPriority > 7 then
-		self.BudgetWeight = 5
-	elseif player.NewsPriority >= 6 then
 		self.BudgetWeight = 4
-	elseif player.NewsPriority >= 5 then
+	elseif player.NewsPriority >= 6 then
 		self.BudgetWeight = 3
-	else
+	elseif player.NewsPriority >= 5 then
 		self.BudgetWeight = 2
+	else
+		self.BudgetWeight = 1
 	end
 
 	-- MODIFIERS

--- a/res/ai/DefaultAIPlayer/TaskStationMap.lua
+++ b/res/ai/DefaultAIPlayer/TaskStationMap.lua
@@ -76,35 +76,23 @@ function TaskStationMap:BeforeBudgetSetup()
 	end
 	local totalReach = player.totalReach
 
-	--TODO cleanup - no investmentPriority anymore
 	if movieCount < 12 and  (totalReach == nil or totalReach > 850000) then
-		self.InvestmentPriority = 0
+		self.BudgetWeight = 0
 	elseif (movieCount < 24) and (totalReach == nil or totalReach > 1300000) then
-		self.InvestmentPriority = 4
+		self.BudgetWeight = 4
 	else
-		self.InvestmentPriority = 8
+		self.BudgetWeight = 8
 	end
 
-	if self.InvestmentPriority == 0 then
-		self.BudgetWeight = 0
-	else
-		self.BudgetWeight = 4
-		if totalReach == nil then
-			--should not happen
-		elseif totalReach < 2000000 then
+	if self.BudgetWeight > 0 and totalReach ~= nil then
+		if totalReach < 2000000 then
 			self.BudgetWeight = 8
-		--elseif movieCount < 30 and totalReach > 4400000 and totalReach < 5000000 then
-		--	self.BudgetWeight = 0
 		end
 	end
 end
 
 
 function TaskStationMap:BudgetSetup()
-	if self.UseInvestment then
-		self:LogInfo("+++ Investition in TaskStationMap!")
-		self.SituationPriority = 15
-	end
 end
 
 

--- a/res/ai/DefaultAIPlayer/TaskStationMap.lua
+++ b/res/ai/DefaultAIPlayer/TaskStationMap.lua
@@ -174,7 +174,7 @@ function JobAnalyseStationMarket:Tick()
 		self.Task.maxReachIncrease = 99000000
 	end
 
-	if TVT.of_getStationCount(TVT.ME) < 30 and (self.Task.intendedAntennaPositions == nil or table.count(self.Task.intendedAntennaPositions) == 0) then
+	if player.totalReach < 60000000 and (self.Task.intendedAntennaPositions == nil or table.count(self.Task.intendedAntennaPositions) == 0) then
 		self:determineIntendedPositions()
 	end
 

--- a/source/game.stationmap.bmx
+++ b/source/game.stationmap.bmx
@@ -3410,7 +3410,7 @@ End Type
 
 
 Type TStationAntenna Extends TStationBase {_exposeToLua="selected"}
-	Field radius:Int = 0
+	Field radius:Int = 0 {_exposeToLua="readonly"}
 
 
 	Method New()


### PR DESCRIPTION
Der Budgetmanager kümmert sich nicht mehr um die Investitionsstrategie.
Antennenpositionen werden nicht mehr zufällig ermittelt, um Überlappungen (und damit Fixkosten) zu vermeiden.