### PR TITLE
Name Highscore-Datei

### DIFF
--- a/source/game.mission.highscore.bmx
+++ b/source/game.mission.highscore.bmx
@@ -55,8 +55,8 @@ Type TAllHighscores
 		TPersist.format=True
 		TPersist.maxDepth = 4096
 		Local p:TPersist = New TXMLPersistenceBuilder.Build()
-		'TODO file location and name
-		Local file:String = "highscores.xml"
+		'TODO file location
+		Local file:String = "missionScores.xml"
 		Local persistedScores:TAllHighscores
 
 		If FileType(file) = 1


### PR DESCRIPTION
In Vorbereitung auf das Speichern ins Nutzerverzeichnis würde ich zunächst nur den Dateinamen anpassen. Vielleicht kommen später noch andere Highscores dazu, die man in einem entsprechenden Verzeichnis speichern möchte (Erfolge so schnell wie möglich errungen, Mehrspieler...).

Das Unterverzeichnis UserData/Highscores habe ich erstmal weggelassen, da es noch nicht existiert und mit einer ähnlichen Logik angelegt werden müsste, wie sie als Hilfsmethode vorgesehen aber noch nicht verfügbar ist. Da für die Spielstände ohnehin eine "Migration" von Bestandsdaten nötig wird, kann die Highscore-Datei dann auf gleichem Wege verschoben werden.