### PR TITLE
Farben für Zielgruppenwerbung (Fix durch lonk0123)

### DIFF
--- a/config/screen_elements.xml
+++ b/config/screen_elements.xml
@@ -70,22 +70,22 @@
 			<scripts>
 				<script do="AddCopySprite"	src="gfx_contracts_base"	dest="gfx_contracts_1"		x="22"		r="200"		g="60"		b="40" />
 				<script do="AddCopySprite"	src="gfx_contracts_base"	dest="gfx_contracts_2"		x="43"		r="40"		g="200"		b="40" />
-				<script do="AddCopySprite"	src="gfx_contracts_base"	dest="gfx_contracts_3"		x="64"		r="100"		g="100"		b="200" />
+				<script do="AddCopySprite"	src="gfx_contracts_base"	dest="gfx_contracts_3"		x="64"		r="255"		g="255"		b="0" />
 				<script do="AddCopySprite"	src="gfx_contracts_base"	dest="gfx_contracts_4"		x="85"		r="20"		g="140"		b="180" />
-				<script do="AddCopySprite"	src="gfx_contracts_base"	dest="gfx_contracts_5"		x="106"		r="40"		g="200"		b="40" />
-				<script do="AddCopySprite"	src="gfx_contracts_base"	dest="gfx_contracts_6"		x="127"		r="150"		g="150"		b="200" />
-				<script do="AddCopySprite"	src="gfx_contracts_base"	dest="gfx_contracts_7"		x="148"		r="20"		g="140"		b="180" />
-				<script do="AddCopySprite"	src="gfx_contracts_base"	dest="gfx_contracts_8"		x="169"		r="40"		g="200"		b="40" />
+				<script do="AddCopySprite"	src="gfx_contracts_base"	dest="gfx_contracts_5"		x="106"		r="185"		g="125"		b="90" />
+				<script do="AddCopySprite"	src="gfx_contracts_base"	dest="gfx_contracts_6"		x="127"		r="155"		g="55"		b="255" />
+				<script do="AddCopySprite"	src="gfx_contracts_base"	dest="gfx_contracts_7"		x="148"		r="170"		g="170"		b="170" />
+				<script do="AddCopySprite"	src="gfx_contracts_base"	dest="gfx_contracts_8"		x="169"		r="255"		g="95"		b="255" />
 				<script do="AddCopySprite"	src="gfx_contracts_base"	dest="gfx_contracts_9"		x="190"		r="90"		g="90"		b="150" />
 
 				<script do="AddCopySprite"	src="gfx_contracts_base_dragged"	dest="gfx_contracts_1_dragged"	x="22"		r="200"		g="60"		b="40" />
 				<script do="AddCopySprite"	src="gfx_contracts_base_dragged"	dest="gfx_contracts_2_dragged"	x="43"		r="40"		g="200"		b="40" />
-				<script do="AddCopySprite"	src="gfx_contracts_base_dragged"	dest="gfx_contracts_3_dragged"	x="64"		r="100"		g="100"		b="200" />
+				<script do="AddCopySprite"	src="gfx_contracts_base_dragged"	dest="gfx_contracts_3_dragged"	x="64"		r="255"		g="255"		b="0" />
 				<script do="AddCopySprite"	src="gfx_contracts_base_dragged"	dest="gfx_contracts_4_dragged"	x="85"		r="20"		g="140"		b="180" />
-				<script do="AddCopySprite"	src="gfx_contracts_base_dragged"	dest="gfx_contracts_5_dragged"	x="106"		r="40"		g="200"		b="40" />
-				<script do="AddCopySprite"	src="gfx_contracts_base_dragged"	dest="gfx_contracts_6_dragged"	x="127"		r="150"		g="150"		b="200" />
-				<script do="AddCopySprite"	src="gfx_contracts_base_dragged"	dest="gfx_contracts_7_dragged"	x="148"		r="20"		g="140"		b="180" />
-				<script do="AddCopySprite"	src="gfx_contracts_base_dragged"	dest="gfx_contracts_8_dragged"	x="169"		r="40"		g="200"		b="40" />
+				<script do="AddCopySprite"	src="gfx_contracts_base_dragged"	dest="gfx_contracts_5_dragged"	x="106"		r="185"		g="125"		b="90" />
+				<script do="AddCopySprite"	src="gfx_contracts_base_dragged"	dest="gfx_contracts_6_dragged"	x="127"		r="155"		g="55"		b="255" />
+				<script do="AddCopySprite"	src="gfx_contracts_base_dragged"	dest="gfx_contracts_7_dragged"	x="148"		r="170"		g="170"		b="170" />
+				<script do="AddCopySprite"	src="gfx_contracts_base_dragged"	dest="gfx_contracts_8_dragged"	x="169"		r="255"		g="95"		b="255" />
 				<script do="AddCopySprite"	src="gfx_contracts_base_dragged"	dest="gfx_contracts_9_dragged"	x="190"		r="90"		g="90"		b="150" />
 			</scripts>
 		</spritepack>


### PR DESCRIPTION
see #813 

Die Frage wäre, ob man im Büro das Ausrufezeichen für Zielgruppe auch noch einfach in derselben Farbe anzeigen kann. Das Ausrufezeichen im png hat jedenfalls nur aktuelle rotbraun.