### PR TITLE
KI Aufräumarbeiten

### DIFF
--- a/res/ai/DefaultAIPlayer/BudgetManager.lua
+++ b/res/ai/DefaultAIPlayer/BudgetManager.lua
@@ -44,7 +44,7 @@ function BudgetManager:CalculateNewDayBudget()
 
 	self.IgnoreMoneyChange = true
 	self.CurrentLogLevel = LOG_INFO
-	local money = TVT.GetMoney()
+	local money = getPlayer().money
 	self:Log("=== Budget day " .. (TVT.GetDaysRun() + 1) .. " ===")
 	self:Log(string.left("Account balance:", 25, true) .. string.right(money, 10, true))
 
@@ -157,7 +157,6 @@ function BudgetManager:OnMoneyChanged(value, reason, reference)
 	if self.IgnoreMoneyChange == true then return end
 
 	reason = tonumber(reason)
-	value = tonumber(value)
 	self.CurrentLogLevel=LOG_DEBUG
 
 	if (reference ~= nil) then
@@ -177,7 +176,7 @@ function BudgetManager:OnMoneyChanged(value, reason, reference)
 
 
 	if renewBudget == true then
-		local budgetNow = TVT.GetMoney()
+		local budgetNow = getPlayer().money
 
 		--update budget when at least 15.000 Euro difference since last
 		--adjustment

--- a/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
+++ b/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
@@ -108,6 +108,7 @@ function DefaultAIPlayer:initParameters()
 		self.gameDay = TVT:GetDaysRun() + 1
 		self.minutesGone = TVT:GetTimeGoneInMinutes()
 	end
+	self.money = TVT:GetMoney()
 
 	if (self.Ventruesome == nil or self.Ventruesome <= 0) then
 		--Waghalsigkeit 3-8
@@ -250,6 +251,8 @@ end
 
 
 function DefaultAIPlayer:OnDayBegins()
+	--ensure money value is correct for all onDayBegins-calls
+	self.money = TVT:GetMoney()
 	--just in case we missed a "OnGameBegins"
 	self.Strategy:Start(self)
 
@@ -285,6 +288,15 @@ end
 
 
 function DefaultAIPlayer:OnMoneyChanged(value, reason, reference)
+	value = tonumber(value)
+	--onDayBegins synchronizes the money for all onDayBegins-Events
+	--ensure that fixed-costs events do not change the already synchronized value
+	if self.hour == 0 and self.minute < 10 then
+		self.money = TVT:GetMoney()
+	else
+		self.money = self.money + value
+	end
+	--self:LogDebug("player money changed: " ..value .. " money " .. self.money .. " TVTmoney " .. TVT:GetMoney())
 	self.Budget:OnMoneyChanged(value, reason, reference)
 	for k,v in pairs(self.TaskList) do
 		v:OnMoneyChanged(value, reason, reference)
@@ -788,6 +800,7 @@ function OnLoadState(data)
 	player.minute = TVT:GetDayMinute()
 	player.gameDay = TVT:GetDaysRun() + 1
 	player.minutesGone = TVT:GetTimeGoneInMinutes()
+	player.money = TVT:GetMoney()
 end
 
 -- called when "saving" a game

--- a/res/ai/DefaultAIPlayer/TaskBoss.lua
+++ b/res/ai/DefaultAIPlayer/TaskBoss.lua
@@ -42,7 +42,7 @@ function TaskBoss:BeforeBudgetSetup()
 	self:CalculateFixedCosts()
 	self.InvestmentPriority = 0
 
-	local money = TVT.GetMoney()
+	local money = getPlayer().money
 	local credit = MY.GetCredit(-1)
 	if (money - credit) > 350000 then
 		if credit > 100000 then
@@ -98,7 +98,7 @@ end
 
 
 function JobCheckCredit:Prepare(pParams)
-	local money = TVT.GetMoney()
+	local money = getPlayer().money
 	local creditAvailable = TVT.bo_getCreditAvailable()
 	if money < 0 then
 		-- ATTENTION: money might change until "tick()", we could handle

--- a/res/ai/DefaultAIPlayer/TaskMovieDistributor.lua
+++ b/res/ai/DefaultAIPlayer/TaskMovieDistributor.lua
@@ -138,7 +138,7 @@ function TaskMovieDistributor:getStrategicPriority()
 	self:LogTrace("TaskMovieDistributor:getStrategicPriority")
 
 	-- no money to buy things? skip even looking...
-	if TVT.getMoney() <= 50000 then
+	if getPlayer().money <= 50000 then
 		return 0.0
 	end
 	return 1.0

--- a/res/ai/DefaultAIPlayer/TaskNewsAgency.lua
+++ b/res/ai/DefaultAIPlayer/TaskNewsAgency.lua
@@ -148,7 +148,7 @@ end
 
 
 function TaskNewsAgency:BudgetMaximum()
-	local money = TVT.GetMoney()
+	local money = getPlayer().money
 	if money <= 500000 then
 		return math.max(50000, math.floor(money / 10))
 	elseif money < 1000000 then
@@ -364,7 +364,7 @@ function JobNewsAgency:Tick()
 
 	if self.Task.CurrentBudget < 0 then
 		local player = getPlayer()
-		if player.Budget.CurrentFixedCosts > 120000 and TVT.GetMoney() > 150000 then
+		if player.Budget.CurrentFixedCosts > 120000 and player.money > 150000 then
 			--TODO with high fixed costs often there is a negative budget although there is money
 			self:LogDebug("raised news budget because there is money")
 			self.Task.CurrentBudget = 50000

--- a/res/ai/DefaultAIPlayer/TaskSchedule.lua
+++ b/res/ai/DefaultAIPlayer/TaskSchedule.lua
@@ -1326,7 +1326,7 @@ function JobAnalyzeEnvironment:Tick()
 			-- we need money - if needed, use all we have (only keep some money
 			-- for news
 			-- 0 - 400.000
-			local budget = math.min(math.max(0, TVT.getMoney() - 5000), 400000)
+			local budget = math.min(math.max(0, Player.money - 5000), 400000)
 
 			if budget > 0 then
 				-- remove old "topicality count" requisition

--- a/res/ai/DefaultAIPlayer/TaskStationMap.lua
+++ b/res/ai/DefaultAIPlayer/TaskStationMap.lua
@@ -403,7 +403,7 @@ function JobBuyStation:Prepare(pParams)
 	local ignoreBudgetChance = 100 - (8-player.ExpansionPriority)*math.min(TVT.of_getStationCount(TVT.ME)-1,10)
 	self:LogTrace("  ignoreBudgetChance: " ..ignoreBudgetChance)
 
-	local moneyExcludingFixedCosts = TVT.GetMoney() - player.Budget.CurrentFixedCosts
+	local moneyExcludingFixedCosts = player.money - player.Budget.CurrentFixedCosts
 	--TODO make constant player character dependent
 	if self.Task.CurrentBudget > 0 and moneyExcludingFixedCosts > 350000 and math.random(0,100) < ignoreBudgetChance then
 		--self.Task.CurrentBudget = (0.4 + 0.06*player.ExpansionPriority) * moneyExcludingFixedCosts


### PR DESCRIPTION
* Player per Funktion verfügbar machen
* Zeit über Player verfügbar - seltener API-Aufrufen
* Raumverlassen nicht loggen
* Funktion im Task "wieviele Minuten seit letzter Ausführung"

Die Taskfunktion wollte ich dafür nutzen, den Roomboard-Task "abzubrechen" wenn man er nicht zu lange zurückliegt. Ich würde das aber ungern beim Überschreiben des getSituationPriority machen, da das ziemlich oft aufgerufen wird. Mir schwebte vor im Task.activate zu prüfen, ob vielleicht doch keine Ausführung nötig ist (setCancel()). Aber das Abbrechen geht schief - denn der "goToRoom"-Job wird immer ausgeführt.
Auch bei externen Abbrüchen, sollte man nicht erst zum falschen Raum gehen, bevor der Abbruch wirklich stattfindet.