### PR TITLE
Sortierung der Besetzung beibehalten

### DIFF
--- a/source/game.programme.adcontract.bmx
+++ b/source/game.programme.adcontract.bmx
@@ -1190,12 +1190,13 @@ Type TAdContract Extends TBroadcastMaterialSource {_exposeToLua="selected"}
 			Return baseValue * GetSpotCount()
 		EndIf
 
-		Local population:Int = GetStationMapCollection().GetPopulation()
-		If population <= 1000
-			Print "StationMap Population too low: "+population
-			population = 1000
+		Local population:Int = 1000
+		Local minAudience:Int = GetTotalMinAudienceForPlayer(playerID)
+		Local reach:Int = population
+		If playerID > 0 
+			population = GetStationMapCollection().GetPopulation()
+			reach = GetStationMap(playerID, True).GetReach()
 		EndIf
-
 
 		'=== DYNAMIC PRICE ===
 		Local difficulty:TPlayerDifficulty = GetPlayerDifficulty(playerID)
@@ -1206,8 +1207,6 @@ Type TAdContract Extends TBroadcastMaterialSource {_exposeToLua="selected"}
 
 		Local price:Float
 
-		Local minAudience:Int = GetTotalMinAudienceForPlayer(playerID)
-		Local reach:Int = GetStationMap(playerID, True).GetReach()
 
 		price = GetCPM(baseValue, Float(reach) / population)
 

--- a/source/game.screen.supermarket.production.bmx
+++ b/source/game.screen.supermarket.production.bmx
@@ -33,6 +33,7 @@ Type TScreenHandler_SupermarketProduction Extends TScreenHandler
 	Field refreshFinishProductionConcept:Int = True
 
 	Field currentProductionConcept:TProductionConcept
+	Global castSortType:Int = 0
 
 	Global hoveredGuiCastItem:TGUICastListItem
 	Global hoveredGuiProductionConcept:TGuiProductionConceptListItem
@@ -1495,6 +1496,7 @@ Type TGUISelectCastWindow Extends TGUIProductionModalWindow
 		sortType = sortType + 1
 		If sortType > 3 Then sortType = 0
 		SortCastList(sortType)
+		TScreenHandler_SupermarketProduction.castSortType = sortType
 		Return True
 	End Method
 
@@ -2188,6 +2190,7 @@ Type TGUICastSlotList Extends TGUISlotList
 		selectCastWindow.listOnlyJobID = job
 		selectCastWindow.listOnlyGenderID = gender
 		selectCastWindow.screenArea = New TRectangle.Init(0,0, 800, 383)
+		selectCastWindow.sortType = TScreenHandler_SupermarketProduction.castSortType
 		selectCastWindow.Open() 'loads the cast
 		GuiManager.Add(selectCastWindow)
 	End Method

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -1952,6 +1952,7 @@ Type TGameState
 	Field _officeProgrammeSortDirection:Int
 	Field _officeContractSortMode:Int
 	Field _officeContractSortDirection:Int
+	Field _supermarketCastSortDirection:Int
 	Field _programmeDataIgnoreUnreleasedProgrammes:Int = False
 	Field _programmeDataFilterReleaseDateStart:Int = False
 	Field _programmeDataFilterReleaseDateEnd:Int = False
@@ -2133,6 +2134,7 @@ Type TGameState
 		TScreenHandler_ProgrammePlanner.PPprogrammeList.ListSortDirection = _officeProgrammeSortDirection
 		TScreenHandler_ProgrammePlanner.PPcontractList.ListSortMode = _officeContractSortMode
 		TScreenHandler_ProgrammePlanner.PPcontractList.ListSortDirection = _officeContractSortDirection
+		TScreenHandler_SupermarketProduction.castSortType = _supermarketCastSortDirection
 
 		TProgrammeData.ignoreUnreleasedProgrammes = _programmeDataIgnoreUnreleasedProgrammes
 		TProgrammeData._filterReleaseDateStart = _programmeDataFilterReleaseDateStart
@@ -2160,6 +2162,7 @@ Type TGameState
 		_officeProgrammeSortDirection = TScreenHandler_ProgrammePlanner.PPprogrammeList.ListSortDirection
 		_officeContractSortMode = TScreenHandler_ProgrammePlanner.PPcontractList.ListSortMode
 		_officeContractSortDirection = TScreenHandler_ProgrammePlanner.PPcontractList.ListSortDirection
+		_supermarketCastSortDirection = TScreenHandler_SupermarketProduction.castSortType
 
 		_programmeDataIgnoreUnreleasedProgrammes = TProgrammeData.ignoreUnreleasedProgrammes
 		_programmeDataFilterReleaseDateStart = TProgrammeData._filterReleaseDateStart


### PR DESCRIPTION
Bei der Auswahl der Besetzung soll die gewählte Sortierung beibehalten werden.

Bei der Prüfung ist aufgefallen, dass das Sortieren der Werbeverträge kaputtgegangen war. Die Sortiermethode gibt den Spieler nicht mit und der Default -1 führt bei der Ermittlung der möglichen Zuschauerzahl zum Absturz.

closes #651