### PR TITLE
KI: Programmplanung bei vielen Filmen mit maximaler Aktualität

### DIFF
--- a/res/ai/CommonAI/AIEngine.lua
+++ b/res/ai/CommonAI/AIEngine.lua
@@ -591,8 +591,9 @@ function AITask:RecalcPriority()
 	local timeFactor = (20 + TimeDiff) / 20
 	local ticksFactor = (20 + TicksDiff) / 20
 
-	local timePriority = self:getStrategicPriority()  * calcPriority * timeFactor
-	local ticksPriority = self:getStrategicPriority()  * calcPriority * ticksFactor
+	local strategicPriority = self:getStrategicPriority()
+	local timePriority = strategicPriority  * calcPriority * timeFactor
+	local ticksPriority = strategicPriority  * calcPriority * ticksFactor
 
 	self.CurrentPriority = math.max(timePriority, ticksPriority)
 

--- a/res/ai/DefaultAIPlayer/BudgetManager.lua
+++ b/res/ai/DefaultAIPlayer/BudgetManager.lua
@@ -44,7 +44,7 @@ function BudgetManager:CalculateNewDayBudget()
 
 	self.IgnoreMoneyChange = true
 	self.CurrentLogLevel = LOG_INFO
-	local money = TVT.GetMoney()
+	local money = getPlayer().money
 	self:Log("=== Budget day " .. (TVT.GetDaysRun() + 1) .. " ===")
 	self:Log(string.left("Account balance:", 25, true) .. string.right(money, 10, true))
 
@@ -160,7 +160,6 @@ function BudgetManager:OnMoneyChanged(value, reason, reference)
 	if self.IgnoreMoneyChange == true then return end
 
 	reason = tonumber(reason)
-	value = tonumber(value)
 	self.CurrentLogLevel=LOG_DEBUG
 
 	if (reference ~= nil) then
@@ -180,7 +179,7 @@ function BudgetManager:OnMoneyChanged(value, reason, reference)
 
 
 	if renewBudget == true then
-		local budgetNow = TVT.GetMoney()
+		local budgetNow = getPlayer().money
 
 		--update budget when at least 15.000 Euro difference since last
 		--adjustment

--- a/res/ai/DefaultAIPlayer/CommonObjects.lua
+++ b/res/ai/DefaultAIPlayer/CommonObjects.lua
@@ -499,11 +499,10 @@ function AIToolsClass:GetBroadcastAttraction(broadcastMaterialSource, day, hour,
 	if broadcastMaterialSource.IsProgrammeLicence() == 1 then
 		local relTop = broadcastMaterialSource:GetRelativeTopicality()
 		if relTop == 1 then
-			result = result * 3
+			result = result * 1.5
 		else
 			result = result * relTop
-			local stats = forPlayer.Stats.MovieQuality
-			if (stats~=nil and stats.Values > 25) or hour < 2 or hour > 16 then
+			if (forPlayer.blocksCount > 56) or hour > 16 then
 				result = result * relTop
 			end
 		end

--- a/res/ai/DefaultAIPlayer/CommonObjects.lua
+++ b/res/ai/DefaultAIPlayer/CommonObjects.lua
@@ -377,6 +377,26 @@ function AIToolsClass:GetAverageBroadcastQualityByLevel(level)
 	return 0.00
 end
 
+--currently hard coded by hour (see old implementation below
+--in the long run a statistic by weekday+hour for reachable audience percentage would be nice
+function AIToolsClass:GetAudienceQualityLevel(day, hour)
+	if hour > 22 or hour <=1 then
+		return 4
+	elseif hour >=20 then
+		return 5
+	elseif hour >=16 then
+		return 4
+	elseif hour >= 11 then
+		return 3
+	elseif hour >=7 then
+		return 2
+	else
+		return 1
+	end
+end
+
+--prevent many uncached calls to BMX for determining audience level
+--[[
 --TODO Problem der Überlappung der MinAudience bei Level 4 und 5 (z.T. gleiche Anforderungen - doppelte Verträge)
 function AIToolsClass:GetAudienceQualityLevel(day, hour)
 	local maxAudience = self:GetMaxAudiencePercentage(day, hour)
@@ -398,7 +418,7 @@ function AIToolsClass:GetMaxAudiencePercentage(day, hour)
 	--debugMsg("AITools:GetMaxAudiencePercentage("..day ..", "..hour..") = " .. TVT.getPotentialAudiencePercentage(day,hour))
 	return TVT.getPotentialAudiencePercentage(day, hour)
 end
-
+--]]
 
 function AIToolsClass:GetBroadcastQualityLevel(broadcastMaterial)
 	if broadcastMaterial == nil then return 0 end

--- a/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
+++ b/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
@@ -114,6 +114,7 @@ function DefaultAIPlayer:initParameters()
 		self.gameDay = TVT:GetDaysRun() + 1
 		self.minutesGone = TVT:GetTimeGoneInMinutes()
 	end
+	self.money = TVT:GetMoney()
 
 	if (self.Ventruesome == nil or self.Ventruesome <= 0) then
 		--Waghalsigkeit 3-8
@@ -270,6 +271,8 @@ end
 
 
 function DefaultAIPlayer:OnDayBegins()
+	--ensure money value is correct for all onDayBegins-calls
+	self.money = TVT:GetMoney()
 	--just in case we missed a "OnGameBegins"
 	self.Strategy:Start(self)
 
@@ -305,6 +308,10 @@ end
 
 
 function DefaultAIPlayer:OnMoneyChanged(value, reason, reference)
+	value = tonumber(value)
+	--multiple fixed-costs events trigger unnecessary calls; but modifying the current value would result
+	--in invalid value (after onDayBegins)
+	self.money = TVT:GetMoney()
 	self.Budget:OnMoneyChanged(value, reason, reference)
 	for k,v in pairs(self.TaskList) do
 		v:OnMoneyChanged(value, reason, reference)
@@ -809,6 +816,7 @@ function OnLoadState(data)
 	player.minute = TVT:GetDayMinute()
 	player.gameDay = TVT:GetDaysRun() + 1
 	player.minutesGone = TVT:GetTimeGoneInMinutes()
+	player.money = TVT:GetMoney()
 end
 
 -- called when "saving" a game

--- a/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
+++ b/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
@@ -166,6 +166,7 @@ function DefaultAIPlayer:initializePlayer()
 
 	self.programmeLicencesInSuitcaseCount = 0
 	self.programmeLicencesInArchiveCount = 0
+	self.licencesToSell = {}
 
 	self.currentAwardType = -1
 	self.currentAwardStartTime = -1
@@ -190,6 +191,9 @@ function DefaultAIPlayer:resume()
 	end
 	if (self.TaskList[TASK_SCRIPTS] == nil) then
 		self.TaskList[TASK_SCRIPTS] = TaskScripts()
+	end
+	if self.licencesToSell == nil then
+		self.licencesToSell = {}
 	end
 
 	self:initParameters()

--- a/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
+++ b/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
@@ -503,13 +503,15 @@ function BusinessStats:ReadStats()
 	if self.lastStatsReadMinute ~= minute then
 		-- read in new audience stats
 		if minute == 0 then
-			local currentBroadcast = TVT.GetCurrentNewsShow()
+			--local currentBroadcast = TVT.GetCurrentNewsShow()
 			local currentAudience = TVT.GetCurrentNewsAudience().GetTotalSum()
 			local currentAttraction = TVT.GetCurrentNewsAudienceAttraction()
 			self.BroadcastStatistics:AddBroadcast(TVT.GetDay(), hour, TVT.Constants.BroadcastMaterialType.NEWSSHOW, currentAttraction, currentAudience)
 		end
 		if minute == 5 then
-			local currentBroadcast = TVT.GetCurrentProgramme()
+			--TODO store genre attraction based on max topicality
+			--local currentBroadcast = TVT.GetCurrentProgramme()
+			--debugMsg("top "..currentBroadcast.getSource().GetTopicality() .." "..currentBroadcast.getSource().GetMaxTopicality().." "..currentBroadcast.getSource().getGenre())
 			local currentAudience = TVT.GetCurrentProgrammeAudience().GetTotalSum()
 			local currentAttraction = TVT.GetCurrentProgrammeAudienceAttraction()
 			self.BroadcastStatistics:AddBroadcast(TVT.GetDay(), hour, TVT.Constants.BroadcastMaterialType.PROGRAMME, currentAttraction, currentAudience)

--- a/res/ai/DefaultAIPlayer/TaskAdAgency.lua
+++ b/res/ai/DefaultAIPlayer/TaskAdAgency.lua
@@ -401,14 +401,10 @@ function SignRequisitedContracts:SignMatchingContracts(requisition, guessedAudie
 	local easy = false
 	local avg = false
 	local hard = false
-	local movieCount = 0
+	local maxTopBlocks = self.Player.maxTopicalityBlocksCount
 	local audienceTotal = guessedAudience:GetTotalSum()
 	if audienceTotal > highAudience then
 		hard = true
-		local stats = self.Player.Stats.MovieQuality
-		if stats ~= nil and stats.Values > 0 then
-			movieCount = stats.Values
-		end
 	elseif audienceTotal > avgAudience then
 		avg = true
 	else
@@ -429,7 +425,7 @@ function SignRequisitedContracts:SignMatchingContracts(requisition, guessedAudie
 		else
 			local daysToFinish = adContract.GetDaysToFinish() - 1
 			if hard == true then
-				if movieCount < 30 then 
+				if maxTopBlocks < 12 then 
 					daysToFinish = daysToFinish -1
 				end
 				if spotsLeft < 3 and spotsLeft < daysToFinish then doSign = true end

--- a/res/ai/DefaultAIPlayer/TaskArchive.lua
+++ b/res/ai/DefaultAIPlayer/TaskArchive.lua
@@ -133,12 +133,12 @@ function JobSellMovies:Tick()
 		minLicenceCount = 25
 	end
 
-	local newLicenceToSell = False
-	--check if licence should sold
+	local newLicenceToSell = false
+	--check if licence should be sold
 	if table.count(movies) - toSellCount > minLicenceCount then
 		local licenceToSell = self:determineLicenceToSell(movies, toSell)
 		if licenceToSell ~= nil then
-			newLicenceToSell = True
+			newLicenceToSell = true
 		end
 	end
 
@@ -159,7 +159,7 @@ function JobSellMovies:Tick()
 	self.Status = JOB_STATUS_DONE
 
 	-- if there is something to sell, send figure to movie dealer now
-	if table.count(case) > 0 or newLicenceToSell == True then
+	if table.count(case) > 0 or newLicenceToSell == true then
 		--set day only if something is to be sold
 		self.Task.latestSaleOnDay = TVT.GetDay()
 
@@ -177,9 +177,7 @@ function JobSellMovies:determineLicenceToSell(movies, toSell)
 	local licenceToSell = nil
 	local rnd = math.random(0,100)
 
-	if rnd > 90 then
-		--to nothing
-	elseif rnd > 45 then
+	if rnd > 50 then
 		local sortMethod = function(a, b)
 			return a.quality < b.quality
 		end

--- a/res/ai/DefaultAIPlayer/TaskBoss.lua
+++ b/res/ai/DefaultAIPlayer/TaskBoss.lua
@@ -42,7 +42,7 @@ function TaskBoss:BeforeBudgetSetup()
 	self:CalculateFixedCosts()
 	self.InvestmentPriority = 1
 
-	local money = TVT.GetMoney()
+	local money = getPlayer().money
 	local credit = MY.GetCredit(-1)
 	self.NeededInvestmentBudget = credit
 	if credit == 0 then
@@ -98,7 +98,7 @@ end
 
 
 function JobCheckCredit:Prepare(pParams)
-	local money = TVT.GetMoney()
+	local money = getPlayer().money
 	local creditAvailable = TVT.bo_getCreditAvailable()
 	self.Task.TryToGetCredit = 0
 	if money < -30000 and getPlayer().hour > 5 then

--- a/res/ai/DefaultAIPlayer/TaskBoss.lua
+++ b/res/ai/DefaultAIPlayer/TaskBoss.lua
@@ -98,10 +98,11 @@ end
 
 
 function JobCheckCredit:Prepare(pParams)
-	local money = getPlayer().money
+	local player = getPlayer()
+	local money = player.money
 	local creditAvailable = TVT.bo_getCreditAvailable()
 	self.Task.TryToGetCredit = 0
-	if money < -30000 and getPlayer().hour > 5 then
+	if money < -30000 and player.hour > 5 then
 		-- ATTENTION: money might change until "tick()", we could handle
 		-- it but this behaviour seems more "natural" (to not see the
 		-- money change in time)
@@ -111,10 +112,14 @@ function JobCheckCredit:Prepare(pParams)
 	end
 	if self.Task.NeededInvestmentBudget > 0 then
 		self.Task.TryToRepayCredit = math.max(0, math.min(money, self.Task.NeededInvestmentBudget))
-	elseif MY.GetCredit(-1) == 0 and getPlayer().hour < 6 then
-		--TODO randomize? - stop if coverage is 90%
+	elseif MY.GetCredit(-1) == 0 and player.hour < 6 then
+		local stationTask = player.TaskList[TASK_STATIONMAP]
 		--get credit and increase chance for good investment
-		self.Task.TryToGetCredit = creditAvailable
+		if stationTask ~= nil and stationTask.maxReachIncrease ~=  nil and stationTask.maxReachIncrease < 0 then
+			--no credit necessary for station purchase
+		else
+			self.Task.TryToGetCredit = creditAvailable
+		end
 	end
 
 

--- a/res/ai/DefaultAIPlayer/TaskCheckSigns.lua
+++ b/res/ai/DefaultAIPlayer/TaskCheckSigns.lua
@@ -87,12 +87,15 @@ function JobCheckRoomSigns:Tick()
 	end
 
 	if scheduleRoomBoardTask == true then
-		local t = getPlayer().TaskList[_G["TASK_ROOMBOARD"]]
-		if t ~= nil then
-			t.SituationPriority = 20
-			t.forceChangeSigns = forceChangeSigns
+		local player = getPlayer()
+		local sc = player.TaskList[_G["TASK_SCHEDULE"]]
+		local rb = player.TaskList[_G["TASK_ROOMBOARD"]]
+		if sc ~= nil and rb ~= nil then
+			sc.SituationPriority = 500
+			rb.SituationPriority = 10
+			rb.forceChangeSigns = forceChangeSigns
 		else
-			self:LogError("did not find roomboard task")
+			self:LogError("did not find tasks for raising priority")
 		end
 	end
 

--- a/res/ai/DefaultAIPlayer/TaskMovieDistributor.lua
+++ b/res/ai/DefaultAIPlayer/TaskMovieDistributor.lua
@@ -238,7 +238,7 @@ function JobBuyStartProgramme:Tick()
 			self:LogDebug("IGNORING PROGRAMME (old, genre) "..v:getTitle())
 		elseif pricePerBlock > 50000 then 
 			self:LogDebug("IGNORING PROGRAMME (price) "..v:getTitle() .. " ".. pricePerBlock)
-		elseif math.random(0,10) > 6 then
+		elseif math.random(0,10) > 8 then
 			-- ignore randomly
 			self:LogDebug("IGNORING PROGRAMME (random) "..v:getTitle())
 		else

--- a/res/ai/DefaultAIPlayer/TaskMovieDistributor.lua
+++ b/res/ai/DefaultAIPlayer/TaskMovieDistributor.lua
@@ -124,7 +124,7 @@ function TaskMovieDistributor:getStrategicPriority()
 	self:LogTrace("TaskMovieDistributor:getStrategicPriority")
 
 	-- no money to buy things? skip even looking...
-	if TVT.getMoney() <= 50000 then
+	if getPlayer().money <= 50000 then
 		return 0.0
 	end
 	return 1.0
@@ -212,7 +212,7 @@ function JobBuyStartProgramme:Tick()
 		self.Status = JOB_STATUS_DONE
 		return True
 	end
-	local budget = TVT.GetMoney()
+	local budget = player.money
 
 	local movies = TVT.convertToProgrammeLicences(licencesResponse.data)
 	local goodMovies = {}

--- a/res/ai/DefaultAIPlayer/TaskNewsAgency.lua
+++ b/res/ai/DefaultAIPlayer/TaskNewsAgency.lua
@@ -141,6 +141,7 @@ function TaskNewsAgency:BudgetSetup()
 	-- scribe to current affairs
 	local baseFee = TVT.GetNewsAbonnementFee(TVT.Constants.NewsGenre.CURRENTAFFAIRS, 1)
 	local tempAbonnementBudget = math.max(baseFee, self.BudgetWholeDay * 0.45)
+	--TODO ensure abonnement bugdet is not subtracted multiple times over the day
 	self.AbonnementBudget = tempAbonnementBudget
 	self.CurrentBudget = self.CurrentBudget - self.AbonnementBudget
 	self:LogTrace("BudgetSetup: AbonnementBudget: " .. self.AbonnementBudget .. "   - CurrentBudget: " .. self.CurrentBudget)
@@ -150,7 +151,7 @@ end
 function TaskNewsAgency:BudgetMaximum()
 	local player = getPlayer()
 	local money = player.money
-	if money <= 500000 then
+	if money <= 500000 or player.gameDay < 2 then
 		return math.max(50000, math.floor(money / 10))
 	elseif money < 1000000 then
 		return math.max(110000, math.floor(money / 10))
@@ -165,10 +166,10 @@ end
 function TaskNewsAgency:OnMoneyChanged(value, reason, reference)
 	reason = tonumber(reason)
 	if (reason == TVT.Constants.PlayerFinanceEntryType.PAY_NEWS) then
-		self:PayFromBudget(value)
+		self:PayFromBudget(math.abs(value))
 		self:CalculateFixedCosts()
 	elseif (reason == TVT.Constants.PlayerFinanceEntryType.PAY_NEWSAGENCIES) then
-		self:PayFromBudget(value)
+		self:PayFromBudget(math.abs(value))
 		self:CalculateFixedCosts()
 	end
 end

--- a/res/ai/DefaultAIPlayer/TaskNewsAgency.lua
+++ b/res/ai/DefaultAIPlayer/TaskNewsAgency.lua
@@ -148,7 +148,8 @@ end
 
 
 function TaskNewsAgency:BudgetMaximum()
-	local money = TVT.GetMoney()
+	local player = getPlayer()
+	local money = player.money
 	if money <= 500000 then
 		return math.max(50000, math.floor(money / 10))
 	elseif money < 1000000 then
@@ -367,7 +368,7 @@ function JobNewsAgency:Tick()
 
 	if self.Task.CurrentBudget < 0 then
 		local player = getPlayer()
-		if player.Budget.CurrentFixedCosts > 120000 and TVT.GetMoney() > 150000 then
+		if player.Budget.CurrentFixedCosts > 120000 and player.money > 150000 then
 			--TODO with high fixed costs often there is a negative budget although there is money
 			self:LogDebug("raised news budget because there is money")
 			self.Task.CurrentBudget = 50000

--- a/res/ai/DefaultAIPlayer/TaskRoomBoard.lua
+++ b/res/ai/DefaultAIPlayer/TaskRoomBoard.lua
@@ -105,8 +105,12 @@ function JobChangeRoomSigns:Tick()
 		local enemyId = player:GetNextEnemyId()
 		local roomId = self:GetEnemyRoomId(enemyId)
 		local roomSign = TVT.rb_GetFirstSignOfRoom(roomId).data
-		TVT.rb_SwitchSigns(sign, roomSign)
-		self:LogDebug("Verschiebe "..name.."-Schild auf Raum " .. roomId .. " (" .. roomSign.GetOwnerName() ..") des Spielers " .. enemyId )
+		if roomSign ~=nil then
+			TVT.rb_SwitchSigns(sign, roomSign)
+			self:LogDebug("Verschiebe "..name.."-Schild auf Raum " .. roomId .. " (" .. roomSign.GetOwnerName() ..") des Spielers " .. enemyId )
+		else
+			self:LogError("Raumschild von enemyId "..enemyId.." nicht ermittelbar")
+		end
 	end
 
 	-- handled the situation "for now"

--- a/res/ai/DefaultAIPlayer/TaskSchedule.lua
+++ b/res/ai/DefaultAIPlayer/TaskSchedule.lua
@@ -2267,7 +2267,7 @@ function JobProgrammeSchedule:FillSlot(day, hour)
 	local guessedAudience = self.Task:GuessedAudienceForHour(fixedDay, fixedHour, previousHourBroadcastMaterial, previousHourBroadcastBlock).GetTotalSum()
 
 	-- table/list of forbidden programme/adcontract IDs
-	local forbiddenIDs = {}
+	local forbiddenIDs = table.copy(getPlayer().licencesToSell)
 	local replaceCurrentBroadcast = false
 
 

--- a/res/ai/DefaultAIPlayer/TaskSchedule.lua
+++ b/res/ai/DefaultAIPlayer/TaskSchedule.lua
@@ -518,8 +518,11 @@ function TaskSchedule:GetFilteredProgrammeLicenceList(minLevel, maxLevel, maxRer
 	for k,licence in pairs(useLicences) do
 		local qLevel = AITools:GetBroadcastQualityLevel(licence)
 		if fixedHour > 21 or fixedHour < 4 and licence.GetData().IsXRated() == 1 then
-			table.insert(resultingLicences, licence)
-		elseif (minLevel < 0 or qLevel >= minLevel) and (maxLevel < 0 or qLevel <= maxLevel) then
+			if qLevel + 1 == maxLevel or qLevel - 2 >= minLevel then
+				if math.random(0, 10) > 6 then qLevel = minLevel end
+			end
+		end
+		if (minLevel < 0 or qLevel >= minLevel) and (maxLevel < 0 or qLevel <= maxLevel) then
 			local sentAndPlannedToday = -1
 			if maxRerunsToday < 0 then
 				--ignoring number of runs

--- a/res/ai/DefaultAIPlayer/TaskSchedule.lua
+++ b/res/ai/DefaultAIPlayer/TaskSchedule.lua
@@ -1258,7 +1258,7 @@ function JobAnalyzeEnvironment:Tick()
 			-- we need money - if needed, use all we have (only keep some money
 			-- for news
 			-- 0 - 400.000
-			local budget = math.min(math.max(0, TVT.getMoney() - 5000), 400000)
+			local budget = math.min(math.max(0, Player.money - 5000), 400000)
 
 			if budget > 0 then
 				-- remove old "topicality count" requisition

--- a/res/ai/DefaultAIPlayer/TaskSchedule.lua
+++ b/res/ai/DefaultAIPlayer/TaskSchedule.lua
@@ -161,7 +161,7 @@ function TaskSchedule:GetNextJobInTargetRoom()
 
 	--TODO
 	--self:SetWait()
-	--when done invalidate cache if available licences
+	--when done invalidate cache of available licences
 	self.availableProgrammes = nil
 	self:SetDone()
 end
@@ -182,8 +182,8 @@ function TaskSchedule:OnUpdateAdSlot(day, hour, newBroadcastMaterial, oldBroadca
 end
 
 
---TODO es scheint, als wird für geänderte Slots "genauer" nach neu benötigter Werbung gesucht
---ansonsten habe ich die Notwendigkeit für Backup noch nicht verstanden
+--allow reacting to programme changes, own planning but also events
+--TODO review and optimize usage later
 function TaskSchedule:BackupPlan(slotType, day)
 	local slots = {}
 	for i=0, 23 do
@@ -1493,7 +1493,6 @@ end
 
 function JobAdSchedule:OnStop(pParams)
 	-- HANDLE ALL CHANGED SLOTS
---TODO what to achieve here?
 --[[
 	local day = TVT.GetDay()
 	local newAdSlots = self.Task:BackupPlan(TVT.Constants.BroadcastMaterialType.ADVERTISEMENT, day)

--- a/res/ai/DefaultAIPlayer/TaskScripts.lua
+++ b/res/ai/DefaultAIPlayer/TaskScripts.lua
@@ -126,7 +126,7 @@ function JobBuyScript:Prepare(pParams)
 		self.minPotential = self.minPotential - 0.1
 		self.minAttractivity = self.minAttractivity - 0.1
 	end
-	self.scriptMaxPrice =  math.min(self.scriptMaxPrice, TVT:getMoney())
+	self.scriptMaxPrice =  math.min(self.scriptMaxPrice, player.money)
 	self:LogDebug("  maxPrice  ".. self.scriptMaxPrice .. " minPotential "..self.minPotential)
 end
 

--- a/res/ai/DefaultAIPlayer/TaskScripts.lua
+++ b/res/ai/DefaultAIPlayer/TaskScripts.lua
@@ -37,7 +37,7 @@ function TaskScripts:Activate()
 	self.JobStartProduction.Task = self
 	self.awardType = ""
 
-	if getPlayer().nextAwardType == TVT.Constants.AwardType.CULTURE then
+	if getPlayer().nextAwardType == TVT.Constants.AwardType.CULTURE or getPlayer().currentAwardType == TVT.Constants.AwardType.CULTURE then
 		self.awardType = "culture"
 	end
 
@@ -100,24 +100,22 @@ end
 
 function JobBuyScript:Prepare(pParams)
 	local player = getPlayer()
-	local stats = player.Stats.MovieQuality
+	local blocks = player.blocksCount
 	self.scriptMaxPrice = 30000
 	self.minPotential = 0.25
 	self.minAttractivity = 0.25
 	self.maxJobCount = 4
-	if stats ~= nil then
-		if stats.Values > 25 then
-			self.Task.BasePriority = 0.15
-			self.scriptMaxPrice = 1300000
-			self.minPotential = 0.5
-			self.minAttractivity = 0.6
-		elseif stats.Values > 15 then
-			self.maxJobCount = 6
-			self.Task.BasePriority = 0.07
-			self.scriptMaxPrice = 100000
-			self.minPotential = 0.35
-			self.minAttractivity = 0.4
-		end
+	if blocks > 64 then
+		self.Task.BasePriority = 0.15
+		self.scriptMaxPrice = 1300000
+		self.minPotential = 0.5
+		self.minAttractivity = 0.6
+	elseif blocks > 48 then
+		self.maxJobCount = 6
+		self.Task.BasePriority = 0.07
+		self.scriptMaxPrice = 100000
+		self.minPotential = 0.35
+		self.minAttractivity = 0.4
 	else
 		self.scriptMaxPrice = 0	
 	end
@@ -263,17 +261,15 @@ end
 
 function JobPlanProduction:Prepare(pParams)
 	local player = getPlayer()
-	local stats = player.Stats.MovieQuality
+	local blocks = player.blocksCount
 	self.MaxBudget = 140000
-	if stats ~= nil then
-		if stats.Values > 32 then
-			self.MaxBudget = 1500000
-		elseif stats.Values > 25 then
-			self.MaxBudget = 750000
-		elseif stats.Values > 15 then
-			self.MaxBudget = 280000
-		end
-	else
+	if blocks > 72 then
+		self.MaxBudget = 1500000
+	elseif blocks > 64 then
+		self.MaxBudget = 750000
+	elseif blocks > 48 then
+		self.MaxBudget = 280000
+	elseif self.Task.awardType ~= "culture" then
 		self.MaxBudget = 0
 	end
 end

--- a/res/ai/DefaultAIPlayer/TaskStationMap.lua
+++ b/res/ai/DefaultAIPlayer/TaskStationMap.lua
@@ -417,7 +417,7 @@ function JobBuyStation:Prepare(pParams)
 	local ignoreBudgetChance = 100 - (8-player.ExpansionPriority)*math.min(TVT.of_getStationCount(TVT.ME)-1,10)
 	self:LogTrace("  ignoreBudgetChance: " ..ignoreBudgetChance)
 
-	local moneyExcludingFixedCosts = TVT.GetMoney() - player.Budget.CurrentFixedCosts
+	local moneyExcludingFixedCosts = player.money - player.Budget.CurrentFixedCosts
 	--TODO make constant player character dependent
 	if self.Task.CurrentBudget > 0 and moneyExcludingFixedCosts > 350000 and math.random(0,100) < ignoreBudgetChance then
 		--self.Task.CurrentBudget = (0.4 + 0.06*player.ExpansionPriority) * moneyExcludingFixedCosts

--- a/res/ai/DefaultAIPlayer/TaskStationMap.lua
+++ b/res/ai/DefaultAIPlayer/TaskStationMap.lua
@@ -95,10 +95,10 @@ function TaskStationMap:OnMoneyChanged(value, reason, reference)
 	--ensure fixed costs are recalculated
 	reason = tonumber(reason)
 	if (reason == TVT.Constants.PlayerFinanceEntryType.PAY_STATION) then
-		self:PayFromBudget(value)
+		self:PayFromBudget(math.abs(value))
 		self.SituationPriority = 50
 	elseif (reason == TVT.Constants.PlayerFinanceEntryType.SELL_STATION) then
-		self:PayFromBudget(value)
+		self:PayFromBudget(-math.abs(value))
 		self.SituationPriority = 50
 	end
 end

--- a/res/ai/DefaultAIPlayer/TaskStationMap.lua
+++ b/res/ai/DefaultAIPlayer/TaskStationMap.lua
@@ -69,26 +69,18 @@ end
 
 function TaskStationMap:BeforeBudgetSetup()
 	local player = getPlayer()
-	local stats = player.Stats.MovieQuality
-	local movieCount = 0
-	if stats ~= nil then
-		movieCount = stats.Values
-	end
+	local maxTopBlocks = player.maxTopicalityBlocksCount
+	local blocks = player.blocksCount
 	local totalReach = player.totalReach
 
-	if movieCount < 12 and (totalReach == nil or totalReach > 1200000) then
+	if blocks < 36 and (totalReach == nil or totalReach > 1200000) then
 		self.BudgetWeight = 0
-	elseif movieCount < 24 and (totalReach == nil or totalReach > 2000000) then
+	elseif blocks < 50 and (totalReach == nil or totalReach > 2000000) then
 		self.BudgetWeight = 4
 	else
 		self.BudgetWeight = 8
 	end
 
-	if self.BudgetWeight > 0 and totalReach ~= nil then
-		if totalReach < 2000000 then
-			self.BudgetWeight = 8
-		end
-	end
 	if self.maxReachIncrease ~=nil and self.maxReachIncrease < 0  then
 		self.BudgetWeight = 0
 	end
@@ -163,13 +155,12 @@ function JobAnalyseStationMarket:Tick()
 	--TODO refresh less often
 	TVT.audiencePredictor.RefreshMarkets()
 	player.LastStationMapMarketAnalysis = player.WorldTicks
-	local stats = player.Stats.MovieQuality
-	local movieCount = 0
-	if stats ~= nil then
-		movieCount = stats.Values
-	end
+	local blocks = player.blocksCount
 	player.totalReach = MY.GetMaxAudience()
 	self.Task.maxReachIncrease = 99000000
+
+	--movie prices do not increas so much anymore...
+	--[[
 	if movieCount < 12 then
 		if player.totalReach < 2500000 then
 			self.Task.maxReachIncrease = 2400000 - player.totalReach
@@ -183,7 +174,7 @@ function JobAnalyseStationMarket:Tick()
 			self.Task.maxReachIncrease = 0
 		end
 	end
-
+	--]]
 	local population = TVT:of_getPopulation()
 
 	if player.totalReach > population * 0.9 then


### PR DESCRIPTION
Bevor ich tatsächliche Änderungen an der Planung für das Nachmittagsprogramm mache, würde ich gern den Code etwas aufräumen/vereinfachen. Dafür hätte ich gern Rückmeldung. Die Commits sollten einzeln betrachtet werden, damit man besser sieht, was geändert werden soll.

Der erste ist ein Vorbereitungscommit, den ich auf alle Fälle integrieren möchte: Verkauf von Lizenzen bei maximaler Aktualität, um kein Geld zu verschenken. Dafür muss natürlich sichergestellt werden, dass die Filme nicht mehr gesendet werden.

Die folgenden Commits sind entweder reine Aufräumarbeiten (Entfernung/Verschieben von nicht aufgerufenem Code) oder kleinere Optimierungen. 
* Statt der Anzahl der Lizenzen möchte ich in Zukunft Enscheidungen aufgrund der Anzahl der ausstrahlbaren Blöcke (uns solcher mit maximaler Aktualität) machen. Gleichzeitig kann bei einem Programmplanlauf eine gecachte Liste verwendet werden.
* Rückbau des Codes für die Tick-Zeit-Analyse. Teile davon sind ins Framework gewandert. Lesbarkeit verbessern (was wird eigentlich verwendet)
* Ich die "Level-Logik" vereinfachen. Anstatt bei jeder Anfrage bei Blitzmax die erreichbare Zuschauerzahl abzufragen, sollen de Level einfach per Zeit ermittelt werden.