### PR TITLE
Änderung der Berechnung der Imageupdates

### DIFF
--- a/source/game.broadcast.base.bmx
+++ b/source/game.broadcast.base.bmx
@@ -308,8 +308,9 @@ Type TBroadcastManager
 
 				Local attractionList:TList = CreateList()
 				For Local i:Int = 1 To 4
+					Local r:TAudienceResult = bc.GetAudienceResult(i)
 					channelImageChanges[i-1] = New TAudience.InitValue(0, 0)
-					channelAudiences[i-1] = bc.GetAudienceResult(i).audience
+					channelAudiences[i-1] = r.audience.Copy().Divide(r.GetPotentialMaxAudience())
 					'store playerID if not done yet
 					If channelAudiences[i-1] And channelAudiences[i-1].id <= 0
 						channelAudiences[i-1].id = i
@@ -324,7 +325,7 @@ Type TBroadcastManager
 					weight = 0.5
 				EndIf
 
-				Local audience:TAudience = New TAudience 'bc.GetAudienceResult(i).audience
+				'Local audience:TAudience = New TAudience 'bc.GetAudienceResult(i).audience
 				'the list order gets modified within ChangeForTargetGroup()
 				'calls
 				Local channelAudiencesList:TList = New TList.FromArray(channelAudiences)

--- a/source/game.publicimage.bmx
+++ b/source/game.publicimage.bmx
@@ -359,11 +359,11 @@ Type TPublicImage {_exposeToLua="selected"}
 		'the audience is the same as for place 1
 		'-> give points for each "PLACE" not "INDEX" of the list
 		Local differentAudienceNumbers:Int = 0
-		Local lastNumber:Int = 0
+		Local lastNumber:Float = 0
 		Local audienceIndex:Int = 0
 		Local audienceRank:Int[] = New Int[channelAudiencesList.Count()]
 		For Local a:TAudience = EachIn channelAudiencesList
-			Local currentNumber:Int = a.GetTotalValue(targetGroup)
+			Local currentNumber:Float = a.GetTotalValue(targetGroup)
 
 			'nothing set yet or worse than before, increase rank
 			If currentNumber < lastNumber Or audienceIndex = 0


### PR DESCRIPTION
In #504 wurden mögliche Anpassungen an der Imageberechnung besprochen. Der aktuelle Vorschlag ist eine (codemäßig) minimalinvasive Änderung für die Berechnung der Imageanpassungen.

Aktuell wird die absolute Zuschauerzahl pro Zielgruppe für die Reihenfolgefestlegung der Sender herangezogen. Das bevorteilt Spieler, die eine schnelle Senderausbaustrategie verfolgen übermäßig, da bei mehr Zuschauern selbst bei schlechterer Einschaltquote mehr Zuschauer erreicht werden können. Dadurch steigt ggf. trotz "schlechterem" Programms bei höheren Werbeeinnahmen auch noch das Image stärker (platt ausgedrückt: viel Mist ist besser als wenig Qualität).

Ich argumentiere, dass die vorgeschlagene Änderung (die Einschaltquote zur Basis der Reihenfolgeermittlung zu machen) dem Zielbild der Einbeziehung der Märkte in die Berechnung sehr nahe kommt und damit mindestens als Zwischenlösung übernommen werden sollte.
Zu Spielanfang (gleicher Zuschauerbereich) und spät im Spiel (alle haben auf das gesamte Sendegebiet ausgebaut) fallen absolute Zuschauerzahl und Einschaltquote praktisch zusammen. Hat ein Spieler die Reichweite ausgebaut, die anderen aber nicht, hat er im "exklusiven" Sendegebiet keine Konkurrenz und kann dort eine entsprechend höhere absolute Zahl von Zuschauern erreichen, was die Gesamteinschaltquote (im Vergleich zum gemeinsamen Markt) erhöht. Einen ähnlichen Einfluss hätten die 10% Berücksichtigung der Zuschauer in einem Gebiet ohne andere Sender.

Die Anpassung macht das Spiel wesentlich ausgeglichener und erhöht den Anreiz, ein gutes Programm zu senden (und zu produzieren) und sich nicht nur auf mehr Reichweite zu stürzen. Gleichzeitig bedeutet sie ungleich weniger Rechenaufwand als das Abgleichen sämtlicher Märkte für eine anteilige Ermittlung der jeweiligen Imageanpassung und ist für den Spieler auch sehr einfach nachvollziehbar (beste Einschaltquote=viel Imagegewinn, schlechteste Einschaltquote=Imageverlust).

Für ein Missionsziel "Image von x% erreichen" kann damit der Senderausbau nicht mehr "alleinige" Strategie sondern nur noch Mittel zum Zweck sein - mehr Reichweite für mehr Werbeeinnahmen für die Finanzierung eines besseren Programms.

Die Testspiele, die ich habe laufen lassen, sahen sehr vielversprechend aus. Es kommt immer noch vor, dass eine KI zurückbleibt (schlechtes Startprogramm, Verluste durch nicht erfüllte Werbung bremsen Sender- und Fundusausbau), aber langfristig kann man beim Image wieder rankommen und bleibt nicht wegen der fehlenden absoluten Zuschauerzahlen. Und es ist durchaus nicht so, dass plötzlich alle Spieler immer dasselbe Image haben.