### PR TITLE
Geschlecht der Rolle an den Job weitergeben (scr0llbaer)

### DIFF
--- a/source/game.production.scripttemplate.bmx
+++ b/source/game.production.scripttemplate.bmx
@@ -353,6 +353,11 @@ Type TScriptTemplate Extends TScriptBase
 		'template jobs)
 		For local i:int = 0 until result.length
 			result[i] = result[i].Copy()
+			Local finalJob:TPersonProductionJob = result[i]
+			If finalJob.gender = 0 And finalJob.roleID <> 0
+				Local role:TProgrammeRole = GetProgrammeRoleCollection().GetByID(finalJob.roleID)
+				If role And role.gender > 0 Then finalJob.gender = role.gender
+			EndIf
 		Next
 
 		rem


### PR DESCRIPTION
Falls ein Job eine Rolle definiert, selbst aber kein Geschlecht vorgibt, sollte das Geschlecht der Rolle verwendet werden.