### PR TITLE
Korrekte Initialisierung des Difficulty-Objekts

### DIFF
--- a/source/game.player.base.bmx
+++ b/source/game.player.base.bmx
@@ -531,8 +531,15 @@ endrem
 
 	Method GetDifficulty:TPlayerDifficulty()
 		if not difficulty
-			SetDifficulty(difficultyGUID)
-
+			'try to obtain difficulty object from savegame
+			local diff:TPlayerDifficulty = GetPlayerDifficulty(playerId)
+			if diff
+				if diff.GetGUID() <> difficultyGUID then throw "TPlayerBase.GetDifficulty() failed: level mismatch for player " + playerId
+				difficulty = diff
+			else
+				'fall back to difficulty by name
+				SetDifficulty(difficultyGUID)
+			endif
 			if not difficulty then Throw "TPlayerBase.GetDifficulty() failed: difficulty ~q"+difficultyGUID+"~q not found."
 		endif
 

--- a/source/game.player.difficulty.bmx
+++ b/source/game.player.difficulty.bmx
@@ -6,6 +6,7 @@ Import "Dig/base.util.data.xmlstorage.bmx"
 
 Type TPlayerDifficultyCollection Extends TGameObjectCollection
 	Field _initializedDefaults:int = False {nosave} 'initialize each time
+	Global _basePath:String = ""
 	Global _instance:TPlayerDifficultyCollection
 
 
@@ -19,7 +20,7 @@ Type TPlayerDifficultyCollection Extends TGameObjectCollection
 	Method InitializeDefaults:int()
 		Local dataLoader:TDataXmlStorage = New TDataXmlStorage
 		dataLoader.setRootNodeKey("difficulties")
-		local difficultyConfig:TData = dataLoader.Load("config/gamesettings/default.xml")
+		local difficultyConfig:TData = dataLoader.Load(_basePath+"config/gamesettings/default.xml")
 
 		local easy:TPlayerDifficulty = ReadDifficultyData("easy", difficultyConfig)
 		local normal:TPlayerDifficulty = ReadDifficultyData("normal", difficultyConfig)


### PR DESCRIPTION
Aktuell kommt man auf zwei Wegen an das Objekt für die Schwierigkeit. Per Player-ID aus der DifficultyCollection und direkt per Getter am Player. Der persistiert aber das Objekt nicht selbst, sondern initialisiert es beim ersten Aufruf anhand des Levelnamens. Beim Laden werden die Level aber neu initialisiert, so dass DifficultyCollection und Player auseinanderlaufen.

Mit diesem Fix holt sich der Spieler seinen Initialwert von der Collection.

closes #823