### PR TITLE
Filmpreis nach Auktion und Reichweitelevelerhöhung

### DIFF
--- a/source/game.roomhandler.movieagency.bmx
+++ b/source/game.roomhandler.movieagency.bmx
@@ -1603,6 +1603,7 @@ Type TAuctionProgrammeBlocks Extends TGameObject {_exposeToLua="selected"}
 			'modify licences new price until a new auction of this licence
 			'might reset it
 			licence.SetModifier("auctionPrice", Float(bestBid) / licence.GetPriceForPlayer(bestBidder, bestBidderLevel))
+			licence.SetLicencedAudienceReachLevel(bestBidderLevel)
 
 			?debug
 			Print "modifier auctionPrice=" + Float(bestBid) / licence.GetPriceForPlayer(bestBidder, bestBidderLevel)


### PR DESCRIPTION
Die Reichweite bei einer gewonnenen Auktion muss persistiert werden, damit bei gleichzeitiger Reichweiteerhöhung kein (nur wenig) Gewinn gemacht werden kann.
Der Verkaufspreis wird nicht identisch dem Kaufpreis sein (andere Rundung).

closes #612 