### PR TITLE
Wettersimulation

### DIFF
--- a/source/game.world.bmx
+++ b/source/game.world.bmx
@@ -85,9 +85,14 @@ Type TWorld
 		sunPoint = New TVec2D(400, 1100 + area.GetY())
 		moonPoint =  New TVec2D(400, 100 + area.GetY())
 
-		If Not weather Then weather = New TWorldWeather
+
+		If Not weather
+			weather = New TWorldWeather
+			'start temperature will be set by internal randomization
+			weather.Init(0, 0, 0, 3600)
+		EndIf
+
 		If Not lighting Then lighting = New TWorldLighting
-		weather.Init(0, 18, 0, 3600)
 		lighting.Init()
 
 		'adjust effect display
@@ -531,6 +536,8 @@ Type TWorld
 		DrawText("wind: "+MathHelper.NumberToString(Weather.GetWindVelocity(),4), x + 10, y + dy)
 		dy :+ 12
 		DrawText("temp: "+MathHelper.NumberToString(Weather.GetTemperature(),4), x + 10, y + dy)
+		dy :+ 12
+		DrawText("targetTemp: "+MathHelper.NumberToString(Weather.currentWeather._targetTemperature, 4), x + 10, y + dy)
 		dy :+ 12
 		DrawText("speed: "+Int(GetWorldTime().GetTimeFactor()), x + 10, y + dy)
 		dy :+ 12

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -1963,7 +1963,7 @@ Type TGameState
 	Field _Game:TGame = Null
 	Field _BuildingTime:TBuildingTime = Null
 	Field _WorldTime:TWorldTime = Null
-	Field _World:TWorld = Null
+	Field _WorldWeather:TWorldWeather = Null
 	Field _GameRules:TGamerules = Null
 	Field _GameConfig:TGameConfig = Null
 	Field _Betty:TBetty = Null
@@ -2190,7 +2190,7 @@ Type TGameState
 		_Assign(_NewsEventSportCollection, TNewsEventSportCollection._instance, "NewsEventSportCollection", MODE_LOAD)
 		_Assign(_Betty, TBetty._instance, "Betty", MODE_LOAD)
 		_Assign(_AwardCollection, TAwardCollection._instance, "AwardCollection", MODE_LOAD)
-'		_Assign(_World, TWorld._instance, "World", MODE_LOAD)
+		_Assign(_WorldWeather, TWorld._instance.weather, "WorldWeather", MODE_LOAD)
 		_Assign(_WorldTime, TWorldTime._instance, "WorldTime", MODE_LOAD)
 		_Assign(_BuildingTime, TBuildingTime._instance, "BuildingTime", MODE_LOAD)
 		_Assign(_GameRules, GameRules, "GameRules", MODE_LOAD)
@@ -2315,7 +2315,7 @@ Type TGameState
 		_Assign(TNewsEventSportCollection._instance, _NewsEventSportCollection, "NewsEventSportCollection", MODE_SAVE)
 		_Assign(TBetty._instance, _Betty, "Betty", MODE_SAVE)
 		_Assign(TAwardCollection._instance, _AwardCollection, "AwardCollection", MODE_SAVE)
-'		_Assign(TWorld._instance, _World, "World", MODE_SAVE)
+		_Assign(TWorld._instance.weather, _WorldWeather, "WorldWeather", MODE_SAVE)
 		_Assign(TAuctionProgrammeBlocks.list, _AuctionProgrammeBlocksList, "AuctionProgrammeBlocks", MODE_SAVE)
 		'special room data
 		_Assign(RoomHandler_Studio._instance, _RoomHandler_Studio, "Studios", MODE_SAVE)

--- a/unittests/test.visual.world.weather.bmx
+++ b/unittests/test.visual.world.weather.bmx
@@ -1,0 +1,111 @@
+SuperStrict
+
+Framework brl.StandardIO
+Import "../source/Dig/base.util.graphicsmanager.bmx"
+Import "../source/Dig/base.util.input.bmx"
+Import "../source/game.world.bmx"
+
+AppTitle = "TVT: Weather Sim Tester"
+
+Local gm:TGraphicsManager = GetGraphicsManager()
+GetGraphicsManager().SetResolution(900,600)
+GetGraphicsManager().InitGraphics()
+
+GetWorld().Initialize() 'weather!
+
+'GetWorldTime()._daysPerSeason = 1
+GetWorldTime().SetTimeGone( GetWorldTime().MakeTime(1985, 0, 0, 0, 0) )
+GetWorldTime().SetTimeStart( GetWorldTime().MakeTime(1985, 0, 0, 0, 0) )
+'set speed 10x realtime
+'GetWorldTime().SetTimeFactor(3600*2)
+
+
+
+
+Function Update:Int()
+	MouseManager.Update()
+	KeyManager.Update()
+
+	EventManager.Update()
+	
+	if KeyHit(KEY_SPACE)
+		GetWorld().Weather.SetPressure(-14)
+		GetWorld().Weather.SetTemperature(-10)
+	EndIf
+	if KeyDown(KEY_RIGHT)
+		GetWorldTime().SetTimeFactor(3600*60)
+	Elseif KeyDown(KEY_LEFT)
+		GetWorldTime().SetTimeFactor(3600*0)
+	Else
+		GetWorldTime().SetTimeFactor(3600*2)
+	EndIf
+	'update worldtime (eg. in games this is the ingametime)
+	GetWorldTime().Update()
+	GetWorld().Update()
+End Function
+
+
+Function Render:Int()
+	SetClsColor 0,0,0
+	SetAlpha 1.0
+	Cls
+
+	'=== RENDER HUD ===
+	DrawText("worldTime: "+GetWorldTime().GetFormattedTime(-1, "h:i:s")+ " at day "+GetWorldTime().GetDayOfYear()+" in "+GetWorldTime().GetYear(), 20, 10)
+	DrawText("Cursor Left:  Pause", 20, 570)
+	DrawText("Cursor Right: Fast Forward", 20, 582)
+
+	Local x:Int = 20
+	Local y:Int = 40
+	DrawText("Weather", x, y)
+	y :+ 16
+	DrawText("Time", x, y)
+	DrawText("Seas", x + 180, y)
+	DrawText("Temp", x + 230, y)
+	DrawText("WindV", x + 300, y)
+	DrawText("WindSp", x + 370, y)
+	DrawText("Press", x + 440, y)
+	DrawText("Okta", x + 520, y) 'Wolkendeckendichte
+	DrawText("Sun", x + 570, y) 'Sonne sichtbar?
+	DrawText("Rain", x + 610, y)
+	DrawText("Storm", x + 650, y)
+	DrawText("targetTemp", x + 710, y)
+	DrawText("Text", x + 810, y)
+	y :+ 14
+
+	For local i:int = 0 until 24
+		local weather:TWorldWeatherEntry = GetWorld().Weather.GetUpcomingWeather(i+1)
+		if not weather then continue
+		DrawText(GetWorldTime().GetFormattedGameDate(weather._time), x, y)
+		DrawText(GetWorldTime().GetSeason(weather._time) + "/4", x + 180, y)
+		DrawText(StringHelper.printf("%3.3f", [string(weather.GetTemperature())]), x + 230, y)
+		If weather.GetWindVelocity() >= 0
+			DrawText(" " + MathHelper.NumberToString(weather.GetWindVelocity(), 3), x + 300, y)
+		Else
+			DrawText(MathHelper.NumberToString(weather.GetWindVelocity(), 3), x + 300, y)
+		EndIf
+		DrawText(MathHelper.NumberToString(weather.GetWindSpeed(), 3), x + 370, y)
+		If weather.GetPressure() >= 0
+			DrawText(" " + MathHelper.NumberToString(weather.GetPressure(), 3), x + 440, y)
+		Else
+			DrawText(MathHelper.NumberToString(weather.GetPressure(), 3), x + 440, y)
+		EndIf
+		DrawText(weather.GetCloudOkta(), x + 520, y)
+		DrawText(weather.IsSunVisible(), x + 570, y)
+		DrawText(weather.IsRaining(), x + 610, y)
+		DrawText(weather.IsStorming(), x + 650, y)
+		DrawText(weather._targetTemperature, x + 710, y)
+		DrawText(weather.GetWorldWeatherText(), x + 810, y)
+		y :+ 14
+	Next
+End Function
+
+
+
+While Not KeyHit(KEY_ESCAPE) Or AppTerminate()
+	Update()
+	Cls
+	Render()
+	Flip
+	Delay(2)
+Wend


### PR DESCRIPTION
Ich spiele gerade mit der Wettersimulation herum. Ich habe den Ansatz verworfen, nur punktuell Temperaturplausibilitätsprüfungen zu machen. Meiner Ansicht nach macht es nur Probleme, sich ausschließlich auf die Sonnenscheindauer etc.zu verlassen. Kurze Begründung: Ziel wäre ja, in den Jahreszeiten halbwegs nachvollziehbare Temparaturbereiche zu erhalten. Die Wettersimulation weiß aber überhaupt nichts über die Anzahl der Tage pro Saison. Und es macht für die Simulation einen erheblichen Unterschied, ob das Ansteigen der Temparatur innerhalb eines Tages erreicht werden muss oder über fünf.
Um diesem Problem komplett aus dem Weg zu gehen, verfolge ich den Ansatz, pro Monat einen Nachttiefsttemparaturbereich und einen Tageshöchsttemparaturbereich zu hinterlegen. Es wird dann jeweils eine Zieltemparatur gewürfelt und mit den zusätzlichen vorhandenen Zufallsparametern versehen.

Die Werte sind im aktuellen Draft erstmal aus den Fingern gesaugt und sollten langfristig Teil der Karte werden (die Temparaturverläufe sind in verschiedenen Ländern ja sehr unterschiedlich). Ein weiteres noch nicht angegangenes Problem sind die Spielstände. Aktuell scheint "World" und insb. das Wetter noch nicht Teil des Spielstands zu sein, d.h. aktuell findet immer eine Neuinitialisierung mit derselben Temparatur statt (da sind die alten 18 Grad genauso falsch wie die im Branch verwendeten Januarnachttemparaturen)

Das aktuelle "lineare" Erreichen der Zieltemparatur in der verbliebenen Zeit führt noch zu seltsamen Effekten (Division durch sehr kleine Zahlen = sehr großer Temparaturunterscheid). Aber ich wollte den Ansatz schon mal zur Diskussion stellen.

see #607 