### PR TITLE
Prüfung der Raumschilder beim Fahrstuhl

### DIFF
--- a/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
+++ b/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
@@ -46,6 +46,7 @@ dofile(scriptPath .. "TaskSchedule.lua")
 dofile(scriptPath .. "TaskStationMap.lua")
 dofile(scriptPath .. "TaskBoss.lua")
 dofile(scriptPath .. "TaskRoomBoard.lua")
+dofile(scriptPath .. "TaskCheckSigns.lua")
 dofile(scriptPath .. "TaskArchive.lua")
 if (unitTestMode) then
 	dofile(scriptPath .. "UnitTests.lua")
@@ -66,6 +67,7 @@ TASK_STATIONMAP			= "StationMap"
 TASK_BETTY				= "Betty"
 TASK_BOSS				= "Boss"
 TASK_ROOMBOARD			= "RoomBoard"
+TASK_CHECKSIGNS			= "CheckSigns"
 
 _G["TASK_MOVIEDISTRIBUTOR"] = TASK_MOVIEDISTRIBUTOR
 _G["TASK_NEWSAGENCY"] = TASK_NEWSAGENCY
@@ -76,6 +78,7 @@ _G["TASK_STATIONMAP"] = TASK_STATIONMAP
 _G["TASK_BETTY"] = TASK_BETTY
 _G["TASK_BOSS"] = TASK_BOSS
 _G["TASK_ROOMBOARD"] = TASK_ROOMBOARD
+_G["TASK_CHECKSIGNS"] = TASK_CHECKSIGNS
 
 -- >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 _G["DefaultAIPlayer"] = class(AIPlayer, function(c)
@@ -179,6 +182,10 @@ function DefaultAIPlayer:resume()
 		self.Strategy = DefaultStrategy()
 	end
 
+	if (self.TaskList[TASK_CHECKSIGNS] == nil) then
+		self.TaskList[TASK_CHECKSIGNS] = TaskCheckSigns()
+	end
+
 	self:initParameters()
 
 	self:CleanUp()
@@ -193,11 +200,9 @@ function DefaultAIPlayer:initializeTasks()
 	self.TaskList[TASK_STATIONMAP]			= TaskStationMap()
 	self.TaskList[TASK_BOSS]				= TaskBoss()
 	self.TaskList[TASK_ROOMBOARD]			= TaskRoomBoard()
+	self.TaskList[TASK_CHECKSIGNS]			= TaskCheckSigns()
 	self.TaskList[TASK_ARCHIVE]				= TaskArchive()
-
-
-	--self.TaskList[TASK_STATIONMAP].InvestmentPriority = 12
-	--self.TaskList[TASK_STATIONMAP].NeededInvestmentBudget = 10000
+	--when adding new tasks, they may have to be added in "resume" as well (save game compatibility)
 
 	--self.TaskList[TASK_BETTY]			= TVTBettyTask()
 

--- a/res/ai/DefaultAIPlayer/TaskCheckSigns.lua
+++ b/res/ai/DefaultAIPlayer/TaskCheckSigns.lua
@@ -1,0 +1,105 @@
+-- File: TaskCheckSigns
+-- >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+_G["TaskCheckSigns"] = class(AITask, function(c)
+	AITask.init(c)	-- must init base!
+	c.Id = _G["TASK_CHECKSIGNS"]
+	c.BudgetWeight = 0
+	c.BasePriority = 1
+	c.NeededInvestmentBudget = 0
+	c.InvestmentPriority = 0
+
+	--no budget to spare
+	c.RequiresBudgetHandling = false
+
+	c.terrorLevel = 0
+end)
+
+function TaskCheckSigns:typename()
+	return "TaskCheckSigns"
+end
+
+function TaskCheckSigns:Activate()
+	-- Was getan werden soll:
+	self.CheckRoomSignsJob = JobCheckRoomSigns()
+	self.CheckRoomSignsJob.Task = self
+	self.TargetRoom = -1
+	--determine target id on every task execution (current floor elevator)
+	self.TargetID = TVT:getTargetID("elevatorplan", -1, TVT:getFigureFloor(), 0)
+
+	--self.LogLevel = LOG_TRACE
+end
+
+function TaskCheckSigns:GetNextJobInTargetRoom()
+	if (self.CheckRoomSignsJob.Status ~= JOB_STATUS_DONE) then
+		return self.CheckRoomSignsJob
+	end
+
+--	self:SetWait()
+	self:SetDone()
+end
+
+function TaskCheckSigns:getSituationPriority()
+	if self.terrorLevel >= 2 then
+		self.SituationPriority = math.max(self.SituationPriority, self.terrorLevel)
+	end
+
+	return self.SituationPriority
+end
+
+-- >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+_G["JobCheckRoomSigns"] = class(AIJob, function(c)
+	AIJob.init(c)	-- must init base!
+	c.Task = nil
+end)
+
+function JobCheckRoomSigns:typename()
+	return "JobCheckRoomSigns"
+end
+
+function JobCheckRoomSigns:Prepare(pParams)
+
+end
+
+function JobCheckRoomSigns:Tick()
+	local scheduleRoomBoardTask = false
+	local forceChangeSigns = false
+	for index = 0, TVT.ep_GetSignCount() - 1, 1 do
+		local response = TVT.ep_GetSignAtIndex(index)
+		if response.result == TVT.RESULT_OK then
+			local sign = response.data
+			if (sign ~= nil and sign.GetOwner() == TVT.ME) then
+				--Noch am richtigen Platz?
+				if sign.IsAtOriginalPosition() == 0 then
+					scheduleRoomBoardTask = true
+					self:LogInfo("own room in danger - need to go to the room board")
+					break
+				end
+			end
+		end
+	end
+
+	--trigger changing enemy room signs
+	if scheduleRoomBoardTask == false and self.Task.terrorLevel >=3 then
+		if math.random(0,100) > 70 then
+			scheduleRoomBoardTask = true
+			forceChangeSigns = true
+		end
+	end
+
+	if scheduleRoomBoardTask == true then
+		local t = getPlayer().TaskList[_G["TASK_ROOMBOARD"]]
+		if t ~= nil then
+			t.SituationPriority = 20
+			t.forceChangeSigns = forceChangeSigns
+		else
+			self:LogError("did not find roomboard task")
+		end
+	end
+
+	-- handled the situation "for now"
+	self.Task.SituationPriority = 0
+	self.Task.terrorLevel = 0
+
+	self.Status = JOB_STATUS_DONE
+end
+-- <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<

--- a/res/ai/DefaultAIPlayer/TaskNewsAgency.lua
+++ b/res/ai/DefaultAIPlayer/TaskNewsAgency.lua
@@ -199,22 +199,25 @@ end
 function JobCheckEventNews:Tick()
 	local terrorLevel = TVT.ne_getTerroristAggressionLevel(-1)
 	local maxTerrorLevel = TVT.ne_getTerroristAggressionLevelMax()
+	local levelDiff = maxTerrorLevel - terrorLevel
 
+	local vrLevel = TVT.ne_getTerroristAggressionLevel(0)
+	local frLevel = TVT.ne_getTerroristAggressionLevel(1)
 
 	local player = getPlayer()
-	if player.TaskList[TASK_ROOMBOARD] ~= nil then
-		local roomBoardTask = player.TaskList[TASK_ROOMBOARD]
-		if terrorLevel >= 2 then
-			roomBoardTask.SituationPriority = terrorLevel * terrorLevel
-		end
+	local checkSignsTask = player.TaskList[TASK_CHECKSIGNS]
+	local roomBoardTask = player.TaskList[TASK_ROOMBOARD]
 
+	if checkSignsTask ~= nil then
+		checkSignsTask.terrorLevel = terrorLevel
+	end
+	if roomBoardTask ~= nil then
 		-- mark the situation of a soon happening attack
-		if terrorLevel > 2 then
+		if levelDiff < 2 then
 			roomBoardTask.RecognizedTerrorLevel = true
 		end
-
-		roomBoardTask.FRDubanTerrorLevel = TVT.ne_getTerroristAggressionLevel(0)
-		roomBoardTask.VRDubanTerrorLevel = TVT.ne_getTerroristAggressionLevel(1)
+		roomBoardTask.FRDubanTerrorLevel = vrLevel
+		roomBoardTask.VRDubanTerrorLevel = frLevel
 	end
 
 	self.Status = JOB_STATUS_DONE

--- a/source/game.ai.bmx
+++ b/source/game.ai.bmx
@@ -1848,6 +1848,25 @@ endrem
 		Return Self.RESULT_NOTFOUND
 	End Method
 
+	'=== ELEVATOR PLAN ===
+
+	Method ep_GetSignCount:Int()
+		If Not _PlayerInRoom("elevatorplan") Then Return Self.RESULT_WRONGROOM
+
+		Return GetRoomBoard().GetSignCount()
+	End Method
+
+
+	Method ep_GetSignAtIndex:TLuaFunctionResult(arrayIndex:Int = -1)
+		If Not _PlayerInRoom("elevatorplan") Then Return TLuaFunctionResult.Create(Self.RESULT_WRONGROOM, Null)
+
+		Local Sign:TRoomBoardSign = GetRoomBoard().GetSignAtIndex(arrayIndex)
+		If Sign
+			Return TLuaFunctionResult.Create(Self.RESULT_OK, Sign)
+		Else
+			Return TLuaFunctionResult.Create(Self.RESULT_NOTFOUND, Null)
+		EndIf
+	End Method
 
 
 	'=== ROOM BOARD ===

--- a/source/gamefunctions_debug.bmx
+++ b/source/gamefunctions_debug.bmx
@@ -347,8 +347,8 @@ Type TDebugScreen
 
 	'=== PLAYER COMMANDS ===
 	Method InitMode_PlayerCommands()
-		Local IDs:Int[]      = [0,           1,         2,      3,              4,             5,                    6,           7]
-		Local texts:String[] = ["Ad Agency", "Archive", "Boss", "Movie Agency", "News Studio", "Programme Schedule", "Roomboard", "Station Map"]
+		Local IDs:Int[]      = [0,           1,         2,      3,              4,             5,                    6,           7,           8]
+		Local texts:String[] = ["Ad Agency", "Archive", "Boss", "Movie Agency", "News Studio", "Programme Schedule", "CheckSigns","Roomboard", "Station Map"]
 		Local button:TDebugControlsButton
 		For Local i:Int = 0 Until texts.length
 			button = New TDebugControlsButton
@@ -399,8 +399,9 @@ Type TDebugScreen
 			Case 3	taskName = "MovieDistributor"
 			Case 4	taskName = "NewsAgency"
 			Case 5	taskName = "Schedule"
-			Case 6	taskName = "RoomBoard"
-			Case 7	taskName = "StationMap"
+			Case 6	taskName = "CheckSigns"
+			Case 7	taskName = "RoomBoard"
+			Case 8	taskName = "StationMap"
 		End Select
 
 		If taskName
@@ -418,8 +419,9 @@ Type TDebugScreen
 					Case 3	 room = GetRoomCollection().GetFirstByDetails("", "movieagency")
 					Case 4	 room = GetRoomCollection().GetFirstByDetails("", "news", playerID)
 					Case 5	 room = GetRoomCollection().GetFirstByDetails("", "office", playerID)
-					Case 6	 room = GetRoomCollection().GetFirstByDetails("", "roomboard", playerID)
-					Case 7	 room = GetRoomCollection().GetFirstByDetails("", "ofice", playerID)
+					Case 6	 room = GetRoomCollection().GetFirstByDetails("", "elevatorPlan", playerID)
+					Case 7	 room = GetRoomCollection().GetFirstByDetails("", "roomboard", playerID)
+					Case 8	 room = GetRoomCollection().GetFirstByDetails("", "ofice", playerID)
 				End Select
 				If room
 					Local door:TRoomDoorBase = GetRoomDoorCollection().GetMainDoorToRoom(room.id)


### PR DESCRIPTION
Statt immer zum Raumplan zu gehen zu müssen, um umgehängte Schilder zu erkennen, macht die KI das nun beim Fahrstuhl. Zum Raumplan wird nur gegangen, wenn für die eigenen Räume Gefahr besteht oder wenn Schilder der Gegner umgehängt werden sollen.