### PR TITLE
Autosave

### DIFF
--- a/res/lang/gen_settings/genSettings_de.txt
+++ b/res/lang/gen_settings/genSettings_de.txt
@@ -68,6 +68,7 @@ SOUND_SFX_VOLUME            = SFX-Lautstärke
 SOUND_MUTED                 = Stumm
 PORT_ONLINEGAME             = Port für Onlinespiele
 GAME_SPEED_IN_ROOMS         = Spielgeschwind. in Räumen
+AUTOSAVE_INTERVAL           = Automatisches Speichern nach
 
 GAME_TITLE  = Spieltitel
 START_YEAR  = Startjahr

--- a/res/lang/gen_settings/genSettings_en.txt
+++ b/res/lang/gen_settings/genSettings_en.txt
@@ -68,6 +68,7 @@ SOUND_SFX_VOLUME            = SFX Volume
 SOUND_MUTED                 = Muted
 PORT_ONLINEGAME             = Port for online games
 GAME_SPEED_IN_ROOMS         = Game speed in rooms
+AUTOSAVE_INTERVAL           = Auto-save after
 
 GAME_TITLE  = Game title
 START_YEAR  = Start year

--- a/res/lang/gen_settings/genSettings_es.txt
+++ b/res/lang/gen_settings/genSettings_es.txt
@@ -68,6 +68,7 @@ SOUND_ENGINE                = Base de audio
 #SOUND_MUTED                 = 
 PORT_ONLINEGAME             = Puerto para jugar en linea
 #GAME_SPEED_IN_ROOMS         = 
+#AUTOSAVE_INTERVAL           = 
 
 GAME_TITLE  = Titulo del Juego
 START_YEAR  = Año de inicio

--- a/res/lang/gen_settings/genSettings_fr.txt
+++ b/res/lang/gen_settings/genSettings_fr.txt
@@ -68,6 +68,7 @@ SOUND_SFX_VOLUME            = Volume des effets sonores
 SOUND_MUTED                 = Son désactivé
 PORT_ONLINEGAME             = Port réseau
 GAME_SPEED_IN_ROOMS         = Vitesse du jeu dans les salles
+#AUTOSAVE_INTERVAL           = 
 
 GAME_TITLE  = Nom de la partie
 START_YEAR  = Début

--- a/res/lang/gen_settings/genSettings_pt-br.txt
+++ b/res/lang/gen_settings/genSettings_pt-br.txt
@@ -68,6 +68,7 @@ RENDERER                    = Renderizador
 #SOUND_MUTED                 = 
 PORT_ONLINEGAME             = Porta para jogos online
 GAME_SPEED_IN_ROOMS         = Velocidade do jogo dentro das salas
+#AUTOSAVE_INTERVAL           = 
 
 GAME_TITLE  = Título do jogo
 START_YEAR  = Ano inicial

--- a/res/lang/gen_settings/genSettings_tr.txt
+++ b/res/lang/gen_settings/genSettings_tr.txt
@@ -68,6 +68,7 @@ SOUND_ENGINE                = Ses Motoru
 #SOUND_MUTED                 = 
 PORT_ONLINEGAME             = Internet Oyunu için Port
 #GAME_SPEED_IN_ROOMS         = 
+#AUTOSAVE_INTERVAL           = 
 
 GAME_TITLE  = Oyun Başlığı
 START_YEAR  = Başlangıç Yılı

--- a/source/game.game.bmx
+++ b/source/game.game.bmx
@@ -2248,8 +2248,8 @@ endrem
 		If Not GetGame().networkGame
 			If GetPlayer().IsInRoom() 'and not GetPlayer().GetFigure().IsInBuilding()
 				If TEntity.globalWorldSpeedFactorMod = 1.0
-					GetWorldTime().SetTimeFactorMod(GameRules.InRoomTimeSlowDownMod)
-					TEntity.globalWorldSpeedFactorMod = GameRules.InRoomTimeSlowDownMod
+					GetWorldTime().SetTimeFactorMod(GameConfig.InRoomTimeSlowDownMod)
+					TEntity.globalWorldSpeedFactorMod = GameConfig.InRoomTimeSlowDownMod
 				EndIf
 			Else
 				If TEntity.globalWorldSpeedFactorMod <> 1.0

--- a/source/game.gameconfig.bmx
+++ b/source/game.gameconfig.bmx
@@ -21,6 +21,11 @@ Type TGameConfig {_exposeToLua}
 	Field savegame_initialSaveGameVersion:String
 	Field savegame_saveCount:Int = 0
 	Field savegame_lastUsedName:String
+	'auto save x hours after last saving - 0=off
+	Field autoSaveIntervalHours:Int = 0 {nosave}
+	'percentage of the gametime when in a room (default = 100%)
+	'use a lower value, to slow down the game then (movement + time)
+	Field InRoomTimeSlowDownMod:Float = 1.0 {nosave}
 
 	Global clNormal:SColor8 = SColor8.Black
 	Global clPositive:SColor8 = new SColor8(90, 110, 90)

--- a/source/game.gamerules.bmx
+++ b/source/game.gamerules.bmx
@@ -3,8 +3,6 @@ Import "Dig/base.util.data.bmx"
 
 'specific variables shared across the whole game
 Type TGameRules {_exposeToLua}
-	'auto save x hours after last saving - 0=off
-	Field autoSaveIntervalHours:Int = 0
 	'should a game start with a credit already given
 	Field startGameWithCredit:Int = True
 	'should licence attributes from the database be randomized
@@ -68,10 +66,6 @@ Type TGameRules {_exposeToLua}
 	'pay live productions already on finish of preproduction (True)
 	'or on finish of actual shooting (False)
 	Field payLiveProductionInAdvance:Int = False
-
-	'percentage of the gametime when in a room (default = 100%)
-	'use a lower value, to slow down the game then (movement + time)
-	Field InRoomTimeSlowDownMod:Float = 1.0
 
 	'how many productions (jobs, so theoretically less productions)
 	'are required to make a person a celebrity

--- a/source/game.gamerules.bmx
+++ b/source/game.gamerules.bmx
@@ -3,6 +3,8 @@ Import "Dig/base.util.data.bmx"
 
 'specific variables shared across the whole game
 Type TGameRules {_exposeToLua}
+	'auto save x hours after last saving - 0=off
+	Field autoSaveIntervalHours:Int = 0
 	'should a game start with a credit already given
 	Field startGameWithCredit:Int = True
 	'should licence attributes from the database be randomized

--- a/source/game.menu.escapemenu.bmx
+++ b/source/game.menu.escapemenu.bmx
@@ -100,7 +100,7 @@ Type TGUIModalMainMenu Extends TGUIModalWindowChainElement
 
 			Case buttons[3]
 				If Not chainSettingsMenu
-					chainSettingsMenu = New TGUIModalSettingsMenu.Create(New SVec2I(0,0), New SVec2I(700,500), "SYSTEM")
+					chainSettingsMenu = New TGUIModalSettingsMenu.Create(New SVec2I(0,0), New SVec2I(700,535), "SYSTEM")
 					chainSettingsMenu._defaultValueColor = TColor.clBlack.copy()
 					chainSettingsMenu.defaultCaptionColor = TColor.clWhite.copy()
 					'set self as previous one
@@ -185,7 +185,7 @@ Type TGUIModalSettingsMenu Extends TGUIModalWindowChainDialogue
 
 
 
-		settingsPanel = New TGUISettingsPanel.Create(New SVec2I(0,0), New SVec2I(700, 500), "SYSTEM")
+		settingsPanel = New TGUISettingsPanel.Create(New SVec2I(0,0), New SVec2I(700, 535), "SYSTEM")
 		'add to canvas of this window
 		'GetGuiContent()
 		AddChild(settingsPanel)

--- a/source/game.menu.settings.bmx
+++ b/source/game.menu.settings.bmx
@@ -27,6 +27,7 @@ Type TGUISettingsPanel Extends TGUIPanel
 	Field inputWindowResolutionHeight:TGUIInput
 	Field inputGameName:TGUIInput
 	Field inputInRoomSlowdown:TGUIInput
+	Field inputAutoSaveInterval:TGUIInput
 	Field inputOnlinePort:TGUIInput
 	Field inputTouchClickRadius:TGUIInput
 	Field checkTouchInput:TGUICheckbox
@@ -126,11 +127,19 @@ Type TGUISettingsPanel Extends TGUIPanel
 		nextY :+ 22
 
 		Local labelInRoomSlowdown:TGUILabel = New TGUILabel.Create(New SVec2I(nextX, nextY), GetLocale("GAME_SPEED_IN_ROOMS")+":")
-		inputInRoomSlowdown = New TGUIInput.Create(New SVec2I(nextX, nextY + labelH), New SVec2I(75,-1), "", 128)
-		Local labelInRoomSlowdownPercentage:TGUILabel = New TGUILabel.Create(New SVec2I(nextX + 75 + 5, nextY + 18), "%")
+		inputInRoomSlowdown = New TGUIInput.Create(New SVec2I(nextX, nextY + labelH), New SVec2I(50,-1), "", 128)
+		Local labelInRoomSlowdownPercentage:TGUILabel = New TGUILabel.Create(New SVec2I(nextX + 50 + 5, nextY + 22), "%")
 		Self.AddChild(labelInRoomSlowdown)
 		Self.AddChild(inputInRoomSlowdown)
 		Self.AddChild(labelInRoomSlowdownPercentage)
+		nextY :+ inputH + guiDistance
+
+		Local labelAutoSaveInterval:TGUILabel = New TGUILabel.Create(New SVec2I(nextX, nextY), GetLocale("AUTOSAVE_INTERVAL")+":")
+		inputAutoSaveInterval = New TGUIInput.Create(New SVec2I(nextX, nextY + labelH), New SVec2I(50,-1), "", 128)
+		Local labelAutoSaveIntervalHours:TGUILabel = New TGUILabel.Create(New SVec2I(nextX + 50 + 5, nextY + 22), GetLocale("HOURS"))
+		Self.AddChild(labelAutoSaveInterval)
+		Self.AddChild(inputAutoSaveInterval)
+		Self.AddChild(labelAutoSaveIntervalHours)
 		nextY :+ inputH + guiDistance
 
 		'-----
@@ -332,6 +341,7 @@ Type TGUISettingsPanel Extends TGUIPanel
 		'data.Add("stationmap", inputStationmap.GetValue())
 		data.Add("databaseDir", inputDatabase.GetValue())
 		data.Add("inroomslowdown", inputInRoomSlowdown.GetValue())
+		data.Add("autosaveInterval", inputAutoSaveInterval.GetValue())
 
 '		data.AddBoolString("sound_music", checkMusic.IsChecked())
 '		data.AddBoolString("sound_effects", checkSfx.IsChecked())
@@ -374,6 +384,7 @@ Type TGUISettingsPanel Extends TGUIPanel
 		EndIf
 		inputDatabase.SetValue(data.GetString("databaseDir", "res/database/Default"))
 		inputInRoomSlowdown.SetValue(data.GetInt("inroomslowdown", 100))
+		inputAutoSaveInterval.SetValue(data.GetInt("autosaveInterval", 0))
 '		checkMusic.SetChecked(data.GetBool("sound_music", True))
 '		checkSfx.SetChecked(data.GetBool("sound_effects", True))
 		checkFullscreen.SetChecked(data.GetBool("fullscreen", False))
@@ -548,7 +559,7 @@ Type TSettingsWindow
 	Method Init:TSettingsWindow()
 		'LAYOUT CONFIG
 		Local windowW:Int = 700
-		Local windowH:Int = 500
+		Local windowH:Int = 535
 
 		modalDialogue = New TGUIGameModalWindow.Create(New SVec2I(0,0), New SVec2I(windowW, windowH), "SYSTEM")
 

--- a/source/game.menu.settings.bmx
+++ b/source/game.menu.settings.bmx
@@ -134,7 +134,7 @@ Type TGUISettingsPanel Extends TGUIPanel
 		Self.AddChild(labelInRoomSlowdownPercentage)
 		nextY :+ inputH + guiDistance
 
-		Local labelAutoSaveInterval:TGUILabel = New TGUILabel.Create(New SVec2I(nextX, nextY), GetLocale("AUTOSAVE_INTERVAL")+":")
+		Local labelAutoSaveInterval:TGUILabel = New TGUILabel.Create(New SVec2I(nextX, nextY), GetLocale("AUTOSAVE_INTERVAL"))
 		inputAutoSaveInterval = New TGUIInput.Create(New SVec2I(nextX, nextY + labelH), New SVec2I(50,-1), "", 128)
 		Local labelAutoSaveIntervalHours:TGUILabel = New TGUILabel.Create(New SVec2I(nextX + 50 + 5, nextY + 22), GetLocale("HOURS"))
 		Self.AddChild(labelAutoSaveInterval)

--- a/source/gamefunctions_debug.bmx
+++ b/source/gamefunctions_debug.bmx
@@ -1379,7 +1379,7 @@ Type TDebugScreen
 					FastForward_TargetTime = -1
 					GetGame().SetGameSpeedPreset(1)
 				Else
-					GameRules.autoSaveIntervalHours = 0
+					GameConfig.autoSaveIntervalHours = 0
 					FastForward_Continuous_Active = True
 					FastForward_TargetTime = GetWorldTime().CalcTime_DaysFromNowAtHour(-1,0,0,23,23) + 56*TWorldTime.MINUTELENGTH
 					GetGame().SetGameSpeed(FastForwardSpeed)

--- a/source/gamefunctions_debug.bmx
+++ b/source/gamefunctions_debug.bmx
@@ -193,8 +193,11 @@ Type TDebugScreen
 		EndIf
 		'continuous fast forward: save game and go to the end of the next day
 		If FastForward_Continuous_Active and FastForward_TargetTime < GetWorldTime().GetTimeGone()
-			Local savegameName:String = "savegames/AI-day-" + StringHelper.RSetChar((GetWorldTime().GetDaysRun() + 1),2,"0")+ ".xml"
-			TSaveGame.SaveURI(savegameName)
+			Local daysRun:Int = GetWorldTime().GetDaysRun() + 1
+			If daysRun mod 5 = 0
+				Local savegameName:String = "savegames/AI-day-" + StringHelper.RSetChar(daysRun,3,"0")+ ".xml"
+				TSaveGame.SaveURI(savegameName)
+			EndIf
 			FastForward_TargetTime = GetWorldTime().CalcTime_DaysFromNowAtHour(-1,1,1,23,23) + 56*TWorldTime.MINUTELENGTH
 			'GetGame().SetGameSpeed(FastForwardSpeed)
 		EndIf
@@ -1370,12 +1373,13 @@ Type TDebugScreen
 			case 6
 				GetPlayer().GetProgrammePlan().printOverview()
 			case 7
-				'continuous fast forward: save game at the end of every day
+				'continuous fast forward: save game at the end of every fifth day
 				If FastForward_Continuous_Active then
 					FastForward_Continuous_Active = False
 					FastForward_TargetTime = -1
 					GetGame().SetGameSpeedPreset(1)
 				Else
+					GameRules.autoSaveIntervalHours = 0
 					FastForward_Continuous_Active = True
 					FastForward_TargetTime = GetWorldTime().CalcTime_DaysFromNowAtHour(-1,0,0,23,23) + 56*TWorldTime.MINUTELENGTH
 					GetGame().SetGameSpeed(FastForwardSpeed)

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -6058,7 +6058,7 @@ endrem
 		If TSaveGame.autoSaveNow and Not GetPlayer().GetFigure().IsInRoom()
 			Local gameName:String = GameConfig.savegame_lastUsedName
 			Local autoSaveName:String = "autosave.xml"
-			If gameName and gameName <> "quicksave"
+			If gameName and gameName <> "quicksave" and not gameName.endsWith("_autosave")
 				autoSaveName = gameName + "_autosave.xml"
 			EndIf
 			TSaveGame.SaveName(autoSaveName, False)

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -293,6 +293,7 @@ Type TApp
 			GetGraphicsManager().InitGraphics()
 
 			GameRules.InRoomTimeSlowDownMod = obj.config.GetInt("inroomslowdown", 100) / 100.0
+			GameRules.autoSaveIntervalHours = obj.config.GetInt("autosaveInterval", 0)
 
 			MouseManager._minSwipeDistance = obj.config.GetInt("touchClickRadius", 10)
 			MouseManager._ignoreFirstClick = obj.config.GetBool("touchInput", False)
@@ -511,6 +512,7 @@ Type TApp
 
 
 		GameRules.InRoomTimeSlowDownMod = config.GetInt("inroomslowdown", 100) / 100.0
+		GameRules.autoSaveIntervalHours = config.GetInt("autosaveInterval", 0)
 
 		GetDeltatimer().SetRenderRate(config.GetInt("fps", -1))
 

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -292,8 +292,8 @@ Type TApp
 			GetGraphicsManager().SetDesignedResolution(800,600)
 			GetGraphicsManager().InitGraphics()
 
-			GameRules.InRoomTimeSlowDownMod = obj.config.GetInt("inroomslowdown", 100) / 100.0
-			GameRules.autoSaveIntervalHours = obj.config.GetInt("autosaveInterval", 0)
+			GameConfig.InRoomTimeSlowDownMod = obj.config.GetInt("inroomslowdown", 100) / 100.0
+			GameConfig.autoSaveIntervalHours = obj.config.GetInt("autosaveInterval", 0)
 
 			MouseManager._minSwipeDistance = obj.config.GetInt("touchClickRadius", 10)
 			MouseManager._ignoreFirstClick = obj.config.GetBool("touchInput", False)
@@ -511,8 +511,8 @@ Type TApp
 		If adjusted And doInitGraphics Then GetGraphicsManager().InitGraphics()
 
 
-		GameRules.InRoomTimeSlowDownMod = config.GetInt("inroomslowdown", 100) / 100.0
-		GameRules.autoSaveIntervalHours = config.GetInt("autosaveInterval", 0)
+		GameConfig.InRoomTimeSlowDownMod = config.GetInt("inroomslowdown", 100) / 100.0
+		GameConfig.autoSaveIntervalHours = config.GetInt("autosaveInterval", 0)
 
 		GetDeltatimer().SetRenderRate(config.GetInt("fps", -1))
 
@@ -2849,6 +2849,8 @@ Type TSaveGame Extends TGameState
 			GameConfig.savegame_initialSaveGameVersion = "-1"
 			GameConfig.savegame_saveCount = 0
 		EndIf
+		GameConfig.InRoomTimeSlowDownMod = App.config.GetInt("inroomslowdown", 100) / 100.0
+		GameConfig.autoSaveIntervalHours = App.config.GetInt("autosaveInterval", 0)
 
 		'tell everybody we finished loading (eg. for clearing GUI-lists)
 		'payload is saveName and saveGame-object
@@ -6176,7 +6178,7 @@ endrem
 		'remove from collection (reuse if possible)
 		GetNewsEventCollection().RemoveEndedNewsEvents()
 
-		If GameRules.autoSaveIntervalHours > 0 And Not TSaveGame.autoSaveNow and TSaveGame.lastSaveTime > 0 and time - TSaveGame.lastSaveTime > GameRules.autoSaveIntervalHours * TWorldTime.HOURLENGTH
+		If GameConfig.autoSaveIntervalHours > 0 And Not TSaveGame.autoSaveNow and TSaveGame.lastSaveTime > 0 and time - TSaveGame.lastSaveTime > GameConfig.autoSaveIntervalHours * TWorldTime.HOURLENGTH
 			TSaveGame.autoSaveNow = True
 		EndIf
 	End Function

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -6056,7 +6056,7 @@ endrem
 		If TSaveGame.autoSaveNow and Not GetPlayer().GetFigure().IsInRoom()
 			Local gameName:String = GameConfig.savegame_lastUsedName
 			Local autoSaveName:String = "autosave.xml"
-			If gameName and gameName <> "" and gameName <> "quicksave"
+			If gameName and gameName <> "quicksave"
 				autoSaveName = gameName + "_autosave.xml"
 			EndIf
 			TSaveGame.SaveName(autoSaveName, False)

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -6174,7 +6174,7 @@ endrem
 		'remove from collection (reuse if possible)
 		GetNewsEventCollection().RemoveEndedNewsEvents()
 
-		If Not TSaveGame.autoSaveNow and TSaveGame.lastSaveTime > 0 and time - TSaveGame.lastSaveTime > TWorldTime.DAYLENGTH
+		If GameRules.autoSaveIntervalHours > 0 And Not TSaveGame.autoSaveNow and TSaveGame.lastSaveTime > 0 and time - TSaveGame.lastSaveTime > GameRules.autoSaveIntervalHours * TWorldTime.HOURLENGTH
 			TSaveGame.autoSaveNow = True
 		EndIf
 	End Function

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -6047,6 +6047,15 @@ endrem
 			GetProgrammeProducerCollection().UpdateAll()
 		EndIf
 
+		If minute = 37
+			Local gameName:String = GameConfig.savegame_lastUsedName
+			Local autoSaveName:String = "autosave.xml"
+			If gameName and gameName <> ""
+				autoSaveName = gameName + "_autosave.xml"
+			EndIf
+			TSaveGame.SaveName(autoSaveName, False)
+		EndIf
+
 
 		Return True
 	End Function


### PR DESCRIPTION
zunächst Prototypimplementierung:
* onHour wird geprüft, ob ein Speichern nötig ist, falls ja wird Flag gesetzt
* OnMinute wird das Flag geprüft und falls der Spieler nicht in einem Raum ist (keine "wichtige" Interaktion), wird gespeichert
* Dateinamen wie im Ticket vorgeschlagen
* gespeichert wird 24h nach dem letzten Speichern, wenn also in der Zwischenzeit manuell gespeichert wird, verlagert sich das nächste automatische Speichern entsprechend nach hinten

Zunächst ist zu prüfen, ob das grundsätzliche Vorgehen so passt - insb. die Stellen, an denen die AutoSave-Informationen gespeichert werden.

Der nächste zu klärende Punkt wäre, wo das Autospeichern aktiviert wird:
* Flag in der DEV.xml
* Toggle bei Spielstart + in den Spieleinstellungen
* Toggle im Laden/Speichern-Dialog

Vom Gefühl her sollte man das auch während eines Spiels an- und ausschalten können. Da gefällt mir die letzte Variante eigentlich ganz gut; nur dass das für ein komplett neues Spiel offen lässt, ob nun gespeichert werden soll oder nicht.