### PR TITLE
KI-Spiel - keine Geschwindigkeitsänderung nach dem Speichern

### DIFF
--- a/source/gamefunctions_debug.bmx
+++ b/source/gamefunctions_debug.bmx
@@ -191,11 +191,10 @@ Type TDebugScreen
 		EndIf
 		'continuous fast forward: save game and go to the end of the next day
 		If FastForward_Continuous_Active and FastForward_TargetTime < GetWorldTime().GetTimeGone()
-			GetGame().SetGameSpeed(0)
 			Local savegameName:String = "savegames/AI-day-" + StringHelper.RSetChar((GetWorldTime().GetDaysRun() + 1),2,"0")+ ".xml"
 			TSaveGame.Save(savegameName)
 			FastForward_TargetTime = GetWorldTime().CalcTime_DaysFromNowAtHour(-1,1,1,23,23) + 56*TWorldTime.MINUTELENGTH
-			GetGame().SetGameSpeed(FastForwardSpeed)
+			'GetGame().SetGameSpeed(FastForwardSpeed)
 		EndIf
 		
 		


### PR DESCRIPTION
Ursprünglich wurde beim KI-Spiel das Tempo auf 0 gesetzt und nach dem Speichern wieder auf den Standardwert, da es zu gelegentlich zu Abstürzen beim Speichern kam. Das soll eigentlich nicht (mehr) vorkommen. Insofern können diese beiden Geschwindigkeitsanpassungen entfallen.
Vorteil ist auch, dass man während des KI-Spiels die Geschwindigeit anpassen kann und dann dauerhaft mit dieser weitergespielt wird.