### PR TITLE
Raumgeschwindigkeit bei Vorspulen nicht ändern

### DIFF
--- a/source/game.game.bmx
+++ b/source/game.game.bmx
@@ -2247,7 +2247,7 @@ endrem
 		'allow slowdown in rooms
 		If Not GetGame().networkGame
 			If GetPlayer().IsInRoom() 'and not GetPlayer().GetFigure().IsInBuilding()
-				If TEntity.globalWorldSpeedFactorMod = 1.0
+				If TEntity.globalWorldSpeedFactorMod <> GameConfig.InRoomTimeSlowDownMod
 					GetWorldTime().SetTimeFactorMod(GameConfig.InRoomTimeSlowDownMod)
 					TEntity.globalWorldSpeedFactorMod = GameConfig.InRoomTimeSlowDownMod
 				EndIf

--- a/source/game.gameconfig.bmx
+++ b/source/game.gameconfig.bmx
@@ -26,6 +26,8 @@ Type TGameConfig {_exposeToLua}
 	'percentage of the gametime when in a room (default = 100%)
 	'use a lower value, to slow down the game then (movement + time)
 	Field InRoomTimeSlowDownMod:Float = 1.0 {nosave}
+	'store configured value for disableing during fast forward
+	Field InRoomTimeSlowDownModBackup:Float {nosave}
 
 	Global clNormal:SColor8 = SColor8.Black
 	Global clPositive:SColor8 = new SColor8(90, 110, 90)

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -1401,12 +1401,15 @@ endrem
 				DEV_FastForward_TimeFactorBackup = GetWorldTime()._timeFactor
 				DEV_FastForward_BuildingTimeSpeedFactorBackup = GetBuildingTime()._timeFactor
 
+				GameConfig.InRoomTimeSlowDownModBackup = GameConfig.InRoomTimeSlowDownMod
+				GameConfig.InRoomTimeSlowDownMod = 1.0
 				GetGame().SetGameSpeed( 30 * 60 )
 			EndIf
 		Else
 			'stop fast forward
 			If DEV_FastForward
 				DEV_FastForward = False
+				GameConfig.InRoomTimeSlowDownMod = GameConfig.InRoomTimeSlowDownModBackup
 				TEntity.globalWorldSpeedFactor = DEV_FastForward_SpeedFactorBackup
 				GetWorldTime()._timeFactor = DEV_FastForward_TimeFactorBackup
 				GetBuildingTime()._timeFactor = DEV_FastForward_BuildingTimeSpeedFactorBackup


### PR DESCRIPTION
Wenn man im normalen Spiel vorspult, sollte auch in einem Raum die gleiche Geschwindigkeit verwendet werden. Man möchte ja explizit vorspulen, ggf. aber Büro sein und den Programmplan beobachten.