### PR TITLE
Größe Spielstände

### DIFF
--- a/config/DEV.xml
+++ b/config/DEV.xml
@@ -9,6 +9,9 @@
 			
 			<!-- wait for AI players so they all finished a certain game minute / tick -->
 			<DEV_SYNC_AI_ON_TIME value="FALSE" />
+			<!--how many days of the AI's programme plan history should be kept (-1 for all);
+				the more days, the bigger the save game size-->
+			<DEV_KEEP_AI_PLAN_DAYS value="2" />
 
 			<!-- 
 			<DEV_WORLD_DAYS_PER_SEASON value="3" comment="value*4 = days per year" />

--- a/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
+++ b/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
@@ -423,6 +423,11 @@ function DefaultAIPlayer:CleanUp()
 		end
 	end
 
+	local day = TVT.GetDay() - 2
+	for hour = 0, 23 do
+		MY:RemoveAIData("guessedaudience_" .. day .."_".. hour)
+	end
+
 	self:LogDebug("Requisitions (after): " .. table.count(self.Requisitions))
 end
 

--- a/res/database/Default/database_scripts.xml
+++ b/res/database/Default/database_scripts.xml
@@ -147,7 +147,7 @@
 			<variables>
 				<!-- international title for all incarnations - so "de" is enough -->
 				<object>
-					<de>Cannons|Guns|Ropes|Knifes|Jaws|Dynamite|Bones</de>
+					<de>Cannons|Guns|Ropes|Knives|Jaws|Dynamite|Bones</de>
 				</object>
 				<adjective>
 					<de>Flying|Burning|Bloody|Rusty|Explosive|Violent|Cruel|Cool|Gangster|Red|Guilty</de>
@@ -175,8 +175,8 @@
 			</variables>
 
 			<jobs>
-				<job index="0" function="1" required="1" gender="1" />
-				<job index="1" function="2" required="1" />
+				<job index="0" function="1" required="1" />
+				<job index="1" function="2" required="1" gender="1" />
 				<!-- there might be up to 2 additional roles without
 				     further specifications -->
 				<job index="2" function="2" required="0" />

--- a/source/game.broadcastmaterial.news.bmx
+++ b/source/game.broadcastmaterial.news.bmx
@@ -440,9 +440,14 @@ endrem
 
 
 	'override default
-    Method GetTitle:string() {_exposeToLua}
-		return GetNewsEvent().GetTitle()
-    End Method
+	Method GetTitle:string() {_exposeToLua}
+		Local event:TNewsEvent=GetNullableNewsEvent()
+		If event
+			return event.GetTitle()
+		Else
+			return "unknown news"
+		EndIf
+	End Method
 
 
 	'override default
@@ -470,10 +475,14 @@ endrem
 		return TNewsEvent.GetGenreString(GetNewsEvent().GetGenre())
 	End Method
 
+	Method GetNullableNewsEvent:TNewsEvent() {_exposeToLua}
+		if newsEventID = 0 and newsEvent then return newsEvent
+		return  GetNewsEventCollection().GetByID(newsEventID)
+	End Method
 
 	Method GetNewsEvent:TNewsEvent() {_exposeToLua}
 		if newsEventID = 0 and newsEvent then return newsEvent
-		Local result:TNewsEvent = GetNewsEventCollection().GetByID(newsEventID)
+		Local result:TNewsEvent = GetNullableNewsEvent()
 		if not result
 			for local ik:TIntKey = EachIn GetNewsEventCollection().allNewsEvents.Keys()
 				print "known: " + ik.value + "   " + GetNewsEventCollection().GetByID(ik.value).GetTitle()

--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -1119,7 +1119,7 @@ Type TDatabaseLoader
 
 				programmeData.GUID = dataGUID
 				programmeData.title = New TLocalizedString
-				programmeData.originalTitle = New TLocalizedString
+				'programmeData.originalTitle = New TLocalizedString
 				programmeData.description = New TLocalizedString
 				programmeData.titleProcessed = Null
 				programmeData.descriptionProcessed = Null
@@ -1161,7 +1161,7 @@ Type TDatabaseLoader
 
 		'=== LOCALIZATION DATA ===
 		programmeData.title.Append( GetLocalizedStringFromNode(xml.FindElementNode(node, "title")) )
-		programmeData.originalTitle.Append( GetLocalizedStringFromNode(xml.FindElementNode(node, "originalTitle")) )
+		'programmeData.originalTitle.Append( GetLocalizedStringFromNode(xml.FindElementNode(node, "originalTitle")) )
 		programmeData.description.Append( GetLocalizedStringFromNode(xml.FindElementNode(node, "description")) )
 
 
@@ -2064,12 +2064,13 @@ Type TDatabaseLoader
 			data = LoadV3CreatorMetaDataFromNode(GUID, data, node, xml)
 		EndIf
 
+		rem
 		'also load the original name if possible
 		xml.LoadValuesToData(node, data, [..
 			"first_name_original", "last_name_original", "nick_name_original", ..
 			"imdb", "tmdb" ..
 		])
-
+		endrem
 
 		Return data
 	End Method

--- a/source/game.debug.screen.page.playerbroadcasts.bmx
+++ b/source/game.debug.screen.page.playerbroadcasts.bmx
@@ -150,6 +150,7 @@ Type TDebugWidget_ProgrammePlanInfo
 		_eventListeners :+ [ EventManager.registerListenerMethod(GameEventKeys.ProgrammePlan_SetNews, self, "onChangeNewsShow") ]
 		_eventListeners :+ [ EventManager.registerListenerMethod(GameEventKeys.StationMap_OnRecalculateAudienceSum, self, "onChangeAudienceSum") ]
 		_eventListeners :+ [ EventManager.registerListenerMethod(GameEventKeys.Game_OnStart, self, "onStartGame") ]
+		_eventListeners :+ [ EventManager.registerListenerMethod(GameEventKeys.Game_OnDay, self, "onGameDay") ]
 	End Method
 
 
@@ -157,6 +158,9 @@ Type TDebugWidget_ProgrammePlanInfo
 		predictionRefreshMarketsNeeded = True
 	End Method
 
+	Method onGameDay:int(triggerEvent:TEventBase)
+		RemoveOutdated()
+	End Method
 
 	Method onChangeAudienceSum:Int(triggerEvent:TEventBase)
 		Local reachBefore:Int = triggerEvent.GetData().GetInt("reachBefore")
@@ -349,6 +353,9 @@ Type TDebugWidget_ProgrammePlanInfo
 				If TAdvertisement(programme) Then progString = "I: "+progString
 
 				progString2 = ((hour - programme.programmedHour + 25) Mod 24) + "/" + programme.GetBlocks(TVTBroadcastMaterialType.PROGRAMME)
+
+				'show predictions only for the current day
+				if dayShown = currentDay
 '				if currHour < hour
 					'uncached
 					If Not predictionCacheProgAudience[hour]
@@ -385,8 +392,6 @@ Type TDebugWidget_ProgrammePlanInfo
 						predictor.RunPrediction(dayShown, hour)
 						predictionCacheProgAudience[hour] = predictor.GetAudience(playerID)
 					EndIf
-				'show predictions only for the current day
-				if dayShown = currentDay
 					progString2 :+ " |color=200,255,200|"+Int(predictionCacheProgAudience[hour].GetTotalSum()/1000)+"k|/color|"
 				else
 					progString2 :+ " |color=200,200,255|??|/color|"

--- a/source/game.player.bmx
+++ b/source/game.player.bmx
@@ -48,10 +48,25 @@ Type TPlayerCollection extends TPlayerBaseCollection
 		_eventListeners :+ [ EventManager.registerListenerFunction(GameEventKeys.Figure_OnFinishEnterRoom, OnFigureFinishEnterRoom) ]
 		_eventListeners :+ [ EventManager.registerListenerFunction(GameEventKeys.Figure_OnFinishLeaveRoom, OnFigureFinishLeaveRoom) ]
 		_eventListeners :+ [ EventManager.registerListenerFunction(GameEventKeys.Figure_OnReachTarget, OnFigureReachTarget) ]
-
+		_eventListeners :+ [ EventManager.registerListenerMethod(GameEventKeys.Game_OnDay, self, "onGameDay") ]
 		return result
 	End Method
 
+
+	Method onGameDay:Int(triggerEvent:TEventBase)
+		Local daysToKeep:Int=GameRules.devConfig.GetInt(TLowerString.Create("DEV_KEEP_AI_PLAN_DAYS"), -1)
+		If daysToKeep > 0
+			daysToKeep = max(2, daysToKeep)
+			For local p:TPlayerBase = EachIn players
+				If p
+					Local id:Int=p.GetPlayerID()
+					If Not IsHuman(id)
+						TPlayerProgrammePlanCollection.GetInstance().Get(id).TruncateHistory(daysToKeep)
+					EndIf
+				EndIf
+			Next
+		EndIf
+	End Method
 
 	Method Get:TPlayer(id:Int=-1)
 		return TPlayer(Super.Get(id))
@@ -282,6 +297,10 @@ Type TPlayer extends TPlayerBase {_exposeToLua="selected"}
 
 	Method SetAIStringData(key:string, value:string) {_exposeToLua}
 		aiData.Add(key, value)
+	End Method
+
+	Method RemoveAIData(key:string) {_exposeToLua}
+		aiData.Remove(key)
 	End Method
 
 

--- a/source/game.player.financehistory.bmx
+++ b/source/game.player.financehistory.bmx
@@ -39,6 +39,21 @@ Type TPlayerFinanceHistoryListCollection
 
 		return historyLists[playerID-1]
 	End Method
+
+	Method RemoveBeforeTime:int(time:long)
+		For Local i:Int = 0 To historyLists.length-1
+			Local list:TList = historyLists[i]
+			Local toRemove:TPlayerFinanceHistoryEntry[]
+			For Local item:TPlayerFinanceHistoryEntry = EachIn list
+				If item.worldTime < time
+					toRemove:+[item]
+				EndIf
+			Next
+			For local entry:TPlayerFinanceHistoryEntry = EachIn toRemove
+				list.Remove(entry)
+			Next
+		Next
+	End Method
 End Type
 
 '===== CONVENIENCE ACCESSOR =====

--- a/source/game.player.programmeplan.bmx
+++ b/source/game.player.programmeplan.bmx
@@ -97,6 +97,7 @@ Type TPlayerProgrammePlan {_exposeToLua="selected"}
 	Field owner:Int
 
 	Field _daysPlanned:int = -1 {nosave}
+	Field dayOffset:int = -1
 
 	'FALSE to avoid recursive handling (network)
 	Global fireEvents:Int = True
@@ -124,6 +125,7 @@ Type TPlayerProgrammePlan {_exposeToLua="selected"}
 		news = New TBroadcastMaterial[3]
 		newsShow = newsShow[..0]
 		advertisements = advertisements[..0]
+		dayOffset = -1
 
 		'unregister events if any
 	End Method
@@ -137,7 +139,7 @@ Type TPlayerProgrammePlan {_exposeToLua="selected"}
 
 
 	Method getSkipHoursFromIndex:Int()
-		Return (GetWorldTime().GetStartDay()-1)*24
+		Return (GetWorldTime().GetStartDay()+dayOffset)*24
 	End Method
 
 
@@ -280,6 +282,16 @@ Type TPlayerProgrammePlan {_exposeToLua="selected"}
 		Return False
 	End Method
 
+	Method TruncateHistory(daysToKeep:Int = 2)
+		local daysToTruncate:Int = GetWorldTime().GetDay() - (GetWorldTime().GetStartDay()+dayOffset) - daysToKeep
+		If daysToTruncate > 0
+			dayOffset = dayOffset + daysToTruncate
+			local hoursToTruncate:Int = daysToTruncate * 24
+			programmes = programmes[hoursToTruncate..]
+			advertisements = advertisements[hoursToTruncate..]
+			newsShow = newsShow[hoursToTruncate..]
+		EndIf
+	End Method
 
 	'Set a time slot locked
 	'each lock is identifyable by "typeID_timeHours"

--- a/source/game.production.scripttemplate.bmx
+++ b/source/game.production.scripttemplate.bmx
@@ -355,8 +355,9 @@ Type TScriptTemplate Extends TScriptBase
 			result[i] = result[i].Copy()
 		Next
 
-
+		rem
 		'assign missing roles to actors
+		'...we do not do that here anymore - hundreds of roles would be created without being used anywhere
 		local actorFlag:int = TVTPersonJob.ACTOR | TVTPersonJob.SUPPORTINGACTOR
 		local usedRoleIDs:Int[]
 		'collect already used role guids
@@ -403,7 +404,7 @@ Type TScriptTemplate Extends TScriptBase
 				usedRoleIDs :+ [role.GetID()]
 			endif
 		Next
-
+		endrem
 		return result
 	End Method
 

--- a/source/game.programme.newsevent.bmx
+++ b/source/game.programme.newsevent.bmx
@@ -228,14 +228,14 @@ Type TNewsEventCollection
 	Method RemoveOutdatedNewsEvents(minAgeInDays:Int=5, genre:Int=-1)
 		Local somethingDeleted:Int = False
 		Local toRemove:TNewsEvent[]
-
-		For Local newsEvent:TNewsEvent = EachIn newsEvents.Values()
+		Local today:Int = GetWorldTime().GetDay()
+		For Local newsEvent:TNewsEvent = EachIn allnewsEvents.Values()
 			'not happened yet - should not happen
 			If Not newsEvent.HasHappened() Then Continue
 			'only interested in a specific genre?
 			If genre <> -1 And newsEvent.GetGenre() <> genre Then Continue
 
-			If Abs(GetWorldTime().GetDay(newsEvent.happenedTime) - GetWorldTime().GetDay()) >= minAgeInDays
+			If Abs(GetWorldTime().GetDay(newsEvent.happenedTime) - today) >= minAgeInDays
 				toRemove :+ [newsEvent]
 
 				somethingDeleted = True
@@ -245,7 +245,7 @@ Type TNewsEventCollection
 		'delete/modify in an extra step - this approach skips creation
 		'of a map-copy just to avoid concurrent modification
 		For Local n:TNewsEvent = EachIn toRemove
-			RemoveActive(n)
+			Remove(n)
 		Next
 
 		'reset caches, so lists get filled correctly

--- a/source/game.programme.programmedata.bmx
+++ b/source/game.programme.programmedata.bmx
@@ -497,7 +497,7 @@ End Function
 'raw data for movies, episodes (series)
 'but also series-headers, collection-headers,...
 Type TProgrammeData Extends TBroadcastMaterialSource {_exposeToLua}
-	Field originalTitle:TLocalizedString
+	'Field originalTitle:TLocalizedString
 	'contains the title with placeholders replaced
 	Field titleProcessed:TLocalizedString {nosave}
 	Field descriptionProcessed:TLocalizedString {nosave}

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -6168,13 +6168,13 @@ endrem
 				Next
 			Next
 
-			'NEWSEVENTS
-			'remove old news events - wait a bit more than "plan time"
-			'this also gets rid of "one time" news events which should
-			'have been "triggered" then
-			Local daysToKeep:Int = Int(Ceil((hoursToKeep)/48.0) + 1)
-			GetNewsEventCollection().RemoveOutdatedNewsEvents(daysToKeep)
 		Next
+		'NEWSEVENTS
+		'remove old news events - wait a bit more than "plan time"
+		'this also gets rid of "one time" news events which should
+		'have been "triggered" then
+		Local daysToKeep:Int = 3
+		GetNewsEventCollection().RemoveOutdatedNewsEvents(daysToKeep)
 		'remove from collection (reuse if possible)
 		GetNewsEventCollection().RemoveEndedNewsEvents()
 
@@ -6242,9 +6242,12 @@ endrem
 
 
 			'remove no longer needed DailyBroadcastStatistics
-			'by default we store maximally 1 year + current day
-			Local statisticDaysToKeep:Int = 4 * GetWorldTime()._daysPerSeason
+			'by default we store maximally one week
+			Local statisticDaysToKeep:Int = 7 '4 * GetWorldTime()._daysPerSeason
 			GetDailyBroadcastStatisticCollection().RemoveBeforeDay( day - statisticDaysToKeep )
+			'history for single transactions of office's financial screen can be shorter
+			statisticDaysToKeep = 2
+			GetPlayerFinanceHistoryListCollection().RemoveBeforeTime(time - statisticDaysToKeep * TWorldTime.DAYLENGTH)
 
 
 			'force adagency to refill their sortiment a bit more intensive


### PR DESCRIPTION
siehe #700. Mit den vorgeschlagenen Änderungen steigen die Sielstandgrößen im späteren Spiel wesentlich geringer an (z.B. Tag 40 42MB statt 78MB). Die Hauptplatztreiber sind NewsEvents, die Finanzeinzeltransaktionshistorie (irrelevant wenn älter als 2 bis 3 Tage) sowie der Programmplan (meiner Ansicht nach irrelevant für die KI-Spieler; selbst wenn man den Generalschlüssel hat, interessiert man sich ja eher für das zukünftige Programm).

Das Kürzen der Programmliste führt dazu, dass für den ersten Tag verfügbaren Tag das Programm von 0 Uhr nicht mit angezeigt wird. Das sollte aber verkraftbar sein.

Bei meiner Analyse sind noch ProgrammeRoleCollection und PlayerCollection aufgefallen. Deren Platz steigen auch kontinuierlich an.