### PR TITLE
Preisänderung bei Reichweiteerhöhung

### DIFF
--- a/source/game.programme.programmelicence.bmx
+++ b/source/game.programme.programmelicence.bmx
@@ -1948,7 +1948,13 @@ Type TProgrammeLicence Extends TBroadcastMaterialSource {_exposeToLua="selected"
 
 
 	Method GetAudienceReachLevelPriceMod:Float(audienceReachLevel:int)
-		return (0.5*Max(1, audienceReachLevel))
+		'price modifier should grow slower; good movies are affordable even in higher levels
+		'0.5; 0.65; 0.85; 1.1; 
+		return (1.3 ^ Max(0, audienceReachLevel-1))/2
+
+		'0.5;    1;  1.5;   2;...
+		'return (0.5*Max(1, audienceReachLevel))
+		
 	End Method
 
 


### PR DESCRIPTION
Diese Änderung adressiert #572. Die Reichweitelevel bleiben in der aktuellen Form erhalten, aber die Lizenzpreise steigen nicht mehr linear an. Siehe auch Analyse in #630. Der langsamere Preisanstieg macht "gute" Lizenzen bei höheren Leveln nicht sofort wieder unattraktiv. Die Werbeeinnahmen steigen stärker als die Lizenzpreise, so dass man durch den Ausbau die Programmqualität verbessern kann (und nicht in niedrigem Level Lizenzen horten muss)