### PR TITLE
weitere KI-Verbesserungen

### DIFF
--- a/res/ai/DefaultAIPlayer/TaskAdAgency.lua
+++ b/res/ai/DefaultAIPlayer/TaskAdAgency.lua
@@ -48,7 +48,7 @@ end
 
 
 function TaskAdAgency:GetNextJobInTargetRoom()
-	if (MY.GetProgrammeCollection().GetAdContractCount() >= 8) then
+	if (MY.GetProgrammeCollection().GetAdContractCount() >= TVT.Rules.adContractsPerPlayerMax-1) then
 		self:SetDone()
 		return nil
 	elseif (self.CheckSpots.Status ~= JOB_STATUS_DONE) then

--- a/res/ai/DefaultAIPlayer/TaskArchive.lua
+++ b/res/ai/DefaultAIPlayer/TaskArchive.lua
@@ -88,7 +88,7 @@ function JobSellMovies:Tick()
 		t.planned = licence.isPlanned()
 		t.price = licence.GetPrice(TVT.ME)
 		t.quality = licence.GetQualityRaw() * licence.GetMaxTopicality()
-		t.timesRun = licence:GetTimesBroadcasted(-1)
+		t.timesRun = licence:GetTimesBroadcasted(TVT.ME)
 		t.licence = licence
 		return t;
 	end
@@ -112,13 +112,13 @@ function JobSellMovies:Tick()
 
 	--TODO sell worst movies based on current antenna reach
 	local reach = self.Task.Player.totalReach
-	local minLicenceCount = 40
+	local minLicenceCount = 35
 	if reach == nil then
 		-- should not happen
 	elseif reach < 2300000 then
-		minLicenceCount = 22
+		minLicenceCount = 20
 	elseif reach < 4700000 then
-		minLicenceCount = 30
+		minLicenceCount = 25
 	end
 
 	--check if licence with minimum quality should sold
@@ -130,7 +130,8 @@ function JobSellMovies:Tick()
 		local worstLicence= table.first(movies)
 		self:LogDebug("worst licence ".. worstLicence.Title .."; loss: "..worstLicence.TopicalityLoss .." planned "..worstLicence.planned )
 		--if worstLicence.TopicalityLoss == 0 and worstLicence.planned <=0 then
-		if worstLicence.planned <= 0 and worstLicence.timesRun >= 7 then
+		--if worstLicence.planned <= 0 and worstLicence.timesRun >= 7 then
+		if worstLicence.timesRun >= 7 then
 			self:LogInfo("mark worst licence for suitcase (selling): "..worstLicence.Title)
 			table.insert(case, worstLicence)
 			table.removeElement(movies, worstLicence)
@@ -149,9 +150,8 @@ function JobSellMovies:Tick()
 		local sellIt = false
 		-- sell when topicality will never raise enough again ("burned")
 		if v.MaxTopicalityLoss > useMaxTopicalityLossTreshold then sellIt = true end
-		-- sell when broadcasted too much and "maxtopicalityloss" wont
-		-- change that much anymore
-		if not sellIt and v.licence.GetMaxTopicality() < 0.2 and v.licence.GetTimesBroadcasted(TVT.ME) > 15 then sellIt = true end
+		-- sell when broadcasted too often
+		if not sellIt and v.licence.GetTimesBroadcasted(TVT.ME) > 15 then sellIt = true end
 
 		-- keep when planned
 		if sellIt and v.planned > 0 then sellIt = false end

--- a/res/ai/DefaultAIPlayer/TaskMovieDistributor.lua
+++ b/res/ai/DefaultAIPlayer/TaskMovieDistributor.lua
@@ -73,6 +73,9 @@ function TaskMovieDistributor:Activate()
 
 	self.BuyMovies = JobBuyMovies()
 	self.BuyMovies.Task = self
+	if startMovies > 2 then
+		self.BuyMovies.Status = JOB_STATUS_DONE
+	end
 
 	self.BidAuctions = JobBidAuctions()
 	self.BidAuctions.Task = self
@@ -237,9 +240,9 @@ function JobBuyStartProgramme:Tick()
 	for k,v in pairs(movies) do
 		--avoid the absolute trash :-)
 		if (v:GetQuality() >= 0.10 and v:GetPrice(TVT.ME) <= startMovieBudgetMax) then
-			--no call-in in start programme
-			if (v:isPaid() > 0) then
-				self:LogTrace("IGNORING PAID PROGRAMME "..v:getTitle())
+			--prevent other problematic start programmes: call-in, horror, too old
+			if (v:isPaid() > 0 or v:getTopicality() < 0.4 or v:GetGenre() == TVT.Constants.ProgrammeGenre.Horror) then
+				self:LogTrace("IGNORING PROGRAMME "..v:getTitle())
 			else
 				table.insert(goodMovies, v)
 			end
@@ -698,6 +701,9 @@ function JobBuyMovies:shouldBuyMovie(movie)
 			return 0
 		end
 		if genre == TVT.Constants.ProgrammeGenre.SciFi and math.random(0,100) > 25 then
+			return 0
+		end
+		if genre == TVT.Constants.ProgrammeGenre.Animation and math.random(0,100) > 25 then
 			return 0
 		end
 		return 1

--- a/res/ai/DefaultAIPlayer/TaskSchedule.lua
+++ b/res/ai/DefaultAIPlayer/TaskSchedule.lua
@@ -326,7 +326,13 @@ function TaskSchedule:GetGuessedAudienceRiskyness(day, hour, broadcast, block)
     c.guessedAudienceAccuracyHourly = {}
     c.guessedAudienceAccuracyHourlyCount = {}
 ]]
-	return 0.90
+	if hour > 0 and hour < 18 then
+		return 1.4
+	elseif hour > 18 then
+		return 0.90
+	else 
+		return 1.0
+	end
 end
 
 
@@ -1917,8 +1923,8 @@ function JobAdSchedule:FillSlot(day, hour, guessedAudience)
 		-- an ad, better place a trailer
 		-- replace "minAudience=0"-spots with trailers!
 		if (newAudienceCoverage > replaceBadAdsWithTrailerRate) then
-			-- only different spots - and when audience requirement is at better
-			if (newAdContract ~= oldAdContract and audienceCoverageIncrease > 0) then
+			-- only different spots - and when audience requirement is at better or it should be finished today
+			if (newAdContract ~= oldAdContract and (audienceCoverageIncrease > 0 or newAdContract.GetDaysLeft(-1) == 0)) then
 				chosenBroadcastSource = newAdContract
 				if currentAdFails then
 					chosenBroadcastLog = "Set ad (avoid failing ad): " .. fixedDay .. "/" .. string.format("%02d", fixedHour) .. ":55  " .. newAdContract.GetTitle() .. " [" .. newAdContract.GetID() .."]  MinAud=" .. newAdContract.GetMinAudience(TVT.ME) .. " (old=" .. oldMinAudience .. ")  guessedAud="..math.floor(guessedAudience.GetTotalValue(newAdContract.GetLimitedToTargetGroup()))


### PR DESCRIPTION
* Faktor für geratene Zuschauerzahl (ein erhöhtes Risiko für frühe Stunden ist nicht so kritisch, meist ist "schlechtere" Werbung ohnehin noch da, auf diese Weise wird aber auch bessere geholt)
* weniger Attraktivität für oft gesendete Programme
* mehr schlechte Lizenzen verkaufen
* weniger Animation (oft Kinderprogramm) zur Primetime
* Werbung, die am selben Tag fertig werden muss nicht von der Berücksichtigung ausschließen