### PR TITLE
Nachrichtencheat verhindern

### DIFF
--- a/source/game.newsagency.base.bmx
+++ b/source/game.newsagency.base.bmx
@@ -755,8 +755,14 @@ Type TNewsAgency
 				'high enough
 				local newsEvent:TNewsEvent = news.GetNewsEvent()
 				local newsAbonnement:Int = player.GetNewsabonnement(newsEvent.GetGenre())
-				If newsEvent.HasFlag(TVTNewsFlag.SEND_TO_ALL) or (newsAbonnement > 0 And newsAbonnement >= newsEvent.GetMinSubscriptionLevel())
+				If newsEvent.HasFlag(TVTNewsFlag.SEND_TO_ALL)
 					__AddNewsToPlayer(news, playerID)
+				ElseIf newsAbonnement > 0
+					If Not player.IsNewsAbonnementEffective(newsEvent.GetGenre())
+						Continue
+					ElseIf newsAbonnement >= newsEvent.GetMinSubscriptionLevel()
+						__AddNewsToPlayer(news, playerID)
+					EndIf
 				EndIf
 
 				'mark the news for removal
@@ -884,6 +890,7 @@ Type TNewsAgency
 						'if playerID=1 then print "ProcessDelayedNews #"+playerID+": NOT subscribed or not ready yet: " + news.GetTitle() + "   announceToPlayer="+ GetWorldTime().GetFormattedDate( news.GetPublishTime() + subscriptionDelay )
 						Return False
 					EndIf
+					If not player.IsNewsAbonnementEffective(newsEvent.GetGenre()) Then Return False
 				EndIf
 			EndIf
 

--- a/source/game.newsagency.base.bmx
+++ b/source/game.newsagency.base.bmx
@@ -759,7 +759,12 @@ Type TNewsAgency
 					__AddNewsToPlayer(news, playerID)
 				ElseIf newsAbonnement > 0
 					If Not player.IsNewsAbonnementEffective(newsEvent.GetGenre())
-						Continue
+						Local maxLevel:Int = player.GetNewsAbonnementDaysMax(genre)
+						If maxLevel > 0 and maxLevel >= newsEvent.GetMinSubscriptionLevel()
+							__AddNewsToPlayer(news, playerID)
+						Else
+							Continue
+						EndIf
 					ElseIf newsAbonnement >= newsEvent.GetMinSubscriptionLevel()
 						__AddNewsToPlayer(news, playerID)
 					EndIf

--- a/source/game.player.base.bmx
+++ b/source/game.player.base.bmx
@@ -261,6 +261,22 @@ Type TPlayerBase {_exposeToLua="selected"}
 	End Method
 
 
+	'check whether the current level is effective
+	'news must not yet be available if not, otherwise cheating is possible
+	Method IsNewsAbonnementEffective:Int(genre:Int)
+		If genre < 0 or genre > 5 Then Return False 'max 6 categories 0-5
+
+		Local level:Int = Self.newsabonnements[genre]
+		If level > 0 and level <> newsabonnementsDayMax[genre]
+			Local setTime:Long = newsabonnementsSetTime[genre]
+			If setTime > 0 And GetWorldTime().GetTimeGone() - GameRules.newsSubscriptionIncreaseFixTime < setTime
+				return False
+			EndIf
+		EndIf
+		Return True
+	End Method
+
+
 	Method HasNewsAbonnementDaysMax:Int(genre:Int) {_exposeToLua}
 		If genre >= TVTNewsGenre.count or genre < 0 Then Return 0
 


### PR DESCRIPTION
Bevor die Nachrichten in der Liste erscheinen, muss das Abo-Level effektiv geworden sein. Diese zusätzliche Prüfung erfolgt ausschließlich an den "Hinzufüge"-Stellen (sonst würde z.B. der Auswahl-Button das falsche Level anzeigen).

Sobald die Prüfung einmal erfolgreich war, wird der Zeitstempel des Abo zurückgesetz, um einen ständigen Zeitvergleich zu vermeinden.

closes #699