### PR TITLE
[Dig] Extend registry - added contains, less objects created

### DIFF
--- a/source/Dig/base.util.registry.imageloader.bmx
+++ b/source/Dig/base.util.registry.imageloader.bmx
@@ -293,10 +293,18 @@ End Type
 
 
 '===== CONVENIENCE REGISTRY ACCESSORS =====
-Function GetImageFromRegistry:TImage(name:object, defaultNameOrSprite:object = Null)
+Function GetImageFromRegistry:TImage(name:object)
+	Return TImage( GetRegistry().Get(name) )
+End Function
+
+Function GetImageFromRegistry:TImage(name:object, defaultNameOrSprite:object)
 	Return TImage( GetRegistry().Get(name, defaultNameOrSprite, TRegistryImageLoader.keyImageLS) )
 End Function
 
-Function GetPixmapFromRegistry:TPixmap(name:object, defaultNameOrSprite:object = Null)
+Function GetPixmapFromRegistry:TPixmap(name:object)
+	Return TPixmap( GetRegistry().Get(name) )
+End Function
+
+Function GetPixmapFromRegistry:TPixmap(name:object, defaultNameOrSprite:object)
 	Return TPixmap( GetRegistry().Get(name, defaultNameOrSprite, TRegistryImageLoader.keyPixmapLS) )
 End Function

--- a/source/Dig/base.util.registry.spriteentityloader.bmx
+++ b/source/Dig/base.util.registry.spriteentityloader.bmx
@@ -11,7 +11,7 @@ Rem
 
 	LICENCE: zlib/libpng
 
-	Copyright (C) 2002-2019 Ronny Otto, digidea.de
+	Copyright (C) 2002-now Ronny Otto, digidea.de
 
 	This software is provided 'as-is', without any express or
 	implied warranty. In no event will the authors be held liable
@@ -171,7 +171,11 @@ End Type
 
 
 '===== CONVENIENCE REGISTRY ACCESSORS =====
-Function GetSpriteEntityFromRegistry:TSpriteEntity(name:Object, defaultNameOrSpriteEntity:Object = Null)
+Function GetSpriteEntityFromRegistry:TSpriteEntity(name:Object)
+	Return TSpriteEntity( GetRegistry().Get(name) )
+End Function
+
+Function GetSpriteEntityFromRegistry:TSpriteEntity(name:Object, defaultNameOrSpriteEntity:Object)
 	Return TSpriteEntity( GetRegistry().Get(name, defaultNameOrSpriteEntity, TRegistrySpriteEntityLoader.keySpriteEntityLS) )
 End Function
 

--- a/source/Dig/base.util.registry.spriteloader.bmx
+++ b/source/Dig/base.util.registry.spriteloader.bmx
@@ -289,15 +289,21 @@ End Type
 
 
 '===== CONVENIENCE REGISTRY ACCESSORS =====
-Function GetSpritePackFromRegistry:TSpritePack(name:Object, defaultNameOrSpritePack:object = Null)
+Function GetSpritePackFromRegistry:TSpritePack(name:Object)
+	Return TSpritePack( GetRegistry().Get(name) )
+End Function
+
+Function GetSpritePackFromRegistry:TSpritePack(name:Object, defaultNameOrSpritePack:object)
 	Return TSpritePack( GetRegistry().Get(name, defaultNameOrSpritePack, TRegistrySpriteLoader.keySpritePackLS) )
 End Function
 
-
-Function GetSpriteFromRegistry:TSprite(name:Object, defaultNameOrSprite:object = Null)
-	Return TSprite( GetRegistry().Get(name, defaultNameOrSprite, TRegistrySpriteLoader.keySpriteLS) )
+Function GetSpriteFromRegistry:TSprite(name:Object)
+	Return TSprite( GetRegistry().Get(name) )
 End Function
 
+Function GetSpriteFromRegistry:TSprite(name:Object, defaultNameOrSprite:object)
+	Return TSprite( GetRegistry().Get(name, defaultNameOrSprite, TRegistrySpriteLoader.keySpriteLS) )
+End Function
 
 Function GetSpriteGroupFromRegistry:TSprite[](baseName:string, defaultNameOrSprite:object = Null)
 	local sprite:TSprite

--- a/source/game.player.base.bmx
+++ b/source/game.player.base.bmx
@@ -477,7 +477,8 @@ endrem
 	'loads a new figurbase and colorizes it
 	Method UpdateFigureBase:int(newfigurebase:Int)
 		'load configuration from registry
-		Local figuresConfig:TData = TData(GetRegistry().Get("figuresConfig", new TData))
+		Local figuresConfig:TData = TData(GetRegistry().Get("figuresConfig"))
+		If not figuresConfig Then figuresConfig = New TData
 		Local playerFigures:string[] = figuresConfig.GetString("playerFigures", "").split(",")
 		Local figureCount:Int = Len(playerFigures)
 

--- a/source/game.programme.newsevent.bmx
+++ b/source/game.programme.newsevent.bmx
@@ -591,7 +591,8 @@ Type TNewsEvent Extends TBroadcastMaterialSource {_exposeToLua="selected"}
 	Method GetMaxTopicality:Float()
 		Local maxTopicality:Float = 1.0
 
-		Local devConfig:TData = TData(GetRegistry().Get("DEV_CONFIG", New TData))
+		Local devConfig:TData = TData(GetRegistry().Get("DEV_CONFIG"))
+		If not devConfig Then devConfig = New TData
 		Local devAgeMod:Float = devConfig.GetFloat("DEV_NEWS_AGE_INFLUENCE", 1.0)
 		Local devQualityAgeMod:Float = devConfig.GetFloat("DEV_NEWS_QUALITYAGE_INFLUENCE", 1.0)
 		Local devBroadcastedMod:Float = devConfig.GetFloat("DEV_NEWS_BROADCAST_INFLUENCE", 1.0)

--- a/source/game.registry.loaders.bmx
+++ b/source/game.registry.loaders.bmx
@@ -91,7 +91,7 @@ Type TRegistryColorLoader Extends TRegistryBaseLoader
 		Local color:TPlayerColor = TPlayerColor.Create(r,g,b,a)
 		'if a listname was given - try to add to that group
 		If listName <> ""
-			Local list:TList = TList(GetRegistry().Get(listName, Null))
+			Local list:TList = TList(GetRegistry().Get(listName))
 			'if list is not existing: create it
 			If Not list
 				list = CreateList()

--- a/source/game.screen.menu.bmx
+++ b/source/game.screen.menu.bmx
@@ -269,7 +269,8 @@ Type TScreen_GameSettings Extends TGameScreen
 		SetLanguage()
 
 
-		Local figuresConfig:TData = TData(GetRegistry().Get("figuresConfig", New TData))
+		Local figuresConfig:TData = TData(GetRegistry().Get("figuresConfig"))
+		If not figuresConfig then figuresConfig = New TData
 		Local playerFigures:String[] = figuresConfig.GetString("playerFigures", "").split(",")
 		figureBaseCount = Len(playerFigures)
 

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -6974,7 +6974,8 @@ Function StartApp:Int()
 	?
 
 	'assign dev config (resources are now loaded)
-	GameRules.devConfig = TData(GetRegistry().Get("DEV_CONFIG", New TData))
+	GameRules.devConfig = TData(GetRegistry().Get("DEV_CONFIG"))
+	If not GameRules.devConfig Then GameRules.devConfig = New TData
 
 	'disable log from now on (if dev wished so)
 	If Not GameRules.devConfig.GetBool("DEV_LOG", True)


### PR DESCRIPTION
Ein paar mehr Bequemlichkeitsfunktionen die es eindeutiger machen, wie man auf Existenz eines Registryeintrags ueberprueft. Gleichzeitig auch `RegistryContains(key)` hinzugefuegt und Aufrufe abgewandelt um nicht immer neue TData anzulegen, die dann nicht gebraucht werden.