### PR TITLE
Debug-Screen Modifiers

### DIFF
--- a/source/game.debug.screen.page.modifiers.bmx
+++ b/source/game.debug.screen.page.modifiers.bmx
@@ -1,0 +1,305 @@
+SuperStrict
+Import "game.debug.screen.page.bmx"
+Import "game.game.bmx"
+Import "game.player.bmx"
+
+Type TDebugScreenPage_Modifiers extends TDebugScreenPage
+	Field buttons:TDebugControlsButton[]
+	Field difficultyX:Int
+	Field difficultyY:Int
+	Field difficultyWidth:Int
+	Field playerID:Int
+	Field difficulty:TPlayerDifficulty
+	Field buttonsCreated:Int = False
+
+	Global _instance:TDebugScreenPage_Modifiers
+
+	Method New()
+		_instance = self
+	End Method
+
+
+	Function GetInstance:TDebugScreenPage_Modifiers()
+		if not _instance then new TDebugScreenPage_Modifiers
+		return _instance
+	End Function
+
+
+	Method Init:TDebugScreenPage_Modifiers()
+		Local texts:String[] = ["Set to easy", "Set to normal", "Set to hard", "Reset Values"]
+		Local button:TDebugControlsButton
+		For Local i:Int = 0 Until texts.length
+			button = CreateActionButton(i, texts[i], position.x, position.y)
+			button._onClickHandler = OnButtonClickHandler
+
+			buttons :+ [button]
+		Next
+
+		Return self
+	End Method
+
+
+	Function OnButtonClickHandler(sender:TDebugControlsButton)
+		Local collection:TPlayerDifficultyCollection=TPlayerDifficultyCollection.GetInstance()
+		Local level:String = ""
+		Local changePlayerLevel:Int = True
+		Select sender.dataInt
+			case 0
+				level ="easy"
+			case 1
+				level ="normal"
+			case 2
+				level ="hard"
+			case 3
+				'reset all level values
+				changePlayerLevel = False
+				local levels:String[] = new String[4]
+				For Local i:Int = 0 Until levels.length
+					levels[i] = GetPlayerDifficulty(i+1).GetGUID()
+				Next
+				collection.InitializeDefaults()
+				For Local i:Int = 0 Until levels.length
+					collection.AddToPlayer(i+1, collection.GetByGUID(levels[i]))
+				Next
+		End Select
+
+		local screen:TDebugScreenPage_Modifiers=TDebugScreenPage_Modifiers.GetInstance()
+		If changePlayerLevel Then
+			collection.AddToPlayer(screen.playerID, collection.GetByGUID(level))
+		EndIf
+		screen.Reset()
+
+		'handled
+		sender.clicked = False
+		sender.selected = False
+	End Function
+
+
+	Method Reset()
+		playerID=-1
+	End Method
+
+
+	Method Activate()
+	End Method
+
+
+	Method Deactivate()
+	End Method
+
+
+	Method MoveBy(dx:Int, dy:Int) override
+		'move buttons action buttons
+		For Local i:Int = 0 Until 4
+			buttons[i].x :+ dx
+			buttons[i].y :+ dy
+		Next
+	End Method
+
+
+	Method Update()
+		Local player:Int = GetShownPlayerID()
+		If player <> playerID then
+			playerID = player
+			difficulty:TPlayerDifficulty = GetPlayerDifficulty(playerID)
+		EndIf 
+		For Local b:TDebugControlsButton = EachIn buttons
+			b.Update()
+		Next
+	End Method
+
+
+	Method Render()
+		RenderGameModifierList(position.x + 5, position.y + 3, 280)
+
+		RenderDifficulties(position.x + 290, position.y + 3)
+
+		For Local i:Int = 0 Until buttons.length
+			buttons[i].Render()
+		Next
+	End Method
+
+
+	Method RenderGameModifierList(x:int, y:int, w:int = 300, h:int = 355)
+		DrawOutlineRect(x, y, w, h)
+		Local textX:Int = x + 5
+		Local textY:Int = y + 2
+
+		titleFont.DrawSimple("Game Modifiers: ", textX, textY)
+
+		textY :+ 12 
+
+		Local data:TData = GameConfig._modifiers
+		If data
+			For Local k:TLowerString = EachIn data.data.Keys()
+				If textY + 12 > y + h Then Continue
+
+				textFont.DrawBox(k.ToString(), textX, textY, w - 10 - 40, 15, sALIGN_LEFT_TOP, SColor8.White)
+				textFont.DrawBox(MathHelper.NumberToString(data.GetFloat(k.ToString()), 3), textX, textY, w - 10, 15, sALIGN_RIGHT_TOP, SColor8.White)
+				textY :+ 12
+			Next
+		EndIf
+	End Method
+
+	Method RenderDifficulties(x:int, y:int, w:int = 220, h:int = 355)
+		DrawOutlineRect(x, y, w, h)
+		difficultyX = x + 5
+		difficultyY = y + 2
+		difficultyWidth = w
+
+		titleFont.DrawSimple("Player " + playerID +" Difficulty (" +difficulty.GetGUID()+"): ", difficultyX, difficultyY)
+		difficultyY = difficultyY + 12
+		'TODO Spieler mit gleichem Level teilen sich wohl dasselbe Objekt - keine spielerindividuellen Difficulty-Werte
+		'programme
+		renderModifier("Programme Price", "licPrice", difficulty.programmePriceMod)
+		renderModifier("Xrated Penalty", "xPenalty", difficulty.sentXRatedPenalty, 5000)
+		renderModifier("Xrated Confiscate Risk", "xRisk", difficulty.sentXRatedConfiscateRisk)
+
+		'Ads
+		renderModifier("Ad Min Audience", "adAudience", difficulty.adcontractRawMinAudienceMod)
+		renderModifier("Ad Price (global)", "adPrice", difficulty.adcontractPriceMod)
+		renderModifier("Ad Profit", "adProfit", difficulty.adcontractProfitMod)
+		renderModifier("Ad Penalty", "adPenalty", difficulty.adcontractPenaltyMod)
+		renderModifier("Target Group", "adTarget", difficulty.adcontractLimitedTargetgroupMod)
+		renderModifier("Infomercial Profit", "infoProfit", difficulty.adcontractInfomercialProfitMod)
+
+		renderModifier("Broadcast Permission", "permPrice", difficulty.broadcastPermissionPriceMod)
+		renderModifier("Antenna Price", "stPrice", difficulty.antennaBuyPriceMod)
+		renderModifier("Antenna Constr. Time", "stTime", difficulty.antennaConstructionTime,1)
+		renderModifier("Antenna Daily Costs", "stDaily", difficulty.antennaDailyCostsMod)
+		renderModifier("Ant. Daily Costs Increase", "stInc", difficulty.antennaDailyCostsIncrease,1)
+		renderModifier("Ant. Daily Increase Max", "stIncMax", difficulty.antennaDailyCostsIncreaseMax,1)
+		renderModifier("Network Price", "cablePrice", difficulty.cableNetworkBuyPriceMod)
+		renderModifier("Network Constr. Time", "cableTime", difficulty.cableNetworkConstructionTime,1)
+		renderModifier("Network Daily Costs", "cableDaily", difficulty.cableNetworkDailyCostsMod,1)
+		renderModifier("Satellite Price", "satPrice", difficulty.satelliteBuyPriceMod)
+		renderModifier("Satellite Constr. Time", "satTime", difficulty.satelliteConstructionTime,1)
+		renderModifier("Satellite Daily Costs", "satDaily", difficulty.satelliteDailyCostsMod,1)
+		
+		'News
+		renderModifier("News Price", "newsPrice", difficulty.newsItemPriceMod)
+
+		'Room
+		renderModifier("Room rent", "roomPrice", difficulty.roomRentMod)
+
+		'credit
+		renderModifier("Credit Base", "credBase", difficulty.creditBaseValue, 500)
+		renderModifier("Credit Interest Rate", "credRate", difficulty.interestRateCredit,1)
+		renderModifier("Interest Rate positive Balance", "credIntPos", difficulty.interestRatePositiveBalance,1)
+		renderModifier("Interest Rate negative Balance", "credIntNeg", difficulty.interestRateNegativeBalance, 1)
+
+		'Production
+		renderModifier("Production Time", "prodTime", difficulty.productionTimeMod)
+
+		buttonsCreated = True
+	End Method
+
+	Method renderModifier(caption:String, fieldName:String, value:Float, change:Int=5)
+		textFont.DrawBox(caption, difficultyX, difficultyY, difficultyWidth - 60 - 25, 15, sALIGN_LEFT_TOP, SColor8.White)
+		textFont.DrawBox(MathHelper.NumberToString(value, 3), difficultyX, difficultyY, difficultyWidth - 60, 15, sALIGN_RIGHT_TOP, SColor8.White)
+
+		if not buttonsCreated then
+			createModifierButtons(fieldName, change, difficultyX + difficultyWidth, difficultyY)
+		endif
+		difficultyY = difficultyY + 12
+	End Method
+
+	Method renderModifier(caption:String, fieldName:String, value:Int, change:Int=10)
+		textFont.DrawBox(caption, difficultyX, difficultyY, difficultyWidth - 60 - 25, 15, sALIGN_LEFT_TOP, SColor8.White)
+		textFont.DrawBox(value, difficultyX, difficultyY, difficultyWidth - 60, 15, sALIGN_RIGHT_TOP, SColor8.White)
+
+		if not buttonsCreated then
+			createModifierButtons(fieldName, change, difficultyX + difficultyWidth, difficultyY)
+		endif
+		difficultyY = difficultyY + 12
+	End Method
+
+	Method createModifierButtons(fieldName:String, change:Int, xOffset:Int, yPos:Int)
+		createModifierButton(fieldName, "+", change, xOffset-55, ypos)
+		createModifierButton(fieldName, "-", -change, xOffset-30, ypos)
+	End Method
+
+	Method createModifierButton(fieldName:String, plusMinus:String, change:Int, xOffset:Int, yPos:Int)
+		Local button:TDebugControlsButton = New TDebugControlsButton
+		button.h = 14
+		button.w = 20
+		button.x = xOffset
+		button.y = yPos
+		button.dataInt = change
+		button.text = plusMinus
+		button.data=fieldName
+		button._onClickHandler = OnClickModifyHandler
+		buttons :+ [button]
+	End Method
+
+	Function OnClickModifyHandler(sender:TDebugControlsButton)
+		Local difficulty:TPlayerDifficulty = TDebugScreenPage_Modifiers.GetInstance().difficulty
+		Local diff:Int = sender.dataInt
+		Local fieldName:String = String(sender.data)
+		Select fieldName
+			case "licPrice"
+				difficulty.programmePriceMod:+ diff/100.0
+			case "xPenalty"
+				difficulty.sentXRatedPenalty:+ diff
+			case "xRisk"
+				difficulty.sentXRatedConfiscateRisk:+ diff
+
+			case "adAudience"
+				difficulty.adcontractRawMinAudienceMod:+ diff/100.0
+			case "adPrice"
+				difficulty.adcontractPriceMod:+ diff/100.0
+			case "adProfit"
+				difficulty.adcontractProfitMod:+ diff/100.0
+			case "adPenalty"
+				difficulty.adcontractPenaltyMod:+ diff/100.0
+			case "adTarget"
+				difficulty.adcontractLimitedTargetgroupMod:+ diff/100.0
+			case "infoProfit"
+				difficulty.adcontractInfomercialProfitMod:+ diff/100.0
+
+			case "permPrice"
+				difficulty.broadcastPermissionPriceMod:+ diff/100.0
+			case "stPrice"
+				difficulty.antennaBuyPriceMod:+ diff/100.0
+			case "stTime"
+				difficulty.antennaConstructionTime:+ diff
+			case "stDaily"
+				difficulty.antennaDailyCostsMod:+ diff/100.0
+			case "stInc"
+				difficulty.antennaDailyCostsIncrease:+ diff/100.0
+			case "stIncMax"
+				difficulty.antennaDailyCostsIncreaseMax:+ diff/100.0
+			case "cablePrice"
+				difficulty.cableNetworkBuyPriceMod:+ diff/100.0
+			case "cableTime"
+				difficulty.cableNetworkConstructionTime:+ diff
+			case "cableDaily"
+				difficulty.cableNetworkDailyCostsMod:+ diff/100.0
+			case "satPrice"
+				difficulty.satelliteBuyPriceMod:+ diff/100.0
+			case "satTime"
+				difficulty.satelliteConstructionTime:+ diff
+			case "satDaily"
+				difficulty.satelliteDailyCostsMod:+ diff/100.0
+			case "newsPrice"
+				difficulty.newsItemPriceMod:+ diff/100.0
+			case "roomPrice"
+				difficulty.roomRentMod:+ diff/100.0
+			case "credBase"
+				difficulty.creditBaseValue:+ diff
+			case "credRate"
+				difficulty.interestRateCredit:+ diff/100.0
+			case "credIntPos"
+				difficulty.interestRatePositiveBalance:+ diff/100.0
+			case "credIntNeg"
+				difficulty.interestRateNegativeBalance:+ diff/100.0
+			case "prodTime"
+				difficulty.productionTimeMod:+ diff/100.0
+			default
+				throw "unkown field for "+ fieldName
+		End Select
+		'handled
+		sender.clicked = False
+		sender.selected = False
+	End Function
+End Type

--- a/source/gamefunctions_debug.bmx
+++ b/source/gamefunctions_debug.bmx
@@ -24,7 +24,6 @@ Type TDebugScreen
 	Field buttonsProducers:TDebugControlsButton[]
 	Field buttonsSports:TDebugControlsButton[]
 	Field buttonsMisc:TDebugControlsButton[]
-	Field buttonsModifiers:TDebugControlsButton[]
 	Field buttonsAwardControls:TDebugControlsButton[]
 	Field sideButtonPanelWidth:Int = 130
 	Field roomHighlight:TRoomBase
@@ -37,7 +36,8 @@ Type TDebugScreen
 	Field pagePlayerBroadcasts:TDebugScreenPage_PlayerBroadcasts
 	Field pageAdAgency:TDebugScreenPage_AdAgency
 	Field pageMovieAgency:TDebugScreenPage_MovieAgency
-	
+	Field pageModifiers:TDebugScreenPage_Modifiers
+
 	Global titleFont:TBitmapFont
 	Global textFont:TBitmapFont
 	Global textFontBold:TBitmapFont
@@ -90,6 +90,9 @@ Type TDebugScreen
 		pageMovieAgency = TDebugScreenPage_MovieAgency.GetInstance().Init()
 		pageMovieAgency.SetPosition(sideButtonPanelWidth, 20)
 
+		pageModifiers = TDebugScreenPage_Modifiers.GetInstance().Init()
+		pageModifiers.SetPosition(sideButtonPanelWidth, 20)
+
 		InitMode_Overview()
 		InitMode_PlayerCommands()
 
@@ -99,7 +102,6 @@ Type TDebugScreen
 		InitMode_Politics()
 		InitMode_Producers()
 		InitMode_Sports()
-		InitMode_Modifiers()
 		InitMode_Misc()
 
 
@@ -112,7 +114,8 @@ Type TDebugScreen
 		If pagePlayerFinancials Then pagePlayerFinancials.Reset()
 		If pagePlayerBroadcasts Then TDebugScreenPage_PlayerBroadcasts.GetInstance().Reset()
 		If pageAdAgency Then TDebugScreenPage_AdAgency.GetInstance().Reset()
-		If pageMovieAgency Then TDebugScreenPage_MovieAgency.GetInstance().Reset()
+		If pageMovieAgency Then TDebugScreenPage_MovieAgency.GetInstance().GetInstance().Reset()
+		If pageModifiers Then pageModifiers.Reset()
 
 		ResetMode_Overview()
 		ResetMode_PlayerCommands()
@@ -123,7 +126,6 @@ Type TDebugScreen
 		ResetMode_Politics()
 		ResetMode_Producers()
 		ResetMode_Sports()
-		ResetMode_Modifiers()
 		ResetMode_Misc()
 	End Method
 	
@@ -148,14 +150,14 @@ Type TDebugScreen
 				Case 5	newPage = pageAdAgency
 				Case 6	newPage = pageMovieAgency
 
-				'Case 6	UpdateMode_NewsAgency()
-				'Case 7	UpdateMode_ScriptAgency()
-				'Case 8	UpdateMode_RoomAgency()
-				'Case 9	UpdateMode_Politics()
-				'Case 10	UpdateMode_Producers()
-				'Case 11	UpdateMode_Sports()
-				'Case 12	UpdateMode_Modifiers()
-				'Case 13	UpdateMode_Misc()
+				'Case 7	UpdateMode_NewsAgency()
+				'Case 8	UpdateMode_ScriptAgency()
+				'Case 9	UpdateMode_RoomAgency()
+				'Case 10	UpdateMode_Politics()
+				'Case 11	UpdateMode_Producers()
+				'Case 12	UpdateMode_Sports()
+				Case 13	newPage = pageModifiers
+				'Case 14	UpdateMode_Misc()
 				default newPage = Null
 			End Select
 			
@@ -233,7 +235,6 @@ Type TDebugScreen
 			Case 10	UpdateMode_Politics()
 			Case 11	UpdateMode_Producers()
 			Case 12	UpdateMode_Sports()
-			Case 13	UpdateMode_Modifiers()
 			Case 14	UpdateMode_Misc()
 			default
 				if currentPage then currentPage.Update()
@@ -282,7 +283,6 @@ Type TDebugScreen
 			Case 10	RenderMode_Politics()
 			Case 11	RenderMode_Producers()
 			Case 12	RenderMode_Sports()
-			Case 13	RenderMode_Modifiers()
 			Case 14	RenderMode_Misc()
 			default
 				if currentPage then currentPage.Render()
@@ -1251,68 +1251,9 @@ Type TDebugScreen
 			textY :+ 12
 			textFont.DrawBox("Attr: " + MathHelper.NumberToString(rank.team.GetAttractivity()*100,0) + "  Pwr: " + MathHelper.NumberToString(rank.team.GetPower()*100,0) + "  Skill: " + MathHelper.NumberToString(rank.Team.GetSkill()*100,0), textX, textY, w, 15, sALIGN_LEFT_TOP, new SColor8(220,220,220))
 			textY :+ 12 + 4 
-		Next		
-		
-	End Method
-
-	
-	
-	'=== MODIFIERS screen ===
-
-	Method InitMode_Modifiers()
-		rem
-		 none for now
-		Local texts:String[] = ["Nothing"]
-		Local button:TDebugControlsButton
-		For Local i:Int = 0 Until texts.length
-			button = New TDebugControlsButton
-			button.w = 180
-			button.h = 15
-			button.x = sideButtonPanelWidth + 10
-			button.y = 10 + i * (button.h + 3)
-			button.dataInt = i
-			button.text = texts[i]
-			button._onClickHandler = OnButtonClickHandler_Modifiers
-
-			buttonsModifiers :+ [button]
-		Next
-		endrem
-	End Method
-
-
-	Method ResetMode_Modifiers()
-	End Method
-
-
-	Function OnButtonClickHandler_Modifiers(sender:TDebugControlsButton)
-		Select sender.dataInt
-			case 0
-				'nothing
-		End Select
-
-		'handled
-		sender.clicked = False
-		sender.selected = False
-	End Function
-
-
-	Method UpdateMode_Modifiers()
-		Local playerID:Int = GetShownPlayerID()
-
-		For Local b:TDebugControlsButton = EachIn buttonsModifiers
-			b.Update()
 		Next
 	End Method
 
-
-	Method RenderMode_Modifiers()
-		Local playerID:Int = GetShownPlayerID()
-
-		RenderActionButtons(buttonsModifiers)
-
-		RenderGameModifierList(playerID, sideButtonPanelWidth + 5, 13)
-	End Method
-	
 
 	'=== MISC screen ===
 
@@ -1696,28 +1637,6 @@ Type TDebugScreen
 		For Local b:TDebugControlsButton = EachIn buttonsAwardControls
 			b.Render()
 		Next
-	End Method
-	
-
-	Method RenderGameModifierList(playerID:int, x:int, y:int, w:int = 300, h:int = 300)
-		DrawOutlineRect(x, y, w, h)
-		Local textX:Int = x + 5
-		Local textY:Int = y + 5
-
-		titleFont.DrawSimple("Game Modifiers: ", textX, textY)
-
-		textY :+ 12 
-
-		Local data:TData = GameConfig._modifiers
-		If data
-			For Local k:TLowerString = EachIn data.data.Keys()
-				If textY + 12 > y + h Then Continue
-
-				textFont.DrawBox(k.ToString(), textX, textY, w - 10 - 40, 15, sALIGN_LEFT_TOP, SColor8.White)
-				textFont.DrawBox(MathHelper.NumberToString(data.GetFloat(k.ToString()), 3), textX, textY, w - 10, 15, sALIGN_RIGHT_TOP, SColor8.White)
-				textY :+ 12
-			Next
-		EndIf
 	End Method
 
 

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -111,6 +111,7 @@ Import "game.debug.screen.page.playerfinancials.bmx"
 Import "game.debug.screen.page.playerbroadcasts.bmx"
 Import "game.debug.screen.page.adagency.bmx"
 Import "game.debug.screen.page.movieagency.bmx"
+Import "game.debug.screen.page.modifiers.bmx"
 
 Import "game.network.networkhelper.bmx"
 Import "game.misc.savegameserializers.bmx"


### PR DESCRIPTION
Prototyp für die Erweiterung - Anzeige der Werte für die Schwierigkeitsgrade, Möglichkeit für die Manipulation.
Mit der aktuellen Implementierung teilen sich alle Spieler mit gleichem Level wohl ein Objekt. D.h. man kann zur Zeit nicht nur für einen Spieler einen Wert anpassen.

Wenn es keine grundsätzlichen Einwände gibt, würde ich das so für weitere relevante Werte erweitern.

closes #559