### PR TITLE
Keine Reduktion des geforderten Image für Satellitenvertrag

### DIFF
--- a/source/game.gameeventkeys.bmx
+++ b/source/game.gameeventkeys.bmx
@@ -120,7 +120,6 @@ Type TGameEventKeys
 	Field BroadcastProvider_OnSetActive:TEventKey = GetEventKey("BroadcastProvider.OnSetActive", True)
 	Field BroadcastProvider_OnSetInactive:TEventKey = GetEventKey("BroadcastProvider.OnSetInactive", True)
 	Field Satellite_OnUpgradeTech:TEventKey = GetEventKey("Satellite.OnUpgradeTech", True)
-	Field Satellite_OnReduceMinimumChannelImage:TEventKey = GetEventKey("Satellite.OnReduceMinimumChannelImage", True)
 	
 	
 	'game.misc.ingamehelp.bmx"

--- a/source/game.stationmap.bmx
+++ b/source/game.stationmap.bmx
@@ -6054,8 +6054,6 @@ Type TStationMap_Satellite Extends TStationMap_BroadcastProvider {_exposeToLua="
 	'name without revision
 	Field brandName:String
 
-	Field nextImageReductionTime:Long = -1
-	Field nextImageReductionValue:Float = 0.97
 	Field nextTechUpgradeTime:Long = -1
 	Field nextTechUpgradeValue:Int = 0
 	Field techUpgradeSpeed:Int
@@ -6200,21 +6198,6 @@ Type TStationMap_Satellite Extends TStationMap_BroadcastProvider {_exposeToLua="
 
 				nextTechUpgradeTime = GetWorldTime().ModifyTime(-1, 0, 0, Int(RandRange(250,350) * 100.0/techUpgradeSpeed))
 				nextTechUpgradeValue = BiasedRandRange(10, 25, 0.2) * 100.0/techUpgradeSpeed
-			EndIf
-
-
-			If minimumChannelImage > 0.1 And nextImageReductionTime < GetWorldTime().GetTimeGone()
-				If nextImageReductionTime > 0
-					Local oldMinimumChannelImage:Float = minimumChannelImage
-					minimumChannelImage :* nextImageReductionValue
-					'avoid reducing very small values for ever and ever
- 					If minimumChannelImage <= 0.1 Then minimumChannelImage = 0
-					'inform others (eg. for news)
-					TriggerBaseEvent(GameEventKeys.Satellite_OnReduceMinimumChannelImage, New TData.AddFloat("minimumChannelImage", minimumChannelImage).AddFloat("oldMinimumChannelImage", oldMinimumChannelImage), Self )
-				EndIf
-
-				nextImageReductionTime = GetWorldTime().ModifyTime(-1, 0, 0, Int(RandRange(20,30)))
-				nextImageReductionValue = nextImageReductionValue^2
 			EndIf
 		EndIf
 	End Method


### PR DESCRIPTION
Mit dieser Änderung findet überhaupt keine Reduktion statt. Es sollte möglich sein, mit Antennen und Kabelverträgen Werbeeinnahmen zu steigern und das geforderte Image zu erreichen.

Im Vergleich zu Sendegenehmigungen für ein neues Bundesland ist der Preis für den Vertragsabschluss für Satelliten ziemlich gering.

closes #811 