### PR TITLE
Modifier in Drehbuchvorlagen unterstützen

### DIFF
--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -1829,6 +1829,20 @@ Type TDatabaseLoader
 		endif
 		endrem
 
+		'read modifiers
+		Local nodeModifiers:TxmlNode = xml.FindChild(node, "programme_data_modifiers")
+		For Local nodeModifier:TxmlNode = EachIn xml.GetNodeChildElements(nodeModifiers)
+			If nodeModifier.getName() <> "modifier" Then Continue
+
+			Local modifierData:TData = New TData
+			xml.LoadAllValuesToData(nodeModifier, modifierData)
+			'check if the modifier has all needed definitions
+			For Local f:String = EachIn ["name", "value"]
+				If Not modifierData.Has(f) Then ThrowNodeError("DB: <modifier> is missing ~q" + f+"~q.", nodeModifier)
+			Next
+			scriptTemplate.programmeDataModifiers.AddFloat(modifierData.GetString("name"), modifierData.GetFloat("value"))
+			'source.SetModifier(modifierData.GetString("name"), modifierData.GetFloat("value"))
+		Next
 
 		'=== EPISODES ===
 		'load children _after_ element is configured

--- a/source/game.production.bmx
+++ b/source/game.production.bmx
@@ -730,6 +730,7 @@ Type TProduction Extends TOwnedGameObject
 		programmeData.broadcastTimeSlotStart = productionConcept.script.broadcastTimeSlotStart
 		programmeData.broadcastTimeSlotEnd = productionConcept.script.broadcastTimeSlotEnd
 
+		programmeData.modifiers.Append(productionConcept.script.programmeDataModifiers)
 		Return programmeLicence
 	End Method
 	

--- a/source/game.production.script.base.bmx
+++ b/source/game.production.script.base.bmx
@@ -22,6 +22,8 @@ Type TScriptBase Extends TNamedGameObject
 	Field scriptFlags:Int = 0
 	Field fixedLiveTime:Long = -1
 
+	Field programmeDataModifiers:TData = New TData
+
 	'is the script title/description editable?
 	Field textsEditable:int = False
 	'scripts of series are parent of episode scripts

--- a/source/game.production.script.bmx
+++ b/source/game.production.script.bmx
@@ -448,12 +448,17 @@ Type TScript Extends TScriptBase {_exposeToLua="selected"}
 
 		'add children
 		If includingEpisodes
+			script.programmeDataModifiers.Append(template.programmeDataModifiers)
 			Local mainTemplateEpisodeCount:Int = template.getEpisodes()
 			If mainTemplateEpisodeCount > 1 and mainTemplateEpisodeCount < template.subScripts.length
 				'if parent restricts the number of episodes - get a subset of templates
 				For Local subTemplate:TScriptTemplate = EachIn template.GetSubTemplateSubset(mainTemplateEpisodeCount)
 					Local subScript:TScript = TScript.CreateFromTemplate(subTemplate, False)
-					If subScript Then script.AddSubScript(subScript)
+					If subScript
+						subScript.programmeDataModifiers.Append(template.programmeDataModifiers)
+						subScript.programmeDataModifiers.Append(subTemplate.programmeDataModifiers)
+						script.AddSubScript(subScript)
+					EndIf
 				Next
 			Else
 				Local episodeTitles:TList=new TList()
@@ -463,7 +468,9 @@ Type TScript Extends TScriptBase {_exposeToLua="selected"}
 					If episodesCount > 0 '0 episodes are supported - do not always include every episode
 						For Local i:Int = 0 until episodesCount
 							Local subScript:TScript = TScript.CreateFromTemplate(subTemplate, False)
-							If subScript 
+							If subScript
+								subScript.programmeDataModifiers.Append(template.programmeDataModifiers)
+								subScript.programmeDataModifiers.Append(subTemplate.programmeDataModifiers)
 								script.AddSubScript(subScript)
 								'try to ensure unique episode names
 								Local title:TLocalizedString = subScript.title

--- a/source/game.production.scripttemplate.bmx
+++ b/source/game.production.scripttemplate.bmx
@@ -108,6 +108,8 @@ Type TScriptTemplate Extends TScriptBase
 	'define an exact time for the live broadcast
 	Field liveDateCode:String
 
+	Field programmeDataModifiers:TData = New TData
+
 	'defines if the script is only available from/to/in a specific date
 	Field available:int = True
 	Field availableScript:string = ""

--- a/source/game.programme.programmedata.bmx
+++ b/source/game.programme.programmedata.bmx
@@ -1659,7 +1659,10 @@ Type TProgrammeData Extends TBroadcastMaterialSource {_exposeToLua}
 		Local minimumAbsoluteRefresh:Float = 0.10 '10%
 
 		refreshModifier :* GetProgrammeDataCollection().refreshFactor
-		refreshModifier :* GetRefreshModifier()
+		Local modifer:Float = GetRefreshModifier()
+		If modifer <> 1.0
+			refreshModifier = 1.0 + (refreshModifier - 1.0) * modifer
+		EndIf
 		refreshModifier :* GetGenreRefreshModifier()
 		refreshModifier :* GetFlagsRefreshModifier()
 
@@ -1678,7 +1681,10 @@ Type TProgrammeData Extends TBroadcastMaterialSource {_exposeToLua}
 		Local minimumAbsoluteRefresh:Float = 0.10 '10%
 
 		refreshModifier :* GetProgrammeDataCollection().trailerRefreshFactor
-		refreshModifier :* GetTrailerRefreshModifier()
+		Local modifer:Float = GetTrailerRefreshModifier()
+		If modifer <> 1.0
+			refreshModifier = 1.0 + (refreshModifier - 1.0) * modifer
+		EndIf
 		refreshModifier :* GetGenreRefreshModifier()
 		refreshModifier :* GetFlagsRefreshModifier()
 


### PR DESCRIPTION
Unterstützung des modifiers-Tags auch in Drehbuchvorlagen.
Der zweite Commit ändert die Semantik des Refresh-Modifiers. Anstatt auf den Gesamtfaktor angewandt zu werden, bezieht er sich auf die "prozentuale Änderung". Wenn also der Basisfaktor 1.4 ist (Anstieg um 40 %) würde der modifier 0.5 den Anstieg auf die Hälfte reduzieren (1.2) zuvor wäre der Faktor komplett halbiert worden (0.7).
Diese Änderung macht die Bedeutung des Modifiers für die Verwendung in der Datenbank verständlicher.

closes #676 