### PR TITLE
Absturz bei Bankrott verhindern

### DIFF
--- a/source/game.game.bmx
+++ b/source/game.game.bmx
@@ -540,9 +540,43 @@ Type TGame Extends TGameBase {_exposeToLua="selected"}
 
 
 
+		'=== ABORT PRODUCTIONS ? ===
+		Local productions:TProduction[]
+		For Local p:TProduction = EachIn GetProductionManager().productionsToProduce
+			If p.owner = playerID Then productions :+ [p]
+		Next
+		For Local p:TProduction = EachIn GetProductionManager().liveProductions
+			If p.owner = playerID Then productions :+ [p]
+		Next
+		For Local p:TProduction = EachIn productions
+			GetProductionManager().AbortProduction(p)
+			'delete corresponding concept too
+			GetProductionConceptCollection().Remove(p.productionConcept)
+			TLogger.Log("ResetPlayer()", "Stopped production: "+p.productionConcept.getTitle(), LOG_DEBUG)
+		Next
+
+		'=== SELL ALL SCRIPTS ===
+		Local lists:TList[] = [ programmeCollection.scripts, ..
+		          programmeCollection.suitcaseScripts, ..
+		          programmeCollection.studioScripts ]
+		Local scripts:TScript[]
+		For Local list:TList = EachIn lists
+			For Local script:TScript = EachIn list
+				scripts :+ [script]
+			Next
+		Next
+
+		For Local script:TScript = EachIn scripts
+			'remove script, sell it and destroy production concepts
+			'linked to that script
+			programmeCollection.RemoveScript(script, True)
+			TLogger.Log("ResetPlayer()", "Sold script: "+script.getTitle(), LOG_DEBUG)
+		Next
+
+
 		'=== SELL ALL PROGRAMMES ===
 		'sell forced too (so also programmed ones)
-		Local lists:TList[] = [ programmeCollection.suitcaseProgrammeLicences, ..
+		lists = [ programmeCollection.suitcaseProgrammeLicences, ..
 		                        programmeCollection.singleLicences, ..
 		                        programmeCollection.seriesLicences, ..
 		                        programmeCollection.collectionLicences ]
@@ -585,43 +619,6 @@ Type TGame Extends TGameBase {_exposeToLua="selected"}
 			contract.Fail( GetWorldTime().GetTimeGone() )
 			TLogger.Log("ResetPlayer()", "Aborted contract: "+contract.getTitle(), LOG_DEBUG)
 		Next
-
-
-
-		'=== SELL ALL SCRIPTS ===
-		lists = [ programmeCollection.scripts, ..
-		          programmeCollection.suitcaseScripts, ..
-		          programmeCollection.studioScripts ]
-		Local scripts:TScript[]
-		For Local list:TList = EachIn lists
-			For Local script:TScript = EachIn list
-				scripts :+ [script]
-			Next
-		Next
-		For Local script:TScript = EachIn scripts
-			'remove script, sell it and destroy production concepts
-			'linked to that script
-			programmeCollection.RemoveScript(script, True)
-			TLogger.Log("ResetPlayer()", "Sold script: "+script.getTitle(), LOG_DEBUG)
-		Next
-
-
-
-		'=== ABORT PRODUCTIONS ? ===
-		Local productions:TProduction[]
-		For Local p:TProduction = EachIn GetProductionManager().productionsToProduce
-			If p.owner = playerID Then productions :+ [p]
-		Next
-		For Local p:TProduction = EachIn GetProductionManager().liveProductions
-			If p.owner = playerID Then productions :+ [p]
-		Next
-		For Local p:TProduction = EachIn productions
-			GetProductionManager().AbortProduction(p)
-			'delete corresponding concept too
-			GetProductionConceptCollection().Remove(p.productionConcept)
-			TLogger.Log("ResetPlayer()", "Stopped production: "+p.productionConcept.getTitle(), LOG_DEBUG)
-		Next
-
 
 
 		'=== STOP ROOM RENT CONTRACTS ===

--- a/source/game.player.programmecollection.bmx
+++ b/source/game.player.programmecollection.bmx
@@ -808,6 +808,7 @@ Type TPlayerProgrammeCollection extends TOwnedGameObject {_exposeToLua="selected
 	Method RemoveScript:Int(script:TScript, sell:int=FALSE)
 		If script = Null Then Return False
 
+		Local currentOwner:Int = script.owner
 		if sell
 			if not script.sell() then return FALSE
 		endif
@@ -817,7 +818,7 @@ Type TPlayerProgrammeCollection extends TOwnedGameObject {_exposeToLua="selected
 
 		'a series becomes tradeable only if it is completely produced (or the script is thrown away)
 		if script.isSeries() And script.usedInProgrammeID
-			local licence:TProgrammeLicence = GetPlayerProgrammeCollection(script.owner).GetProgrammeLicence(script.usedInProgrammeID)
+			local licence:TProgrammeLicence = GetPlayerProgrammeCollection(currentOwner).GetProgrammeLicence(script.usedInProgrammeID)
 			if licence and not licence.hasLicenceFlag(TVTProgrammeLicenceFlag.TRADEABLE)
 				licence.setLicenceFlag(TVTProgrammeLicenceFlag.TRADEABLE, True)
 			end if


### PR DESCRIPTION
Seit die KI Eigenproduktionen machen kann, kann es zum Absturz bei Bankrott kommen. Das Script wird erst verkauft, danach werden ggf. Lizenzen angepasst. Der Verkauf setzt aber den Owner schon auf -1, so dass die ProgrammeCollection nicht mehr existieren kann.
Zur Sicherheit habe ich auch die Schritte für den Bankrott getauscht: Produktionen abbrechen, dann Scripte verkaufen und zuletzt Lizenzen.

Das Problem war (indirekt) aufgefallen, weil es bei den Testspielen mit Level schwer, häufiger frühe Abstürze gab. Die KI kommt hier mit Reichweite und Geld nicht so gut in die Gänge - laufende Serienproduktionen (noch kein sauberes Budget-Handling) führen dann öfter zu negativem Kontostand und ggf. Bankrott.