### PR TITLE
KI-Spielerbankrott

### DIFF
--- a/config/gamesettings/default.xml
+++ b/config/gamesettings/default.xml
@@ -14,6 +14,8 @@
 		<cableNetworkDailyCostsMod value="1.0"/>
 		<satelliteBuyPriceMod value="1.0"/>
 		<satelliteDailyCostsMod value="1.0"/>
+
+		<restartingPlayerMoneyRatio value="1.0"/> 
 	</easy>
 	<normal>
 	</normal>
@@ -33,6 +35,8 @@
 		<satelliteBuyPriceMod value="1.4"/>
 		<satelliteDailyCostsMod value="1.25"/>
 		<broadcastPermissionPriceMod value="1.5"/>
+
+		<restartingPlayerMoneyRatio value="0.6"/> 
 	</hard>
 
 	<!--
@@ -78,9 +82,8 @@
 		<satelliteDailyCostsMod value="1.15"/><!--factor for satellite daily costs-->
 		<broadcastPermissionPriceMod value="1.0"/><!--factor for broadcast permission prices-->
 
-		<restartingPlayerPropertyCacheRatio value="0.25"/> 
-		<restartingPlayerReachRatio value="1.0"/>
-		<restartingPlayerMoneyRatio value="1.0"/> 
+		<!--relevant only for AI-player -->
+		<restartingPlayerMoneyRatio value="0.8"/><!--start money ratio for restarting AI based on other players' money and licences-->
 	</defaults>
 
 	<!-- properties not yet(?) part of the difficulty object-->

--- a/res/ai/DefaultAIPlayer/TaskStationMap.lua
+++ b/res/ai/DefaultAIPlayer/TaskStationMap.lua
@@ -448,6 +448,8 @@ function JobBuyStation:Prepare(pParams)
 		self:SetCancel()
 	end
 	self.Task.CurrentBudget = math.min(self.Task.CurrentBudget, moneyExcludingFixedCosts)
+	--TODO do no spend all money on one task run
+	self.purchaseCount = 0
 end
 
 function JobBuyStation:SetCancel()
@@ -672,9 +674,10 @@ function JobBuyStation:Tick()
 
 		self.Task:PayFromBudget(price)
 		self.Task.maxReachIncrease = self.Task.maxReachIncrease - bestOffer.GetExclusiveReach(false)
+		self.purchaseCount = self.purchaseCount + 1
 	end
 
-	if bestOffer == nil or self.Task.maxReachIncrease < 1000000 or self.Task.CurrentBudget < 300000 then
+	if bestOffer == nil or self.Task.maxReachIncrease < 1000000 or self.Task.CurrentBudget < 300000 or self.purchaseCount >= 3 then
 		self.Status = JOB_STATUS_DONE
 	end
 end

--- a/source/game.player.difficulty.bmx
+++ b/source/game.player.difficulty.bmx
@@ -72,8 +72,6 @@ Type TPlayerDifficultyCollection Extends TGameObjectCollection
 			result.satelliteConstructionTime = ReadInt("satelliteConstructionTime", spec, def, 0, 10)
 			result.satelliteDailyCostsMod = ReadFloat("satelliteDailyCostsMod", spec, def, 0.1, 5)
 			result.broadcastPermissionPriceMod = ReadFloat("broadcastPermissionPriceMod", spec, def, 0.1, 5.0)
-			result.restartingPlayerPropertyCacheRatio = ReadFloat("restartingPlayerPropertyCacheRatio", spec, def, 0.1, 2.0)
-			result.restartingPlayerReachRatio = ReadFloat("restartingPlayerReachRatio", spec, def, 0.1, 2.0)
 			result.restartingPlayerMoneyRatio = ReadFloat("restartingPlayerMoneyRatio", spec, def, 0.1, 2.0)
 			return result
 		End Function
@@ -163,8 +161,6 @@ Type TPlayerDifficulty extends TGameObject
 	Field satelliteConstructionTime:int
 	Field satelliteDailyCostsMod:Float
 	Field broadcastPermissionPriceMod:Float
-	Field restartingPlayerPropertyCacheRatio:Float
-	Field restartingPlayerReachRatio:Float
 	Field restartingPlayerMoneyRatio:Float
 
 	Method GenerateGUID:string()


### PR DESCRIPTION
Vereinfachung der Berechnung für Startkapital; nur Geld und Lizenzen zählen, nur ein Startsender, dafür höheres Startkapital. Zunächst als Draft, da ich noch schaue, ob ich durch eine kleine Anpassung am KI-Verhalten verhindern kann, dass nicht sofort superteure Lizenzen gekauft werden.

closes #555 