### PR TITLE
Nachrichtenwindwerte

### DIFF
--- a/source/game.newsagency.bmx
+++ b/source/game.newsagency.bmx
@@ -1,4 +1,4 @@
-﻿SuperStrict
+SuperStrict
 Import "game.newsagency.base.bmx"
 Import "game.newsagency.sports.soccer.bmx"
 Import "game.newsagency.sports.icehockey.bmx"
@@ -399,8 +399,8 @@ Type TNewsAgencyNewsProvider_Weather extends TNewsAgencyNewsProvider
 			tempMin = Min(tempMin, weather.GetTemperature())
 			tempMax = Max(tempMax, weather.GetTemperature())
 
-			windMin = Min(windMin, weather.GetWindSpeed() * 20)
-			windMax = Max(windMax, weather.GetWindSpeed() * 20)
+			windMin = Min(windMin, weather.GetWindSpeedKmh())
+			windMax = Max(windMax, weather.GetWindSpeedKmh())
 
 			if weather.GetTemperature() < 0 then isBelowZero = True
 			if weather.IsRaining() and weather.GetTemperature() >= 0 then isRaining = True
@@ -465,11 +465,11 @@ Type TNewsAgencyNewsProvider_Weather extends TNewsAgencyNewsProvider
 
 
 		local weatherText:string
-		if windMin < 2 and windMax < 2
+		if windMin <= 10 and windMax <= 10
 			weatherText = GetRandomLocale("NEARLY_NO_WIND")
 		elseif windMin <> windMax
-			if windMin > 0 and windMax > 10
-				if windMin > 20 and windMax > 35
+			if windMin > 20 and windMax > 20
+				if windMin > 40 and windMax > 60
 					weatherText = GetRandomLocale("STORMY_WINDS_OF_UP_TO_X")
 				else
 					weatherText = GetRandomLocale("SLOW_WIND_WITH_X_AND_GUST_OF_WIND_WITH_Y")
@@ -482,7 +482,7 @@ Type TNewsAgencyNewsProvider_Weather extends TNewsAgencyNewsProvider
 		endif
 
 		if temperatureText <> "" then description :+ " " + temperatureText.replace("%TEMPERATURE%", tempMin).replace("%MINTEMPERATURE%", tempMin).replace("%MAXTEMPERATURE%", tempMax)
-		if weatherText <> ""  then description :+ " " + weatherText.replace("%MINWINDVELOCITY%", MathHelper.NumberToString(windMin, 2, True)).replace("%MAXWINDVELOCITY%", MathHelper.NumberToString(windMax, 2, True))
+		if weatherText <> ""  then description :+ " " + weatherText.replace("%MINWINDVELOCITY%", MathHelper.NumberToString(windMin, 0, True)).replace("%MAXWINDVELOCITY%", MathHelper.NumberToString(windMax, 0, True))
 
 
 		local localizeTitle:TLocalizedString = new TLocalizedString

--- a/source/game.world.worldweather.bmx
+++ b/source/game.world.worldweather.bmx
@@ -465,6 +465,12 @@ Type TWorldWeatherEntry
 		return abs(GetWindVelocity())
 	End Method
 
+	Method GetWindSpeedKmh:Int()
+		Local speed:Float = GetWindSpeed()
+		If speed <=1 Then Return speed * 20
+		If speed <=2 Then Return speed * 25
+		return speed * 30
+	End Method
 
 	Method GetWindVelocity:Float()
 		return _windVelocity

--- a/unittests/test.visual.world.weather.bmx
+++ b/unittests/test.visual.world.weather.bmx
@@ -84,7 +84,7 @@ Function Render:Int()
 		Else
 			DrawText(MathHelper.NumberToString(weather.GetWindVelocity(), 3), x + 300, y)
 		EndIf
-		DrawText(MathHelper.NumberToString(weather.GetWindSpeed(), 3), x + 370, y)
+		DrawText(MathHelper.NumberToString(weather.GetWindSpeedKmh(), 0, True), x + 370, y)
 		If weather.GetPressure() >= 0
 			DrawText(" " + MathHelper.NumberToString(weather.GetPressure(), 3), x + 440, y)
 		Else


### PR DESCRIPTION
Bei einem Wertebereich von -4 bis 4 für die Windgeschwindigkeit, ist der Faktor 40 für die Geschwindigkeit in km/h sinnvoller. Zudem wurden die Werte für die Nachrichten angepasst (ungefähr anhand der Skala aus der Wikipedia).

see #607 