### PR TITLE
KI-Geschwindigkeit

### DIFF
--- a/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
+++ b/res/ai/DefaultAIPlayer/DefaultAIPlayer.lua
@@ -129,7 +129,7 @@ function DefaultAIPlayer:initParameters()
 	end
 	if (self.BrainSpeed == nil or self.BrainSpeed <= 0) then
 		--Handlungsgeschwindigkeit
-		self.BrainSpeed = math.random(5,7)
+		self.BrainSpeed = math.random(4,6)
 	end
 	--eagerness to start the next task
 	if (self.startTaskAtPriority == nil or self.startTaskAtPriority <= 0) then
@@ -892,9 +892,10 @@ function OnTick(realTimeGone, gameTimeGone, systemTicks, totalTicks)
 		-- also run 1 TickProcessTask()
 		getAIPlayer():Tick()
 
-		-- the faster the brain, the more tasks it does per tick
 		-- 1 Task processing is done already in "Tick()"
-		for i=1,getAIPlayer().BrainSpeed-1 do
+		-- with higher brain speed there is a higher chance
+		-- for doing another tick
+		if math.random(1,10) <= getAIPlayer().BrainSpeed then
 			getAIPlayer():TickProcessTask()
 		end
 	end

--- a/res/ai/DefaultAIPlayer/TaskSchedule.lua
+++ b/res/ai/DefaultAIPlayer/TaskSchedule.lua
@@ -1523,7 +1523,7 @@ function JobAdSchedule:Tick()
 	--self:LogDebug("JobAdSchedule:Tick()  Time: " .. getPlayer().hour..":"..getPlayer().minute)
 	local currentDay = TVT.GetDay()
 	local currentHour = getPlayer().hour
-	local planSlots = 2
+	local planSlots = 3
 	local planHours = self.hoursToPlan
 --TODO plan advertisement less far
 --	if self.planRunsLeft > 0 then
@@ -1996,7 +1996,7 @@ function JobProgrammeSchedule:Tick()
 	local player = getPlayer()
 	local currentHour = player.hour
 
-	local planSlots = 2
+	local planSlots = 3
 	local planHours = self.hoursToPlan
 
 	--programmes


### PR DESCRIPTION
Ich habe angefangen, ein kleines Analysetool für die KI-Logs zu schreiben (Branch im Dictionary-Check-Repo). Hintergrund war die Frage, wie lange die KI eigentlich (in Spielminuten) für die jeweiligen Tasks benötigt und wie lange sie zwischen den Räumen unterwegs ist. Insb. auch im Vergleich zwischen den verschiedenen Geschwindigkeiten.

Ein wenig verwunderliches Ergebnis ist, dass die Taskausführung bei Geschwindigkeit 1 wesentlich schneller (oft weniger als 1 Minute) geht als bei Geschwindigkeit 3 oder den Vorspulgeschwindigkeiten. Das liegt vor allem daran, dass die Realzeitsekundenticks dazukommen. Interessanter war da schon die Erkenntnis, dass der Schedulingtask (bei mir) bei den hohen Geschwindigkeiten um die 20 Spielminuten dauert (und zwar auch, wenn man brainSpeed variiert). Das liegt daran, dass die Realzeitberechnung so lange dauert und sich Ticks ansammeln.

Daher ist ein Vorschlag, den BrainSpeed-Wert umzudeuten. Anstatt entsprechend viele zusätzliche Ticks abzuarbeiten erhöht sich nur die Wahrscheinlichkeit für einen weiteren Tick. Dadurch nähern sich die Taskausführungszeiten in Spielminuten für langsame und schnelle Spiele an, bleiben aber in einem sinnvollen Rahmen. Das Ticksaufstauen in hohen Geschwindigkeiten reduziert sich. Außerdem wird das Verhalten zwischen den KIs fairer (eine nicht dauerhaft so viel schneller als eine andere). Im langsamen Spiel wird die KI automatisch weniger hektisch.

Der mit Abstand aufwändigste Task ist ja die Programmplanung. Dort habe ich die Anzahl der geplanten Slots pro Tick leicht erhöht. Im Vergleich zu vorher könnte die Erhöhung noch stärker ausfallen, da ja mehrere KI-interne Ticks pro gesendetem entfallen sind. Aber eine durchschnittliche Ausführungszeit von 20 Minuten pro Planung (im schnellen Spiel) erscheint mir nicht unplausibel. (Anpassung später möglich)

In figure#LeaveRoom gab es immer mal wieder Segmentation-Faults, da "inRoom" nach der ersten Prüfung in der Methode wohl durch einen parallelen Aufruf null geworden ist. Mit der zweiten Prüfung kommt es nun bei schnellen Spielen noch seltener zu Fehlern. (Allerdings bleibt das Spiel häufiger in einem Deadlock hängen).

Ich hänge mal einen Auszug der Analyse für Tempo 3600 (unerwünschtes Spielende nach 29 Tagen) für Spieler 2 und 3 an.
```
2
2047 tasks
TaskAdAgency 247 13.30 5.82
TaskArchive 74 5.08 8.30
TaskBoss 80 5.16 2.24
TaskCheckSigns 178 3.90 2.47
TaskMovieDistributor 192 12.51 10.78
TaskNewsAgency 407 7.06 8.00
TaskRoomBoard 41 13.05 2.49
TaskSchedule 614 8.13 21.95
TaskScripts 68 12.87 1.63
TaskStationMap 88 6.25 11.85
3
2157 tasks
TaskAdAgency 276 12.41 6.10
TaskArchive 79 5.77 8.41
TaskBoss 78 6.38 2.21
TaskCheckSigns 183 3.91 2.47
TaskMovieDistributor 209 12.61 10.99
TaskNewsAgency 406 6.69 8.09
TaskRoomBoard 43 14.28 2.44
TaskSchedule 659 8.12 18.61
TaskScripts 76 11.83 1.66
TaskStationMap 91 6.56 9.48
```

Gemeldet wird die Anzahl bearbeiteter Tasks in der Zeit sowie pro Task die Anzahl, die durchschnittliche Zeit nach Start bis zum Betreten des Raums und die durchschnittliche Taskbearbeitungszeit in Spielminuten (bei News, Archive und StationMap ist das Idlen von 7 Minuten schon mit dabei). Im Geschwindigkeitslevel 3 sind die Laufzeiten besonders hoch, da hier der Fahrstuhl im Vergleich zur Spielzeit sehr langsam ist.