### PR TITLE
KI Eigenproduktionen

### DIFF
--- a/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
+++ b/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
@@ -48,6 +48,7 @@ dofile(scriptPath .. "TaskBoss.lua")
 dofile(scriptPath .. "TaskRoomBoard.lua")
 dofile(scriptPath .. "TaskCheckSigns.lua")
 dofile(scriptPath .. "TaskArchive.lua")
+dofile(scriptPath .. "TaskScripts.lua")
 if (unitTestMode) then
 	dofile(scriptPath .. "UnitTests.lua")
 end
@@ -68,6 +69,7 @@ TASK_BETTY				= "Betty"
 TASK_BOSS				= "Boss"
 TASK_ROOMBOARD			= "RoomBoard"
 TASK_CHECKSIGNS			= "CheckSigns"
+TASK_SCRIPTS			= "Scripts"
 
 _G["TASK_MOVIEDISTRIBUTOR"] = TASK_MOVIEDISTRIBUTOR
 _G["TASK_NEWSAGENCY"] = TASK_NEWSAGENCY
@@ -79,6 +81,7 @@ _G["TASK_BETTY"] = TASK_BETTY
 _G["TASK_BOSS"] = TASK_BOSS
 _G["TASK_ROOMBOARD"] = TASK_ROOMBOARD
 _G["TASK_CHECKSIGNS"] = TASK_CHECKSIGNS
+_G["TASK_SCRIPTS"] = TASK_SCRIPTS
 
 -- >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 _G["DefaultAIPlayer"] = class(AIPlayer, function(c)
@@ -185,6 +188,9 @@ function DefaultAIPlayer:resume()
 	if (self.TaskList[TASK_CHECKSIGNS] == nil) then
 		self.TaskList[TASK_CHECKSIGNS] = TaskCheckSigns()
 	end
+	if (self.TaskList[TASK_SCRIPTS] == nil) then
+		self.TaskList[TASK_SCRIPTS] = TaskScripts()
+	end
 
 	self:initParameters()
 
@@ -202,6 +208,7 @@ function DefaultAIPlayer:initializeTasks()
 	self.TaskList[TASK_ROOMBOARD]			= TaskRoomBoard()
 	self.TaskList[TASK_CHECKSIGNS]			= TaskCheckSigns()
 	self.TaskList[TASK_ARCHIVE]				= TaskArchive()
+	self.TaskList[TASK_SCRIPTS]				= TaskScripts()
 	--when adding new tasks, they may have to be added in "resume" as well (save game compatibility)
 
 	--self.TaskList[TASK_BETTY]			= TVTBettyTask()

--- a/res/ai/DefaultAIPlayer/TaskScripts.lua
+++ b/res/ai/DefaultAIPlayer/TaskScripts.lua
@@ -1,0 +1,306 @@
+-- ##### CONSTANTS #####
+PROD_STATUS_BUY              = "buy"
+PROD_STATUS_GET_CONCEPTS     = "concept" --also used for checking studio state - if scripts need to be purchased
+PROD_STATUS_SUPERMARKET      = "supermarket"
+PROD_STATUS_START_PRODUCTION = "produce"
+SAMMY_SIT_PRIORITY = 2
+
+--TODO buy and keep good scripts for Sammy
+
+-- File: TaskScripts
+-- >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+_G["TaskScripts"] = class(AITask, function(c)
+	AITask.init(c)	-- must init base!
+	c.Id = _G["TASK_SCRIPTS"]
+	c.BudgetWeight = 0
+	c.BasePriority = 0
+	c.PriorityBackup = c.BasePriority
+
+	--TODO true - buying and paying production
+	c.RequiresBudgetHandling = false
+	c.prodStatus = PROD_STATUS_GET_CONCEPTS --check state on activation
+	c.producedForSammy = false
+end)
+
+function TaskScripts:typename()
+	return "TaskScripts"
+end
+
+function TaskScripts:Activate()
+	self.JobBuyScript = JobBuyScript()
+	self.JobBuyScript.Task = self
+	self.JobGetConcepts = JobGetConcepts()
+	self.JobGetConcepts.Task = self
+	self.JobPlanProduction = JobPlanProduction()
+	self.JobPlanProduction.Task = self
+	self.JobStartProduction = JobStartProduction()
+	self.JobStartProduction.Task = self
+
+	--depending on state: buy script/bring to studio and get list/supermarket/start production
+	if self.prodStatus == PROD_STATUS_BUY then
+		self.TargetRoom = TVT.ROOM_SCRIPTAGENCY
+	elseif self.prodStatus == PROD_STATUS_GET_CONCEPTS then
+		self.TargetRoom = TVT.GetFirstRoomByDetails("studio", TVT.ME).id
+	elseif self.prodStatus == PROD_STATUS_SUPERMARKET then
+		self.TargetRoom = TVT.ROOM_SUPERMARKET
+	elseif self.prodStatus == PROD_STATUS_START_PRODUCTION then
+		self.TargetRoom = TVT.GetFirstRoomByDetails("studio", TVT.ME).id
+	end
+
+	--self.LogLevel = LOG_TRACE
+end
+
+function TaskScripts:GetNextJobInTargetRoom()
+	--depending on state: buy script/bring to studio and get list/supermarket/start production
+	if (self.prodStatus == PROD_STATUS_BUY and self.JobBuyScript.Status ~= JOB_STATUS_DONE) then
+		return self.JobBuyScript
+	elseif (self.prodStatus == PROD_STATUS_GET_CONCEPTS and self.JobGetConcepts.Status ~= JOB_STATUS_DONE) then
+		return self.JobGetConcepts
+	elseif (self.prodStatus == PROD_STATUS_SUPERMARKET and self.JobPlanProduction.Status ~= JOB_STATUS_DONE) then
+		return self.JobPlanProduction
+	elseif (self.prodStatus == PROD_STATUS_START_PRODUCTION and self.JobStartProduction.Status ~= JOB_STATUS_DONE) then
+		return self.JobStartProduction
+	else
+		self:LogInfo("  found nothing to do - status: " ..self.prodStatus)
+	end
+
+	self:SetDone()
+end
+
+function TaskScripts:getStrategicPriority()
+	if getPlayer().currentAwardType == TVT.Constants.AwardType.CUSTOMPRODUCTION then
+		if self.producedForSammy == false then
+			self.SituationPriority = SAMMY_SIT_PRIORITY
+			return 5.0
+		else
+			return 1.0
+		end
+	else
+		self.producedForSammy = false
+		return 1.0
+	end
+end
+
+-- >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+_G["JobBuyScript"] = class(AIJob, function(c)
+	AIJob.init(c)	-- must init base!
+	c.Task = nil
+end)
+
+function JobBuyScript:typename()
+	return "JobBuyScript"
+end
+
+function JobBuyScript:Prepare(pParams)
+	local player = getPlayer()
+	local stats = player.Stats.MovieQuality
+	self.scriptMaxPrice = 30000
+	self.minPotential = 0.25
+	self.minAttractivity = 0.25
+	self.maxJobCount = 4
+	if stats ~= nil then
+		if stats.Values > 25 then
+			self.Task.BasePriority = 0.15
+			self.scriptMaxPrice = 1300000
+			self.minPotential = 0.5
+			self.minAttractivity = 0.6
+		elseif stats.Values > 15 then
+			self.maxJobCount = 6
+			self.Task.BasePriority = 0.07
+			self.scriptMaxPrice = 100000
+			self.minPotential = 0.35
+			self.minAttractivity = 0.4
+		end
+	else
+		self.scriptMaxPrice = 0	
+	end
+	if self.Task.SituationPriority == SAMMY_SIT_PRIORITY then
+		self.minPotential = self.minPotential - 0.1
+		self.minAttractivity = self.minAttractivity - 0.1
+	end
+	self.scriptMaxPrice =  math.min(self.scriptMaxPrice, TVT:getMoney())
+	self:LogDebug("  maxPrice  ".. self.scriptMaxPrice .. " minPotential "..self.minPotential)
+end
+
+function JobBuyScript:Tick()
+	local response = TVT:da_getScripts()
+	if response.result == TVT.RESULT_OK then
+		local scripts = response.data
+		local count = scripts:Count()
+		
+		local scCopy = {}
+		for i=0, (count-1)
+		do
+			local script= scripts:ValueAtIndex(i)
+			if script ~= nil then
+				table.insert(scCopy, script)
+			end
+		end
+
+		local sortByAttractivity = function(a, b)
+			return self:getAttractivity(a) > self:getAttractivity(b)
+		end
+
+		table.sort(scCopy, sortByAttractivity)
+
+		for k,script in pairs(scCopy) do
+			if self:canBuy(script) == true then
+				self:LogInfo("  buying script ".. script:getTitle().." attractivity ".. self:getAttractivity(script))
+				TVT:da_buyScript(script)
+				--less idling for remaining jobs
+				self.Task.PriorityBackup = self.Task.BasePriority
+				self.Task.BasePriority = self.Task.BasePriority * 5
+				self.Task.prodStatus = PROD_STATUS_GET_CONCEPTS
+				break
+			end
+		end
+	end
+	self.Task:SetDone()
+	self.Status = JOB_STATUS_DONE
+end
+
+function JobBuyScript:getAttractivity(script)
+	local potential = script:GetPotential()
+	if potential < self.minPotential then
+		return -1
+	else
+		return (script:GetSpeed() + script:GetReview()) * potential
+	end
+end
+
+function JobBuyScript:canBuy(script)
+	--hard restrictions
+	if script.requiredStudioSize > 1 then
+		return false
+	elseif script:GetPrice() > self.scriptMaxPrice then
+		return false
+	elseif script:IsLive() == 1 then
+		return false
+	elseif TVT:da_getJobCount(script) > self.maxJobCount then
+		return false
+	elseif script:GetProductionLimit() > 1 then
+		return false
+	elseif script:IsSeries() == 1 then
+		if self.scriptMaxPrice > 100000 then
+			--not tested if check state fallback works for series with many episodes
+			if script:GetEpisodes() > 8 then
+				return false
+			end
+		else
+			return false
+		end
+	end
+
+	--less hard restrictions
+	if self:getAttractivity(script) < self.minAttractivity then
+		return false
+	end
+
+	return true
+end
+-- <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+-- >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+_G["JobGetConcepts"] = class(AIJob, function(c)
+	AIJob.init(c)	-- must init base!
+	c.Task = nil
+end)
+
+function JobGetConcepts:typename()
+	return "JobGetConcepts"
+end
+
+function JobGetConcepts:Prepare(pParams)
+
+end
+
+function JobGetConcepts:Tick()
+	local response = TVT:st_dropScriptAndGetConcepts()
+	if response == TVT.RESULT_OK then
+		self.Task.prodStatus = PROD_STATUS_SUPERMARKET
+	elseif response == TVT.RESULT_NOTFOUND then
+		--indicator that no script was in the studio - buy new one
+		self.Task.prodStatus = PROD_STATUS_BUY
+	else
+		self:LogInfo("problem dropping script in studio")
+	end
+	self.Task:SetDone()
+	self.Status = JOB_STATUS_DONE
+end
+-- <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+-- >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+_G["JobPlanProduction"] = class(AIJob, function(c)
+	AIJob.init(c)	-- must init base!
+	c.Task = nil
+end)
+
+function JobPlanProduction:typename()
+	return "JobPlanProduction"
+end
+
+function JobPlanProduction:Prepare(pParams)
+	local player = getPlayer()
+	local stats = player.Stats.MovieQuality
+	self.MaxBudget = 140000
+	if stats ~= nil then
+		if stats.Values > 32 then
+			self.MaxBudget = 1500000
+		elseif stats.Values > 25 then
+			self.MaxBudget = 750000
+		elseif stats.Values > 15 then
+			self.MaxBudget = 280000
+		end
+	else
+		self.MaxBudget = 0
+	end
+end
+
+function JobPlanProduction:Tick()
+	if self.MaxBudget > 0 then
+		local response = TVT:sm_PlanProduction(self.MaxBudget, 0.7)
+		if response == TVT.RESULT_OK then
+			self.Task.prodStatus = PROD_STATUS_START_PRODUCTION
+		else
+			self:LogInfo("problem planning production")
+		end
+	else
+		self:LogInfo(" no budget for planning production")
+	end
+	self.Task:SetDone()
+	self.Status = JOB_STATUS_DONE
+end
+-- <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+-- >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+_G["JobStartProduction"] = class(AIJob, function(c)
+	AIJob.init(c)	-- must init base!
+	c.Task = nil
+end)
+
+function JobStartProduction:typename()
+	return "JobStartProduction"
+end
+
+function JobStartProduction:Prepare(pParams)
+
+end
+
+function JobStartProduction:Tick()
+	local response = TVT:st_StartProduction()
+	if response == TVT.RESULT_OK then
+		--restore original priority after production start
+		self.Task.BasePriority = self.Task.PriorityBackup
+		self:LogInfo("Start production")
+	else
+		self:LogInfo("problem starting production")
+	end
+	self.SituationPriority = 0
+	self.producedForSammy = true
+	--check state
+	self.Task.prodStatus = PROD_STATUS_GET_CONCEPTS
+	self.Task:SetDone()
+	self.Status = JOB_STATUS_DONE
+end
+-- <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<

--- a/source/game.person.base.bmx
+++ b/source/game.person.base.bmx
@@ -197,7 +197,8 @@ Type TPersonBaseCollection Extends TGameObjectCollection
 		Local found:Int = 0
 		Local insignificant:Int=-1, celebrity:Int=-1, castable:Int=-1
 		_FillPersonMeetsRequirementsVariables(filterIndex, insignificant, celebrity, castable)
-		
+		'undefined job-gender 0 corrensponds to filter value -1
+		If gender = 0 then gender = -1
 		For Local p:TPersonBase = EachIn list
 			If Not _PersonMeetsRequirements(p, insignificant, celebrity, castable, gender, alive, countryCode) Then Continue
 			If onlyFictional And Not p.IsFictional() Then Continue
@@ -470,8 +471,8 @@ Type TPersonBaseCollection Extends TGameObjectCollection
 	End Method
 
 
-	Method GetRandomInsignificant:TPersonBase(array:TPersonBase[] = Null, onlyFictional:Int = False, onlyBookable:Int = False, job:Int = 0, gender:Int = -1, alive:Int = -1, countryCode:String="", forbiddenGUIDs:String[] = Null, forbiddenIDs:Int[] = Null)
-		Return GetRandomFromArrayOrFilter(array, FILTER_INSIGNIFICANT, onlyFictional, onlyBookable, job, gender, alive, countryCode.ToUpper(), forbiddenGUIDs, forbiddenIDs)
+	Method GetRandomCastableInsignificant:TPersonBase(array:TPersonBase[] = Null, onlyFictional:Int = False, onlyBookable:Int = False, job:Int = 0, gender:Int = -1, alive:Int = -1, countryCode:String="", forbiddenGUIDs:String[] = Null, forbiddenIDs:Int[] = Null)
+		Return GetRandomFromArrayOrFilter(array, FILTER_CASTABLE_INSIGNIFICANT, onlyFictional, onlyBookable, job, gender, alive, countryCode.ToUpper(), forbiddenGUIDs, forbiddenIDs)
 	End Method
 
 
@@ -480,8 +481,8 @@ Type TPersonBaseCollection Extends TGameObjectCollection
 	End Method
 
 
-	Method GetRandomCelebrity:TPersonBase(array:TPersonBase[] = Null, onlyFictional:Int = False, onlyBookable:Int = False, job:Int = 0, gender:Int = -1, alive:Int = -1, countryCode:String="", forbiddenGUIDs:String[] = Null, forbiddenIDs:Int[] = Null)
-		Return GetRandomFromArrayOrFilter(array, FILTER_CELEBRITY, onlyFictional, onlyBookable, job, gender, alive, countryCode.ToUpper(), forbiddenGUIDs, forbiddenIDs)
+	Method GetRandomCastableCelebrity:TPersonBase(array:TPersonBase[] = Null, onlyFictional:Int = False, onlyBookable:Int = False, job:Int = 0, gender:Int = -1, alive:Int = -1, countryCode:String="", forbiddenGUIDs:String[] = Null, forbiddenIDs:Int[] = Null)
+		Return GetRandomFromArrayOrFilter(array, FILTER_CASTABLE_CELEBRITY, onlyFictional, onlyBookable, job, gender, alive, countryCode.ToUpper(), forbiddenGUIDs, forbiddenIDs)
 	End Method
 
 	

--- a/source/game.production.script.base.bmx
+++ b/source/game.production.script.base.bmx
@@ -202,7 +202,7 @@ Type TScriptBase Extends TNamedGameObject
 	End Method
 
 
-	Method IsLive:int()
+	Method IsLive:int() {_exposeToLua}
 		return HasFlag(TVTProgrammeDataFlag.LIVE)
 	End Method
 
@@ -215,7 +215,7 @@ Type TScriptBase Extends TNamedGameObject
 	End Method
 
 
-	Method IsCulture:Int()
+	Method IsCulture:Int() {_exposeToLua}
 		return HasFlag(TVTProgrammeDataFlag.CULTURE)
 	End Method
 
@@ -245,7 +245,7 @@ Type TScriptBase Extends TNamedGameObject
 	End Method
 
 
-	Method isSeries:int()
+	Method isSeries:int() {_exposeToLua}
 		return scriptLicenceType = TVTProgrammeLicenceType.SERIES
 	End Method
 

--- a/source/game.production.script.bmx
+++ b/source/game.production.script.bmx
@@ -332,7 +332,7 @@ Type TScript Extends TScriptBase {_exposeToLua="selected"}
 	'See TVTPersonJob
 	Field allowedGuestTypes:Int	= 0
 
-	Field requiredStudioSize:Int = 1
+	Field requiredStudioSize:Int = 1 {_exposeToLua="readonly"}
 	'more expensive
 	Field requireAudience:Int = 0
 
@@ -568,7 +568,7 @@ Type TScript Extends TScriptBase {_exposeToLua="selected"}
 	End Function
 
 	'override
-	Method GetTitle:String()
+	Method GetTitle:String() {_exposeToLua}
 		If customTitle Then Return customTitle
 		Return Super.GetTitle()
 	End Method

--- a/source/gamefunctions_debug.bmx
+++ b/source/gamefunctions_debug.bmx
@@ -347,8 +347,8 @@ Type TDebugScreen
 
 	'=== PLAYER COMMANDS ===
 	Method InitMode_PlayerCommands()
-		Local IDs:Int[]      = [0,           1,         2,      3,              4,             5,                    6,           7,           8]
-		Local texts:String[] = ["Ad Agency", "Archive", "Boss", "Movie Agency", "News Studio", "Programme Schedule", "CheckSigns","Roomboard", "Station Map"]
+		Local IDs:Int[]      = [0,           1,         2,      3,              4,             5,                    6,           7,           8,             9]
+		Local texts:String[] = ["Ad Agency", "Archive", "Boss", "Movie Agency", "News Studio", "Programme Schedule", "CheckSigns","Roomboard", "Station Map", "Scripts"]
 		Local button:TDebugControlsButton
 		For Local i:Int = 0 Until texts.length
 			button = New TDebugControlsButton
@@ -402,6 +402,7 @@ Type TDebugScreen
 			Case 6	taskName = "CheckSigns"
 			Case 7	taskName = "RoomBoard"
 			Case 8	taskName = "StationMap"
+			Case 9	taskName = "Scripts"
 		End Select
 
 		If taskName
@@ -421,7 +422,8 @@ Type TDebugScreen
 					Case 5	 room = GetRoomCollection().GetFirstByDetails("", "office", playerID)
 					Case 6	 room = GetRoomCollection().GetFirstByDetails("", "elevatorPlan", playerID)
 					Case 7	 room = GetRoomCollection().GetFirstByDetails("", "roomboard", playerID)
-					Case 8	 room = GetRoomCollection().GetFirstByDetails("", "ofice", playerID)
+					Case 8	 room = GetRoomCollection().GetFirstByDetails("", "office", playerID)
+					Case 9	 room = GetRoomCollection().GetFirstByDetails("", "scriptagency")
 				End Select
 				If room
 					Local door:TRoomDoorBase = GetRoomDoorCollection().GetMainDoorToRoom(room.id)
@@ -2002,7 +2004,7 @@ Type TDebugScreen
 
 		If player.playerAI
 			SetColor 40,40,40
-			DrawRect(x, y, 185, 135)
+			DrawRect(x, y, 185, 155)
 			SetColor 50,50,40
 			DrawRect(x+1, y+1, 183, 23)
 			SetColor 255,255,255


### PR DESCRIPTION
Erste Version. Drehbuchkauf und Produktion funktionieren im Prinzip. Für die Planung wird der Producer-Code verwendet. Da eine komplette Planung innerhalb LUA ziemlich aufwändig wäre, würde ich das auch grundsätzlich so lassen. Man könnte noch weitere Parameter für die Planung mitgeben (Budgetaufteilung Cast/Firma) oder den gewürfelten Cast auswerten, um noch Modifkationen vorzunehmen.

Die KI reagiert auf den Sammy, ansonsten ist der Task aber niedrig priorisiert. Vielleicht sollte man die Anzahl der Produktionen in einer Sammy-Phase aber noch auf 1 beschränken, sonst gibt es ggf. zu viele pro Spieler. Es wird auch noch keine "echte" Budgetplanung gemacht, was ich aber auch nicht so schlimm finde.

Closes #549 