### PR TITLE
Neue Daten

### DIFF
--- a/res/database/Default/user/cujo.xml
+++ b/res/database/Default/user/cujo.xml
@@ -675,6 +675,62 @@
             <data genre="3" price="0.47" quality="47" />
 			<availability year_range_from="1995" year_range_to="1995" />
         </news>
+		<!-- "TVT AG" -->
+        <news id="cujo-news-tvt-01" type="0" thread_id="cujo-news-tvt" creator="8827" created_by="Cujo">
+            <title>
+                <de>TVT-Entwickler arbeiten im Home-Office</de>
+                <en>TVT developers work in a home office</en>
+            </title>
+            <description>
+                <de>Wegen der Pandemie arbeiten ab sofort alle TVT-Entwickler im Home-Office. Laut der TVT AG sind weltweit etwa 35.000 Mitarbeiter davon betroffen.</de>
+                <en>Due to the pandemic, all TVT developers are working in their home offices with immediate effect. According to TVT AG, about 35,000 employees worldwide are affected.</en>
+            </description>
+			<effects>
+                <effect trigger="happen" type="triggernews" time="2,1,2,12,16" news="cujo-news-tvt-02" />
+            </effects>
+            <data genre="0" price="0.5" quality="20" />
+            <availability year_range_from="2020" year_range_to="" />
+        </news>
+        <news id="cujo-news-tvt-02" type="2" thread_id="cujo-news-tvt" creator="8827" created_by="Cujo">
+            <title>
+                <de>News werden verschlüsselt</de>
+                <en>News are encrypted</en>
+            </title>
+            <description>
+                <de>Laut der TVT AG werden die News wegen der geltenden GSDVO ab sofort verschlüsselt. v/KNne yTZbUgc+p FMJ6 MH8qT XQFrZsi.</de>
+                <en>According to TVT AG, the news will be encrypted with immediate effect due to the GSDVO in force. v/KNne yTZbUgc+p FMJ6 MH8qT XQFrZsi.</en>
+            </description>
+			<effects>
+                <effect trigger="happen" type="triggernews" time="2,1,2,13,17" news="cujo-news-tvt-03" />
+            </effects>
+            <data genre="0" price="0.5" quality="30" />
+        </news>
+        <news id="cujo-news-tvt-03" type="2" thread_id="cujo-news-tvt" creator="8827" created_by="Cujo">
+            <title>
+                <de>TVT AG schafft Schreibmaschinen ab</de>
+                <en>TVT AG abolishes typewriters</en>
+            </title>
+            <description>
+                <de>Wie die Pressesprecherin der TVT AG mitteilte, müssen die Entwickler nicht mehr auf Schreibmaschinen programmieren: "Unsere Programmierer werden ab sofort mit leistungsfähigen 16-Bit-Bandium-Computern ausgestattet."</de>
+                <en>According to TVT AG's press spokeswoman, developers no longer have to program on typewriters: "Our programmers will be equipped with powerful 16-bit Bandium computers from now on."</en>
+            </description>
+			<effects>
+                <effect trigger="happen" type="triggernews" time="2,1,2,14,18" news="cujo-news-tvt-04" />
+            </effects>
+            <data genre="0" price="0.5" quality="30" />
+        </news>
+        <news id="cujo-news-tvt-04" type="2" thread_id="cujo-news-tvt" creator="8827" created_by="Cujo">
+            <title>
+                <de>Schokoriegel sollen verboten werden</de>
+                <en>Candy bars to be banned</en>
+            </title>
+            <description>
+                <de>Wie Gesundheitsminister Kurt Leisenfluss in einem TVT-Sender bekanntgab, sollen Schokoriegel wegen ihres hohen Zuckergehalts verboten werden. Pludo-Hersteller Pferreri prüft, ob er weiterhin Werbung auf den TVT-Sendern schaltet.</de>
+                <en>Health Minister Kurt Leisenfluss announced on a TVT station that candy bars will be banned because of their high sugar content. Pludo manufacturer Pferreri is considering whether to continue advertising on TVT stations.</en>
+            </description>
+            <effects />
+            <data genre="0" price="0.5" quality="40" />
+        </news>
     </allnews>
 	<celebritypeople>
         <!-- Danny Pintauro -->
@@ -957,6 +1013,16 @@
 			<first_name_original>Carlo</first_name_original>
 			<last_name_original>Rola</last_name_original>
 			<details job="1" gender="1" birthday="1958-10-06" deathday="2016-03-14" country="D" />
+		</person>
+		<!-- Moderator -->
+		<!-- Bob Ross -->
+		<person id="cujo-person-ross-blob" tmdb_id="" imdb_id="nm1470679" creator="8827" created_by="Cujo">
+			<first_name>Ross</first_name>
+			<last_name>Blob</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Bob</first_name_original>
+			<last_name_original>Ross</last_name_original>
+			<details job="8" gender="1" birthday="1942-10-29" deathday="1995-07-04" country="USA" />
 		</person>
 	</celebritypeople>
     <allprogrammes>
@@ -1622,6 +1688,83 @@
                 </programme>
             </children>
         </programme>
+			<programme id="cujo-serien-spass-malen" product="2" licence_type="3" tmdb_id="0" imdb_id="tt0383795" creator="8827" created_by="Cujo">
+            <title>
+                <de>Spaß am Malen</de>
+                <en>Fun painting</en>
+            </title>
+			<title_original>
+				<de>Bob Ross: The Joy of Painting</de>
+				<en>The Joy of Painting</en>
+			</title_original>
+            <description>
+                <de>Ross Blob malt ein Bild und erklärt mit sanfter Stimme, wie die Zuschauer den Pinsel halten sollen.</de>
+                <en>Ross Blob paints a picture and explains in a gentle voice how the audience should hold the brush.</en>
+            </description>
+			<staff>
+				<member index="0" function="8">cujo-ross-blob</member>
+			</staff>
+            <groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
+            <data country="USA" year="1983" distribution="2" maingenre="6" subgenre="" flags="4" blocks="1" price_mod="1.25" />
+            <ratings critics="29" speed="3" outcome="42" />
+            <children>
+                <programme id="cujo-serien-spass-malen-01" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Wasserfall in den Bergen</de>
+                        <en>Waterfall in the mountains</en>
+                    </title>
+                    <description>
+                        <de>Ross Blob malt einen Wasserfall in den Bergen und zeigt, wie die Wassertropfen zum Glitzern gebracht werden können.</de>
+                        <en>Ross Blob paints a waterfall in the mountains and shows how to make the water droplets sparkle.</en>
+                    </description>
+                    <ratings critics="29" speed="5" />
+                </programme>
+                <programme id="cujo-serien-spass-malen-02" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Ein Sonnenuntergang am Meer</de>
+                        <en>A sunset by the sea</en>
+                    </title>
+                    <description>
+                        <de>Ross Blob malt einen orange-leuchtenden Sonnenuntergang und motiviert damit die Zuschauer zum Selbermalen.</de>
+                        <en>Ross Blob paints an orange-glowing sunset, motivating the audience to paint it themselves.</en>
+                    </description>
+                    <ratings critics="29" speed="5" />
+                </programme>
+                <programme id="cujo-serien-spass-malen-03" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Die Windmühle</de>
+                        <en>The windmill</en>
+                    </title>
+                    <description>
+                        <de>Ross Blob malt eine Windmühle vor einem Weizenfeld und erklärt den Zuschauern, wie einfach es ist die Getreideähren zu malen.</de>
+                        <en>Ross Blob paints a windmill in front of a wheat field and explains to the audience how easy it is to paint the ears of grain.</en>
+                    </description>
+                    <ratings critics="29" speed="5" />
+                </programme>
+                <programme id="cujo-serien-spass-malen-04" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Dunkle Wolken am Himmel</de>
+                        <en>Dark clouds in the sky</en>
+                    </title>
+                    <description>
+                        <de>Blob Ross malt dunkle Wolken an einem Himmel und gibt den Zuschauern Tipps, wie sie ein Gewitter malen können.</de>
+                        <en>Blob Ross paints dark clouds in a sky and gives viewers tips on how to paint a thunderstorm.</en>
+                    </description>
+                    <ratings critics="29" speed="5" />
+                </programme>
+                <programme id="cujo-serien-spass-malen-05" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Sonnenblumen am Wegesrand</de>
+                        <en>Sunflowers by the wayside</en>
+                    </title>
+                    <description>
+                        <de>Blob Ross malt drei Sonnenblumen am Wegesrand und zeigt das richtige Malen des Schattenwurfs.</de>
+                        <en>Blob Ross paints three sunflowers by the wayside and demonstrates how to properly paint the shadow cast.</en>
+                    </description>
+                    <ratings critics="29" speed="5" />
+                </programme>
+            </children>
+        </programme>
     </allprogrammes>
 	<allads>
 		<!-- Toyota - Nichts ist unmöglich -->
@@ -1630,11 +1773,35 @@
 				<de>Yotota</de>
 			</title>
 			<description>
-				<de>Alles ist möglich - Yotota</de>
-				<en>Everything is possible - Yotota</en>
+				<de>Alles ist möglich - Yotota - Helfen Sie mit: Yotota stiftet für jedes verkaufte Auto 10 Cent an eine Initiative zur Rettung des Regenwalds.</de>
+				<en>Anything is possible - Yotota - Help: Yotota donates 10 cents for every car sold to an initiative to save the rainforest.</en>
 			</description>
 			<conditions min_audience="10" min_image="0" target_group="0" prohibited_genre="8" prohibited_programme_type="5" prohibited_programme_flag="16" pro_pressure_groups="0" contra_pressure_groups="0"/>
 			<data quality="20" repetitions="5" duration="3" profit="350" penalty="475" infomercial_profit="50" fix_infomercial_profit="1"/>
+		</ad>
+		<!-- Duplo -->
+		<ad id="cujo-werbung-pludo">
+			<title>
+				<de>Pludo</de>
+			</title>
+			<description>
+				<de>Pludo - Der wahrscheinlich längste Schokoriegel der Welt - Neu: Sonderaktion - 9 Riegel zum Preis von 11</de>
+				<en>Pludo - Probably the longest chocolate bar in the world - New: Special offer - 9 bars for the price of 11</en>
+			</description>
+			<conditions min_audience="1.2" min_image="0" target_group="0" prohibited_genre="0" prohibited_programme_type="" prohibited_programme_flag="" pro_pressure_groups="0" contra_pressure_groups="0"/>
+			<data quality="12" repetitions="4" duration="3" profit="1100" penalty="1650" fix_infomercial_profit="1"/>
+		</ad>
+		<!-- Schwartau -->
+		<ad id="cujo-werbung-schwalltau">
+			<title>
+				<de>Schwalltau</de>
+			</title>
+			<description>
+				<de>Schwalltau - Die süßeste Versuchung seit es Marmelade gibt - Jetzt auch mit Tollkirschen</de>
+				<en>Schwalltau - The sweetest temptation since there is jam - Now also with belladonna cherries</en>
+			</description>
+			<conditions min_audience="2.4" min_image="0" target_group="0" prohibited_genre="0" prohibited_programme_type="" prohibited_programme_flag="" pro_pressure_groups="0" contra_pressure_groups="0"/>
+			<data quality="14" repetitions="3" duration="2" profit="750" penalty="1125" fix_infomercial_profit="1"/>
 		</ad>
 	</allads>
 </tvtdb>

--- a/res/database/Default/user/cujo.xml
+++ b/res/database/Default/user/cujo.xml
@@ -1,0 +1,1640 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<tvtdb>
+    <version value="3" comment="Cujos Daten" />
+    <allnews>
+		<!-- "Superman und Supergirl" -->
+        <news id="cujo-news-superkerl-01" type="0" thread_id="cujo-news-superkerl" creator="8827" created_by="Cujo">
+            <title>
+                <de>Superweib verliebt sich in Superkerl</de>
+                <en>Superwoman falls in love with Superguy</en>
+            </title>
+            <description>
+                <de>Die beiden weltbekannten Superhelden haben sich gefunden. Sie findet ihn super. Er sie auch. Beide: "Unser erstes Date war super".</de>
+                <en>The world-famous superheroes have found each other. She thinks he's great. He her too. Both: "Our first date was great".</en>
+            </description>
+            <effects>
+                <!-- "morgen oder uebermorgen, 12-16 Uhr" -->
+                <effect trigger="happen" type="triggernews" time="2,1,2,12,16" news="cujo-news-superkerl-02" />
+            </effects>
+            <data genre="1" price="1.0" quality="10" />
+            <availability year_range_from="1985" year_range_to="1995" />
+        </news>
+        <news id="cujo-news-superkerl-02" type="2" thread_id="cujo-news-superkerl" creator="8827" created_by="Cujo">
+            <title>
+                <de>Superweib und Superkerl verloben sich</de>
+                <en>Superwoman and Superguy get engaged</en>
+            </title>
+            <description>
+                <de>Superkerl kann sein Glück nicht fassen: "Sie küsst super".</de>
+                <en>Superguy can't believe his luck: "She kisses great".</en>
+            </description>
+            <effects>
+                <!-- "morgen oder uebermorgen, 13-17 Uhr" -->
+                <effect trigger="happen" type="triggernews" time="2,1,2,13,17" news="cujo-news-superkerl-03" />
+            </effects>
+            <data genre="1" price="1.0" quality="30" />
+        </news>
+        <news id="cujo-news-superkerl-03" type="2" thread_id="cujo-news-superkerl" creator="8827" created_by="Cujo">
+            <title>
+                <de>Superkerl und Superweib haben geheiratet</de>
+                <en>Superguy and Superwoman got married</en>
+            </title>
+            <description>
+                <de>Superweib über Superkerl: "In der Hochzeitsnacht war er super".</de>
+                <en>Superweib about Superguy: "On the wedding night he was super".</en>
+            </description>
+            <effects>
+                <!-- "morgen oder uebermorgen, 14-18 Uhr" -->
+                <effect trigger="happen" type="triggernews" time="2,1,2,14,18" news="cujo-news-superkerl-04" />
+            </effects>
+            <data genre="1" price="1.0" quality="50" />
+        </news>
+        <news id="cujo-news-superkerl-04" type="2" thread_id="cujo-news-superkerl" creator="8827" created_by="Cujo">
+            <title>
+                <de>Superweib ist schwanger</de>
+                <en>Superwoman is pregnant</en>
+            </title>
+            <description>
+                <de>Superkerl: "Ich will ein super Vater werden".</de>
+                <en>Superguy: "I want to be a super father".</en>
+            </description>
+            <effects>
+                <!-- "morgen oder uebermorgen, 15-19 Uhr" -->
+                <effect trigger="happen" type="triggernews" time="2,1,2,15,19" news="cujo-news-superkerl-05" />
+            </effects>
+            <data genre="1" price="1.0" quality="60" />
+        </news>
+        <news id="cujo-news-superkerl-05" type="2" thread_id="cujo-news-superkerl" creator="8827" created_by="Cujo">
+            <title>
+                <de>Superweib bringt einen Jungen zur Welt</de>
+                <en>Superwoman gives birth to a boy</en>
+            </title>
+            <description>
+                <de>Superkerl und Superweib sind glücklich: "Das ist unser Superboy".</de>
+                <en>Superguy and Superwoman are happy: "This is our Superboy".</en>
+            </description>
+                <!-- "morgen oder uebermorgen, 16-20 Uhr" -->
+            <effects>
+                <effect trigger="happen" type="triggernewschoice" choose="or" probability="50" time="2,1,2,16,20"
+                    news1="cujo-news-superkerl-06a" probability1="50"
+                    news2="cujo-news-superkerl-06b" probability2="50"
+                />
+            </effects>
+            <data genre="1" price="1.0" quality="40" />
+        </news>
+        <news id="cujo-news-superkerl-06a" type="2" thread_id="cujo-news-superkerl" creator="8827" created_by="Cujo">
+            <title>
+                <de>Trennungsgerüchte um Superkerl und Superweib</de>
+                <en>Superguy and Superwoman separation rumors</en>
+            </title>
+            <description>
+                <de>Superkerl: "Sie kocht nicht gerade super."</de>
+                <en>Superguy: "She's not a great cook."</en>
+            </description>
+            <effects>
+                <!-- "morgen oder uebermorgen, 17-21 Uhr" -->
+                <effect trigger="happen" type="triggernews" time="2,1,2,17,21" news="cujo-news-superkerl-07" />
+            </effects>
+            <data genre="1" price="1.0" quality="70" />
+        </news>
+        <news id="cujo-news-superkerl-06b" type="2" thread_id="cujo-news-superkerl" creator="8827" created_by="Cujo">
+            <title>
+                <de>Trennungsgerüchte um Superkerl und Superweib</de>
+                <en>Superguy and Superwoman separation rumors</en>
+            </title>
+            <description>
+                <de>Superweib: "Er kann keinen Nagel in die Wand schlagen."</de>
+                <en>Superweib: "He can't drive a nail into the wall."</en>
+            </description>
+            <effects>
+                <!-- "morgen oder uebermorgen, 17-21 Uhr" -->
+                <effect trigger="happen" type="triggernews" time="2,1,2,17,21" news="cujo-news-superkerl-07" />
+            </effects>
+            <data genre="1" price="1.0" quality="80" />
+        </news>
+        <news id="cujo-news-superkerl-07" type="2" thread_id="cujo-news-superkerl" creator="8827" created_by="Cujo">
+            <title>
+                <de>Superweib und Superkerl versöhnen sich wieder</de>
+                <en>Superwoman and Superguy reconcile again</en>
+            </title>
+            <description>
+                <de>Superkerl: "Wir sind wieder glücklich. Unsere Versöhnung war super.</de>
+                <en>Superguy: "We are happy again. Our reconciliation was super."</en>
+            </description>
+            <effects>
+                <!-- "morgen oder uebermorgen, 18-22 Uhr" -->
+                <effect trigger="happen" type="triggernewschoice" choose="or" probability="50" time="2,1,2,18,22"
+                    news1="cujo-news-superkerl-08a" probability1="50"
+                    news2="cujo-news-superkerl-08b" probability2="50"
+                />
+            </effects>
+            <data genre="1" price="1.0" quality="40" />
+        </news>
+        <news id="cujo-news-superkerl-08a" type="2" thread_id="cujo-news-superkerl" creator="8827" created_by="Cujo">
+            <title>
+                <de>Superkerl und Superweib lassen sich scheiden</de>
+                <en>Superguy and Superwoman get a divorce</en>
+            </title>
+            <description>
+                <de>Superboy leidet unter Trennung. Er will einen Supervater und eine Supermutter. Das unappetitliche Essen stört ihn nicht.</de>
+                <en>Superboy suffers from separation. He wants a super father and a super mother. The unappetizing food does not bother him.</en>
+            </description>
+            <effects />
+            <data genre="1" price="1.0" quality="70" />
+        </news>
+        <news id="cujo-news-superkerl-08b" type="2" thread_id="cujo-news-superkerl" creator="8827" created_by="Cujo">
+            <title>
+                <de>Superkerl und Superweib lassen sich scheiden</de>
+                <en>Superguy and Superwoman get a divorce</en>
+            </title>
+            <description>
+                <de>Superboy leidet unter Trennung. Er will einen Supervater und eine Supermutter. "Ich brauche kein neues Regal".</de>
+                <en>Superboy suffers from separation. He wants a super father and a super mother. "I do not need a new shelf".</en>
+            </description>
+            <effects />
+            <data genre="1" price="1.0" quality="70" />
+        </news>		
+        <!-- "Fifa-WM 2022 in Katar" -->
+        <news id="cujo-news-quantar-01" type="0" thread_id="cujo-news-quantar" creator="8827" created_by="Cujo">
+            <title>
+                <de>Fufa vergibt heute die Fußball-WM 2022</de>
+                <en>Fufa awards the 2022 World Cup today</en>
+            </title>
+            <description>
+                <de>Heute gibt die Fufa den Austragungsort der Fußball-WM 2022 bekannt. SUA, Pajan und Intralien gelten als Favoriten. Der Wüstenstaat Quantar gilt als krasser Außenseiter.</de>
+                <en>Today Fufa announces the venue for the 2022 World Cup. SUA, Pajan and Intralia are considered favorites. The desert state of Quantar is considered a glaring outsider.</en>
+            </description>
+            <effects>
+                <effect trigger="happen" type="triggernews" time="1,7,8" news="cujo-news-quantar-02" />
+            </effects>
+            <data genre="2" price="1.0" quality="50" />
+            <availability year_range_from="2010" year_range_to="2012" />
+        </news>
+        <news id="cujo-news-quantar-02" type="2" thread_id="cujo-news-quantar" creator="8827" created_by="Cujo">
+            <title>
+                <de>Sensation - Quantar richtet die Fußball-WM 2022 aus</de>
+                <en>Sensation - Quantar to host the 2022 World Cup</en>
+            </title>
+            <description>
+                <de>Fufa-Generalsekretär Jupp Lauber öffnet den Briefumschlag und liest den Namen des Ausrichters vor. Es ist Quantar.</de>
+                <en>Fufa Secretary General Jupp Lauber opens the envelope and reads out the name of the organizer. It is Quantar.</en>
+            </description>
+            <effects>
+                <effect trigger="happen" type="triggernews" time="2,1,1,13,17" news="cujo-news-quantar-03" />
+            </effects>
+            <data genre="2" price="1.0" quality="90" />
+        </news>
+        <news id="cujo-news-quantar-03" type="2" thread_id="cujo-news-quantar" creator="8827" created_by="Cujo">
+            <title>
+                <de>Wurde die Fufa-WM gekauft?</de>
+                <en>Was the Fufa World Cup bought?</en>
+            </title>
+            <description>
+                <de>War bei der Vergabe der Fufa-WM Korruption im Spiel? SUA, Pajan und Intralien fühlen sich benachteiligt.</de>
+                <en>Was corruption involved in the awarding of the Fufa World Cup? SUA, Pajan and Intralia feel disadvantaged.</en>
+            </description>
+            <effects>
+                <effect trigger="happen" type="triggernews" time="2,1,2,14,18" news="cujo-news-quantar-04" />
+            </effects>
+            <data genre="2" price="1.0" quality="80" />
+        </news>
+        <news id="cujo-news-quantar-04" type="2" thread_id="cujo-news-quantar" creator="8827" created_by="Cujo">
+            <title>
+                <de>Lauber: "Vergabe war völlig in Ordnung."</de>
+                <en>Lauber: "Award was perfectly fine."</en>
+            </title>
+            <description>
+                <de>Fufa-Generalsekretär Jupp Lauber bestreitet alle Korruptionsvorwürfe. "Bei der Fufa gibt es nur ehrliche Menschen."</de>
+                <en>Fufa Secretary General Jupp Lauber denies all allegations of corruption. "There are only honest people at Fufa."</en>
+            </description>
+            <effects>
+                <effect trigger="happen" type="triggernews" time="2,1,2,15,19" news="cujo-news-quantar-05" />
+            </effects>
+            <data genre="2" price="1.0" quality="40" />
+        </news>
+        <news id="cujo-news-quantar-05" type="2" thread_id="cujo-news-quantar" creator="8827" created_by="Cujo">
+            <title>
+                <de>Funktionär aus Trunedad und Topigo gibt Bestechung zu</de>
+                <en>Official from Trunedad and Topigo admits bribery</en>
+            </title>
+            <description>
+                <de>Der trunedanische Fufa-Funktionär Jeff Worner hat zugegeben, dass er für seine Stimme Geld aus Quantar kassiert hat.</de>
+                <en>Trunedan Fufa official Jeff Worner has admitted that he collected money from Quantar for his vote.</en>
+            </description>
+            <effects>
+                <effect trigger="happen" type="triggernews" time="2,1,2,16,20" news="cujo-news-quantar-06" />
+            </effects>
+            <data genre="2" price="1.0" quality="50" />
+        </news>
+        <news id="cujo-news-quantar-06" type="2" thread_id="cujo-news-quantar" creator="8827" created_by="Cujo">
+            <title>
+                <de>Jupp Lauber bezeichnet Korruption als Einzelfall.</de>
+                <en>Jupp Lauber calls corruption an isolated incident.</en>
+            </title>
+            <description>
+                <de>Jupp Lauber: "Jeff Worner ist ein Krimineller. Alle anderen sind unschuldig."</de>
+                <en>Jupp Lauber: "Jeff Worner is a criminal. Everyone else is innocent."</en>
+            </description>
+            <effects>
+                <effect trigger="happen" type="triggernews" time="2,1,2,17,21" news="cujo-news-quantar-07" />
+            </effects>
+            <data genre="2" price="1.0" quality="40" />
+        </news>
+       <news id="cujo-news-quantar-07" type="2" thread_id="cujo-news-quantar" creator="8827" created_by="Cujo">
+            <title>
+                <de>Weitere Korruptionsfälle bei Fufa</de>
+                <en>Further cases of corruption at Fufa</en>
+            </title>
+            <description>
+                <de>Auch Funktionäre aus Muategela, Praskilien, Pasnien und Gäypten haben Geld aus Quantar angenommen.</de>
+                <en>Officials from Muategela, Praskilien, Pasnien and Gäypten have also accepted money from Quantar.</en>
+            </description>
+            <effects>
+                <effect trigger="happen" type="triggernews" time="2,1,2,18,22" news="cujo-news-quantar-08" />
+            </effects>
+            <data genre="2" price="1.0" quality="70" />
+        </news>
+        <news id="cujo-news-quantar-08" type="2" thread_id="cujo-news-quantar" creator="8827" created_by="Cujo">
+            <title>
+                <de>Jupp Lauber kann es nicht glauben</de>
+                <en>Jupp Lauber can't believe it</en>
+            </title>
+            <description>
+                <de>Jupp Lauber gibt dem FRS ein Interview: "Das hätte ich niemals gedacht. Bin ich wirklich der einzige ehrliche Fufa-Funktionär?"</de>
+                <en>Jupp Lauber gives an interview to FRS: "I would never have thought that. Am I really the only honest Fufa official?"</en>
+            </description>
+            <effects />
+            <data genre="2" price="1.0" quality="30" />
+        </news>
+		<!-- "Challenger-Unglück" -->
+        <news id="cujo-news-passenger-01" type="0" thread_id="cujo-news-passenger" creator="8827" created_by="Cujo">
+            <title>
+                <de>Start der Raumfähre Passenger geplant</de>
+                <en>Launch of space shuttle Passenger planned</en>
+            </title>
+            <description>
+                <de>Morgen soll die Raumfähre Passenger ins Weltall starten. Sie wird dort einen Kommunikationssatelliten aussetzen. Außerdem ist eine Beobachtung des Kometen Hallie geplant.</de>
+                <en>Tomorrow, the space shuttle Passenger is scheduled to launch into space. It will launch a communications satellite there. In addition, an observation of comet Hallie is planned.</en>
+            </description>
+            <effects>
+                <effect trigger="happen" type="triggernews" time="2,1,1,10,11" news="cujo-news-passenger-02" />
+            </effects>
+            <data genre="4" price="1.0" quality="40" />
+            <availability year_range_from="1986" year_range_to="1987" />
+        </news>
+        <news id="cujo-news-passenger-02" type="2" thread_id="cujo-news-passenger" creator="8827" created_by="Cujo">
+            <title>
+                <de>Start der Raumfähre Passenger verschoben</de>
+                <en>Launch of space shuttle Passenger postponed</en>
+            </title>
+            <description>
+                <de>Der Start der Raumfähre Passenger wurde um 2 Tage verschoben. Der Grund dafür waren heftige Gewitter zum geplanten Startzeitpunkt.</de>
+                <en>The launch of the space shuttle Passenger was postponed by 2 days. The reason for this was heavy thunderstorms at the planned launch time.</en>
+            </description>
+            <effects>
+                <effect trigger="happen" type="triggernews" time="2,2,2,1,2" news="cujo-news-passenger-03" />
+            </effects>
+            <data genre="4" price="1.0" quality="50" />
+        </news>
+        <news id="cujo-news-passenger-03" type="2" thread_id="cujo-news-passenger" creator="8827" created_by="Cujo">
+            <title>
+                <de>Raumfähre Passenger soll heute Vormittag starten</de>
+                <en>Space shuttle Passenger to launch this morning</en>
+            </title>
+            <description>
+                <de>Nachdem der Start der Raumfähre Passenger aufgrund schlechten Wetters um 2 Tage verschoben wurde, gibt es heute Vormittag einen erneuten Startversuch.</de>
+                <en>After the launch of the space shuttle Passenger was postponed for 2 days due to bad weather, there is another launch attempt this morning.</en>
+            </description>
+            <effects>
+                <effect trigger="happen" type="triggernewschoice" choose="or" probability="100" time="1,9,10"
+                    news1="cujo-news-passenger-04a" probability1="50"
+                    news2="cujo-news-passenger-04b" probability2="50"
+                />
+            </effects>
+            <data genre="4" price="1.0" quality="40" />
+        </news>
+        <news id="cujo-news-passenger-04a" type="2" thread_id="cujo-news-passenger" creator="8827" created_by="Cujo">
+            <title>
+                <de>Raumfähre Passenger explodiert</de>
+                <en>Space shuttle Passenger explodes</en>
+            </title>
+            <description>
+                <de>70 Sekunden nach dem Start ist die Raumfähre Passenger explodiert. Die sechs Astronauten sowie eine mitreisende Lehrerin sind wahrscheinlich tot.</de>
+                <en>70 seconds after launch, the space shuttle Passenger exploded. The six astronauts and a teacher traveling with them are probably dead.</en>
+            </description>
+            <effects>
+                <effect trigger="happen" type="triggernews" time="2,1,1,18,20" news="cujo-news-passenger-05a" />
+            </effects>
+            <data genre="4" price="1.0" quality="100" />
+        </news>
+        <news id="cujo-news-passenger-04b" type="2" thread_id="cujo-news-passenger" creator="8827" created_by="Cujo">
+            <title>
+                <de>Erfolgreicher Start der Raumfähre Passenger</de>
+                <en>Successful launch of the space shuttle Passenger</en>
+            </title>
+            <description>
+                <de>Die Raumfähre Passenger ist erfolgreich ins Weltall gestartet. Die sechs Astronauten haben bereits eine Grußbotschaft geschickt. Die Lehrerin Chrissie McAtlife wird bald den ersten Unterrichtsblock aus dem Weltall senden.</de>
+                <en>The space shuttle Passenger has successfully launched into space. The six astronauts have already sent a greeting message. Teacher Chrissie McAtlife will soon send the first block of lessons from space.</en>
+            </description>
+            <effects>
+                <effect trigger="happen" type="triggernews" time="2,3,4,20,23" news="cujo-news-passenger-05b" />
+            </effects>
+            <data genre="4" price="1.0" quality="50" />
+        </news>
+        <news id="cujo-news-passenger-05a" type="2" thread_id="cujo-news-passenger" creator="8827" created_by="Cujo">
+            <title>
+                <de>Weltweites Entsetzen nach Passenger-Katastrophe</de>
+                <en>Worldwide horror after passenger disaster</en>
+            </title>
+            <description>
+                <de>Einen Tag nach der Passenger-Katastrophe ist die gesamte Welt-Bevölkerung immer noch erschüttert. Wie konnte dieses Unglück geschehen? Hätte es verhindert werden können?</de>
+                <en>One day after the Passenger disaster, the entire world population is still shaken. How could this disaster have happened? Could it have been prevented?</en>
+            </description>
+            <effects>
+                <effect trigger="happen" type="triggernews" time="2,3,4,20,23" news="cujo-news-passenger-06" />
+            </effects>
+            <data genre="4" price="1.0" quality="40" />
+        </news>
+        <news id="cujo-news-passenger-05b" type="2" thread_id="cujo-news-passenger" creator="8827" created_by="Cujo">
+            <title>
+                <de>Landung der Passenger-Raumfähre geglückt</de>
+                <en>Successful landing of the passenger space shuttle</en>
+            </title>
+            <description>
+                <de>Die Passenger-Raumfähre ist im Kenidi Space-Center in Florida gelandet. Die sechs Astronauten und die Lehrerin stiegen wohlbehalten aus. Die NUSA bezeichnet die Mission als vollen Erfolg. Alle Ziele wurden erreicht.</de>
+                <en>The Passenger Space Shuttle has landed at the Kenidi Space Center in Florida. The six astronauts and the teacher disembark safely. NUSA calls the mission a complete success. All goals were achieved.</en>
+            </description>
+			<effects />
+            <data genre="4" price="1.0" quality="50" />
+        </news>	
+        <news id="cujo-news-passenger-06" type="2" thread_id="cujo-news-passenger" creator="8827" created_by="Cujo">
+            <title>
+                <de>Passenger-Katastrophe: Unglücksursache steht fest</de>
+                <en>Passenger disaster: cause of accident established</en>
+            </title>
+            <description>
+                <de>Die Unglücksursache für die Passenger-Katastrophe, bei der sieben Menschen ums Leben kamen, steht fest. Die Dichtungsringe einer Feststoffrakete waren defekt.</de>
+                <en>The cause of the passenger disaster that killed seven people has been determined. The sealing rings of a solid rocket were defective.</en>
+            </description>
+			<effects />
+            <data genre="4" price="1.0" quality="60" />
+        </news>
+		<!-- "Mathias Rust landet auf Rotem Platz" -->
+        <news id="cujo-news-roter-platz-01" type="0" thread_id="cujo-news-roter-platz" creator="8827" created_by="Cujo">
+            <title>
+                <de>Schessnah in der Nähe von Moskau gesichtet</de>
+                <en>Schessnah spotted near Moscow</en>
+            </title>
+            <description>
+                <de>Die russische Luftabwehr hat in der Nähe von Moskau ein deutsches Kleinflugzeug der Marke Schessnah gesichtet. Handelt es sich dabei um einen Selbstmordattentäter?</de>
+                <en>Russian air defense has spotted a German small plane of the brand Schessnah near Moscow. Is it a suicide bomber?</en>
+            </description>
+            <effects>
+                <effect trigger="happen" type="triggernews" time="1,2,3" news="cujo-news-roter-platz-02" />
+            </effects>
+            <data genre="4" price="0.55" quality="10" />
+        </news>
+        <news id="cujo-news-roter-platz-02" type="2" thread_id="cujo-news-roter-platz" creator="8827" created_by="Cujo">
+            <title>
+                <de>Schessnah 127 auf Rotem Platz in Moskau gelandet</de>
+                <en>Schessnah 127 landed on Red Square in Moscow</en>
+            </title>
+            <description>
+                <de>Auf dem Roten Platz in Moskau ist eine Schessnah 127 gelandet. Noch steht der Pilot des Flugzeugs nicht fest. Handelt es sich um einen Deutschen?</de>
+                <en>A Schessnah 127 has landed on Moscow's Red Square. The pilot of the plane has not yet been identified. Is it a German?</en>
+            </description>
+            <effects>
+                <effect trigger="happen" type="triggernews" time="1,2,3" news="cujo-news-roter-platz-03" />
+            </effects>
+            <data genre="4" price="1.2" quality="100" />
+        </news>
+        <news id="cujo-news-roter-platz-03" type="2" thread_id="cujo-news-roter-platz" creator="8827" created_by="Cujo">
+            <title>
+                <de>Schessnah-Pilot stammt aus Deutschland</de>
+                <en>Schessnah pilot comes from Germany</en>
+            </title>
+            <description>
+                <de>Der Pilot, der vor wenigen Stunden auf dem Roten Platz in Moskau gelandeten Schessnah, stammt aus Deutschland. Sein Name ist Markus Trust und er kommt aus Hamburg.</de>
+                <en>The pilot of the Schessnah, which landed on Moscow's Red Square a few hours ago, is from Germany. His name is Markus Trust and he comes from Hamburg.</en>
+            </description>
+            <effects>
+                <effect trigger="happen" type="triggernews" time="1,2,3" news="cujo-news-roter-platz-04" />
+            </effects>
+            <data genre="4" price="1.05" quality="80" />
+        </news>
+        <news id="cujo-news-roter-platz-04" type="2" thread_id="cujo-news-roter-platz" creator="8827" created_by="Cujo">
+            <title>
+                <de>Schessnah-Pilot wirbt für Völkerverständigung</de>
+                <en>Schessnah pilot promotes international understanding</en>
+            </title>
+            <description>
+                <de>Markus Trust, der Hamburger Pilot, der mit seiner Schessnah auf dem Roten Platz gelandet ist, appelliert an alle Menschen: "Lasst uns in Frieden leben."</de>
+                <en>Markus Trust, the Hamburg pilot who landed his Schessnah on Red Square, appeals to all people: "Let's live in peace."</en>
+            </description>
+            <effects>
+                <effect trigger="happen" type="triggernews" time="1,2,3" news="cujo-news-roter-platz-05" />
+            </effects>
+            <data genre="4" price="0.94" quality="70" />
+        </news>
+        <news id="cujo-news-roter-platz-05" type="2" thread_id="cujo-news-roter-platz" creator="8827" created_by="Cujo">
+            <title>
+                <de>Schessnah-Pilot vom KGB verhaftet</de>
+                <en>Schessnah pilot arrested by KGB</en>
+            </title>
+            <description>
+                <de>Der Schessnah-Pilot Markus Trust wurde vom KGB verhaftet. Muss er jetzt lebenslang hinter Gitter?</de>
+                <en>The Schessnah pilot Markus Trust was arrested by the KGB. Does he now have to spend his life behind bars?</en>
+            </description>
+            <effects>
+                <effect trigger="happen" type="triggernews" time="2,3,4,16,20" news="cujo-news-roter-platz-06" />
+            </effects>
+            <data genre="4" price="1.1" quality="85" />
+        </news>
+        <news id="cujo-news-roter-platz-06" type="2" thread_id="cujo-news-roter-platz" creator="8827" created_by="Cujo">
+            <title>
+                <de>Schessnah-Pilot zu 5 Jahren Arbeitslager verurteilt</de>
+                <en>Schessnah pilot sentenced to 5 years in labor camp</en>
+            </title>
+            <description>
+                <de>Markus Trust, der vor einigen Tagen mit seiner Schessnah-Landung auf dem Roten Platz in Moskau die russische Luftwaffe blamiert hatte, wurde von einem Richter wegen schweren Rowdytums zu 5 Jahren Arbeitslager verurteilt.</de>
+                <en>Markus Trust, who embarrassed the Russian Air Force a few days ago with his Schessnah landing on Moscow's Red Square, was sentenced by a judge to 5 years in a labor camp for serious hooliganism.</en>
+            </description>
+            <effects>
+                <effect trigger="happen" type="triggernews" time="2,5,6,18,22" news="cujo-news-roter-platz-07" />
+            </effects>
+            <data genre="4" price="0.85" quality="65" />
+        </news>
+        <news id="cujo-news-roter-platz-07" type="2" thread_id="cujo-news-roter-platz" creator="8827" created_by="Cujo">
+            <title>
+                <de>Schessnah-Pilot wird begnadigt</de>
+                <en>Schessnah pilot is pardoned</en>
+            </title>
+            <description>
+                <de>Der auf dem Roten Platz gelandete Schessnah-Pilot Markus Trust wird begnadigt. Nach 15 Monaten Arbeitslager kann er morgen zu seiner Familie zurückkehren. Seine Schessnah wird verschrottet.</de>
+                <en>Schessnah pilot Markus Trust, who landed in Red Square, is pardoned. After 15 months in a labor camp, he can return to his family tomorrow. His Schessnah will be scrapped.</en>
+            </description>
+			<effects />
+            <data genre="4" price="0.78" quality="55" />
+        </news>
+		<!-- "Ältester Mensch der Welt" -->
+        <news id="cujo-news-aeltestermensch-01" type="0" thread_id="cujo-news-aeltestermensch" creator="8827" created_by="Cujo">
+            <title>
+                <de>Ältester Mensch der Welt gestorben</de>
+                <en>Oldest person in the world died</en>
+            </title>
+            <description>
+                <de>Im Alter von 120 Jahren, 8 Monaten und 13 Tagen ist der Japaner Shigeko Izmari gestorben. Als er geboren wurde, produzierte der Konsolenhersteller Nidennto noch Gummistiefel.</de>
+                <en>At the age of 120 years, 8 months and 13 days, Japanese Shigeko Izmari has died. When he was born, the console manufacturer Nidennto was still producing rubber boots.</en>
+            </description>
+            <data genre="4" price="0.9" quality="30" />
+        </news>
+		<!-- "Bill Gates: Internet ist nur ein Hype" -->
+        <news id="cujo-news-internet-trend-01" type="0" thread_id="cujo-news-internet-trend" creator="8827" created_by="Cujo">
+            <title>
+                <de>Willy Bates: Internet ist nur ein Trend</de>
+                <en>Willy Bates: Internet is just a trend</en>
+            </title>
+            <description>
+                <de>In einem Fernseh-Interview prophezeit der Software-Entwickler Willy Bates dem Internet keine große Zukunft: "Das ist nur ein kurzfristiger Trend. In 10 Jahren gibt es das nicht mehr."</de>
+                <en>In a television interview, software developer Willy Bates doesn't predict a great future for the Internet: "It's just a short-term trend. It won't be around in 10 years."</en>
+            </description>
+            <data genre="3" price="0.8" quality="37" />
+            <availability year_range_from="1993" year_range_to="1995" />
+        </news>
+		<!-- "Wildecker Herzbuben" -->
+        <news id="cujo-news-wildberger-karobuben-01" type="0" thread_id="cujo-news-wildberger-karobuben" creator="8827" created_by="Cujo">
+            <title>
+                <de>Wildberger Karobuben: "Wir sind jetzt schlank"</de>
+                <en>Wildberger Karobuben: "We are now slim"</en>
+            </title>
+            <description>
+                <de>In einem Exklusiv-Interview mit der Zeitschrift FARBIGE erzählen die Wildberger Karobuben von ihrer Hungerkur: "Wir haben 7 Monate lang fast nichts gegessen und in dieser Zeit 300 Gramm abgenommen. Zusammengerechnet natürlich."</de>
+                <en>In an exclusive interview with FARBIGE magazine, the Wildberg Karobuben talk about their starvation diet: "We ate almost nothing for 7 months and lost 300 grams in that time. Added up, of course."</en>
+            </description>
+            <data genre="1" price="1.03" quality="19" />
+            <availability year_range_from="1989" year_range_to="" />
+        </news>
+		<!-- "Stiftung Warentest" -->		
+        <news id="cujo-news-stiftung-guetertest-01" type="0" thread_id="cujo-news-stiftung-guetertest" creator="8827" created_by="Cujo">
+            <title>
+                <de>Stiftung Gütertest testet Kugelschreiber</de>
+                <en>Fondation goodstest tests ballpoint pens</en>
+            </title>
+            <description>
+                <de>Die Stiftung Gütertest hat 5.748 Kugelschreiber getestet. Den besten Stift stellte die Firma Bastilo her. Erst nach einer Schreibdauer von 723 Stunden war seine Mine leer. 7 Tester wurden wegen eines Schreibkrampfes stationär behandelt.</de>
+                <en>Fondation goodstest tested 5,748 ballpoint pens. The best ballpoint pen was produced by the Bastilo company. Its refill was only empty after writing for 723 hours. 7 testers were hospitalized due to writer's cramp.</en>
+            </description>
+            <effects>
+                <effect trigger="happen" type="triggernews" time="2,2,5,17,21" news="cujo-news-stiftung-guetertest-02" />
+            </effects>
+            <data genre="4" price="0.81" quality="59" />
+        </news>
+        <news id="cujo-news-stiftung-guetertest-02" type="2" thread_id="cujo-news-stiftung-guetertest" creator="8827" created_by="Cujo">
+            <title>
+                <de>Stiftung Gütertest testet Vibratoren</de>
+                <en>Fondation goodstest tests vibrators</en>
+            </title>
+            <description>
+                <de>In einem großen Praxistest hat die Stiftung Gütertest 27 Vibratoren getestet. Acht Modelle wurden von den Testerinnen mit "befriedigend" bewertet.</de>
+                <en>In a major practical test, Fondation goodstest tested 27 vibrators. Eight models were rated "satisfactory" by the testers.</en>
+            </description>
+            <effects />
+            <data genre="4" price="0.82" quality="58" />
+        </news>
+        <!-- "Marathon-Weltrekorde -->
+        <news id="cujo-news-marathon-2003" type="0" thread_id="cujo-news-marathon-2003" creator="8827" created_by="Cujo">
+            <title>
+                <de>Erster Marathon-Weltrekord</de>
+                <en>First marathon world record</en>
+            </title>
+            <description>
+                <de>Der Kenianer Saul Taggert hat den ersten offiziellen Marathon-Weltrekord aufgestellt. In Berlin lief er die 42,195 Kilometer lange Strecke in einer Zeit von 2:04:55 Stunden. Bisher wurden beim Marathon nur Weltbestzeiten gelistet.</de>
+                <en>Kenyan Saul Taggert has set the first official marathon world record. In Berlin, he ran the 42.195-kilometer course in a time of 2:04:55 hours. Until now, only world best times have been listed for the marathon.</en>
+            </description>
+            <data genre="2" price="1.0" quality="80" />
+            <availability year_range_from="2003" year_range_to="2003" />
+        </news>
+        <news id="cujo-news-marathon-2007" type="0" thread_id="cujo-news-marathon-2007" creator="8827" created_by="Cujo">
+            <title>
+                <de>Neuer Marathon-Weltrekord</de>
+                <en>New marathon world record</en>
+            </title>
+            <description>
+                <de>Der Äthiopier Helle Geberlassy hat einen neuen Marathon-Weltrekord aufgestellt. In Berlin lief er die 42,195 Kilometer lange Strecke in der neuen Bestzeit von 2:04:26 Stunden. Er verbesserte damit den bisherigen Weltrekord um 29 Sekunden.</de>
+                <en>Ethiopian Helle Geberlassy has set a new marathon world record. In the German capital Berlin, he ran the 42.195 kilometer course in the new best time of 2:04:26 hours. He thus improved the previous world record by 29 seconds.</en>
+            </description>
+            <data genre="2" price="1.0" quality="80" />
+            <availability year_range_from="2007" year_range_to="2007" />
+        </news>
+        <news id="cujo-news-marathon-2008" type="0" thread_id="cujo-news-marathon-2008" creator="8827" created_by="Cujo">
+            <title>
+                <de>Neuer Marathon-Weltrekord</de>
+                <en>New marathon world record</en>
+            </title>
+            <description>
+                <de>Der Äthiopier Helle Geberlassy hat einen neuen Marathon-Weltrekord aufgestellt. In Berlin lief er die 42,195 Kilometer lange Strecke in der neuen Bestzeit von 2:03:59 Stunden. Er verbesserte damit den von ihm gehaltenen Weltrekord um 27 Sekunden.</de>
+                <en>Ethiopian Helle Geberlassy has set a new marathon world record. In Berlin, he ran the 42.195 kilometer course in the new best time of 2:03:59 hours. He thus improved the world record held by him by 27 seconds.</en>
+            </description>
+            <data genre="2" price="1.0" quality="80" />
+            <availability year_range_from="2008" year_range_to="2008" />
+        </news>
+        <news id="cujo-news-marathon-2011" type="0" thread_id="cujo-news-marathon-2011" creator="8827" created_by="Cujo">
+            <title>
+                <de>Neuer Marathon-Weltrekord</de>
+                <en>New marathon world record</en>
+            </title>
+            <description>
+                <de>Der Kenianer Patt Mattku hat einen neuen Marathon-Weltrekord aufgestellt. In Berlin lief er die 42,195 Kilometer lange Strecke in der neuen Bestzeit von 2:03:38 Stunden. Er verbesserte damit den bisherigen Weltrekord um 21 Sekunden.</de>
+                <en>Kenyan Patt Mattku has set a new marathon world record. In the German capital Berlin, he ran the 42.195 kilometer course in the new best time of 2:03:38 hours. He thus improved the previous world record by 21 seconds.</en>
+            </description>
+            <data genre="2" price="1.0" quality="80" />
+            <availability year_range_from="2011" year_range_to="2011" />
+        </news>
+        <news id="cujo-news-marathon-2013" type="0" thread_id="cujo-news-marathon-2013" creator="8827" created_by="Cujo">
+            <title>
+                <de>Neuer Marathon-Weltrekord</de>
+                <en>New marathon world record</en>
+            </title>
+            <description>
+                <de>Der Kenianer Nelson Sigpang hat einen neuen Marathon-Weltrekord aufgestellt. In Berlin lief er die 42,195 Kilometer lange Strecke in der neuen Bestzeit von 2:03:23 Stunden. Er verbesserte damit den bisherigen Weltrekord um 15 Sekunden.</de>
+                <en>Kenyan Nelson Sigpang has set a new marathon world record. In Berlin, he ran the 42.195 kilometer course in the new best time of 2:03:23 hours. He thus improved the previous world record by 15 seconds.</en>
+            </description>
+            <data genre="2" price="1.0" quality="80" />
+            <availability year_range_from="2013" year_range_to="2013" />
+        </news>
+        <news id="cujo-news-marathon-2014" type="0" thread_id="cujo-news-marathon-2014" creator="8827" created_by="Cujo">
+            <title>
+                <de>Neuer Marathon-Weltrekord</de>
+                <en>New marathon world record</en>
+            </title>
+            <description>
+                <de>Der Kenianer Danny Komitti hat einen neuen Marathon-Weltrekord aufgestellt. In Berlin lief er die 42,195 Kilometer lange Strecke in der neuen Bestzeit von 2:02:57 Stunden. Er verbesserte damit den bisherigen Weltrekord um 26 Sekunden.</de>
+                <en>Kenyan Danny Komitti has set a new marathon world record. In Berlin, he ran the 42.195 kilometer course in the new best time of 2:02:57 hours. He thus improved the previous world record by 26 seconds.</en>
+            </description>
+            <data genre="2" price="1.0" quality="80" />
+            <availability year_range_from="2014" year_range_to="2014" />
+        </news>
+        <news id="cujo-news-marathon-2018" type="0" thread_id="cujo-news-marathon-2018" creator="8827" created_by="Cujo">
+            <title>
+                <de>Neuer Marathon-Weltrekord</de>
+                <en>New marathon world record</en>
+            </title>
+            <description>
+                <de>Der Kenianer Elwood Pogchige hat einen neuen Marathon-Weltrekord aufgestellt. In Berlin lief er die 42,195 Kilometer lange Strecke in der neuen Bestzeit von 2:01:39 Stunden. Er verbesserte damit den bisherigen Weltrekord um 78 Sekunden.</de>
+                <en>Kenyan Elwood Pogchige has set a new marathon world record. In Berlin, he ran the 42.195 kilometer course in the new best time of 2:01:39 hours. He thus improved the previous world record by 78 seconds.</en>
+            </description>
+            <data genre="2" price="1.0" quality="80" />
+            <availability year_range_from="2018" year_range_to="2018" />
+        </news>
+        <news id="cujo-news-marathon-2022" type="0" thread_id="cujo-news-marathon-2022" creator="8827" created_by="Cujo">
+            <title>
+                <de>Neuer Marathon-Weltrekord</de>
+                <en>New marathon world record</en>
+            </title>
+            <description>
+                <de>Der Kenianer Elwood Pogchige hat einen neuen Marathon-Weltrekord aufgestellt. In Berlin lief er die 42,195 Kilometer lange Strecke in der neuen Bestzeit von 2:01:09 Stunden. Er verbesserte damit seinen eigenen Weltrekord um 30 Sekunden.</de>
+                <en>Kenyan Elwood Pogchige has set a new marathon world record. In the German capital Berlin, he ran the 42.195 kilometer course in the new best time of 2:01:09 hours. He thus improved his own world record by 30 seconds.</en>
+            </description>
+            <data genre="2" price="1.0" quality="80" />
+            <availability year_range_from="2022" year_range_to="2022" />
+        </news>
+		<!-- Spiele des Jahres -->
+        <news id="cujo-news-brettspiel-1985" type="0" thread_id="cujo-news-brettspiel-1985" creator="8827" created_by="Cujo">
+            <title>
+                <de>Detektivspiel ist das Brettspiel des Jahres 1985</de>
+                <en>Detective game is voted board game of the year 1985</en>
+            </title>
+            <description>
+                <de>"Dr. Watson Kriminalzimmer" wurde zum Brettspiel des Jahres 1985 gekürt. Der Jury imponierte, dass das Spiel sowohl allein als auch in einer Gruppe gespielt werden kann.</de>
+                <en>"Dr. Watson Crime Room" was chosen as the board game of the year 1985. The jury was impressed by the fact that the game can be played both alone and in a group.</en>
+            </description>
+            <data genre="3" price="0.49" quality="45" />
+			<availability year_range_from="1985" year_range_to="1985" />
+        </news>
+        <news id="cujo-news-brettspiel-1990" type="0" thread_id="cujo-news-brettspiel-1990" creator="8827" created_by="Cujo">
+            <title>
+                <de>Jury kürt Brettspiel des Jahres 1990</de>
+                <en>Jury selects board game of the year 1990</en>
+            </title>
+            <description>
+                <de>Das Brettspiel des Jahres 1990 heißt "Blaues Blut wird zur Pflicht". Mehrere Barone kämpfen in Auktionen um die besten Antiquitäten. Um ihr Ziel zu erreichen, können sie Diebe und Spione verpflichten.</de>
+                <en>The board game of the year 1990 is called "Blue Blood Becomes Duty". Several barons fight in auctions for the best antiques. To achieve their goal, they can hire thieves and spies.</en>
+            </description>
+            <data genre="3" price="0.48" quality="46" />
+			<availability year_range_from="1990" year_range_to="1990" />
+        </news>
+        <news id="cujo-news-brettspiel-1995" type="0" thread_id="cujo-news-brettspiel-1995" creator="8827" created_by="Cujo">
+            <title>
+                <de>Das Brettspiel des Jahres 1995 ist ein Aufbauspiel</de>
+                <en>The board game of the year 1995 is a building game</en>
+            </title>
+            <description>
+                <de>"Die Pioniere von Kastlan" wurde zum Brettspiel des Jahres 1995 gewählt. Die Spieler müssen Rohstoffe sammeln, um damit Straßen, Siedlungen und Städte bauen zu können. Erfunden wurde es von dem Spieleentwickler Karl Stäuber.</de>
+                <en>"The Pioneers of Kastlan" was voted board game of the year in 1995. Players have to collect raw materials in order to build roads, settlements and cities. It was invented by the game developer Karl Stäuber.</en>
+            </description>
+            <data genre="3" price="0.47" quality="47" />
+			<availability year_range_from="1995" year_range_to="1995" />
+        </news>
+    </allnews>
+	<celebritypeople>
+        <!-- Danny Pintauro -->
+		<person id="cujo-person-johnny-tinpauro" tmdb_id="0" imdb_id="nm0001622" creator="8827" created_by="Cujo">
+			<first_name>Johnny</first_name>
+			<last_name>Tinpauro</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Danny</first_name_original>
+			<last_name_original>Pintauro</last_name_original>
+			<details job="2" gender="1" birthday="1976-01-06" deathday="" country="USA" fictional="0" />
+			<data popularity="66" affinity="33" fame="43" scandalizing="44" price_mod="0.91" power="41" humor="76" charisma="61" appearance="88" topgenre="5" />
+		</person>
+        <!-- Helen Slater -->
+		<person id="cujo-person-ellen-laser" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+			<first_name>Ellen</first_name>
+			<last_name>Laser</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Helen</first_name_original>
+			<last_name_original>Slater</last_name_original>
+			<details job="18" gender="2" birthday="1963-12-15" deathday="" country="USA" fictional="0" />
+			<data popularity="59" affinity="60" fame="68" scandalizing="12" price_mod="0.72" power="39" humor="60" charisma="72" appearance="65" topgenre="7" />
+		</person>	
+        <!-- Tim Robbins -->
+		<person id="cujo-person-tom-hoppins" tmdb_id="0" imdb_id="nm0000209" creator="8827" created_by="Cujo">
+			<first_name>Tom</first_name>
+			<last_name>Hoppins</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Tim</first_name_original>
+			<last_name_original>Robbins</last_name_original>
+			<details job="23" gender="1" birthday="" deathday="" country="USA" fictional="0" />
+			<data popularity="65" affinity="71" fame="81" scandalizing="27" price_mod="1.05" power="55" humor="39" charisma="82" appearance="76" topgenre="17" />
+		</person>
+        <!-- Loriot -->
+		<person id="cujo-person-torilo" tmdb_id="0" imdb_id="nm0902086" creator="8827" created_by="Cujo">
+			<first_name>Ricco</first_name>
+			<last_name>von Lübow</last_name>
+			<nick_name>Torilo</nick_name>
+			<first_name_original>Vicco</first_name_original>
+			<last_name_original>von Bülow</last_name_original>
+			<details job="3" gender="1" birthday="" deathday="" country="D" fictional="0" />
+			<data popularity="80" affinity="60" fame="30" scandalizing="8" price_mod="1.1" power="10" humor="80" charisma="60" appearance="35" topgenre="5" />
+		</person>
+        <!-- Evelyn Hamann -->
+		<person id="cujo-person-emilie-mahann" tmdb_id="0" imdb_id="nm0357327" creator="8827" created_by="Cujo">
+			<first_name>Emilie</first_name>
+			<last_name>Mahann</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Evelyn</first_name_original>
+			<last_name_original>Hamann</last_name_original>
+			<details job="2" gender="2" birthday="" deathday="" country="D" fictional="0" />
+			<data popularity="75" affinity="40" fame="8" scandalizing="6" price_mod="0.7" power="10" humor="80" charisma="20" appearance="15" topgenre="5" />
+		</person>
+        <!-- Marie-Luise Marjan -->
+		<person id="cujo-person-marlene-lotte-hajan" tmdb_id="0" imdb_id="nm0548184" creator="8827" created_by="Cujo">
+			<first_name>Marlene-Lotte</first_name>
+			<last_name>Hajan</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Marie-Luise</first_name_original>
+			<last_name_original>Marjan</last_name_original>
+			<details job="2" gender="2" birthday="" deathday="" country="D" fictional="0" />
+			<data popularity="79" affinity="69" fame="78" scandalizing="12" price_mod="0.88" power="63" humor="62" charisma="72" appearance="35" topgenre="9" />
+		</person>
+        <!-- Annemarie Wendl -->
+		<person id="cujo-person-marianne-stendel" tmdb_id="0" imdb_id="nm0920864" creator="8827" created_by="Cujo">
+			<first_name>Marianne</first_name>
+			<last_name>Stendel</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Annemarie</first_name_original>
+			<last_name_original>Wendl</last_name_original>
+			<details job="2" gender="2" birthday="" deathday="" country="D" fictional="0" />
+			<data popularity="69" affinity="55" fame="58" scandalizing="42" price_mod="0.69" power="33" humor="42" charisma="42" appearance="25" topgenre="9" />
+		</person>
+        <!-- Til Schweiger -->
+		<person id="cujo-person-will-schweitzer" tmdb_id="0" imdb_id="nm0001709" creator="8827" created_by="Cujo">
+			<first_name>Will</first_name>
+			<last_name>Schweitzer</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Til</first_name_original>
+			<last_name_original>Schweiger</last_name_original>
+			<details job="2" gender="1" birthday="" deathday="" country="D" fictional="0" />
+			<data popularity="39" affinity="28" fame="38" scandalizing="82" price_mod="1.04" power="63" humor="22" charisma="56" appearance="77" topgenre="5" />
+		</person>
+        <!-- Willi Herren -->
+		<person id="cujo-person-olli-herden" tmdb_id="0" imdb_id="nm0380337" creator="8827" created_by="Cujo">
+			<first_name>Olli</first_name>
+			<last_name>Herden</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Willi</first_name_original>
+			<last_name_original>Herren</last_name_original>
+			<details job="2" gender="1" birthday="1975-06-17" deathday="2021-04-20" country="D" fictional="0" />
+			<data popularity="25" affinity="16" fame="78" scandalizing="89" price_mod="0.39" power="33" humor="22" charisma="7" appearance="44" topgenre="9" />
+		</person>
+        <!-- Sontje Peplow -->
+		<person id="cujo-person-antje-poppwol" tmdb_id="0" imdb_id="nm0672548" creator="8827" created_by="Cujo">
+			<first_name>Antje</first_name>
+			<last_name>Poppwol</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Sontje</first_name_original>
+			<last_name_original>Peplow</last_name_original>
+			<details job="2" gender="2" birthday="1981-04-01" deathday="" country="D" fictional="0" />
+			<data popularity="55" affinity="56" fame="48" scandalizing="12" price_mod="0.57" power="53" humor="54" charisma="67" appearance="78" topgenre="9" />
+		</person>
+        <!-- Hermes Hodolides -->
+		<person id="cujo-person-herakles-dododiles" tmdb_id="0" imdb_id="nm0388318" creator="8827" created_by="Cujo">
+			<first_name>Herakles</first_name>
+			<last_name>Dododiles</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Hermes</first_name_original>
+			<last_name_original> Hodolides</last_name_original>
+			<details job="2" gender="1" birthday="1963-09-15" deathday="" country="GR" fictional="0" />
+			<data popularity="49" affinity="42" fame="24" scandalizing="13" price_mod="0.55" power="42" humor="31" charisma="55" appearance="32" topgenre="9" />
+		</person>
+        <!-- Amorn Surangkanjanajai -->
+		<person id="cujo-person-amon-surganjankanayani" tmdb_id="0" imdb_id="nm0839539" creator="8827" created_by="Cujo">
+			<first_name>Amorn</first_name>
+			<last_name>Surangkanjanajai</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Amorn</first_name_original>
+			<last_name_original>Surangkanjanajai</last_name_original>
+			<details job="2" gender="1" birthday="1953-03-23" deathday="" country="HK" fictional="0" />
+			<data popularity="69" affinity="31" fame="12" scandalizing="6" price_mod="0.28" power="22" humor="71" charisma="65" appearance="52" topgenre="9" />
+		</person>
+        <!-- Irene Fischer -->
+		<person id="cujo-person-marlene-angler" tmdb_id="0" imdb_id="nm5874034" creator="8827" created_by="Cujo">
+			<first_name>Marlene</first_name>
+			<last_name>Angler</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Irene</first_name_original>
+			<last_name_original>Fischer</last_name_original>
+			<details job="7" gender="2" birthday="1959-12-24" deathday="" country="D" fictional="0" />
+			<data popularity="43" affinity="62" fame="22" scandalizing="16" price_mod="0.39" power="55" humor="31" charisma="45" appearance="42" topgenre="9" />
+		</person>
+		<!-- Moritz A. Sachs -->
+		<person id="cujo-person-max-b-sax" tmdb_id="0" imdb_id="nm0755176" creator="8827" created_by="Cujo">
+			<first_name>Max B.</first_name>
+			<last_name>Sax</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Moritz A.</first_name_original>
+			<last_name_original>Sachs</last_name_original>
+			<details job="7" gender="2" birthday="1978-08-13" deathday="" country="D" fictional="0" />
+			<data popularity="55" affinity="50" fame="32" scandalizing="26" price_mod="0.44" power="69" humor="57" charisma="65" appearance="71" topgenre="9" />
+		</person>
+		<!-- Jim Parsons -->
+		<person id="cujo-person-tim-sparson" tmdb_id="0" imdb_id="nm1433588" creator="8827" created_by="Cujo">
+			<first_name>Tim</first_name>
+			<last_name>Sparson</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Jim</first_name_original>
+			<last_name_original>Parsons</last_name_original>
+			<details job="2" gender="1" birthday="" deathday="" country="USA" fictional="0" />
+			<data popularity="58" affinity="48" fame="62" scandalizing="27" price_mod="0.98" power="53" humor="59" charisma="57" appearance="55" topgenre="5" />
+		</person>
+        <!-- Johnny Galecki -->
+		<person id="cujo-person-jerry-lakecki" tmdb_id="0" imdb_id="nm0301959" creator="8827" created_by="Cujo">
+			<first_name>Jerry</first_name>
+			<last_name>Lakecki</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Johnny</first_name_original>
+			<last_name_original>Galecki</last_name_original>
+			<details job="2" gender="1" birthday="" deathday="" country="USA" fictional="0" />
+			<data popularity="53" affinity="43" fame="59" scandalizing="33" price_mod="0.91" power="49" humor="64" charisma="63" appearance="69" topgenre="5" />
+		</person>
+        <!-- Kaley Cuoco -->
+		<person id="cujo-person-kelly-kukoko" tmdb_id="0" imdb_id="nm0192505" creator="8827" created_by="Cujo">
+			<first_name>Kelly</first_name>
+			<last_name>Kukoko</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Kaley</first_name_original>
+			<last_name_original>Cuoco</last_name_original>
+			<details job="2" gender="2" birthday="" deathday="" country="USA" fictional="0" />
+			<data popularity="55" affinity="45" fame="51" scandalizing="53" price_mod="0.83" power="41" humor="67" charisma="73" appearance="83" topgenre="5" />
+		</person>
+        <!-- Peter Lustig -->
+		<person id="cujo-person-paul-witzig" tmdb_id="0" imdb_id="nm0527341" creator="8827" created_by="Cujo">
+			<first_name>Paul</first_name>
+			<last_name>Witzig</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Peter</first_name_original>
+			<last_name_original>Lustig</last_name_original>
+			<details job="10" gender="2" birthday="1937-10-27" deathday="2016-02-23" country="D" fictional="0" />
+			<data popularity="87" affinity="81" fame="92" scandalizing="11" price_mod="0.94" power="31" humor="72" charisma="71" appearance="51" topgenre="9" />
+		</person>
+        <!-- Helmut Krauss -->
+		<person id="cujo-person-horst-krause" tmdb_id="0" imdb_id="nm0527341" creator="8827" created_by="Cujo">
+			<first_name>Horst</first_name>
+			<last_name>Krause</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Helmut</first_name_original>
+			<last_name_original>Krauss</last_name_original>
+			<details job="34" gender="2" birthday="1941-06-11" deathday="2019-08-26" country="D" fictional="0" />
+			<data popularity="37" affinity="41" fame="15" scandalizing="17" price_mod="0.69" power="49" humor="52" charisma="41" appearance="35" topgenre="9" />
+		</person>
+		<!-- Regisseure -->
+        <!-- Lewis Teague -->
+		<person id="cujo-person-louis-tiggu" tmdb_id="" imdb_id="nm0853546" creator="8827" created_by="Cujo">
+			<first_name>Louis</first_name>
+			<last_name>Tiggu</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Lewis</first_name_original>
+			<last_name_original>Teague</last_name_original>
+			<details job="1" gender="1" birthday="1938-03-08" deathday="" country="USA" />
+		</person>
+        <!-- Jeannot Szwarc -->
+		<person id="cujo-person-jane-swart" tmdb_id="" imdb_id="nm0844358" creator="8827" created_by="Cujo">
+			<first_name>Jane</first_name>
+			<last_name>Swart</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Jeannot</first_name_original>
+			<last_name_original>Szwarc</last_name_original>
+			<details job="1" gender="2" birthday="1939-11-21" deathday="" country="F" />
+		</person>
+        <!-- Richard Donner -->
+		<person id="cujo-person-robert-turner" tmdb_id="" imdb_id="nm0078346" creator="8827" created_by="Cujo">
+			<first_name>Robert</first_name>
+			<last_name>Turner</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Richard</first_name_original>
+			<last_name_original>Donner</last_name_original>
+			<details job="1" gender="1" birthday="1930-04-24" deathday="2021-07-05" country="USA" />
+		</person>
+        <!-- Sidney Lumet -->
+		<person id="cujo-person-siggy-tumle" tmdb_id="" imdb_id="nm0001486" creator="8827" created_by="Cujo">
+			<first_name>Siggy</first_name>
+			<last_name>Tumle</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Sidney</first_name_original>
+			<last_name_original>Lumet</last_name_original>
+			<details job="1" gender="1" birthday="1924-06-25" deathday="2011-04-09" country="USA" />
+		</person>
+        <!-- E. B. Clutcher -->
+		<person id="cujo-person-enrico-klatscher" tmdb_id="" imdb_id="nm0005645" creator="8827" created_by="Cujo">
+			<first_name>Enrico</first_name>
+			<last_name>Klatscher</last_name>
+			<nick_name></nick_name>
+			<first_name_original>E. B.</first_name_original>
+			<last_name_original>Clucher</last_name_original>
+			<details job="1" gender="1" birthday="1922-07-10" deathday="2002-03-23" country="I" />
+		</person>
+        <!-- Hans W. Geißendörfer -->
+		<person id="cujo-person-horst-ziegenstaedter" tmdb_id="" imdb_id="nm0312078" creator="8827" created_by="Cujo">
+			<first_name>Horst</first_name>
+			<last_name>Ziegenstädter</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Hans W.</first_name_original>
+			<last_name_original>Geißendörfer</last_name_original>
+			<details job="1" gender="1" birthday="1941-04-06" deathday="" country="D" />
+		</person>
+        <!-- Ester Amrami -->
+		<person id="cujo-person-elvira-pampami" tmdb_id="" imdb_id="nm2539925" creator="8827" created_by="Cujo">
+			<first_name>Elvira</first_name>
+			<last_name>Pampami</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Ester</first_name_original>
+			<last_name_original>Amrami</last_name_original>
+			<details job="5" gender="2" birthday="1979-02-05" deathday="" country="IL" />
+		</person>
+        <!-- Dominikus Probst -->
+		<person id="cujo-person-damian-prost" tmdb_id="" imdb_id="nm0698239" creator="8827" created_by="Cujo">
+			<first_name>Damian</first_name>
+			<last_name>Prost</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Dominikus</first_name_original>
+			<last_name_original>Probst</last_name_original>
+			<details job="3" gender="1" birthday="1958-08-09" deathday="" country="D" />
+		</person>
+        <!-- Chuck Lorre -->
+		<person id="cujo-person-jack-klor" tmdb_id="" imdb_id="nm521143" creator="8827" created_by="Cujo">
+			<first_name>Jack</first_name>
+			<last_name>Klor</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Chuck</first_name_original>
+			<last_name_original>Lorre</last_name_original>
+			<details job="1" gender="1" birthday="1952-10-18" deathday="" country="USA" />
+		</person>
+		<!-- Carlo Rola -->
+		<person id="cujo-person-karl-lora" tmdb_id="" imdb_id="nm0738001" creator="8827" created_by="Cujo">
+			<first_name>Karl</first_name>
+			<last_name>Lora</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Carlo</first_name_original>
+			<last_name_original>Rola</last_name_original>
+			<details job="1" gender="1" birthday="1958-10-06" deathday="2016-03-14" country="D" />
+		</person>
+	</celebritypeople>
+    <allprogrammes>
+		<programme id="cujo-film-juco" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0057687" creator="8827" created_by="Cujo"> 
+			<title>
+				<de>Juco</de>
+				<en>Juco</en>
+			</title>
+			<title_original>
+				<de>Cujo</de>
+				<en>Cujo</en>
+			</title_original>
+			<description>
+				<de>Der Bernhardiner Juco wird von einer Fledermaus mit Tollwut infiziert. Er belagert Mona, die mit ihrem Sohn Ted in einem Auto Schutz sucht. Ein Horror-Klassiker von Steffen König.</de>
+				<en>St. Bernard Juco is infected with rabies by a bat. He besieges Mona, who seeks shelter in a car with her son Ted.</en>
+			</description>
+			<staff>
+				<member index="0" function="1">cujo-person-louis-tiggu</member>
+				<member index="1" function="2">923edac9-ac51-46c8-89de-8631559e3a1a</member> <!-- Dee Wallace-Stone -->
+				<member index="2" function="2">cujo-person-johnny-tinpauro</member>
+			</staff>
+			<groups target_groups="256" pro_pressure_groups="0" contra_pressure_groups="0" />
+			<data country="USA" year="1983" distribution="1" maingenre="12" subgenre="" flags="64" blocks="2" price_mod="0.64" />
+			<ratings critics="49" speed="60" outcome="53" />
+		</programme>
+		<programme id="cujo-film-superweib" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0088206" creator="8827" created_by="Cujo"> 
+			<title>
+				<de>Superweib</de>
+				<en>Superwoman</en>
+			</title>
+			<title_original>
+				<de>Supergirl</de>
+				<en>Supergirl</en>
+			</title_original>
+			<description>
+				<de>Klara-Zora spielt mit einem wertvollen Kristall. Durch ein Versehen lässt sie ihn fallen. Er landet auf der Erde. Als sie ihn dort wieder findet, spürt sie, dass sie auf diesem Planeten übernatürliche Kräfte hat.</de>
+				<en>Klara-Zora is playing with a valuable crystal. By an accident she drops it. It lands on the earth. When she follows it, she feels that she has supernatural powers on this planet.</en>
+			</description>
+			<staff>
+				<member index="0" function="1">cujo-person-jane-swart</member>
+				<member index="1" function="2">cujo-person-ellen-laser</member>
+			</staff>
+			<groups target_groups="130" pro_pressure_groups="0" contra_pressure_groups="0" />
+			<data country="USA" year="1984" distribution="1" maingenre="16" subgenre="2" flags="0" blocks="2" price_mod="0.67" />
+			<ratings critics="31" speed="59" outcome="45" />
+			<availability year_range_from="1986" year_range_to="" />
+		</programme>
+		<programme id="cujo-film-vier-haende-rio" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0087481" creator="8827" created_by="Cujo">
+			<title>
+				<de>Vier Hände fliegen nach Rio</de>
+				<en>Four hands fly to Rio</en>
+			</title>
+			<title_original>
+				<de>Vier Fäuste gegen Rio</de>
+				<en>Double Trouble</en>
+			</title_original>
+			<description>
+				<de>Zwei Milliardäre buchen in New York zwei Doppelgänger um mit ihnen nach Rio zu fliegen. Dort verprügeln sie einige Söldner.</de>
+				<en>Two billionaires book two doubles in New York to fly with them to Rio. There they beat up some mercenaries.</en>
+			</description>
+			<staff>
+				<member index="0" function="1">cujo-person-enrico-klatscher</member>
+				<member index="1" function="2">ac09552a-75f0-46cc-85ac-c49c232309d2</member> <!-- Bud Spencer -->
+				<member index="2" function="2">3993454a-cbc2-471e-835c-0b0a44dc8f01</member> <!-- Terence Hill -->
+			</staff>
+			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
+			<data country="D" year="1984" distribution="1" maingenre="5" subgenre="2" flags="0" blocks="2" price_mod="0.85" />
+			<ratings critics="10" speed="22" outcome="42" />
+			<availability year_range_from="1986" year_range_to="" />
+		</programme>
+			<programme id="cujo-film-verurteilte-bankier" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0111161" creator="8827" created_by="Cujo"> 
+			<title>
+				<de>Der verurteilte Bankier</de>
+				<en>The convicted banker</en>
+			</title>
+			<title_original>
+				<de>Die Verurteilten</de>
+				<en>The Shawshank Redemption</en>
+			</title_original>
+			<description>
+				<de>Harry Duftenese wird unschuldig wegen Mordes verurteilt und ins Gefängnis gesperrt. Anfangs wird er verprügelt, doch schon bald wird er von den Gefangenen und den Wärtern respektiert. Nach 19 Jahren Haft verhilft ihm das Poster eines Pin-Up-Girls zur Freiheit.</de>
+				<en>Harry Duftenese is innocently convicted of murder and imprisoned. At first he is beaten up by his fellow inmates, but soon his recognition among the prisoners and the guards increases. After 19 years in prison, the poster of a pin-up girl helps him to freedom.</en>
+			</description>
+			<staff>
+				<member index="0" function="1">DF-Celebreties-Frank_Darabont</member>
+				<member index="1" function="2">cujo-person-tom-hoppins</member>
+				<member index="2" function="2">c104b4c8-449c-4fb6-8cbe-5dbf3e074c96</member> <!-- Morgan Freeman -->
+			</staff>
+			<groups target_groups="256" pro_pressure_groups="0" contra_pressure_groups="0" />
+			<data country="USA" year="1994" distribution="1" maingenre="7" subgenre="" flags="0" blocks="3" price_mod="1.25" />
+			<ratings critics="96" speed="22" outcome="88" />
+			<availability year_range_from="1996" year_range_to="" />
+		</programme>
+		<programme id="cujo-film-zwoelf-geschworene" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0050083" creator="8827" created_by="Cujo"> 
+			<title>
+				<de>Der zwölfte Geschworene</de>
+				<en>The twelfth juror</en>
+			</title>
+			<title_original>
+				<de>Die zwölf Geschworenen</de>
+				<en>12 Angry Men</en>
+			</title_original>
+			<description>
+				<de>Ein 19-jähriger Mexikaner ist des Mordes angeklagt. Zwölf Geschworene sollen über seine Schuld entscheiden. Elf sind überzeugt, dass er der Täter ist. Nur einer ist sich nicht sicher.</de>
+				<en>A 19-year-old Mexican man has been charged with murder. Twelve jurors are to decide on his guilt. Eleven are convinced that he is the culprit. Only one is not sure.</en>
+			</description>
+			<staff>
+				<member index="0" function="1">cujo-person-siggy-tumle</member>
+				<member index="1" function="2">a80152d6-43dc-4f9c-a562-a5dbf821bc1f</member> <!-- Henry Fonda -->
+			</staff>
+			<groups target_groups="64" pro_pressure_groups="0" contra_pressure_groups="0" />
+			<data country="USA" year="1957" distribution="1" maingenre="0" subgenre="" flags="0" blocks="2" price_mod="0.77" />
+			<ratings critics="89" speed="12" outcome="34" />
+		</programme>
+		<programme id="cujo-film-oedenussi" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0094407" creator="8827" created_by="Cujo">
+			<title>
+				<de>Ödenussi</de>
+				<en>Oedinuti</en>
+			</title>
+			<title_original>
+				<de>Ödipussi</de>
+			</title_original>
+			<description>
+				<de>Der 56-jährige Geschäftsführer Karl Minkelwann lebt zwar allein, lässt sich aber noch von seiner Mutter bekochen. Als er die Psychologin Margret kennenlernt, verliebt er sich zum ersten Mal in seinem Leben.</de>
+				<en>The 56-year-old business manager Karl Minkelwann lives alone, but still lets his mother cook for him. When he meets the psychologist Margret, he falls in love for the first time in his life.</en>
+			</description>
+			<staff>
+				<member index="0" function="1">cujo-person-torilo</member>
+				<member index="1" function="2">cujo-person-torilo</member>
+				<member index="2" function="2">cujo-person-emilie-mahann</member>
+			</staff>
+			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
+			<data country="D" year="1988" distribution="1" maingenre="5" subgenre="" flags="8" blocks="2" price_mod="0.93" />
+			<ratings critics="80" speed="15" outcome="70" />
+			<availability year_range_from="1990" year_range_to="" />
+		</programme>
+		<programme id="cujo-film-vati-ante-portas" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0102629" creator="8827" created_by="Cujo">
+			<title>
+				<de>Vati ante portas</de>
+				<en>Daddy ante portas</en>
+			</title>
+			<title_original>
+				<de>Pappa ante Portas</de>
+			</title_original>
+			<description>
+				<de>Friedrich Loose ist beruflich überfordert und wird in den Vorruhestand versetzt. Um sich zu beschäftigen, will er seiner Frau bei der Hausarbeit helfen und sorgt dabei für Chaos.</de>
+				<en>Friedrich Loose is overburdened professionally and is put into early retirement. To keep himself busy, he wants to help his wife with the housework and causes chaos in the process.</en>
+			</description>
+			<staff>
+				<member index="0" function="1">cujo-person-torilo</member>
+				<member index="1" function="2">cujo-person-torilo</member>
+				<member index="2" function="2">cujo-person-emilie-mahann</member>
+			</staff>
+			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
+			<data country="D" year="1991" distribution="1" maingenre="5" subgenre="" flags="8" blocks="2" price_mod="0.98" />
+			<ratings critics="67" speed="19" outcome="65" />
+			<availability year_range_from="1993" year_range_to="" />
+		</programme>		
+		<programme id="cujo-film-rache-erben" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0087148" creator="8827" created_by="Cujo">
+			<title>
+				<de>Titi und die Rache der Erben</de>
+				<en>Titi and the revenge of the heirs</en>
+			</title>
+			<title_original>
+				<de>Didi und die Rache der Enterbten</de>
+			</title_original>
+			<description>
+				<de>Ein alter Bankier enterbt seine komplette Verwandschaft und setzt den Totengräber Dietmar Knödel zum Alleinerben ein. Dieter Wall vom Norden spielt sieben Rollen. Ein echter Blödelspaß.</de>
+				<en>An old banker disinherits his entire family and names the gravedigger Dietmar Knödel as his sole heir. Titi Vollerharden plays seven roles. A real goofball fun.</en>
+			</description>
+			<staff>
+				<member index="0" function="1">TheRob-TowerTV-DieterWallvomNorden</member>
+				<member index="1" function="2">TheRob-TowerTV-DieterWallvomNorden</member>
+			</staff>
+			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
+			<data country="D" year="1985" distribution="1" maingenre="5" subgenre="" flags="0" blocks="2" price_mod="0.85" />
+			<ratings critics="10" speed="22" outcome="42" />
+			<availability year_range_from="1987" year_range_to="" />
+		</programme>
+        <programme id="cujo-serien-kastanienstrasse-01-05" product="2" licence_type="3" tmdb_id="0" imdb_id="tt0088554" creator="8827" created_by="Cujo">
+            <title>
+                <de>Kastanienstraße</de>
+                <en>Chestnut Street</en>
+            </title>
+			<title_original>
+				<de>Lindenstraße</de>
+			</title_original>
+            <description>
+                <de>Die Kastanienstraße zeigt das Leben mehrerer Familien in einer ganz normalen Münchener Straße.</de>
+                <en>Chestnut Street shows the life of several families in an ordinary Munich street.</en>
+            </description>
+			<staff>
+				<member index="0" function="1">cujo-person-horst-ziegenstaedter</member>
+				<member index="1" function="2">cujo-person-marlene-lotte-hajan</member>
+				<member index="2" function="2">cujo-person-marianne-stendel</member>
+				<member index="3" function="2">cujo-person-will-schweitzer</member>
+			</staff>			
+            <groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
+            <data country="D" year="1985" distribution="2" maingenre="9" subgenre="" flags="" blocks="1" price_mod="0.9" />
+            <ratings critics="30" speed="27" outcome="49" />
+			<availability year_range_from="1985" year_range_to="1996" />
+            <children>
+                <programme id="cujo-serien-kastanienstrasse-01" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Willkommen bei den Bleimers</de>
+                        <en>Welcome to the Bleimers</en>
+                    </title>
+                    <description>
+                        <de>Helga öffnet die Tür und begrüßt die Fernsehzuschauer.</de>
+                        <en>Helga opens the door and welcomes the TV viewers.</en>
+                    </description>
+                    <ratings critics="30" speed="27" />
+                </programme>
+                <programme id="cujo-serien-kastanienstrasse-02" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Tanja und der Tennislehrer</de>
+                        <en>Tanja and the tennis instructor</en>
+                    </title>
+                    <description>
+                        <de>Tanja wird vom Tennislehrer verführt. Er vermittelt ihr das richtige Ballgefühl.</de>
+                        <en>Tanja is seduced by the tennis instructor. It gives her the right feel for the ball.</en>
+                    </description>
+                    <ratings critics="30" speed="27" />
+                </programme>
+                <programme id="cujo-serien-kastanienstrasse-03" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Drasler sitzt im Rollstuhl</de>
+                        <en>Drasler sits in a wheelchair</en>
+                    </title>
+                    <description>
+                        <de>Vasily fährt betrunken Auto und übersieht Doktor Drasler. Nach dem Unfall sitzt der Doc bis zum Rest seines Lebens im Rollstuhl.</de>
+                        <en>Vasily is driving drunk and overlooks Doctor Drasler. After the accident, the doc sits in a wheelchair for the rest of his life.</en>
+                    </description>
+                    <ratings critics="30" speed="27" />
+                </programme>
+                <programme id="cujo-serien-kastanienstrasse-04" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Ein schwuler Kuss</de>
+                        <en>A gay kiss</en>
+                    </title>
+                    <description>
+                        <de>Carsten und Robert küssen sich. Es ist der erste Schwulenkuss in einer TVT-Fernsehserie.</de>
+                        <en>Carsten and Robert kiss each other. It is the first gay kiss in a TVT television series.</en>
+                    </description>
+                    <ratings critics="30" speed="27" />
+                </programme>
+                <programme id="cujo-serien-kastanienstrasse-05" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Der mexikanische Adoptivjunge</de>
+                        <en>A gay kiss</en>
+                    </title>
+                    <description>
+                        <de>Gotthold und Britta adoptieren einen mexikanischen Adoptivjungen. Manolo hat große Schwierigkeiten mit der Mentalität der Deutschen. Die Menschen in der Kastanienstraße sind ganz anders als die Mexikaner.</de>
+                        <en>Gotthold and Britta adopt a Mexican adopted boy. Manolo has great difficulty with the mentality of the Germans. The people on Kastanienstrasse are very different from the Mexicans.</en>
+                    </description>
+                    <ratings critics="30" speed="27" />
+                </programme>
+            </children>
+        </programme>
+        <programme id="cujo-serien-kastanienstrasse-06-10" product="2" licence_type="3" tmdb_id="0" imdb_id="tt0088554" creator="8827" created_by="Cujo">
+            <title>
+                <de>Kastanienstraße: Eine schicksalhafte Zeit</de>
+                <en>Chestnut Street: A fateful time</en>
+            </title>
+			<title_original>
+				<de>Lindenstraße II</de>
+			</title_original>
+            <description>
+                <de>Die Menschen in der Kastanienstraße müssen schwere Krisen meistern. Sie halten aber zusammen und bestehen diese schicksalhafte Zeit gemeinsam.</de>
+                <en>The people in Chestnut Street have to overcome serious crises. But they stick together and endure this fateful time together.</en>
+            </description>
+			<staff>
+				<member index="0" function="1">cujo-person-elvira-pampami</member>
+				<member index="1" function="2">cujo-person-olli-herden</member>
+				<member index="2" function="2">cujo-person-antje-poppwol</member>
+				<member index="3" function="2">cujo-person-herakles-dododiles</member>
+			</staff>			
+            <groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
+            <data country="D" year="1997" distribution="2" maingenre="9" subgenre="" flags="" blocks="1" price_mod="0.95" />
+            <ratings critics="40" speed="32" outcome="39" />
+			<availability year_range_from="1997" year_range_to="2008" />
+            <children>
+                <programme id="cujo-serien-kastanienstrasse-06" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Lisa schlägt mit der Pfanne zu</de>
+                        <en>Lisa strikes with the pan</en>
+                    </title>
+                    <description>
+                        <de>Lisa schlägt dem Priester mit der Pfanne auf den Kopf. War es Mord, Totschlag oder Notwehr?</de>
+                        <en>Lisa hits the priest on the head with the pan. Was it murder, manslaughter or self-defense?</en>
+                    </description>
+                    <ratings critics="40" speed="32" />
+                </programme>
+                <programme id="cujo-serien-kastanienstrasse-07" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Anna schubst Dobelbein</de>
+                        <en>Anna pushes Dobelbein</en>
+                    </title>
+                    <description>
+                        <de>Anna wird von Dobelbein bedrängt. Um sich zu retten, schubst sie ihn die Treppe runter.</de>
+                        <en>Anna is being harassed by Dobelbein. To save herself, she pushes him down the stairs.</en>
+                    </description>
+                    <ratings critics="40" speed="32" />
+                </programme>
+                <programme id="cujo-serien-kastanienstrasse-08" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Else: "Sodom und Gomerra"</de>
+                        <en>Else: "Sodom and Gomerra"</en>
+                    </title>
+                    <description>
+                        <de>Else ist mit dem Lebensstil der Nachbarn nicht einverstanden. Für sie herrscht in der Kastanienstraße "Sodom und Gomerra".</de>
+                        <en>Else does not agree with the lifestyle of the neighbors. For her, "Sodom and Gomerra" reigns in Chestnut Street.</en>
+                    </description>
+                    <ratings critics="40" speed="32" />
+                </programme>
+                <programme id="cujo-serien-kastanienstrasse-09" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Olafs Attentat</de>
+                        <en>Olaf's assassination</en>
+                    </title>
+                    <description>
+                        <de>Olaf fühlt sich von allen verraten. Er besorgt sich ein Gewehr und schießt auf die Hochzeitsgäste.</de>
+                        <en>Olaf feels betrayed by everyone. He gets a rifle and shoots at the wedding guests.</en>
+                    </description>
+                    <ratings critics="40" speed="32" />
+                </programme>
+                <programme id="cujo-serien-kastanienstrasse-10" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Ines liegt im Koma</de>
+                        <en>Ines is in a coma</en>
+                    </title>
+                    <description>
+                        <de>Ines wird von Olaf verfolgt und stürzt die Treppe runter. Sie verletzt sich dabei schwer und liegt mehrere Monate im Koma.</de>
+                        <en>Ines is chased by Olaf and falls down the stairs. She is seriously injured and lies in a coma for several months.</en>
+                    </description>
+                    <ratings critics="40" speed="32" />
+                </programme>
+            </children>
+        </programme>
+        <programme id="cujo-serien-kastanienstrasse-11-15" product="2" licence_type="3" tmdb_id="0" imdb_id="tt0088554" creator="8827" created_by="Cujo">
+            <title>
+                <de>Best of Kastanienstraße</de>
+                <en>Best of Chestnut Street</en>
+            </title>
+			<title_original>
+				<de>Lindenstraße III</de>
+			</title_original>
+            <description>
+                <de>Liebe, Hochzeit, Streit, Scheidung, Hass und Tod. Das alles und noch viel mehr bieten die besten Folgen der Kastanienstraße.</de>
+                <en>Love, marriage, quarrels, divorce, hatred and death. The best episodes of Chestnut Street offer all this and much more.</en>
+            </description>
+			<staff>
+				<member index="0" function="1">cujo-person-damian-prost</member>
+				<member index="1" function="2">cujo-person-amon-surganjankanayani</member>
+				<member index="2" function="2">cujo-person-marlene-angler</member>
+				<member index="3" function="2">cujo-person-max-b-sax</member>
+			</staff>			
+            <groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
+            <data country="D" year="2009" distribution="2" maingenre="9" subgenre="" flags="" blocks="1" price_mod="1" />
+            <ratings critics="50" speed="37" outcome="29" />
+			<availability year_range_from="2009" year_range_to="" />
+            <children>
+                <programme id="cujo-serien-kastanienstrasse-11" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Mary holt die Geflügelschere raus</de>
+                        <en>Mary gets out the poultry shears</en>
+                    </title>
+                    <description>
+                        <de>Mary will sich vor einer Vergewaltigung schützen und schneidet mit einer Geflügelschere Olafs bestes Stück ab.</de>
+                        <en>Mary wants to protect herself from rape and cuts off Olaf's best piece with a pair of poultry shears.</en>
+                    </description>
+                    <ratings critics="50" speed="37" />
+                </programme>
+                <programme id="cujo-serien-kastanienstrasse-12" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Tiffi kennt den Vater nicht</de>
+                        <en>Tiffi does not know the father</en>
+                    </title>
+                    <description>
+                        <de>Tiffi hat Jens mit ihrem Ex-Lover Dodo betrogen. Nach der Geburt von Anita weiß sie nicht, wer von beiden der Vater ist.</de>
+                        <en>Tiffi has cheated on Jens with her ex-lover Dodo. After the birth of Anita she does not know which of the two is the father.</en>
+                    </description>
+                    <ratings critics="50" speed="37" />
+                </programme>
+                <programme id="cujo-serien-kastanienstrasse-13" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Willi zündet die Handgranate</de>
+                        <en>Willi ignites the hand grenade</en>
+                    </title>
+                    <description>
+                        <de>Willi hat sich im Darknet einige Handgranaten gekauft. Beim Herumspielen damit zündet er eine davon.</de>
+                        <en>Willi has bought some hand grenades on the darknet. While playing around with them, he detonates one of them.</en>
+                    </description>
+                    <ratings critics="50" speed="37" />
+                </programme>
+                <programme id="cujo-serien-kastanienstrasse-14" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Doktor Drasler stirbt</de>
+                        <en>Doctor Drasler dies</en>
+                    </title>
+                    <description>
+                        <de>Als beim Anhören einer Oper ein falscher Ton gespielt wird, erleidet Doktor Drasler einen Herzinfarkt. Drei Tage später wird er zusammen mit seinem Rollstuhl begraben.</de>
+                        <en>When a wrong note is played while listening to an opera, Doctor Drasler suffers a heart attack. Three days later he is buried together with his wheelchair.</en>
+                    </description>
+                    <ratings critics="50" speed="37" />
+                </programme>
+                <programme id="cujo-serien-kastanienstrasse-15" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Helga erinnert sich</de>
+                        <en>Mary gets out the poultry shears</en>
+                    </title>
+                    <description>
+                        <de>Helga feiert ihren 70. Geburtstag im Restaurant Sakiraris. Nach dem Ende der Feierlichkeiten erinnert sie sich daran, was sie alles in der Kastanienstraße erlebt hat.</de>
+                        <en>Helga celebrates her 70th birthday at Sakiraris Restaurant. After the festivities are over, she remembers everything she experienced on Chestnut Street.</en>
+                    </description>
+                    <ratings critics="50" speed="37" />
+                </programme>
+            </children>
+        </programme>		
+        <programme id="cujo-serien-large-detonation" product="2" licence_type="3" tmdb_id="0" imdb_id="tt0898266" creator="8827" created_by="Cujo">
+            <title>
+                <de>The Large Detonation Theory</de>
+                <en>The Large Detonation Theory</en>
+            </title>
+			<title_original>
+				<de>The Big Bang Theory</de>
+			</title_original>
+            <description>
+                <de>Die beiden Physiker Nelson und Lennert leben zusammen in einer WG. Sie sind beide Nerds und haben eine unterentwickelte Sozialkompetenz. Besonders der richtige Umgang mit Frauen bereitet ihnen Schwierigkeiten.</de>
+                <en>The two physicists Nelson and Lennert live together in a shared flat. They are both nerds and have underdeveloped social skills. They especially have trouble dealing with women.</en>
+            </description>
+			<staff>
+				<member index="0" function="1">cujo-person-jack-klor</member>
+				<member index="1" function="2">cujo-person-tim-sparson</member>
+				<member index="2" function="2">cujo-person-jerry-lakecki</member>
+				<member index="3" function="2">cujo-person-kelly-kukoko</member>
+			</staff>
+            <groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
+            <data country="D" year="2007" distribution="2" maingenre="5" subgenre="" flags="256" blocks="1" price_mod="1" />
+            <ratings critics="30" speed="67" outcome="73" />
+            <children>
+                <programme id="cujo-serien-large-detonation-01" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Ponny zieht ein</de>
+                        <en>Ponny moves in</en>
+                    </title>
+                    <description>
+                        <de>Ponny zieht in die Wohnung gegenüber ein. Sie ist nicht so intelligent wie Nelson und Lennart, verfügt aber über einen gesunden Menschenverstand.</de>
+                        <en>Ponny moves into the apartment across the street. She is not as intelligent as Nelson and Lennart, but has common sense.</en>
+                    </description>
+                    <ratings critics="30" speed="67" />
+                </programme>
+                <programme id="cujo-serien-large-detonation-02" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Der defekte Fahrstuhl</de>
+                        <en>The broken elevator</en>
+                    </title>
+                    <description>
+                        <de>Lennart stellt einen Behälter mit einer gefährlichen Chemikalie im Aufzug ab. Dieser explodiert und zerstört dadurch den Fahrstuhl.</de>
+                        <en>Lennart puts a container with a dangerous chemical in the elevator. It explodes and destroys the elevator.</en>
+                    </description>
+                    <ratings critics="30" speed="67" />
+                </programme>
+                <programme id="cujo-serien-large-detonation-03" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Spaß mit Fahnen</de>
+                        <en>Fun with flags</en>
+                    </title>
+                    <description>
+                        <de>Nelson und Emmi moderieren gemeinsam für ihren Video-Kanal die Sendung "Spaß mit Fahnen".´</de>
+                        <en>Nelson and Emmi co-host the show "Fun with Flags" for their video channel.</en>
+                    </description>
+                    <ratings critics="30" speed="67" />
+                </programme>
+                <programme id="cujo-serien-large-detonation-04" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Nelson trifft Professor Atom</de>
+                        <en>Nelson meets Professor Atom</en>
+                    </title>
+                    <description>
+                        <de>Nelson liebte in seiner Kindheit die Wissenschaftssendung von Professor Atom. Auf einer Party lernt er ihn kennen und outet sich als großer Fan seiner Sendung.</de>
+                        <en>Nelson loved Professor Atom's science show when he was a kid. He meets him at a party and reveals himself to be a big fan of his show.</en>
+                    </description>
+                    <ratings critics="30" speed="67" />
+                </programme>
+                <programme id="cujo-serien-large-detonation-05" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Das Date mit Ponny</de>
+                        <en>The date with Ponny</en>
+                    </title>
+                    <description>
+                        <de>Lennert und Ponny gehen zusammen essen. Ponny wartet zuerst auf ihre gemeinsamen Freunde. Erst später realisiert sie, dass es sich bei dem Restaurantbesuch um ein Date mit Lennert gehandelt hat.</de>
+                        <en>Lennert and Ponny go out to eat together. Ponny first waits for her mutual friends. Only later does she realize that the restaurant visit was a date with Lennert.</en>
+                    </description>
+                    <ratings critics="30" speed="67" />
+                </programme>
+                <programme id="cujo-serien-large-detonation-06" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Howie im Weltall</de>
+                        <en>Howie in space</en>
+                    </title>
+                    <description>
+                        <de>Howie hat eine Weltraumtoilette für eine Raumstation entwickelt. Gemeinsam mit anderen Astronauten fliegt er dorthin und wird von ihnen geärgert.</de>
+                        <en>Howie has developed a space toilet for a space station. Together with other astronauts he flies there and is annoyed by them.</en>
+                    </description>
+                    <ratings critics="30" speed="67" />
+                </programme>
+                <programme id="cujo-serien-large-detonation-07" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Der Comicbuchladen</de>
+                        <en>The comic book store</en>
+                    </title>
+                    <description>
+                        <de>Stu betreibt einen Comicbuchladen. Nelson, Lennert und ihre Freunde sind dort Stammgäste.</de>
+                        <en>Stu runs a comic book store. Nelson, Lennert and their friends are regulars there.</en>
+                    </description>
+                    <ratings critics="30" speed="67" />
+                </programme>
+            </children>
+        </programme>
+        <programme id="cujo-serien-best-torilo" product="2" licence_type="3" tmdb_id="0" imdb_id="tt0329874" creator="8827" created_by="Cujo">
+            <title>
+                <de>Best of Torilo</de>
+                <en>Best of Torilo</en>
+            </title>
+			<title_original>
+				<de>Loriot</de>
+			</title_original>
+            <description>
+                <de>Die besten Sketche und Zeichentrickfilme mit Torilo. Zum Totlachen.</de>
+                <en>The best sketches and cartoons with Torilo. Hilarious.</en>
+            </description>
+			<staff>
+				<member index="0" function="1">cujo-person-torilo</member>
+				<member index="1" function="2">cujo-person-torilo</member>
+				<member index="2" function="2">cujo-person-emilie-mahann</member>
+			</staff>
+            <groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
+            <data country="D" year="1976" distribution="2" maingenre="5" subgenre="" flags="264" blocks="1" price_mod="0.88" />
+            <ratings critics="22" speed="25" outcome="89" />
+            <children>
+                <programme id="cujo-serien-best-torilo-01" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Ernst Buchemann gewinnt im Lotto</de>
+                        <en>Ernst Buchemann wins the lottery</en>
+                    </title>
+                    <description>
+                        <de>Ernst Buchemann ist Rentner und 65 Jahre alt. Mit seinem Lottogewinn von 600.000 DM will er eine Damenboutique in Wiesbaden eröffnen.</de>
+                        <en>Ernst Buchemann is a pensioner and 65 years old. He wants to use his lottery winnings of DM 600,000 to open a ladies' boutique in Wiesbaden.</en>
+                    </description>
+                    <ratings critics="22" speed="25" />
+                </programme>
+                <programme id="cujo-serien-best-torilo-02" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Die Felsenlaus</de>
+                        <en>The rock louse</en>
+                    </title>
+                    <description>
+                        <de>Die Felsenlaus ist ein Nagetier, das Brücken zum Einsturz bringen kann. Jedes Exemplar frisst pro Tag 25 Kilogramm Beton und Ziegelsteine.</de>
+                        <en>The rock louse is a rodent that can cause bridges to collapse. Each specimen eats 25 kilograms of concrete and bricks per day.</en>
+                    </description>
+                    <ratings critics="22" speed="25" />
+                </programme>
+                <programme id="cujo-serien-best-torilo-03" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Das Bild hängt schief</de>
+                        <en>The picture hangs crooked</en>
+                    </title>
+                    <description>
+                        <de>Ein Freund des Hauses kommt zu Besuch. Das Dienstmädchen lässt ihn ein und sagt, er soll im Salon warten. Als er dort ein schiefes Bild gerade rücken will, zerstört er die Einrichtung.</de>
+                        <en>A friend of the house comes to visit. The maid lets him in and tells him to wait in the parlor. When he tries to straighten a crooked picture there, he destroys the furnishings.</en>
+                    </description>
+                    <ratings critics="22" speed="25" />
+                </programme>
+                <programme id="cujo-serien-best-torilo-04" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Das Reiskorn</de>
+                        <en>The grain of rice</en>
+                    </title>
+                    <description>
+                        <de>Bei einem Rendezvous entdeckt Hannelore ein Reiskorn am Mund ihres Verehrers. Trotz mehreren Versuchen es zu entfernen, taucht es immer wieder auf.</de>
+                        <en>On a date, Hannelore discovers a grain of rice on her beau's mouth. Despite several attempts to remove it, it keeps reappearing.</en>
+                    </description>
+                    <ratings critics="22" speed="25" />
+                </programme>
+                <programme id="cujo-serien-best-torilo-05" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Das Gummientchen</de>
+                        <en>The rubber ducky</en>
+                    </title>
+                    <description>
+                        <de>Meier-Schüdenleidt will in seinem Hotelzimmer baden. In seiner Badewanne sitzt aber bereits Doktor Blögner mit seinem Gummientchen.</de>
+                        <en>Meier-Schüdenleidt wants to take a bath in his hotel room. But Doctor Blögner is already sitting in his bathtub with his rubber ducky.</en>
+                    </description>
+                    <ratings critics="22" speed="25" />
+                </programme>
+            </children>
+        </programme>		
+        <programme id="cujo-serien-tigerzahn" product="2" licence_type="3" tmdb_id="0" imdb_id="tt0135097" creator="8827" created_by="Cujo">
+            <title>
+                <de>Tigerzahn</de>
+                <en>Tiger Tooth</en>
+            </title>
+			<title_original>
+				<de>Löwenzahn</de>
+			</title_original>
+            <description>
+                <de>Paul Witzig wohnt in dem kleinen Städtchen Löwendorf. Er trägt eine Nickelbrille und eine Latzhose. Paul beobachtet interessiert die Natur und Umwelt rund um seinen Bauwagen.</de>
+                <en>Paul Witzig lives in the small town of Löwendorf. He wears nickel glasses and dungarees. Paul observes nature and the environment around his construction trailer with interest.</en>
+            </description>
+			<staff>
+				<member index="0" function="1">cujo-person-karl-lora</member>
+				<member index="1" function="2">cujo-person-paul-witzig</member>
+				<member index="2" function="2">cujo-person-horst-krause</member>
+			</staff>
+            <groups target_groups="1" pro_pressure_groups="0" contra_pressure_groups="0" />
+            <data country="D" year="1981" distribution="2" maingenre="9" subgenre="" flags="264" blocks="1" price_mod="0.71" />
+            <ratings critics="64" speed="21" outcome="83" />
+            <children>
+                <programme id="cujo-serien-tigerzahn-01" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Paul rettet einen Käfer</de>
+                        <en>Paul rescues a beetle</en>
+                    </title>
+                    <description>
+                        <de>Pauls Nachbar Kuschalke tritt auf einen Hirschkäfer. Paul kümmert sich um das verletzte Insekt und päppelt es wieder auf.</de>
+                        <en>Paul's neighbor Kuschalke steps on a stag beetle. Paul takes care of the injured insect and nurses it back to health.</en>
+                    </description>
+                    <ratings critics="64" speed="21" />
+                </programme>
+                <programme id="cujo-serien-tigerzahn-02" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Paul macht seine Butter selbst</de>
+                        <en>Paul makes his own butter</en>
+                    </title>
+                    <description>
+                        <de>Der Löwendorfer Supermarkt hat wegen eines Stromausfalls geschlossen. Für Paul kein Problem. Er stellt die Butter für seine Brote einfach selbst her.</de>
+                        <en>The Löwendorf supermarket is closed due to a power outage. No problem for Paul. He simply makes the butter for his bread himself.</en>
+                    </description>
+                    <ratings critics="64" speed="21" />
+                </programme>
+                <programme id="cujo-serien-tigerzahn-03" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Paul baut sich einen Roboter</de>
+                        <en>Paul builds himself a robot</en>
+                    </title>
+                    <description>
+                        <de>Paul ist das ständige Putzen leid. Er baut sich einen Roboter, der ihn bei der Hausarbeit unterstützen soll.</de>
+                        <en>Paul is tired of cleaning all the time. He builds a robot to help him with the housework.</en>
+                    </description>
+                    <ratings critics="64" speed="21" />
+                </programme>
+                <programme id="cujo-serien-tigerzahn-04" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8827" created_by="Cujo">
+                    <title>
+                        <de>Paul gräbt was aus</de>
+                        <en>Paul digs up something</en>
+                    </title>
+                    <description>
+                        <de>Paul findet im Garten einen Knochen. Stammt der etwa von einem Dinosaurier? Er lässt ihn im Museum untersuchen und erfährt dort viel über Archäologie.</de>
+                        <en>Paul finds a bone in the garden. Does it come from a dinosaur? He has it examined at the museum and learns a lot about archaeology.</en>
+                    </description>
+                    <ratings critics="64" speed="21" />
+                </programme>
+            </children>
+        </programme>
+    </allprogrammes>
+	<allads>
+		<!-- Toyota - Nichts ist unmöglich -->
+		<ad id="cujo-werbung-yotota">
+			<title>
+				<de>Yotota</de>
+			</title>
+			<description>
+				<de>Alles ist möglich - Yotota</de>
+				<en>Everything is possible - Yotota</en>
+			</description>
+			<conditions min_audience="10" min_image="0" target_group="0" prohibited_genre="8" prohibited_programme_type="5" prohibited_programme_flag="16" pro_pressure_groups="0" contra_pressure_groups="0"/>
+			<data quality="20" repetitions="5" duration="3" profit="350" penalty="475" infomercial_profit="50" fix_infomercial_profit="1"/>
+		</ad>
+	</allads>
+</tvtdb>

--- a/res/database/Default/user/cujo.xml
+++ b/res/database/Default/user/cujo.xml
@@ -1702,7 +1702,7 @@
                 <en>Ross Blob paints a picture and explains in a gentle voice how the audience should hold the brush.</en>
             </description>
 			<staff>
-				<member index="0" function="8">cujo-ross-blob</member>
+				<member index="0" function="8">cujo-person-ross-blob</member>
 			</staff>
             <groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
             <data country="USA" year="1983" distribution="2" maingenre="6" subgenre="" flags="4" blocks="1" price_mod="1.25" />


### PR DESCRIPTION
Noch einige Infos zu meinen Daten:

Die Passenger-Newskette spaltet sich nach der dritten News in zwei Handlungsstränge auf. Entweder stürzt die Raumfähre ab oder landet sicher. Zu Beginn der Newskette weiß der Spieler nicht, was passiert :)

Die Schessnah-Newskette überschneidet sich thematisch leider mit 2 kurzen News von Jorgaeff. Ich habe es erst beim Testen gemerkt. Da wurden mir am selben Tag zwei verschiedene News zum gleichen Thema angezeigt. Was sollen wir damit machen? Beide drin lassen oder eins von beiden rauswerfen?

Bei den Filmen habe ich es so gemacht, dass sie erst 2 Jahre nach Veröffentlichung verfügbar sind. Zum einen deshalb, damit der Preis nicht so hoch ist. Zum anderen ist es auch etwas realistischer, da Filme normalerweise nicht direkt nach Veröffentlichung im Free-TV gesendet werden. Bei dem einen Film aus den 50ern habe ich die Einschränkung weg gelassen. Da dürfte es nicht relevant sein.

Die Kastanienstraße-Serie habe ich in 3 Blöcke à 5 Folgen aufgeteilt. Durch die Aufteilung wird die Serie nicht so teuer. Die ersten beiden Blöcke sind jeweils 12 Jahre verfügbar. Der letzte Block endlos. Es ist immer nur ein Block gleichzeitig verfügbar.