### PR TITLE
Lokalisierung von Personen und Rollen

### DIFF
--- a/source/game.game.bmx
+++ b/source/game.game.bmx
@@ -248,7 +248,7 @@ Type TGame Extends TGameBase {_exposeToLua="selected"}
 			TriggerBaseEvent(GameEventKeys.Game_OnDay, timeData)
 			'time after day
 			TriggerBaseEvent(GameEventKeys.Game_OnMinute, timeData)
-			TriggerBaseEvent(GameEventKeys.Game_OnHour, timeData) 
+			TriggerBaseEvent(GameEventKeys.Game_OnHour, timeData)
 		Else
 			if not GetProductionManager().currentAvailableAmateurs or GetProductionManager().currentAvailableAmateurs.length = 0
 				TLogger.Log("TGame", "Ensure enough castable amateurs exist (old savegame).", LOG_DEBUG)
@@ -264,6 +264,8 @@ Type TGame Extends TGameBase {_exposeToLua="selected"}
 		TriggerBaseEvent(GameEventKeys.Game_OnStart, timeData)
 		'inform about the begin of this game (for now equal to "OnStart")
 		TriggerBaseEvent(GameEventKeys.Game_OnBegin, timeData)
+		'trigger setting current language for database language update
+		TriggerBaseEvent(GameEventKeys.App_OnSetLanguage, New TData.Add("languageCode", TLocalization.GetCurrentLanguageCode()), Self)
 
 		?bmxng
 		if OCM.enabled

--- a/source/game.programme.programmedata.bmx
+++ b/source/game.programme.programmedata.bmx
@@ -53,7 +53,7 @@ Type TProgrammeDataCollection Extends TGameObjectCollection
 		_eventListeners = new TEventListenerBase[0]
 
 		'=== register event listeners
-		'_eventListeners :+ [ EventManager.registerListenerFunction( "App.onSetLanguage", onSetLanguage ) ]
+		_eventListeners :+ [ EventManager.registerListenerFunction( "App.onSetLanguage", onSetLanguage ) ]
 	End Method
 
 
@@ -436,6 +436,8 @@ Type TProgrammeDataCollection Extends TGameObjectCollection
 		For Local data:TProgrammeData = EachIn entries.Values()
 			data.titleProcessed = Null
 			data.descriptionProcessed = Null
+			data.cachedActors = data.cachedActors[..0]
+			data.cachedDirectors = data.cachedDirectors[..0]
 		Next
 	End Method
 
@@ -477,11 +479,9 @@ Type TProgrammeDataCollection Extends TGameObjectCollection
 	End Function
 
 	'=== EVENT HANDLERS ===
-	Rem
 	Function onSetLanguage:int( triggerEvent:TEventBase )
 		GetInstance().RemoveReplacedPlaceholderCaches()
 	End Function
-	endrem
 End Type
 
 '===== CONVENIENCE ACCESSOR =====
@@ -791,7 +791,7 @@ Type TProgrammeData Extends TBroadcastMaterialSource {_exposeToLua}
 	Method GetActors:TPersonBase[]()
 		If cachedActors.length = 0
 			For Local job:TPersonProductionJob = EachIn cast
-				If job.job = TVTPersonJob.ACTOR
+				If job.job & TVTPersonJob.ACTOR
 					cachedActors :+ [ GetPersonBaseCollection().GetByID( job.personID ) ]
 				EndIf
 			Next
@@ -804,7 +804,7 @@ Type TProgrammeData Extends TBroadcastMaterialSource {_exposeToLua}
 	Method GetDirectors:TPersonBase[]()
 		If cachedDirectors.length = 0
 			For Local job:TPersonProductionJob = EachIn cast
-				If job.job = TVTPersonJob.DIRECTOR
+				If job.job & TVTPersonJob.DIRECTOR
 					cachedDirectors :+ [ GetPersonBaseCollection().GetByID( job.personID ) ]
 				EndIf
 			Next


### PR DESCRIPTION
Es soll grundsätzlich die Möglichkeit geschaffen werden, Personennamen und Rollen zu lokalisieren.
Statt alle Sprachvarianten in die Hauptdatei zu integrieren, was eine Anpassung der Datenbanksyntax erfordert, werden die sprachspezifischen Daten analog den Sprachpropertydateien ausgelagert.

Per Konvention gibt es im Hauptdatenbankverzeichnis ein Unterverzeichnis "lang", in dem für jede unterstützte Sprache eine XML-Datei liegt. Diese XML-Datei enthält dann die Daten ausschließllich für die Datensätze, die eine Lokalisierung benötigen. Beim Start eines neuen Spiels oder beim Laden, wird die jeweilige Sprachvariante gelesen, damit die Namen für das gestartete Spiel zur Sprache passen.

Per Konvention ist Englisch die Standardsprache. D.h. Wenn ein Eintrag für eine andere Sprache ergänzt werden soll, muss auch für Englisch die Standardvariante definiert werden. Damit soll verhindert werden, dass bei Sprachwechsel die "falsche" Version bestehen bleibt.

closes #887