### PR TITLE
Besetzung mit mehreren Funktionen im Datenblatt anzeigen

### DIFF
--- a/source/game.programme.programmedata.bmx
+++ b/source/game.programme.programmedata.bmx
@@ -769,7 +769,7 @@ Type TProgrammeData Extends TBroadcastMaterialSource {_exposeToLua}
 	Method GetCastGroup:TPersonBase[](jobFlag:Int)
 		Local res:TPersonBase[0]
 		For Local job:TPersonProductionJob = EachIn cast
-			If job.job = jobFlag
+			If job.job & jobFlag
 				res :+ [ GetPersonBaseCollection().GetByID( job.personID) ]
 			EndIf
 		Next


### PR DESCRIPTION
Für ein fertiges Programm sollten Personen mit mehreren Funktionen im Datenblatt nicht ignoriert werden.

closes #833 