### PR TITLE
GUI-Listenaktualisierung bei Antennenverkauf

### DIFF
--- a/source/game.screen.stationmap.bmx
+++ b/source/game.screen.stationmap.bmx
@@ -2799,7 +2799,7 @@ Type TScreenHandler_StationMap
 		'if stationmap changed or we changed the room meanwhile
 		'then we have to rebuild the stationList and potentially remove
 		'selections in lists
-		If changedSubRoom or stationMapChanged & currentSubRoom.owner
+		If changedSubRoom or stationMapChanged
 			ReactToStationMapChanges()
 		EndIf
 


### PR DESCRIPTION
Beim Update wurde die Aktualisierung mit einem anderen Flag-Pattern geprüft als in ReactToStationMapChanges selbst. Daher würde ich die Aktualisierung bei jeder Änderung aufrufen und die Prüfung nur in ReactToStationMapChanges machen.

closes #851 