### PR TITLE
Propagieren von Variablen für Nachrichten

### DIFF
--- a/source/common.misc.templatevariables.bmx
+++ b/source/common.misc.templatevariables.bmx
@@ -30,7 +30,50 @@ Type TTemplateVariables
 	Method GetParentTemplateVariables:TTemplateVariables()
 		return null
 	End Method
+	
+	
+	Method CopyFrom:TTemplateVariables(v:TTemplateVariables)
+		If Not v.variables 
+			self.variables = Null
+		Else
+			self.variables = New TMap
+			For local key:Object = EachIn v.variables.Keys()
+				local ls:TLocalizedString = TLocalizedString(v.variables.ValueForKey(key))
+				If not ls
+					Throw "TTemplateVariables: Unsupported content in variables."
+				EndIf
+				self.variables.Insert(key, ls.Copy())
+			Next
+		EndIf
 
+		If Not v.variablesLanguagesIDs
+			self.variablesLanguagesIDs = Null
+		Else
+			self.variablesLanguagesIDs = v.variablesLanguagesIDs[ .. ]
+		EndIf
+
+
+		If Not v.placeholderVariables
+			self.placeholderVariables = Null
+		Else
+			self.placeholderVariables = New TMap
+			For local key:Object = EachIn v.placeholderVariables.Keys()
+				local ls:TLocalizedString = TLocalizedString(v.placeholderVariables.ValueForKey(key))
+				If not ls
+					Throw "TTemplateVariables: Unsupported content in placeholderVariables."
+				EndIf
+				self.placeholderVariables.Insert(key, ls.Copy())
+			Next
+		EndIf
+		Return Self
+	End Method
+
+	
+	Method Copy:TTemplateVariables()
+		local c:TTemplateVariables = New TTemplateVariables
+		Return c.CopyFrom(self)
+	End Method
+		
 
 	Method Reset()
 		placeholderVariables = null

--- a/source/game.production.bmx
+++ b/source/game.production.bmx
@@ -680,7 +680,12 @@ Type TProduction Extends TOwnedGameObject
 			Local job:TPersonProductionJob = productionConcept.script.jobs[castIndex]
 			If Not p Or Not job Then Continue
 
-			programmeData.AddCast(New TPersonProductionJob.Init(p.GetID(), job.job))
+			If job.roleID
+				'transfer role to licence cast for potential variable substitution
+				programmeData.AddCast(New TPersonProductionJob.Init(p.GetID(), job.job, job.gender, job.country, job.roleId))
+			Else
+				programmeData.AddCast(New TPersonProductionJob.Init(p.GetID(), job.job))
+			EndIF
 		Next
 
 		Return programmeData

--- a/source/game.production.scripttemplate.bmx
+++ b/source/game.production.scripttemplate.bmx
@@ -645,6 +645,28 @@ Type TScriptTemplateVariables extends TTemplateVariables
 	Field parent:TScriptTemplate {nosave}
 
 
+	Method CopyFrom:TScriptTemplateVariables(v:TTemplateVariables) override
+		throw "copying of script variables is not supported!"
+		rem
+		Local scriptV:TScriptTemplateVariables = TScriptTemplateVariables(v)
+		If scriptV
+			self.parentID = scriptV.parentID
+			self.parent = scriptV.parent
+		Else
+			Super.CopyFrom(v)
+		EndIf
+
+		Return self
+		endrem
+	End Method
+
+
+	Method Copy:TScriptTemplateVariables() override
+		local c:TScriptTemplateVariables = New TScriptTemplateVariables
+		Return c.CopyFrom(self)
+	End Method
+
+
 	Method GetParentTemplateVariables:TTemplateVariables()
 		if parentID and not parent
 			parent = GetScriptTemplateCollection().GetByID(parentID)


### PR DESCRIPTION
Da das Expressionrefactoring die Erweiterung der Referenzierbarkeit von Rollen und Personen verzögert, habe ich den entsprechenden PR aufgetrennt. Damit können schon erste Verbesserungen (insb. im Bereich Nachrichten) angegangen werden. Im ersten Teil sind folgende Punkte enthalten

* Propagieren des Rollengeschlechts auf den Job
* Propagieren von Variablen an angestoßene Folgenachrichten (Personenreferenzen noch nicht unterstützt)
* Rollendefinition auch in Programmen (für späteres Referenzieren der Cast-Rollen in Titel/Beschreibung)

closes #836