### PR TITLE
Supermarktsortierung

### DIFF
--- a/source/game.screen.supermarket.production.bmx
+++ b/source/game.screen.supermarket.production.bmx
@@ -1493,6 +1493,8 @@ Type TGUISelectCastWindow Extends TGUIProductionModalWindow
 	End Method
 
 	Method onClickSortCastButton:Int(triggerEvent:TEventBase )
+		If triggerEvent.GetSender() <> sortCastButton Then Return False
+
 		sortType = sortType + 1
 		If sortType > 3 Then sortType = 0
 		SortCastList(sortType)


### PR DESCRIPTION
Da die Methode auch bei anderen Buttons aufgerufen wurde, hat sich bei Auswahl der Besetzung die Sortierung geändert. Mit diesem Commit wird zunächst geprüft, ob der Sortierbutton geklickt wurde.