### PR TITLE
ID für Spiel

### DIFF
--- a/source/game.game.base.bmx
+++ b/source/game.game.base.bmx
@@ -8,6 +8,7 @@ Import "game.world.worldtime.bmx"
 
 'Game - holds time, audience, money and other variables (typelike structure makes it easier to save the actual state)
 Type TGameBase {_exposeToLua="selected"}
+	Field gameId:Int
 	'used so that random values are the same on all computers having
 	'the same seed value
 	Field randomSeedValue:Int = 0
@@ -113,6 +114,9 @@ Type TGameBase {_exposeToLua="selected"}
 
 	'(re)set everything to default values
 	Method Initialize()
+		SeedRand(MilliSecs())
+		gameId = Rand32()
+		SeedRand(0)
 		randomSeedValue = 0
 		title = "MyGame"
 		SetCursor(TGameBase.CURSOR_DEFAULT)

--- a/source/game.game.bmx
+++ b/source/game.game.bmx
@@ -257,7 +257,7 @@ Type TGame Extends TGameBase {_exposeToLua="selected"}
 		EndIf
 		
 		If mission
-			mission.Initialize()
+			mission.Initialize(gameId)
 		EndIf
 
 		'so we could add news etc.

--- a/source/game.gameconstants.bmx
+++ b/source/game.gameconstants.bmx
@@ -2145,3 +2145,12 @@ Type TVTAwardType {_exposeToLua}
 		End Select
 	End Function
 End Type
+
+Type TVTMissionDifficulty
+	Const NONE:Int = 0
+	Const EASY:Int = 1
+	Const NORMAL:Int = 2
+	Const HARD:Int = 3
+	Const HARDER:Int = 4
+	Const HARDEST:Int = 5
+End Type

--- a/source/game.mission.base.bmx
+++ b/source/game.mission.base.bmx
@@ -1,24 +1,17 @@
 SuperStrict
 Import "Dig/base.util.event.bmx"
+Import "game.gameconstants.bmx"
 Import "game.gameeventkeys.bmx"
 Import "game.gameobject.bmx"
 Import "game.world.worldtime.bmx"
 
-Enum MissionDifficulty
-	NONE = 0
-	EASY = 1
-	NORMAL = 2
-	HARD = 3
-	HARDER = 4
-	HARDEST = 5
-End Enum
-
 Type TMission
 	Global _eventListeners:TEventListenerBase[]
-	Field difficulty:MissionDifficulty
+	Field difficulty:Int = -1
 	Field daysForAchieving:Int = -1
 	Field playerID:Int = -1
 	Field daysRun:Int = -1
+	Field gameId:Int
 
 	Method getTitle:String() abstract
 
@@ -37,7 +30,8 @@ Type TMission
 		return id.toUpper()
 	End Method
 
-	Method initialize()
+	Method initialize(gameId:Int)
+		Self.gameId = gameId
 		'=== EVENTS ===
 		'remove old listeners
 		EventManager.UnregisterListenersArray(_eventListeners)
@@ -70,81 +64,82 @@ Type TMission
 	Method checkMissionResult(forceFinish:Int=False) abstract
 
 	'Array of enum values does not work!! - the values of the array cannot be converted back via "ordinal"
+	'enum is also not persisted in xml!
 	Method getSupportedDifficulties:Int[]()
-		return [ MissionDifficulty.EASY.ordinal(), MissionDifficulty.NORMAL.ordinal(), MissionDifficulty.HARD.ordinal(), MissionDifficulty.HARDER.ordinal(), MissionDifficulty.HARDEST.ordinal(), MissionDifficulty.NONE.ordinal()]
+		return [ TVTMissionDifficulty.EASY, TVTMissionDifficulty.NORMAL, TVTMissionDifficulty.HARD, TVTMissionDifficulty.HARDER, TVTMissionDifficulty.HARDEST, TVTMissionDifficulty.NONE ]
 	End Method
 
-	Method getHumanPlayerPosition:Int(difficulty:MissionDifficulty)
+	Method getHumanPlayerPosition:Int(difficulty:Int)
 		Return -1
 		rem
 		'a mission difficulty level might define a specific floor for the player
 		Select difficulty
-			case MissionDifficulty.NONE
+			case TVTMissionDifficulty.NONE
 				return -1
-			case MissionDifficulty.EASY
+			case TVTMissionDifficulty.EASY
 				return 3
-			case MissionDifficulty.NORMAL
+			case TVTMissionDifficulty.NORMAL
 				return 2
-			case MissionDifficulty.HARD
+			case TVTMissionDifficulty.HARD
 				return 4
-			case MissionDifficulty.HARDER
+			case TVTMissionDifficulty.HARDER
 				return 4
-			case MissionDifficulty.HARDEST
+			case TVTMissionDifficulty.HARDEST
 				return 4
 		End Select
 		throw "TMission:illegal difficulty "+ difficulty
 		endrem
 	End Method
 
-	Method getHumanPlayerDifficulty:String(difficulty:MissionDifficulty)
+	Method getHumanPlayerDifficulty:String(difficulty:Int = -1)
 		Select difficulty
-			case MissionDifficulty.NONE
+			case TVTMissionDifficulty.NONE
 				return ""
-			case MissionDifficulty.EASY
+			case TVTMissionDifficulty.EASY
 				return "easy"
-			case MissionDifficulty.NORMAL
+			case TVTMissionDifficulty.NORMAL
 				return "normal"
-			case MissionDifficulty.HARD
+			case TVTMissionDifficulty.HARD
 				return "normal"
-			case MissionDifficulty.HARDER
+			case TVTMissionDifficulty.HARDER
 				return "hard"
-			case MissionDifficulty.HARDEST
+			case TVTMissionDifficulty.HARDEST
 				return "hard"
 		End Select
 		throw "TMission:illegal difficulty "+ difficulty
 	End Method
 
-	Method getAiPlayerDifficulty:String(difficulty:MissionDifficulty)
+	Method getAiPlayerDifficulty:String(difficulty:Int = -1)
 		Select difficulty
-			case MissionDifficulty.NONE
+			case TVTMissionDifficulty.NONE
 				return ""
-			case MissionDifficulty.EASY
+			case TVTMissionDifficulty.EASY
 				return "normal"
-			case MissionDifficulty.NORMAL
+			case TVTMissionDifficulty.NORMAL
 				return "normal"
-			case MissionDifficulty.HARD
+			case TVTMissionDifficulty.HARD
 				return "easy"
-			case MissionDifficulty.HARDER
+			case TVTMissionDifficulty.HARDER
 				return "normal"
-			case MissionDifficulty.HARDEST
+			case TVTMissionDifficulty.HARDEST
 				return "easy"
 		End Select
 		throw "TMission:illegal difficulty "+ difficulty
 	End Method
 
-	Method getStartYear:Int(difficulty:MissionDifficulty)
+	Method getStartYear:Int(difficulty:Int = -1)
 		Select difficulty
-			case MissionDifficulty.NONE
+			case TVTMissionDifficulty.NONE
 				return -1
-			case MissionDifficulty.EASY
+			case TVTMissionDifficulty.EASY
 				return 1990
-			case MissionDifficulty.NORMAL
+			case TVTMissionDifficulty.NORMAL
 				return 1985
-			case MissionDifficulty.HARD
+			case TVTMissionDifficulty.HARD
 				return 1995
-			case MissionDifficulty.HARDER
+			case TVTMissionDifficulty.HARDER
 				return 1995
-			case MissionDifficulty.HARDEST
+			case TVTMissionDifficulty.HARDEST
 				return 1995
 		End Select
 		throw "TMission:illegal difficulty "+ difficulty

--- a/source/game.mission.bmx
+++ b/source/game.mission.bmx
@@ -269,10 +269,10 @@ Type TSimpleMission extends TMission
 		Local winningPlayer:Int
 		If targetValue > 0
 			If currentValue >= targetValue
+				winningPlayer = currentPlayer
 				If playerID = currentPlayer
 					'player wins
 					fireEvent = True
-					winningPlayer = currentPlayer
 				Else
 					Local playerName:String = GetPlayer(currentPlayer).Name
 					text = "~n"+ GetLocale("MISSION_OTHER_PLAYER").replace("%NAME%", playerName) + text
@@ -294,6 +294,7 @@ Type TSimpleMission extends TMission
 
 		If fireEvent
 			Local score:TMissionHighscore = new TMissionHighscore
+			score.gameId = gameId
 			If key = GameEventKeys.Mission_Achieved
 				score.missionAccomplished = True
 			Else
@@ -497,6 +498,7 @@ Type TCombinedMission extends TMission
 			Local fireEvent:Int = False
 			Local key:TEventKey = GameEventKeys.Mission_Achieved
 			Local score:TMissionHighscore = new TMissionHighscore
+			score.gameId = gameId
 			Local text:String
 			Local winningPlayer:Int
 			If (money < 0 And currentMoney > abs(money)) ..

--- a/source/game.mission.highscore.bmx
+++ b/source/game.mission.highscore.bmx
@@ -26,6 +26,7 @@ Type TMissionHighscorePlayerData
 End Type
 
 Type TMissionHighscore
+	Field gameId:Int
 	Field realDate:String
 	Field primaryPlayer:Int
 	Field winningPlayer:Int
@@ -49,7 +50,7 @@ Type TAllHighscores
 	Global lastDifficulty:String {noSave}
 	Global lastScore:TMissionHighscore {noSave}
 
-	Function addEntry(missionID:String, difficulty:MissionDifficulty, score:TMissionHighscore)
+	Function addEntry(missionID:String, difficulty:Int, score:TMissionHighscore)
 		score.realDate = CurrentDate("%Y-%m-%d %H:%M:%S")
 		TPersist.format=True
 		TPersist.maxDepth = 4096
@@ -67,7 +68,7 @@ Type TAllHighscores
 		Local missionScore:TMissionHighscores
 		For Local index:Int = 0 Until persistedScores.scores.length
 			missionScore = persistedScores.scores[index]
-			If missionScore and missionScore.missionID = missionID and missionScore.missiondifficulty = difficulty.ordinal()
+			If missionScore and missionScore.missionID = missionID and missionScore.missiondifficulty = difficulty
 				highScoreExisted = True
 				missionScore.scores:+ [score]
 				persistedScores.scores[index] = missionScore
@@ -77,7 +78,7 @@ Type TAllHighscores
 		If Not highScoreExisted
 			missionScore = new TMissionHighscores
 			missionScore.missionID = missionID
-			missionScore.missiondifficulty = difficulty.ordinal()
+			missionScore.missiondifficulty = difficulty
 			missionScore.scores = [score]
 			persistedScores.scores:+ [missionScore]
 		EndIf

--- a/source/game.screen.menu.bmx
+++ b/source/game.screen.menu.bmx
@@ -474,7 +474,7 @@ Type TScreen_GameSettings Extends TGameScreen
 						Local mission:TMission = null
 						If guiMissions.getSelectedEntry() Then mission = TMission(guiMissions.getSelectedEntry().data.get("value"))
 						If mission
-							mission.difficulty = MissionDifficulty(guiMissionDifficulty.getSelectedEntry().data.getInt("value"))
+							mission.difficulty = guiMissionDifficulty.getSelectedEntry().data.getInt("value")
 							For Local p:Int = 1 To 4
 								If GetPlayerBase(p).IsLocalHuman() Then mission.playerID = p
 							Next
@@ -599,7 +599,7 @@ Type TScreen_GameSettings Extends TGameScreen
 				For Local s:Int = EachIn difficultyValues
 					Local item:TGUIDropDownItem = New TGUIDropDownItem.Create(New SVec2I(0,0), New SVec2I(100,20), GetLocale("MISSION_DIFFICULTY_"+s))
 					item.data.AddInt("value", s)
-					If not itemToSelect Or MissionDifficulty.NORMAL.Ordinal() = s Then itemToSelect = item
+					If not itemToSelect Or TVTMissionDifficulty.NORMAL = s Then itemToSelect = item
 
 					guiMissionDifficulty.AddItem( item )
 					If itemHeight = 0 Then itemHeight = item.GetScreenRect().GetH()
@@ -615,7 +615,7 @@ Type TScreen_GameSettings Extends TGameScreen
 		Return True
 	End Method
 
-	Method updateMissionValues(mission:TMission, difficulty:MissionDifficulty)
+	Method updateMissionValues(mission:TMission, difficulty:Int)
 		If not mission
 			missionForbidsPositionChange = False
 			'guiGameTitleLabel.hide()
@@ -633,7 +633,7 @@ Type TScreen_GameSettings Extends TGameScreen
 			guiDifficulty[3].enable()
 			guiMissions.hide()
 			guiMissionDifficulty.hide()
-		ElseIf difficulty = MissionDifficulty.NONE
+		ElseIf difficulty = TVTMissionDifficulty.NONE
 			guiStartYear.enable()
 			guiFilterUnreleased.show()
 			guiRandomizeLicence.show()
@@ -947,12 +947,12 @@ endrem
 			guiGameTitle.hide()
 			If modifiedMissions
 				Local mission:TMission = null
-				Local difficultyInt:Int = 0
+				Local difficultyInt:Int = TVTMissionDifficulty.NONE
 				If guiMissions.getSelectedEntry()
 					mission = TMission(guiMissions.getSelectedEntry().data.get("value"))
 					difficultyInt = guiMissionDifficulty.getSelectedEntry().data.getInt("value")
 				EndIf
-				updateMissionValues(mission, MissionDifficulty(difficultyInt))
+				updateMissionValues(mission, difficultyInt)
 			EndIf
 			guiSettingsWindow.SetCaption(GetLocale("MENU_SOLO_GAME"))
 			'guiChat.setOption(GUI_OBJECT_VISIBLE,False)


### PR DESCRIPTION
Ich glaube, das Einführen einer ID für ein Spiel wäre doch keine schlechte Idee. Selbst wenn sie nicht unmittelbar benötigt wird, würde sie uns dennoch erlauben, später Highscore-Einträge aufzuräumen bzw. Abfragen "Es gibt schon einen Highscore für dieses Spiel. Überschreiben/Aktuellen verwerfen/beide speichern?" zu integrieren.

Achtung: Es gibt aktuell noch einen unschönen Missionsbug. Der Missionsschwierigkeitsgrad geht beim Speichern aktuell verloren. D.h. Highscores für dieselbe Mission werden derzeit mit unterschiedlichen Missions-IDs gespeichert. Ich bin dran.