### PR TITLE
Fix: Q für Raumverlassen (Report ARC-2000)

### DIFF
--- a/source/game.roomhandler.roomagency.bmx
+++ b/source/game.roomhandler.roomagency.bmx
@@ -1,4 +1,4 @@
-﻿SuperStrict
+SuperStrict
 Import "Dig/base.gfx.gui.bmx"
 Import "Dig/base.gfx.tooltip.base.bmx"
 Import "common.misc.datasheet.bmx"
@@ -101,6 +101,8 @@ Type RoomHandler_RoomAgency extends TRoomHandler
 
 		'=== FOR WATCHED PLAYERS ===
 		If IsObservedFigure(figure)
+			mode = MODE_NONE
+			selectedRoomState = 0
 			_actionInfoTooltip = Null
 			_actionInfoTooltipUpdate = 0
 			selectedRoom = Null

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -1420,7 +1420,10 @@ endrem
 
 		'Simuliere Rechtsklick (Verlassen eines Screens/Raums, Abbruch einer Aktion, Löschen etc.)
 		'If KeyManager.IsHit(KEY_Q) Then MOUSEMANAGER._AddClickEntry(2, 1, New TVec2D(0, 0), 5)
-		If KeyManager.IsHit(KEY_Q) Then GetPlayer().GetFigure().KickOutOfRoom()
+		If KeyManager.IsHit(KEY_Q)
+			Local figure:TFigure = GetPlayer().GetFigure()
+			If Not figure.IsInRoom() Or Not figure.LeaveRoom() Then figure.KickOutOfRoom()
+		EndIf
 
 		'Schnellvorlauf
 		If KeyManager.IsDown(KEY_RIGHT)


### PR DESCRIPTION
Reguläres Raumverlassen versuchen, bevor Kick als Fallback ausgeführt wird.
Q ist laut Handbuch für das Verlassen des Raums vorgesehen. Insofern sollte reguläres Raumverlassen simuliert werden (Werbeverträge unterschreiben).
Wenn man kein versehentliches Werbevertragsunterschreiben möchte, sollte man die Verträge nicht in den Koffer legen...

Die Änderung beim Makler ist dafür, dass beim Raumbetreten nicht schon der Raumplan geöffnet ist. Mit Q wird der Raum ja verlassen, ohne dass alle Screens zu sein müssen.