### PR TITLE
[Misc] Extend variables/expressions to allow conditions in there

### DIFF
--- a/res/database/Default/user/ronny.xml
+++ b/res/database/Default/user/ronny.xml
@@ -646,7 +646,7 @@ Illustrious guests and music by [3|Nick].</en>
 
 		<news id="ronny-news-sandsturm-01" type="0" thread_id="ronny-news-sandsturm" creator="5578" created_by="Ronny">
 			<title>
-				<de>Sandsturm am nördlichen Polarkreis</de>
+				<de>${hashtag} ${yearBigger1985} ${yearIs1985} ${yearSmaller1985} Sandsturm am nördlichen Polarkreis</de>
 				<en>Sandstorm near the Arctic Circle</en>
 			</title>
 			<description>
@@ -658,6 +658,24 @@ Illustrious guests and music by [3|Nick].</en>
 				<effect trigger="happen" type="triggernews" time="2,1,1,9,15" news="ronny-news-sandsturm-02" />
 			</effects>
 			<data genre="4" price="1.0" quality="48" />
+			<variables>
+				<hashtag>
+						<de>${TIME_YEAR = 1985,&quot;#Area 51, #SolarEnergy&quot;,&quot;&quot;}</de>
+				</hashtag>
+   
+				<year>
+					<de>${TIME_YEAR}</de>
+				</year>
+				<yearBigger1985>
+					<de>${TIME_YEAR &gt; 1985}</de>
+				</yearBigger1985>
+				<yearIs1985>
+					<de>${TIME_YEAR = 1985}</de>
+				</yearIs1985>
+				<yearSmaller1985>
+					<de>${TIME_YEAR &lt; 1985}</de>
+				</yearSmaller1985>
+			</variables>
 		</news>
 		<news id="ronny-news-sandsturm-02" type="2" thread_id="ronny-news-sandsturm" creator="5578" created_by="Ronny">
 			<title>

--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -687,7 +687,7 @@ Type TDatabaseLoader
 		newsEventTemplate.availableYearRangeTo = data.GetInt("year_range_to", newsEventTemplate.availableYearRangeTo)
 
 		If newsEventTemplate.availableScript
-			If Not GetScriptExpression().IsValid(newsEventTemplate.availableScript)
+			If Not GetScriptExpression().IsValidConditionExpression(newsEventTemplate.availableScript)
 				TLogger.Log("DB", "Script of NewsEventTemplate ~q" + newsEventTemplate.GetGUID() + "~q contains errors:", LOG_WARNING)
 				TLogger.Log("DB", GetScriptExpression()._error, LOG_WARNING)
 			EndIf
@@ -983,7 +983,7 @@ Type TDatabaseLoader
 		adContract.availableYearRangeTo = data.GetInt("year_range_to", adContract.availableYearRangeTo)
 
 		If adContract.availableScript
-			If Not GetScriptExpression().IsValid(adContract.availableScript)
+			If Not GetScriptExpression().IsValidConditionExpression(adContract.availableScript)
 				TLogger.Log("DB", "Script of AdContract ~q" + adContract.GetGUID() + "~q contains errors:", LOG_WARNING)
 				TLogger.Log("DB", GetScriptExpression()._error, LOG_WARNING)
 			EndIf

--- a/source/game.production.scripttemplate.bmx
+++ b/source/game.production.scripttemplate.bmx
@@ -209,7 +209,7 @@ Type TScriptTemplate Extends TScriptBase
 
 		'a special script expression defines custom rules for adcontracts
 		'to be available or not
-		if availableScript and not GetScriptExpression().Eval(availableScript)
+		if availableScript and not GetScriptExpression().EvalCondition(availableScript)
 			return False
 		endif
 

--- a/source/game.programme.adcontract.bmx
+++ b/source/game.programme.adcontract.bmx
@@ -459,7 +459,7 @@ Type TAdContractBase Extends TBroadcastMaterialSource {_exposeToLua}
 
 		'a special script expression defines custom rules for adcontracts
 		'to be available or not
-		If availableScript And Not GetScriptExpression().Eval(availableScript)
+		If availableScript And Not GetScriptExpression().EvalCondition(availableScript)
 			Return False
 		EndIf
 

--- a/source/game.programme.newsevent.template.bmx
+++ b/source/game.programme.newsevent.template.bmx
@@ -489,7 +489,7 @@ Type TNewsEventTemplate extends TBroadcastMaterialSourceBase
 		
 		'a special script expression defines custom rules for adcontracts
 		'to be available or not
-		if availableScript and not GetScriptExpression().Eval(availableScript)
+		if availableScript and not GetScriptExpression().EvalCondition(availableScript)
 			return False
 		endif
 

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -901,6 +901,20 @@ Type TApp
 
 
 			If KeyManager.IsHit(KEY_Y)
+				Local newsGUID:String = "sandsturm-01"
+				'check template first
+				Local news:TNewsEvent
+				Local template:TNewsEventTemplate = GetNewsEventTemplateCollection().GetByGUID(newsGUID)
+				If Not template Then template = GetNewsEventTemplateCollection().SearchByPartialGUID(newsGUID)
+
+				If template and template.IsAvailable()
+					news = New TNewsEvent.InitFromTemplate(template)
+					print news.GetTitle()
+					print news.GetDescription()
+				EndIf
+					
+
+
 				'DebugScreen.Dev_FastForwardToTime(GetWorldTime().GetTimeGone() + 1*TWorldTime.DAYLENGTH, DebugScreen.GetShownPlayerID())
 				'print some debug for stationmap
 				rem


### PR DESCRIPTION
Extends Scriptexpression-handling to allow conditional expressions (true/false) to result in "true text", "false text"


Closes #878



Examples:
Allows:
```XML
<variables>
   <HashtagsExist><de>${TIME_YEAR&gt;2006}</de></HashtagsExist>
   <Hashtag><de>${Hashtag_${HashtagsExist}}</de></Hashtag>
   <Hashtag_0><de></de></Hashtag_0>
   <Hashtag_1><de>#Area 51 #SolarEnergy</de></Hashtag_1>
</variables>
```

or
```XML
<variables>
	<hashtag>
		<de>${hashtag_${TIME_YEAR &gt;= 2007}}</de>
	</hashtag>
	<hashtag_0>
		<de></de>
	</hashtag_0>
	<hashtag_1>
		<de>#Area 51 #SolarEnergy</de>
	</hashtag_1>
</variables>
```

or
```XML
<variables>
	<hashtag>
		<de>${hashtag_${TIME_YEAR &gt;= 2007,"exists","notexists"}}</de>
	</hashtag>
	<hashtag_notexists>
		<de></de>
	</hashtag_notexists>
	<hashtag_exists>
		<de>#Area 51 #SolarEnergy</de>
	</hashtag_exists>
</variables>
```

or
```XML
<variables>
	<hashtag>
		<de>${TIME_YEAR &gt;= 2007,&quot;${hashtag_exists}&quot;}</de>
	</hashtag>
	<hashtag_exists>
		<de>#Area 51, #SolarEnergy</de>
	</hashtag_exists>
</variables>
```

or
```XML
<variables>
	<hashtag>
		<de>${TIME_YEAR &gt;= 2007,&quot;#Area 51, #SolarEnergy&quot;}</de>
	</hashtag>
</variables>
```
