### PR TITLE
KI - Werbeplanung, Lizenzverkauf

### DIFF
--- a/res/ai/CommonAI/AIEngine.lua
+++ b/res/ai/CommonAI/AIEngine.lua
@@ -143,8 +143,7 @@ function AIPlayer:ForceNextTask()
 				-- target room)
 				cancelTask = true
 				if self.CurrentTask.Status ~= TASK_STATUS_PREPARE and
-				   self.CurrentTask.Status ~= TASK_STATUS_OPEN and
-				   self.CurrentTask.Status ~= TASK_STATUS_RUN then
+				   self.CurrentTask.Status ~= TASK_STATUS_OPEN then
 					cancelTask = false
 				end
 			end
@@ -152,15 +151,20 @@ function AIPlayer:ForceNextTask()
 			if cancelTask then
 				self:LogDebug("ForceNextTask: Cancel current task...")
 				self.CurrentTask:SetAbort()
-			end
 
-			--assign next task
-			self.CurrentTask = nextTask
-			self.CurrentTask.Status = TASK_STATUS_OPEN
-			--activate it
-			self.CurrentTask:CallActivate()
-			--start the next job of the new task
-			self.CurrentTask:StartNextJob()
+				--assign next task only when cancelling the old one
+				self.CurrentTask = nextTask
+				self.CurrentTask.Status = TASK_STATUS_OPEN
+				--leave room in case new task in same room (otherwise no onReachTarget)
+				if(TVT.doLeaveRoom(false) == TVT.RESULT_FAILED) then
+					self:LogDebug("Failed leaving room normally. Forcefully leaving the room now!")
+					TVT.doLeaveRoom(true)
+				end
+				--activate it
+				self.CurrentTask:CallActivate()
+				--start the next job of the new task
+				self.CurrentTask:StartNextJob()
+			end
 		else
 			self:LogInfo("ForceNextTask() failed: no follow up task found...")
 		end

--- a/res/ai/DefaultAIPlayer/TaskCheckSigns.lua
+++ b/res/ai/DefaultAIPlayer/TaskCheckSigns.lua
@@ -66,12 +66,20 @@ function JobCheckRoomSigns:Tick()
 		local response = TVT.ep_GetSignAtIndex(index)
 		if response.result == TVT.RESULT_OK then
 			local sign = response.data
-			if (sign ~= nil and sign.GetOwner() == TVT.ME) then
+			if sign ~= nil then
 				--Noch am richtigen Platz?
 				if sign.IsAtOriginalPosition() == 0 then
-					scheduleRoomBoardTask = true
-					self:LogInfo("own room in danger - need to go to the room board")
-					break
+					if sign.GetOwner() == TVT.ME then
+						scheduleRoomBoardTask = true
+						self:LogInfo("own room in danger - need to go to the room board")
+						break
+					elseif TVT:isRoomPotentialStudio(sign:GetRoomId()) == TVT.RESULT_OK then
+						--just guess - one of the changed signs is a potential studio
+						--fix just in case
+						scheduleRoomBoardTask = true
+						self:LogInfo("potential attempt to gain new studio - need to go to the room board")
+						break
+					end
 				end
 			end
 		end

--- a/res/ai/DefaultAIPlayer/TaskSchedule.lua
+++ b/res/ai/DefaultAIPlayer/TaskSchedule.lua
@@ -983,7 +983,7 @@ function TaskSchedule:GuessedAudienceForHour(day, hour, broadcast, block, guessC
 
 	--requesting audience for the current broadcast?
 	if (guessCurrentHour == false) and (TVT.GetDay() == fixedDay and getPlayer().hour == fixedHour and getPlayer().minute >= 5) then
-		return TVT.GetCurrentProgrammeAudience()
+		return TVT.GetCurrentProgrammeAudienceResult().Audience
 	end
 
 	-- predicted level of the news show for the given time

--- a/source/game.broadcast.audienceresult.bmx
+++ b/source/game.broadcast.audienceresult.bmx
@@ -20,7 +20,7 @@ Type TAudienceResultBase {_exposeToLua="selected"}
 	Field broadcastOutage:Int = False
 	'Die Zahl der Zuschauer die erreicht wurden.
 	'Sozusagen das Ergenis das zählt und angezeigt wird.
-	Field Audience:TAudience
+	Field Audience:TAudience {_exposeToLua}
 	'Der Gesamtmarkt: Also wenn alle die einen TV haben schauen wuerden
 	Field WholeMarket:TAudience
 	'Die Gesamtzuschauerzahl die in dieser Stunde den TV an hat!

--- a/source/game.stationmap.bmx
+++ b/source/game.stationmap.bmx
@@ -2157,11 +2157,11 @@ Type TStationMap Extends TOwnedGameObject {_exposeToLua="selected"}
 
 	'returns a station-object wich can be used for further
 	'information getting (share etc)
-	Method GetTemporaryAntennaStation:TStationBase(X:Int, Y:Int)  {_exposeToLua}
+	Method GetTemporaryAntennaStation:TStationBase(X:Int, Y:Int, fullyInit:Int = True)  {_exposeToLua}
 		Local station:TStation = New TStation
 		station.radius = GetStationMapCollection().antennaStationRadius
 
-		Return station.Init(X, Y, -1, owner)
+		Return station.Init(X, Y, -1, owner, fullyInit)
 	End Method
 
 
@@ -2859,7 +2859,7 @@ Type TStationBase Extends TOwnedGameObject {_exposeToLua="selected"}
 	Field listSpriteNameOff:String = "gfx_datasheet_icon_antenna.off"
 
 
-	Method Init:TStationBase( X:Int, Y:Int, price:Int=-1, owner:Int)
+	Method Init:TStationBase( X:Int, Y:Int, price:Int=-1, owner:Int, fullyInit:Int = True)
 		Self.owner = owner
 		Self.X = X
 		Self.Y = Y
@@ -2872,7 +2872,7 @@ Type TStationBase Extends TOwnedGameObject {_exposeToLua="selected"}
 		'by default each station could get sold
 		Self.SetFlag(TVTStationFlag.SELLABLE, True)
 
-		Self.RefreshData()
+		If fullyInit Then Self.RefreshData()
 
 		Return Self
 	End Method
@@ -3551,8 +3551,8 @@ End Type
 'compatibility for now
 'Todo: DEPRECATED, remove in v0.8 or later (last in use at 0.6)
 Type TStation Extends TStationAntenna {_exposeToLua="selected"}
-	Method Init:TStation(X:Int, Y:Int, price:Int=-1, owner:Int) Override
-		Super.Init(X, Y, price, owner)
+	Method Init:TStation(X:Int, Y:Int, price:Int=-1, owner:Int, fullyInit:Int = True) Override
+		Super.Init(X, Y, price, owner, fullyInit)
 		Return Self
 	End Method
 End Type
@@ -3574,8 +3574,8 @@ Type TStationAntenna Extends TStationBase {_exposeToLua="selected"}
 	End Method
 
 
-	Method Init:TStationAntenna(X:Int, Y:Int, price:Int=-1, owner:Int) Override
-		Super.Init(X, Y, price, owner)
+	Method Init:TStationAntenna(X:Int, Y:Int, price:Int=-1, owner:Int, fullyInit:Int = True) Override
+		Super.Init(X, Y, price, owner, fullyInit)
 		Return Self
 	End Method
 
@@ -3818,8 +3818,8 @@ Type TStationCableNetworkUplink Extends TStationBase {_exposeToLua="selected"}
 	End Method
 
 
-	Method Init:TStationCableNetworkUplink(X:Int, Y:Int, price:Int=-1, owner:Int) Override
-		Super.Init(X, Y, price, owner)
+	Method Init:TStationCableNetworkUplink(X:Int, Y:Int, price:Int=-1, owner:Int, fullyInit:Int = True) Override
+		Super.Init(X, Y, price, owner, fullyInit)
 
 		Return Self
 	End Method
@@ -4221,8 +4221,8 @@ Type TStationSatelliteUplink Extends TStationBase {_exposeToLua="selected"}
 	End Method
 
 
-	Method Init:TStationSatelliteUplink(X:Int, Y:Int, price:Int=-1, owner:Int) Override
-		Super.Init(X, Y, price, owner)
+	Method Init:TStationSatelliteUplink(X:Int, Y:Int, price:Int=-1, owner:Int, fullyInit:Int = True) Override
+		Super.Init(X, Y, price, owner, fullyInit)
 
 		Return Self
 	End Method


### PR DESCRIPTION
Wieder zunächst zur Begutachtung zwei Punkte, die mir für die KI-Performance seit einer Weile auf der Seele lagen. Zu Sendungsbeginn hat die KI ja schon geprüft, ob die Werbebedingung erfüllt ist - aber nur wenn keine Zielgruppe involviert war und der aktuelle Task wurde nicht wirklich unterbrochen. Weiterhin eine rudimentäre Auswertung der Einschaltquote um schlechte Filme frühzeitig zu verkaufen.

Die Erkennung beinhaltet nun auch Zielgruppen und ich habe die Engine so angepasst, dass ein unterbrechbarer Task (noch auf dem Weg) wirklich abgebrochen wird. Dadurch kommt es gefühlt zu wesentlich weniger Werbeausfällen.
Beim Erstellen der BusinessStatistik wird für Sendungen (mit nahezu maximaler Aktualität wegen der Vergleichbarkeit) die Einschaltquote ermittelt und abgespeichert. Bei schlechten Einschaltquoten wird die Lizenz wesentlich früher abgestoßen.

Eine weitere kleine Änderung ist noch, dass die KI-Spieler den Raumplan auch dann aufräumen, wenn ein potentielles Studio umgehängt war. Das könnte es für Spieler etwas aufwändiger machen, sich ein neues Studio zu holen.