### PR TITLE
[Misc] replace and fix RandRangeArray

### DIFF
--- a/source/Dig/base.util.mersenne.bmx
+++ b/source/Dig/base.util.mersenne.bmx
@@ -198,44 +198,14 @@ Function WeightedRandRange:Int(lo:int, hi:int, weight:Float = 0.5, strength:Floa
 End Function
 
 
-'returns an array of random numbers (no repetitions)
-'as the costs of the no-repetition-check are directly dependend of the
+'returns an array of random numbers (no repetitions, including lo and hi)
+'as the costs of the pre-filling all indices depend directly on
 'amount it is only useful for small amount values.
 Function RandRangeArray:int[](lo:int, hi:int, amount:int = 1)
-	'if hi-lo does not contain enough possible candidates then limit
-	'amount to that
-	if hi - lo < amount then amount = hi - lo
+	'if lo...hi does not contain enough possible candidates 
+	if amount < 1 or lo > hi or hi - lo + 1 < amount then throw "invalid parameters to RandRangeArray; lo "+lo+", hi "+ hi+", amount "+amount
 
-	local result:int[] = new int[amount]
-	local number:int
-	local numberOK:int
-
-	For local i:int = 0 until amount
-		repeat
-			numberOK = True
-			number = RandRange(lo, hi)
-			For local d:Int = EachIn result
-				if d = number
-					numberOK = False
-					exit
-				endif
-			Next
-		until numberOK
-		result[i] = number
-	Next
-	return result
-End Function
-
-
-'returns an array of random numbers (no repetitions)
-'as the costs of the pre-filling all indices are directly dependend of the
-'amount it is only useful for small amount values.
-Function RandRangeArray2:int[](lo:int, hi:int, amount:int = 1)
-	'if hi-lo does not contain enough possible candidates then limit
-	'amount to that
-	if hi - lo < amount then amount = hi - lo
-
-	Local all:int = hi - lo
+	Local all:int = hi - lo + 1
 	Local indexes:Int[all]
 	Local iptr:Int Ptr = indexes
 	For Local i:Int = 0 Until all


### PR DESCRIPTION
Verwendung der alternativen Implementierung, die nur höchstens so viele Zufallsanfragen stellt, wie die gewünschte Liste lang ist. Ergänzung des Kommentars, dass die Grenzwerte inklusive sind (wie von den verwendenden Methoden erwartet).