### PR TITLE
Beim Speichern länger auf die KI warten

### DIFF
--- a/source/game.game.bmx
+++ b/source/game.game.bmx
@@ -1687,7 +1687,7 @@ Type TGame Extends TGameBase {_exposeToLua="selected"}
 						endif
 					EndIf
 				Next
-				if Millisecs() - t > 1000
+				if Millisecs() - t > 5000
 					For Local player:TPlayer = EachIn GetPlayerCollection().players
 						If player.isLocalAI() 
 							if player.PlayerAI.GetNextEventCount() > 0


### PR DESCRIPTION
Der Abbruch sollte nicht schon nach einer Sekunde passieren. Längeres Warten ist einem "Absturz" ohne Speichern vorgezogen werden. Das KI-Spiel setzt nicht mehr wie im Ticket beschrieben die Geschwindigkeit wieder hoch - aus meiner Sicht kann es geschlossen werden. Bei weiteren Auffälligkeiten sollte ein neues aufgemacht werden

closes #653 