### PR TITLE
Berechne korrekte Nachrichtenkosten

### DIFF
--- a/source/game.player.base.bmx
+++ b/source/game.player.base.bmx
@@ -285,7 +285,9 @@ Type TPlayerBase {_exposeToLua="selected"}
 
 
 	'return which is the highest level for the given genre today
-	'(which was active for longer than X game minutes)
+	'as a side effect of the call, the maximum level is calculated
+	'if it differs from the current level (a change with a delay
+	'of X game minutes may have occurred)
 	'if the last time a abonnement level was set was before today
 	'use the current level value
 	Method GetNewsAbonnementDaysMax:Int(genre:Int) {_exposeToLua}
@@ -294,6 +296,10 @@ Type TPlayerBase {_exposeToLua="selected"}
 		local abonnementLevel:int = GetNewsAbonnement(genre)
 
 		'if level of genre changed - adjust maximum
+		'I.e. changing the level is a side effect of the getter call.
+		'In order to ensure the usage of the correct level for the price calculation,
+		'GameEvents#onMinute in main.bmx regularly calls this method.
+		'When extracting the calculation from the getter, those calls may become obsolete.
 		if newsabonnementsDayMax[genre] <> abonnementLevel
 
 			'if the "set time" is not the current day, we assume

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -6148,6 +6148,16 @@ endrem
 			GetProgrammeDataCollection().UpdateDynamicData()
 		EndIf
 
+		'=== UPDATE Players' news max Level ===
+		'it is determined as a side-effect of the getter
+		If minute Mod 5 = 0
+			For Local player:TPlayer = EachIn GetPlayerCollection().players
+				For Local genre:Int = 0 To TVTNewsGenre.count
+					player.GetNewsAbonnementDaysMax(genre)
+				Next
+			Next
+		EndIf
+
 		'=== UPDATE ACHIEVEMENTS ===
 		'(do that AFTER setting the broadcasts and calculating the
 		' audience as some achievements check audience of a broadcast)


### PR DESCRIPTION
(Report scr0llbaer) Das Setzen des max-Levels in der Get-Methode funktioniert nur, wenn sie auch zur richtigen Zeit aufgerufen wird; z.B. wenn man aus Versehen auf den Knöpfen hovert.
Durch die regelmäßige Prüfung ist sichergestellt, dass das Max-Level des Tages auch ermittelt wird.

closes #745