### PR TITLE
KI-Verbesserung

### DIFF
--- a/res/ai/DefaultAIPlayer/TaskMovieDistributor.lua
+++ b/res/ai/DefaultAIPlayer/TaskMovieDistributor.lua
@@ -757,19 +757,19 @@ function JobBidAuctions:Tick()
 			self:LogDebug("auction: " .. v:GetTitle() .."   price=" .. price .."  nextBid=" .. nextBid .. "  currentBidder=" .. currentBidder)
 
 			if currentBidder ~= TVT.ME then
-
-				if (price <= self.Task.CurrentBudget) then
+				--TODO maybe pay higher price if you really want a licence
+				if (nextBid <= self.Task.CurrentBudget and nextBid <= price) then
 					-- daily budget for good offers without direct need
-					if (price <= self.Task.CurrentBargainBudget) then
+					if (nextBid <= self.Task.CurrentBargainBudget) then
 						--TODO genre bias analogous to movies
 						if (v:GetAttractiveness() > 1) then
 							self:LogInfo("[Licence auction] placing bet for: " .. v:GetTitle() .. " (id=" .. v:GetId() .. ", price=" .. price ..", attractivity=" .. v:GetAttractiveness() .. ", quality=" ..v:GetQuality() ..")")
 							TVT.md_doBidAuctionProgrammeLicence(v:GetId())
 
-							self.Task:PayFromBudget(v:GetPrice(TVT.ME))
-							self.Task.CurrentBargainBudget = self.Task.CurrentBargainBudget - v:GetPrice(TVT.ME)
+							self.Task:PayFromBudget(nextBid)
+							self.Task.CurrentBargainBudget = self.Task.CurrentBargainBudget - nextBid
 						else
-							self:LogDebug("[Licence auction] too low attractivity: " .. v:GetTitle() .. " (" .. v:GetId() .. ") - Price: " .. v:GetPrice(TVT.ME) .." - Attractivity: " .. v:GetAttractiveness())
+							self:LogDebug("[Licence auction] too low attractivity: " .. v:GetTitle() .. " (" .. v:GetId() .. ") - Price: " .. nextBid .." - Attractivity: " .. v:GetAttractiveness())
 						end
 					end
 				end

--- a/res/ai/DefaultAIPlayer/TaskNewsAgency.lua
+++ b/res/ai/DefaultAIPlayer/TaskNewsAgency.lua
@@ -277,6 +277,14 @@ function JobNewsAgencyAbonnements:Tick()
 		end
 	end
 
+	local player = getPlayer()
+	--TODO raise on day before award?; randomize
+	if player.currentAwardType == TVT.Constants.AwardType.CULTURE then
+		if newSubscriptionLevels[TVT.Constants.NewsGenre.CULTURE] == 0 then
+			newSubscriptionLevels[TVT.Constants.NewsGenre.CULTURE] = 1
+		end
+	end
+
 	local preventDowngrade = false
 	local player = getPlayer()
 	if player.Budget.CurrentFixedCosts > 300000 or oldFees < 40000 then
@@ -441,12 +449,20 @@ function JobNewsAgency:GetNewsList(paidBonus)
 		table.insert(currentNewsList, news)
 	end
 
+	local cultureAward = 0
+	if getPlayer().currentAwardType == TVT.Constants.AwardType.CULTURE then
+		cultureAward = 1
+	end 
 
 	-- sort by attractivity modifed by paid-state-bonus
 	-- precache complex weight calculation
 	local weights = {}
 	for k,v in pairs(currentNewsList) do
-		weights[ v.GetID() ] = v.GetAttractiveness() * (1.0 + v.IsPaid() * paidBonus)
+		local weight = v.GetAttractiveness() * (1.0 + v.IsPaid() * paidBonus)
+		if cultureAward == 1 and v.GetGenre() == TVT.Constants.NewsGenre.CULTURE then
+			weight = weight * 3
+		end
+		weights[ v.GetID() ] = weight
 	end
 
 	-- sort


### PR DESCRIPTION
* Aufteilung des Restbudgets, wenn ein Task Tagesmaximum hat
* bei Auktionen sollte das Gebot und nicht der eigentliche Preis herangezogen werden
* mehrfache Senderkäufe ermöglichen, wenn das Restbudget groß genug ist
* mit der angepassten Stationsauswahl kann die Auswahl attraktiver Sender vereinfacht werden
* Beim Kultur-Sammy Kulturnachrichten senden (alle mit derselben Prio, da sonst die mit gewürfelt höherer Nachrichtenprio bevorteilt werden)