### PR TITLE
Fix: Liveproduktionen unterbrechen laufende Produktion

### DIFF
--- a/source/game.production.bmx
+++ b/source/game.production.bmx
@@ -1136,6 +1136,14 @@ Type TProduction Extends TOwnedGameObject
 
 
 			Case TVTProductionStep.PREPRODUCTION
+				'TODO abort live production if live time reached but preproduction is not yet done
+				rem
+				If productionConcept.script.fixedLiveTime >= 0 and productionConcept.script.fixedLiveTime < GetWorldTime().GetTimeGone()
+					'preproduction not finished but live time reached - abort
+					Abort()
+					Return UpdateProductionStep()
+				EndIf
+				endrem
 				'finished preproduction?
 				'ignore milliseconds/seconds difference
 				If GetWorldTime().GetTimeGone()/TWorldTime.MINUTELENGTH >= (endTime + pauseDuration)/TWorldTime.MINUTELENGTH
@@ -1149,16 +1157,8 @@ Type TProduction Extends TOwnedGameObject
 
 
 			Case TVTProductionStep.PREPRODUCTION_DONE
-				'with livetime being "past" current time we should
-				'begin with shooting as fast as possible
-				'TODO eigentlich ist es jetzt schon zu spät - Livesendung gar nicht möglich, wenn die Vorproduktion noch nicht abgeschlossen ist
-				'oder aber es wird eine "schlechte Show, da man mitten in den Vorbereitungen senden musste.
-				If productionConcept.script.fixedLiveTime >= 0 and productionConcept.script.fixedLiveTime <= GetWorldTime().GetTimeGone()
-					BeginShooting()
-					
-					'maybe next step is also fulfilled
-					Return UpdateProductionStep()
-				EndIf
+				'live productions should not start themselves
+				'alwaysLive is started on airing, fixed live time is started by production manager's UpdateLiveProductions
 				Return False
 
 

--- a/source/game.production.productionmanager.bmx
+++ b/source/game.production.productionmanager.bmx
@@ -570,6 +570,10 @@ Type TProductionManager
 			production.Update()
 			if production.IsProduced() or production.IsAborted()
 				removeProductions :+ [production]
+			elseif production.IsPreProductionDone() And production.productionConcept.script.fixedLiveTime >= 0
+				If production.productionConcept.script.fixedLiveTime <= GetWorldTime().GetTimeGone()
+					StartLiveProductionInStudio(production.GetID())
+				EndIf
 			endif
 		Next
 		'remove all productions which finished


### PR DESCRIPTION
Mit dem zur Verfügung gestellten Spielstand sieht man, dass die Liveproduktion bei der Ausstrahlung nicht das "pausierende" GetProductionManager().StartLiveProductionInStudio(production.GetID()) ausführt.
Wenn man wie im Commit die Zeit für die Prüfung nach vorne verlegt, funktioniert das Pausieren... allerdings nur, wenn die Ausstrahlung auch wirklich zur geplanten Live-Zeit stattfinden. Verlegt man die Ausstrahlung um eine Stunde nach hinten, tritt wieder der "ursprüngliche" Fehler auf. Die laufende Produktion wird nicht korrekt pausiert.

closes #770 