### PR TITLE
Variablenersetzung mit Default-Sprache

### DIFF
--- a/source/common.misc.templatevariables.bmx
+++ b/source/common.misc.templatevariables.bmx
@@ -254,10 +254,12 @@ Type TTemplateVariables
 		'placeholders (at least some of them)!
 		For local i:int = 0 until 20
 			local replacedPlaceholdersAllLang:int = 0
+			'as base value for the next recursive round, copy the previous result
+			'otherwise replacements in the "default language" would be used for other languages as well
+			local langBaseCopy:TLocalizedString = result.copy()
 			For local langID:int = eachIn languageIDs 'text.GetLanguageIDs()
 				local replacedPlaceholdersThisLang:int = 0
-				'use result already (to allow recursive-replacement)
-				local value:string = result.Get(langID)
+				local value:string = langBaseCopy.Get(langID)
 				local placeholders:string[] = StringHelper.ExtractPlaceholdersCombined(value, True)
 
 				if placeholders.length > 0


### PR DESCRIPTION
Wie im großen Lokalisierungs-PR bemerkt (und lokal verifiziert), müssen aktuell Titel-Einträge mit Variablen gedoppelt werden, auch wenn sie für alle Sprachen gleich aussehen würden.
Ich denke, der Bug lag darin, als Ausgangspunkt für eine Sprache direkt den resultierenden Eintrag zu verwenden. Der wurde beim Iterieren über mehrere Sprachen aber vielleicht schon modifiziert und enthält gar keine Variablen mehr.

* Titel mit Variablen nur für de
* Ersetzungen für de haben stattgefunden
* Basiseintrag für en = resultierender Eintrag für de -> enthält keine Variablen mehr
* vorhandene Variablen für en werden gar nicht verwendet

Als Fix wird in jedem rekursiven Schritt das vorige Ergebnis zwischengespeichert und *dieses* wird als Ausgangspunkt für alle Sprachen in diesem Schritt verwendet.

Unit-Tests für diesen Mechanismus wären ziemlich sinnvoll...