### PR TITLE
Idling

### DIFF
--- a/res/ai/DefaultAIPlayer/TaskAdAgency.lua
+++ b/res/ai/DefaultAIPlayer/TaskAdAgency.lua
@@ -38,10 +38,6 @@ function TaskAdAgency:Activate()
 	self.SignContracts = SignContracts()
 	self.SignContracts.Task = self
 
-	self.IdleJob = AIIdleJob()
-	self.IdleJob.Task = self
-	self.IdleJob:SetIdleTicks( math.random(5,15) )
-
 	self.SpotsInAgency = {}
 	--self.LogLevel = LOG_TRACE
 end
@@ -59,12 +55,8 @@ function TaskAdAgency:GetNextJobInTargetRoom()
 		return self.SignRequisitedContracts
 	elseif (self.SignContracts.Status ~= JOB_STATUS_DONE) then
 		return self.SignContracts
-
-	elseif (self.IdleJob.Status ~= JOB_STATUS_DONE) then
-		return self.IdleJob
 	end
 
---	self:SetWait()
 	self:SetDone()
 end
 

--- a/res/ai/DefaultAIPlayer/TaskArchive.lua
+++ b/res/ai/DefaultAIPlayer/TaskArchive.lua
@@ -35,8 +35,12 @@ function TaskArchive:GetNextJobInTargetRoom()
 		return self.SellMoviesJob
 	end
 
-	--self:SetWait()
-	self:SetDone()
+	local taskTime = getPlayer().minutesGone - self.StartTask
+	if taskTime < 7 then
+		self:SetIdle(7-taskTime)
+	else
+		self:SetDone()
+	end
 end
 
 

--- a/res/ai/DefaultAIPlayer/TaskCheckSigns.lua
+++ b/res/ai/DefaultAIPlayer/TaskCheckSigns.lua
@@ -34,7 +34,6 @@ function TaskCheckSigns:GetNextJobInTargetRoom()
 		return self.CheckRoomSignsJob
 	end
 
---	self:SetWait()
 	self:SetDone()
 end
 

--- a/res/ai/DefaultAIPlayer/TaskMovieDistributor.lua
+++ b/res/ai/DefaultAIPlayer/TaskMovieDistributor.lua
@@ -18,8 +18,6 @@ _G["TaskMovieDistributor"] = class(AITask, function(c)
 	c.CurrentBargainBudget = 0
 	c.MovieQuality = nil
 	c:ResetDefaults()
-
-	c.ActivationTime = os.clock()
 end)
 
 function TaskMovieDistributor:typename()
@@ -43,7 +41,6 @@ function TaskMovieDistributor:ResetDefaults()
 end
 
 function TaskMovieDistributor:Activate()
-	self.ActivationTime = os.clock()
 	self.MovieQuality = StatisticEvaluator()
 
 	--init movie count for task's decisions
@@ -69,10 +66,6 @@ function TaskMovieDistributor:Activate()
 
 	self.BidAuctions = JobBidAuctions()
 	self.BidAuctions.Task = self
-
-	--self.IdleJob = AIIdleJob()
-	--self.IdleJob.Task = self
-	--self.IdleJob:SetIdleTicks( math.random(5,15) )
 
 	self.MoviesAtDistributor = {}
 	self.MoviesAtAuctioneer = {}
@@ -107,15 +100,8 @@ function TaskMovieDistributor:GetNextJobInTargetRoom()
 		return self.BuyMovies
 	elseif (self.BidAuctions.Status ~= JOB_STATUS_DONE) then
 		return self.BidAuctions
-
-	--elseif (self.IdleJob ~= nil and self.IdleJob.Status ~= JOB_STATUS_DONE) then
-	--	return self.IdleJob
 	end
 
-	--self:LogTrace("####TIME############ done moviedealer task in " .. (os.clock() - self.ActivationTime) .."s.")
-	self.ActivationTime = os.clock()
-
-	--self:SetWait()
 	self:SetDone()
 end
 
@@ -195,8 +181,6 @@ end
 
 function JobBuyStartProgramme:Tick()
 	local player = getPlayer()
-
-	self.Task.ActivationTime = os.clock()
 
 	local movieBlocksNeeded = -1
 	if player.blocksCount ~= nil then

--- a/res/ai/DefaultAIPlayer/TaskNewsAgency.lua
+++ b/res/ai/DefaultAIPlayer/TaskNewsAgency.lua
@@ -48,9 +48,6 @@ function TaskNewsAgency:Activate()
 	self.NewsAgencyJob = JobNewsAgency()
 	self.NewsAgencyJob.Task = self
 
-	self.IdleJob = AIIdleJob()
-	self.IdleJob.Task = self
-	self.IdleJob:SetIdleTicks( math.random(5,15) )
 	--self.LogLevel = LOG_TRACE
 end
 
@@ -64,11 +61,14 @@ function TaskNewsAgency:GetNextJobInTargetRoom()
 	end
 	if (self.NewsAgencyJob.Status ~= JOB_STATUS_DONE) then
 		return self.NewsAgencyJob
-	--elseif (self.IdleJob ~= nil and self.IdleJob.Status ~= JOB_STATUS_DONE) then
-	--	return self.IdleJob
 	end
 
-	self:SetDone()
+	local taskTime = getPlayer().minutesGone - self.StartTask
+	if taskTime < 7 then
+		self:SetIdle(7-taskTime)
+	else
+		self:SetDone()
+	end
 end
 
 

--- a/res/ai/DefaultAIPlayer/TaskRoomBoard.lua
+++ b/res/ai/DefaultAIPlayer/TaskRoomBoard.lua
@@ -42,7 +42,6 @@ function TaskRoomBoard:GetNextJobInTargetRoom()
 		return self.ChangeRoomSignsJob
 	end
 
---	self:SetWait()
 	self:SetDone()
 end
 

--- a/res/ai/DefaultAIPlayer/TaskStationMap.lua
+++ b/res/ai/DefaultAIPlayer/TaskStationMap.lua
@@ -49,8 +49,6 @@ end
 function TaskStationMap:GetNextJobInTargetRoom()
 	if (self.AnalyseStationMarketJob.Status ~= JOB_STATUS_DONE) then
 		return self.AnalyseStationMarketJob
---	elseif (self.BuyStationJob.Status == JOB_STATUS_DONE) then
---		self:SetWait() --Wenn der Einkauf geklappt hat... muss nichs weiter gemacht werden.
 	end
 
 	if (self.BuyStationJob.Status ~= JOB_STATUS_DONE) then
@@ -59,11 +57,15 @@ function TaskStationMap:GetNextJobInTargetRoom()
 		return self.AdjustStationInvestmentJob
 	end
 
---	self:SetWait()
-
 	--is successful only when in the room!
 	self:CalculateFixedCosts()
-	self:SetDone()
+
+	local taskTime = getPlayer().minutesGone - self.StartTask
+	if taskTime < 7 then
+		self:SetIdle(7-taskTime)
+	else
+		self:SetDone()
+	end
 end
 
 
@@ -684,7 +686,7 @@ function JobBuyStation:Tick()
 		self.purchaseCount = self.purchaseCount + 1
 	end
 
-	if bestOffer == nil or self.Task.maxReachIncrease < 1000000 or self.Task.CurrentBudget < 300000 or self.purchaseCount >= 3 then
+	if bestOffer == nil or self.Task.maxReachIncrease < 1000000 or self.Task.CurrentBudget < 300000 or self.purchaseCount >= 3 or getPlayer().minutesGone - self.Task.StartTask > 20 then
 		self.Status = JOB_STATUS_DONE
 	end
 end


### PR DESCRIPTION
Vorschlag für ein paar Aufräumarbeiten
* Mutex für die Fahrstuhlpassagiere
* weniger häufiges Prüfen, ob der Raum blockiert ist (geht eigentlich erst, wenn man hovern kann; für KI, wenn sie vor dem Raum steht)
* wait als Task-API entfernt - idle reicht
* Task-idle auf Minuten umgestellt, das ist die kanonische Zeiteinheit; Ticks funktionieren nicht (langsames vs. fast-forward Spiel)
* Tasks entsprechend aufgeräumt
* Schedule, Nachrichten, Archiv dauern immer mindestens 7 Minuten (KI sonst immer zu schnell fertig im langsamen Spiel)
* Optimierung für Werbeplanung (ab Minute 55 warten auf die nächste Sendung)