### PR TITLE
Datumsangabe im Interface

### DIFF
--- a/source/game.ingameinterface.bmx
+++ b/source/game.ingameinterface.bmx
@@ -570,7 +570,8 @@ Type TInGameInterface
 				content :+ "~n"
 				content :+ "|b|"+GetLocale("DAY_OF_YEAR")+":|/b| "+GetWorldTime().getDayOfYear()+"/"+GetWorldTime().GetDaysPerYear()
 				content :+ "~n"
-				content :+ "|b|"+GetLocale("DATE")+":|/b| "+GetWorldTime().GetFormattedDate(GameConfig.dateFormat)+" ("+GetLocale("SEASON_"+GetWorldTime().GetSeasonName())+")"
+				'content :+ "|b|"+GetLocale("DATE")+":|/b| "+GetWorldTime().GetFormattedDate(GameConfig.dateFormat)+" ("+GetLocale("SEASON_"+GetWorldTime().GetSeasonName())+")"
+				content :+ GetLocale("SEASON_"+GetWorldTime().GetSeasonName())+" "+ GetWorldTime().GetYear()
 				CurrentTimeToolTip.SetContent(content)
 				CurrentTimeToolTip.enabled = 1
 				CurrentTimeToolTip.Hover()

--- a/source/game.room.base.bmx
+++ b/source/game.room.base.bmx
@@ -896,7 +896,7 @@ Type TRoomBase extends TOwnedGameObject {_exposeToLua="selected"}
 			Return GetLocale("TOMORROW") + " " + GetWorldTime().GetFormattedTime(self.blockedUntil)
 		'other day: show game day + hour
 		else
-			Return GetWorldTime().GetFormattedDate(self.blockedUntil)
+			Return GetLocale("GAMEDAY") + " "+ GetWorldTime().GetFormattedDate(self.blockedUntil, "g (h:i)")
 		endif
 		Return ""
 	End Method

--- a/source/game.room.roomdoor.bmx
+++ b/source/game.room.roomdoor.bmx
@@ -191,7 +191,7 @@ Type TRoomDoor extends TRoomDoorBase  {_exposeToLua="selected"}
 				If not (HasFlag(TVTRoomDoorFlag.TOOLTIP_ONLY_ON_SAME_FLOOR) and GetPlayerBase().GetFigure().GetFloor() <> onFloor)
 					If not tooltip
 						tooltip = TRoomDoorTooltip.Create("", "", 100, 140, 0, 0)
-						tooltip.SetMinTitleAndContentWidth(100, 160)
+						tooltip.SetMinTitleAndContentWidth(100, 180)
 						tooltip.AssignRoom(room.id)
 					endif
 

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -6029,7 +6029,8 @@ endrem
 		ElseIf GetWorldTime().GetDay() + 1 = GetWorldTime().GetDay(subscriptionEndTime)
 			t = t.Replace("%DAYX%", GetLocale("TOMORROW") )
 		Else
-			t = t.Replace("%DAYX%", GetWorldTime().GetFormattedGameDate(subscriptionEndTime) )
+			'(currently not used - notification only one day in advance)
+			t = t.Replace("%DAYX%", GetLocale("GAMEDAY") + " " +(GetWorldTime().GetDaysRun(subscriptionEndTime)+1))
 		EndIf
 
 		toast.SetText( t )


### PR DESCRIPTION
Nur Jahr+Monat im Interface anzeigen

closes #808

Eine Alternative wäre noch, den Monat in GetDayOfMonth auszuwerten und bei Februar ein Max von 28 zuzulassen. Aber die Methode wird schon ziemlich häufig aufgerufen...