### PR TITLE
Debug-Screens bei Moduswechsel deaktivieren

### DIFF
--- a/source/main.bmx
+++ b/source/main.bmx
@@ -711,6 +711,9 @@ Type TApp
 				__DevHotKeys()
 			Else
 				__NonDevHotKeys()
+				DebugScreen._enabled = 0
+				TVTDebugInfo = 0
+				debugAudienceInfo.mode = 0
 			EndIf
 
 


### PR DESCRIPTION
Da es diverse Möglichkeiten gibt, vom Entwicklermodus in den Produktionsmodus zu wechseln, wird beim Update sichergestellt, dass die Screens deaktiviert sind).