### PR TITLE
Schneller Sprachwechsel im Entwicklermodus

### DIFF
--- a/source/main.bmx
+++ b/source/main.bmx
@@ -1235,6 +1235,16 @@ Type TApp
 			EndIf
 
 
+			If KeyManager.IsHit(KEY_U)
+				Local currentIndex:Int = 0
+				For Local lang:TLocalizationLanguage = EachIn TLocalization.languages
+					If lang = TLocalization.currentLanguage Then exit
+					currentIndex:+ 1
+				Next
+				App.SetLanguage(TLocalization.languages[(currentIndex+1) Mod (TLocalization.languages.length)].languageCode)
+			EndIf
+
+
 			If Not GetPlayer().GetFigure().isChangingRoom()
 				If GameConfig.highSpeedObservation
 					If KeyManager.IsHit(KEY_1) Then GetGame().SetActivePlayer(1)


### PR DESCRIPTION
Mit U kann man die Sprachen wechseln. Das könnte nicht nur für Übersetzungen interessant sein sondern auch für die UI-Entwicklung (Breiten von Controls...) - wenn denn die Übersetzungen einmal da sind.