### PR TITLE
Kabel statt Antenne bei zu geringer Zuschauerzahl

### DIFF
--- a/source/game.game.bmx
+++ b/source/game.game.bmx
@@ -801,6 +801,18 @@ Type TGame Extends TGameBase {_exposeToLua="selected"}
 		'add new station
 		Local s:TStationBase = New TStationAntenna.Init( 310, 260, -1, playerID )
 		TStationAntenna(s).radius = GetStationMapCollection().antennaStationRadius
+		If s.getReach() < GameRules.stationInitialIntendedReach
+			For Local cableIndex:Int = 0 To GetStationMapCollection().GetSectionCount() - 1
+				Local cable:TStationBase = map.GetTemporaryCableNetworkUplinkStation(cableIndex)
+				If cable
+					If cable.getReach() >= GameRules.stationInitialIntendedReach and cable.GetProvider().isLaunched()
+						If TStationAntenna(s) or cable.getReach() < s.getReach()
+							s = cable
+						EndIf
+					EndIf
+				EndIf
+			Next
+		EndIf
 		'first station is not sellable (this enforces competition)
 		s.SetFlag(TVTStationFlag.SELLABLE, False)
 		'mark it as being gifted (by your boss or so)
@@ -812,6 +824,10 @@ Type TGame Extends TGameBase {_exposeToLua="selected"}
 		Local section:TStationMapSection = GetStationMapCollection().GetSectionByName(s.GetSectionName())
 		If section Then section.SetBroadcastPermission(playerID, True, 0)
 
+		If TStationCableNetworkUplink(s)
+			s.SetFlag(TVTStationFlag.AUTO_RENEW_PROVIDER_CONTRACT,True)
+			s.GetProvider().minimumChannelImage = 0
+		EndIf
 		map.AddStation( s, False )
 
 

--- a/source/game.stationmap.bmx
+++ b/source/game.stationmap.bmx
@@ -1015,6 +1015,10 @@ Type TStationMapCollection
 					Exit
 				EndIf
 			Next
+			If station.getReach(True) < GameRules.stationInitialIntendedReach
+				'player will get cable, reduce station radius
+				antennaStationRadius = 60
+			EndIf
 		EndIf
 
 		Return True
@@ -1598,6 +1602,8 @@ Type TStationMapCollection
 			'add federal state name for cable providers etc (else this
 			'is only appended when using GetName() instead of ".name"
 			cableNetwork.name = cableNetwork.GetName()
+			'update immediately, otherwise the network is not launched for the first player
+			cableNetwork.Update()
 		Next
 
 		Return True
@@ -5843,7 +5849,7 @@ Type TStationMap_CableNetwork Extends TStationMap_BroadcastProvider {_exposeToLu
 		If Not Super.Launch() Then Return False
 
 		GetStationMapCollection().OnLaunchCableNetwork(Self)
-		TLogger.Log("CableNetwork.Launch", "Launching cable network ~q"+GetName()+"~q. Reach: " + GetReach() +"  Date: " + GetWorldTime().GetFormattedGameDate(launchTime), LOG_DEBUG)
+		TLogger.Log("CableNetwork.Launch", "Launching cable network ~q"+GetName()+"~q. Date: " + GetWorldTime().GetFormattedGameDate(launchTime), LOG_DEBUG)
 
 		Return True
 	End Method


### PR DESCRIPTION
Wenn die Reichweite der Startantenne zu klein ist, sollte ein kleiner Kabelvertrag verwendet werden. Beim aktuellen DEV-Parameter von 950000 Zuschauern ist das im Startjahr 2000 der Fall.

Zum aktuellen Zeitpunkt bin ich mir nicht mehr sicher, ob man die Startreichweite für die Schwierigkeitsgrade unterscheiden sollte. Es sollte eigentlich ausreichen, die Preise etc. zu variieren. Da die Werbeeinnahmen im direkten Verhältnis zur Reichweite stehen, wäre es ziemlich aufwändig hier eine gute Balance zu finden (unterschiedliche Startreichweite impliziert ggf. unterschiedliche Antennenradien, die das gesamte Spiel über bestehen bleiben).
Ich denke, auch mit der gleichen Startzuschauerzahl gibt es genügend Stellschrauben, unterschiedliche Level zu erreichen und die Initialreichweite kann in der DEV.xml global für alle Spieler bleiben.

Der PR ist erstmal nur ein Draft, da die KI noch angepasst werden muss (wo würden Antennen hingebaut werden - ohne Startantenne funktioniert der Bestandscode noch nicht).