### PR TITLE
[KI] Performanceverbesserungen

### DIFF
--- a/res/ai/DefaultAIPlayer/BudgetManager.lua
+++ b/res/ai/DefaultAIPlayer/BudgetManager.lua
@@ -62,7 +62,7 @@ function BudgetManager:UpdateBudget(money)
 	if bossTask ~= nil and bossTask.GuessCreditAvailable > 0 then
 		if money < 100000 then
 			bossTask.SituationPriority = 5
-		elseif money <= 0 then
+		elseif money <= 0 and player.hour > 5 then
 			bossTask.SituationPriority = 15
 		end
 	end
@@ -88,8 +88,11 @@ function BudgetManager:AllocateBudgetToTasks(money)
 	local allFixedCostsSavings = 0
 	for k,v in pairs(player.TaskList) do
 		budgetUnits = budgetUnits + v:getBudgetUnits()
-		self:Log(string.left(v:typename() .. " fix", 25, true) .. string.right(v:GetFixedCosts(), 10, true))
-		allFixedCostsSavings = allFixedCostsSavings + v:GetFixedCosts()
+		local taskFixCosts = v:GetFixedCosts()
+		if taskFixCosts > 0 then
+			self:Log(string.left(v:typename() .. " fix", 25, true) .. string.right(taskFixCosts, 10, true))
+		end
+		allFixedCostsSavings = allFixedCostsSavings + taskFixCosts
 	end
 	if budgetUnits == 0 then budgetUnits = 1 end
 

--- a/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
+++ b/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
@@ -532,10 +532,10 @@ function BusinessStats:AddMovie(licence)
 		if licence ~= nil then
 			if licence.IsSingle() == 1 then
 				self.MovieQualityAcceptable:AddValue( licence.GetQuality() )
-				self.MoviePricePerBlockAcceptable:AddValue(licence:GetPricePerBlock(TVT.ME))
+				self.MoviePricePerBlockAcceptable:AddValue(licence:GetPricePerBlock(TVT.ME, TVT.Constants.BroadcastMaterialType.PROGRAMME))
 			else
 				self.SeriesQualityAcceptable:AddValue( licence.GetQuality() )
-				self.SeriesPricePerBlockAcceptable:AddValue(licence:GetPricePerBlock(TVT.ME))
+				self.SeriesPricePerBlockAcceptable:AddValue(licence:GetPricePerBlock(TVT.ME, TVT.Constants.BroadcastMaterialType.PROGRAMME))
 			end
 		end
 	end

--- a/res/ai/DefaultAIPlayer/Strategy.lua
+++ b/res/ai/DefaultAIPlayer/Strategy.lua
@@ -4,9 +4,6 @@ _G["AIStrategy"] = class(KIDataObjekt, function(c)
 	KIDataObjekt.init(c)	-- must init base!
 --	c.TodayStartAccountBalance = 0 -- Kontostand zu Beginn des Tages
 
-	--amount to spend for start programme
-	c.startProgrammePriceMax = 90000
-	c.startProgrammeBudget = 300000
 	c.startProgrammeAmount = 4
 	c.initDone = false
 
@@ -50,10 +47,6 @@ end
 function DefaultStrategy:initialize()
 	if playerAI == nil then playerAI = _G["globalPlayer"] end
 
-	-- a risky player (Ventruesome = 10) will spend 30000 less for each
-	-- programme, a non-risky one up to 30000 more
-	self.startProgrammePriceMax = self.startProgrammePriceMax + 3000 * (5 - playerAI.Ventruesome)
-
 	if playerAI.Ventruesome > 7 then
 		self.startProgrammeAmount = 5
 	elseif playerAI.Ventruesome >= 5 then
@@ -61,8 +54,6 @@ function DefaultStrategy:initialize()
 	else
 		self.startProgrammeAmount = 7
 	end
-	self.startProgrammeBudget = self.startProgrammeAmount * self.startProgrammePriceMax + 8000 * (5 - playerAI.Ventruesome)
-	TVT.PrintOut(TVT.ME .. ": startProgramme=" .. self.startProgrammeAmount .. "  priceMax=" .. self.startProgrammePriceMax .. "  totalBudget=" .. self.startProgrammeBudget)
 
 	self.initDone = true
 end

--- a/res/ai/DefaultAIPlayer/TaskArchive.lua
+++ b/res/ai/DefaultAIPlayer/TaskArchive.lua
@@ -101,7 +101,7 @@ function JobSellMovies:Tick()
 	do
 		m = TVT.convertToProgrammeLicence(TVT.ar_GetProgrammeLicence(i).data)
 		--ignore episodes/collection-elements
-		if m ~= nil and m.HasParentLicence()==0 and m.isAvailable() then
+		if m ~= nil and m.HasParentLicence()==0 and m.isAvailable() == 1 then
 			vm = newarchivedMovie(m)
 			self:LogTrace("# found "..vm.Title.." (guid="..vm.GUID.."  id="..vm.Id..") ".." "..vm.price..",  TopicalityLoss="..string.format("%.4f", vm.TopicalityLoss*100).."% (Max="..string.format("%.2f", vm.MaxTopicalityLoss*100).."%), planned: "..tostring(vm.planned))
 			table.insert(movies,vm)
@@ -136,6 +136,9 @@ function JobSellMovies:Tick()
 			table.insert(case, worstLicence)
 			table.removeElement(movies, worstLicence)
 		end
+	else
+		--do not sell anything
+		movies = {}
 	end
 
 	-- check licences

--- a/res/ai/DefaultAIPlayer/TaskBoss.lua
+++ b/res/ai/DefaultAIPlayer/TaskBoss.lua
@@ -100,7 +100,8 @@ end
 function JobCheckCredit:Prepare(pParams)
 	local money = TVT.GetMoney()
 	local creditAvailable = TVT.bo_getCreditAvailable()
-	if money < 0 then
+	self.Task.TryToGetCredit = 0
+	if money < -30000 and getPlayer().hour > 5 then
 		-- ATTENTION: money might change until "tick()", we could handle
 		-- it but this behaviour seems more "natural" (to not see the
 		-- money change in time)
@@ -110,6 +111,10 @@ function JobCheckCredit:Prepare(pParams)
 	end
 	if self.Task.NeededInvestmentBudget > 0 then
 		self.Task.TryToRepayCredit = math.max(0, math.min(money, self.Task.NeededInvestmentBudget))
+	elseif MY.GetCredit(-1) == 0 and getPlayer().hour < 6 then
+		--TODO randomize? - stop if coverage is 90%
+		--get credit and increase chance for good investment
+		self.Task.TryToGetCredit = creditAvailable
 	end
 
 

--- a/res/ai/DefaultAIPlayer/TaskNewsAgency.lua
+++ b/res/ai/DefaultAIPlayer/TaskNewsAgency.lua
@@ -437,7 +437,9 @@ function JobNewsAgency:GetNewsList(paidBonus)
 	end
 	local allNews = response.DataArray()
 	for i, news in ipairs(allNews) do
-		table.insert(currentNewsList, news)
+		if news ~= nil then
+			table.insert(currentNewsList, news)
+		end
 	end
 
 	-- fetch news show news
@@ -449,7 +451,9 @@ function JobNewsAgency:GetNewsList(paidBonus)
 	-- "pairs", not "ipairs" as the result might contains empty slots
 	-- which "ipairs" does not like
 	for i, news in pairs(broadcastedNews) do
-		table.insert(currentNewsList, news)
+		if news ~= nil then
+			table.insert(currentNewsList, news)
+		end
 	end
 
 	local cultureAward = 0

--- a/res/ai/DefaultAIPlayer/TaskSchedule.lua
+++ b/res/ai/DefaultAIPlayer/TaskSchedule.lua
@@ -327,7 +327,7 @@ function TaskSchedule:GetGuessedAudienceRiskyness(day, hour, broadcast, block)
     c.guessedAudienceAccuracyHourlyCount = {}
 ]]
 	if hour > 0 and hour < 18 then
-		return 1.4
+		return 1.35
 	elseif hour > 18 then
 		return 0.90
 	else 
@@ -1992,7 +1992,7 @@ function JobAdSchedule:FillSlot(day, hour, guessedAudience)
 				-- nothing found: use a random one (if possible)
 				if TVT.of_getProgrammeLicenceCount() > 0 then
 					local choosenLicence = TVT.of_getProgrammeLicenceAtIndex( math.random(0, TVT.of_getProgrammeLicenceCount()-1) )
-					if choosenLicence.IsNewBroadcastPossible() then
+					if choosenLicence.IsNewBroadcastPossible() > 0 then
 						upcomingProgrammesLicences = { choosenLicence }
 					end
 				end
@@ -2132,8 +2132,8 @@ function JobProgrammeSchedule:Tick()
 			if self.plannedHours < planHours then
 				local fixedDay, fixedHour = FixDayAndHour(currentDay, currentHour + self.plannedHours)
 
-				-- skip current hour if already started
-				if fixedHour == currentHour and getPlayer().minute >= 5 then
+				-- skip current hour if already started or about to start
+				if fixedHour == currentHour and getPlayer().minute >= 4 then
 					--
 				-- skip if we cannot change this slot
 				elseif TVT.of_IsModifyableProgrammePlanSlot(TVT.Constants.BroadcastMaterialType.PROGRAMME, fixedDay, fixedHour) ~= TVT.RESULT_OK then
@@ -2247,7 +2247,8 @@ function JobProgrammeSchedule:FillSlot(day, hour)
 	local chosenBroadcastMaterial = nil
 	local chosenBroadcastLog = ""
 
-	local infomercialAllowed = getPlayer().gameDay <= 1
+	--TODO allow infomercials again if programme selection has been improved
+	local infomercialAllowed = false --getPlayer().gameDay <= 1
 	local programmeAllowed = true
 
 	local currentBroadcastMaterial = MY.GetProgrammePlan().GetProgramme(fixedDay, fixedHour)


### PR DESCRIPTION
* Senderausbau: Null-Prüfungen, höhere Reichweiteschwellen (schnellerer Ausbau bei sinkenden Zuschauerzahlen)
* Negativer Kontostand wird etwas später ausgeglichen (zwischenzeitliche Werbeeinnahmen)
* neuen Kredit aufnehmen, wenn alter abbezahlt (mehr Geld für Investitionen vorhanden)
* kein Lizenzverkauf, wenn zu wenige da sind
* Startprogrammanpassungen (keine globale Budgetbegrenzung, Preis pro Block statt Gesamtpreis), Startprogramm muss erst komplett sein, bevor normaler Lizenzkauf startet