### PR TITLE
fix fictional, correct some content & whitespace

### DIFF
--- a/res/database/Default/database_people.xml
+++ b/res/database/Default/database_people.xml
@@ -234,9 +234,9 @@
 			<first_name>Tim</first_name>
 			<last_name>Cruz</last_name>
 			<nick_name></nick_name>
-            <first_name_original>Tom</first_name_original>
-            <last_name_original>Cruise</last_name_original>
-            <details job="2" gender="1" birthday="1962-07-03" deathday="" country="USA" />
+			<first_name_original>Tom</first_name_original>
+			<last_name_original>Cruise</last_name_original>
+			<details job="2" gender="1" birthday="1962-07-03" deathday="" country="USA" />
 		</person>
 		<person id="6b53e3ec-0d66-4131-84ec-a48b9bbe3b77" tmdb_id="0" imdb_id="nm0000361" creator="">
 			<first_name>Brain</first_name>
@@ -904,7 +904,7 @@
 			<nick_name></nick_name>
 			<first_name_original>Liam</first_name_original>
 			<last_name_original>Neeson</last_name_original>
-            <details job="2" gender="1" birthday="1952-06-07" deathday="" country="IRL" />
+			<details job="2" gender="1" birthday="1952-06-07" deathday="" country="IRL" />
 			<data popularity="20" affinity="0" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="0" topgenre="0" />
 		</person>
 		<person id="61b52966-3363-4fb3-a8d1-61a5555a0961" tmdb_id="0" imdb_id="nm0000559" creator="">
@@ -1466,211 +1466,211 @@
 			<data popularity="20" affinity="0" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="0" topgenre="0" />
 		</person>
 
-        <person id="05c93694-ceb0-488c-b49a-f64169323d23" tmdb_id="" imdb_id="nm0000323" creator="8782" created_by="DerFronck">
-            <first_name>Mikey</first_name>
-            <last_name>Kain</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Michael</first_name_original>
-            <last_name_original>Caine</last_name_original>
-            <details job="2" gender="1" birthday="1933-03-14" deathday="" country="GB" />
-        </person>
-        <person id="0bc5cf6c-b76f-4feb-bfda-ae838f61b317" tmdb_id="" imdb_id="nm0001099" creator="8782" created_by="DerFronck">
-            <first_name>Jay</first_name>
-            <last_name>Denyeal</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Jeff</first_name_original>
-            <last_name_original>Daniels</last_name_original>
-            <details job="2" gender="1" birthday="1955-02-19" deathday="" country="USA" />
-        </person>
+		<person id="05c93694-ceb0-488c-b49a-f64169323d23" tmdb_id="" imdb_id="nm0000323" creator="8782" created_by="DerFronck">
+			<first_name>Mikey</first_name>
+			<last_name>Kain</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Michael</first_name_original>
+			<last_name_original>Caine</last_name_original>
+			<details job="2" gender="1" birthday="1933-03-14" deathday="" country="GB" />
+		</person>
+		<person id="0bc5cf6c-b76f-4feb-bfda-ae838f61b317" tmdb_id="" imdb_id="nm0001099" creator="8782" created_by="DerFronck">
+			<first_name>Jay</first_name>
+			<last_name>Denyeal</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Jeff</first_name_original>
+			<last_name_original>Daniels</last_name_original>
+			<details job="2" gender="1" birthday="1955-02-19" deathday="" country="USA" />
+		</person>
 
 
 		<!-- persons in DerFroncks programmes -->
-        <person id="DF-Celebreties-Noomi_Rapace" tmdb_id="" imdb_id="nm0636426" creator="8782" created_by="DerFronck">
-            <first_name>Naomi</first_name>
-            <last_name>Rabatz</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Noomi</first_name_original>
-            <last_name_original>Rapace</last_name_original>
-            <details job="2" gender="2" birthday="1979-12-28" deathday="" country="S" />
-        </person>
-        <person id="DF-Celebreties-Kristin_Wiig" tmdb_id="" imdb_id="nm1325419" creator="8782" created_by="DerFronck">
-            <first_name>Kirsten</first_name>
-            <last_name>Wegg</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Kristin</first_name_original>
-            <last_name_original>Wiig</last_name_original>
-            <details job="2" gender="2" birthday="1973-08-22" deathday="" country="USA" />
-        </person>
-        <person id="DF-Celebreties-Charlize_Theron" tmdb_id="" imdb_id="nm0000234" creator="8782" created_by="DerFronck">
-            <first_name>Karli</first_name>
-            <last_name>Zeron</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Charlize</first_name_original>
-            <last_name_original>Theron</last_name_original>
-            <details job="2" gender="2" birthday="1977-08-07" deathday="" country="ZA" />
-        </person>
-        <person id="DF-Celebreties-Emilia_Clarke" tmdb_id="" imdb_id="nm3592338" creator="8782" created_by="DerFronck">
-            <first_name>Emilie</first_name>
-            <last_name>Klaag</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Emilia</first_name_original>
-            <last_name_original>Clarke</last_name_original>
-            <details job="2" gender="2" birthday="1986-10-23" deathday="" country="GB" />
-        </person>
-        <person id="DF-Celebreties-Katie_Holmes" tmdb_id="" imdb_id="nm0005017" creator="8782" created_by="DerFronck">
-            <first_name>Cathy</first_name>
-            <last_name>Holm</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Katie</first_name_original>
-            <last_name_original>Holmes</last_name_original>
-            <details job="2" gender="2" birthday="1974-01-30" deathday="" country="USA" />
-        </person>
-        <person id="DF-Celebreties-Jessica_Chastain" tmdb_id="" imdb_id="nm1567113" creator="8782" created_by="DerFronck">
-            <first_name>Jessica</first_name>
-            <last_name>Chestvain</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Jessica</first_name_original>
-            <last_name_original>Chastain</last_name_original>
-            <details job="2" gender="2" birthday="1977-03-24" deathday="" country="USA" />
-        </person>
-        <person id="DF-Celebreties-Lena_Headey" tmdb_id="" imdb_id="nm0372176" creator="8782" created_by="DerFronck">
-            <first_name>Lenora</first_name>
-            <last_name>Headache</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Lena</first_name_original>
-            <last_name_original>Headey</last_name_original>
-            <details job="2" gender="2" birthday="1973-10-03" deathday="" country="BM" />
-        </person>
-        <person id="DF-Celebreties-Sophie_Turner" tmdb_id="" imdb_id="nm3849842" creator="8782" created_by="DerFronck">
-            <first_name>Sofi</first_name>
-            <last_name>Tanner</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Sophie</first_name_original>
-            <last_name_original>Turner</last_name_original>
-            <details job="2" gender="2" birthday="1996-02-21" deathday="" country="GB" />
-        </person>
-        <person id="DF-Celebreties-Peter_Dinklage" tmdb_id="" imdb_id="nm0227759" creator="8782" created_by="DerFronck">
-            <first_name>Petr</first_name>
-            <last_name>Dinkelauge</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Peter</first_name_original>
-            <last_name_original>Dinklage</last_name_original>
-            <details job="2" gender="1" birthday="1969-06-11" deathday="" country="USA" />
-        </person>
-        <person id="DF-Celebreties-Kit_Harrington" tmdb_id="" imdb_id="nm3229685" creator="8782" created_by="DerFronck">
-            <first_name>Kitt</first_name>
-            <last_name>Heringson</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Kit</first_name_original>
-            <last_name_original>Harington</last_name_original>
-            <details job="2" gender="1" birthday="1986-12-26" deathday="" country="GB" />
-        </person>
-        <person id="DF-Celebreties-Nikolaj_Coster-Waldau" tmdb_id="" imdb_id="nm0182666" creator="8782" created_by="DerFronck">
-            <first_name>Nikolaus</first_name>
-            <last_name>Koster-Waldlauf</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Nikolaj</first_name_original>
-            <last_name_original>Coster-Waldau</last_name_original>
-            <details job="2" gender="1" birthday="1970-07-27" deathday="" country="DK" />
-        </person>
-        <person id="d300cc4e-dcba-4bbf-b9d4-b111412718e1" tmdb_id="" imdb_id="nm0000293" creator="8782" created_by="DerFronck" comment="merged duplicate. Previous id: DF-Celebreties-Sean_Bean">
-            <first_name>Shawn</first_name>
-            <last_name>Biehn</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Sean</first_name_original>
-            <last_name_original>Bean</last_name_original>
-            <details job="2" gender="1" birthday="1959-04-17" deathday="" country="GB" />
-            <data popularity="20" affinity="0" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="0" topgenre="0" />
-        </person>
-        <person id="DF-Celebreties-Aiden_Gillen" tmdb_id="" imdb_id="nm0318821" creator="8782" created_by="DerFronck">
-            <first_name>Ey'Dan</first_name>
-            <last_name>Gyllen</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Aidan</first_name_original>
-            <last_name_original>Gillen</last_name_original>
-            <details job="2" gender="1" birthday="1968-04-24" deathday="" country="IRL" />
-        </person>
-        <person id="DF-Celebreties-Iain_Glenn" tmdb_id="" imdb_id="nm0322513" creator="8782" created_by="DerFronck">
-            <first_name>Jearn</first_name>
-            <last_name>Klern</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Iain</first_name_original>
-            <last_name_original>Glenn</last_name_original>
-            <details job="2" gender="1" birthday="1968-04-24" deathday="" country="GB" />
-        </person>
-        <person id="DF-Celebreties-Michael_Fassbender" tmdb_id="" imdb_id="nm1055413" creator="8782" created_by="DerFronck">
-            <first_name>Mike</first_name>
-            <last_name>Basspfänder</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Michael</first_name_original>
-            <last_name_original>Fassbender</last_name_original>
-            <details job="2" gender="1" birthday="1970-04-02" deathday="" country="D" />
-        </person>
-        <person id="DF-Celebreties-Idris_Elba" tmdb_id="" imdb_id="nm0252961" creator="8782" created_by="DerFronck">
-            <first_name>Eidris</first_name>
-            <last_name>Elbe</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Idris</first_name_original>
-            <last_name_original>Elba</last_name_original>
-            <details job="2" gender="1" birthday="1972-09-06" deathday="" country="GB" />
-        </person>
-        <person id="DF-Celebreties-Christian_Bale" tmdb_id="" imdb_id="nm0000288" creator="8782" created_by="DerFronck">
-            <first_name>Christian</first_name>
-            <last_name>Baleys</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Christian</first_name_original>
-            <last_name_original>Bale</last_name_original>
-            <details job="2" gender="1" birthday="1974-01-30" deathday="" country="GB" />
-            <data popularity="10" affinity="0" fame="0" scandalizing="10" price_mod="1" power="25" humor="0" charisma="21" appearance="21" topgenre="0" />
-        </person>
-        <person id="DF-Celebreties-Matt_Damon" tmdb_id="" imdb_id="nm0000354" creator="8782" created_by="DerFronck">
-            <first_name>Mett</first_name>
-            <last_name>Dähmlon</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Matt</first_name_original>
-            <last_name_original>Damon</last_name_original>
-            <details job="2" gender="1" birthday="1970-10-08" deathday="" country="USA" />
-        </person>
-        <person id="DF-Celebreties-Wil_Wheaton" tmdb_id="" imdb_id="nm0000696" creator="8782" created_by="DerFronck">
-            <first_name>Will</first_name>
-            <last_name>Bieten</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Wil</first_name_original>
-            <last_name_original>Wheaton</last_name_original>
-            <details job="2" gender="1" birthday="1972-07-29" deathday="" country="USA" />
-        </person>
-        <person id="DF-Celebreties-Corey_Feldman" tmdb_id="" imdb_id="nm0000397" creator="8782" created_by="DerFronck">
-            <first_name>Corey</first_name>
-            <last_name>Fälltmann</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Corey</first_name_original>
-            <last_name_original>Feldman</last_name_original>
-            <details job="2" gender="1" birthday="1971-07-16" deathday="" country="USA" />
-        </person>
-        <person id="DF-Celebreties-Jerry_O'Connell" tmdb_id="" imdb_id="nm0005278" creator="8782" created_by="DerFronck">
-            <first_name>Cherry</first_name>
-            <last_name>Oh' Konnill</last_name>
-            <nick_name></nick_name>
-            <first_name_original>Jerry</first_name_original>
-            <last_name_original>O'Connell</last_name_original>
-            <details job="2" gender="1" birthday="1974-02-17" deathday="" country="USA" />
-        </person>
-        <person id="DF-Celebreties-David_Benioff" tmdb_id="" imdb_id="nm1125275" creator="8782" created_by="DerFronck">
-            <first_name>Dave</first_name>
-            <last_name>Benniov</last_name>
-            <nick_name></nick_name>
-            <first_name_original>David</first_name_original>
-            <last_name_original>Benioff</last_name_original>
-            <details job="1" gender="1" birthday="1970-09-25" deathday="" country="USA" />
-        </person>
-        <person id="DF-Celebreties-D.B._Weiss" tmdb_id="" imdb_id="nm1888967" creator="8782" created_by="DerFronck">
-            <first_name>Dee Bee</first_name>
-            <last_name>Vice</last_name>
-            <nick_name></nick_name>
-            <first_name_original>D.B.</first_name_original>
-            <last_name_original>Weiss</last_name_original>
-            <details job="1" gender="1" birthday="1971-04-23" deathday="" country="USA" />
-        </person>
+		<person id="DF-Celebreties-Noomi_Rapace" tmdb_id="" imdb_id="nm0636426" creator="8782" created_by="DerFronck">
+			<first_name>Naomi</first_name>
+			<last_name>Rabatz</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Noomi</first_name_original>
+			<last_name_original>Rapace</last_name_original>
+			<details job="2" gender="2" birthday="1979-12-28" deathday="" country="S" />
+		</person>
+		<person id="DF-Celebreties-Kristin_Wiig" tmdb_id="" imdb_id="nm1325419" creator="8782" created_by="DerFronck">
+			<first_name>Kirsten</first_name>
+			<last_name>Wegg</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Kristin</first_name_original>
+			<last_name_original>Wiig</last_name_original>
+			<details job="2" gender="2" birthday="1973-08-22" deathday="" country="USA" />
+		</person>
+		<person id="DF-Celebreties-Charlize_Theron" tmdb_id="" imdb_id="nm0000234" creator="8782" created_by="DerFronck">
+			<first_name>Karli</first_name>
+			<last_name>Zeron</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Charlize</first_name_original>
+			<last_name_original>Theron</last_name_original>
+			<details job="2" gender="2" birthday="1977-08-07" deathday="" country="ZA" />
+		</person>
+		<person id="DF-Celebreties-Emilia_Clarke" tmdb_id="" imdb_id="nm3592338" creator="8782" created_by="DerFronck">
+			<first_name>Emilie</first_name>
+			<last_name>Klaag</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Emilia</first_name_original>
+			<last_name_original>Clarke</last_name_original>
+			<details job="2" gender="2" birthday="1986-10-23" deathday="" country="GB" />
+		</person>
+		<person id="DF-Celebreties-Katie_Holmes" tmdb_id="" imdb_id="nm0005017" creator="8782" created_by="DerFronck">
+			<first_name>Cathy</first_name>
+			<last_name>Holm</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Katie</first_name_original>
+			<last_name_original>Holmes</last_name_original>
+			<details job="2" gender="2" birthday="1974-01-30" deathday="" country="USA" />
+		</person>
+		<person id="DF-Celebreties-Jessica_Chastain" tmdb_id="" imdb_id="nm1567113" creator="8782" created_by="DerFronck">
+			<first_name>Jessica</first_name>
+			<last_name>Chestvain</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Jessica</first_name_original>
+			<last_name_original>Chastain</last_name_original>
+			<details job="2" gender="2" birthday="1977-03-24" deathday="" country="USA" />
+		</person>
+		<person id="DF-Celebreties-Lena_Headey" tmdb_id="" imdb_id="nm0372176" creator="8782" created_by="DerFronck">
+			<first_name>Lenora</first_name>
+			<last_name>Headache</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Lena</first_name_original>
+			<last_name_original>Headey</last_name_original>
+			<details job="2" gender="2" birthday="1973-10-03" deathday="" country="BM" />
+		</person>
+		<person id="DF-Celebreties-Sophie_Turner" tmdb_id="" imdb_id="nm3849842" creator="8782" created_by="DerFronck">
+			<first_name>Sofi</first_name>
+			<last_name>Tanner</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Sophie</first_name_original>
+			<last_name_original>Turner</last_name_original>
+			<details job="2" gender="2" birthday="1996-02-21" deathday="" country="GB" />
+		</person>
+		<person id="DF-Celebreties-Peter_Dinklage" tmdb_id="" imdb_id="nm0227759" creator="8782" created_by="DerFronck">
+			<first_name>Petr</first_name>
+			<last_name>Dinkelauge</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Peter</first_name_original>
+			<last_name_original>Dinklage</last_name_original>
+			<details job="2" gender="1" birthday="1969-06-11" deathday="" country="USA" />
+		</person>
+		<person id="DF-Celebreties-Kit_Harrington" tmdb_id="" imdb_id="nm3229685" creator="8782" created_by="DerFronck">
+			<first_name>Kitt</first_name>
+			<last_name>Heringson</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Kit</first_name_original>
+			<last_name_original>Harington</last_name_original>
+			<details job="2" gender="1" birthday="1986-12-26" deathday="" country="GB" />
+		</person>
+		<person id="DF-Celebreties-Nikolaj_Coster-Waldau" tmdb_id="" imdb_id="nm0182666" creator="8782" created_by="DerFronck">
+			<first_name>Nikolaus</first_name>
+			<last_name>Koster-Waldlauf</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Nikolaj</first_name_original>
+			<last_name_original>Coster-Waldau</last_name_original>
+			<details job="2" gender="1" birthday="1970-07-27" deathday="" country="DK" />
+		</person>
+		<person id="d300cc4e-dcba-4bbf-b9d4-b111412718e1" tmdb_id="" imdb_id="nm0000293" creator="8782" created_by="DerFronck" comment="merged duplicate. Previous id: DF-Celebreties-Sean_Bean">
+			<first_name>Shawn</first_name>
+			<last_name>Biehn</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Sean</first_name_original>
+			<last_name_original>Bean</last_name_original>
+			<details job="2" gender="1" birthday="1959-04-17" deathday="" country="GB" />
+			<data popularity="20" affinity="0" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="0" topgenre="0" />
+		</person>
+		<person id="DF-Celebreties-Aiden_Gillen" tmdb_id="" imdb_id="nm0318821" creator="8782" created_by="DerFronck">
+			<first_name>Ey'Dan</first_name>
+			<last_name>Gyllen</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Aidan</first_name_original>
+			<last_name_original>Gillen</last_name_original>
+			<details job="2" gender="1" birthday="1968-04-24" deathday="" country="IRL" />
+		</person>
+		<person id="DF-Celebreties-Iain_Glenn" tmdb_id="" imdb_id="nm0322513" creator="8782" created_by="DerFronck">
+			<first_name>Jearn</first_name>
+			<last_name>Klern</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Iain</first_name_original>
+			<last_name_original>Glenn</last_name_original>
+			<details job="2" gender="1" birthday="1968-04-24" deathday="" country="GB" />
+		</person>
+		<person id="DF-Celebreties-Michael_Fassbender" tmdb_id="" imdb_id="nm1055413" creator="8782" created_by="DerFronck">
+			<first_name>Mike</first_name>
+			<last_name>Basspfänder</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Michael</first_name_original>
+			<last_name_original>Fassbender</last_name_original>
+			<details job="2" gender="1" birthday="1970-04-02" deathday="" country="D" />
+		</person>
+		<person id="DF-Celebreties-Idris_Elba" tmdb_id="" imdb_id="nm0252961" creator="8782" created_by="DerFronck">
+			<first_name>Eidris</first_name>
+			<last_name>Elbe</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Idris</first_name_original>
+			<last_name_original>Elba</last_name_original>
+			<details job="2" gender="1" birthday="1972-09-06" deathday="" country="GB" />
+		</person>
+		<person id="DF-Celebreties-Christian_Bale" tmdb_id="" imdb_id="nm0000288" creator="8782" created_by="DerFronck">
+			<first_name>Christian</first_name>
+			<last_name>Baleys</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Christian</first_name_original>
+			<last_name_original>Bale</last_name_original>
+			<details job="2" gender="1" birthday="1974-01-30" deathday="" country="GB" />
+			<data popularity="10" affinity="0" fame="0" scandalizing="10" price_mod="1" power="25" humor="0" charisma="21" appearance="21" topgenre="0" />
+		</person>
+		<person id="DF-Celebreties-Matt_Damon" tmdb_id="" imdb_id="nm0000354" creator="8782" created_by="DerFronck">
+			<first_name>Mett</first_name>
+			<last_name>Dähmlon</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Matt</first_name_original>
+			<last_name_original>Damon</last_name_original>
+			<details job="2" gender="1" birthday="1970-10-08" deathday="" country="USA" />
+		</person>
+		<person id="DF-Celebreties-Wil_Wheaton" tmdb_id="" imdb_id="nm0000696" creator="8782" created_by="DerFronck">
+			<first_name>Will</first_name>
+			<last_name>Bieten</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Wil</first_name_original>
+			<last_name_original>Wheaton</last_name_original>
+			<details job="2" gender="1" birthday="1972-07-29" deathday="" country="USA" />
+		</person>
+		<person id="DF-Celebreties-Corey_Feldman" tmdb_id="" imdb_id="nm0000397" creator="8782" created_by="DerFronck">
+			<first_name>Corey</first_name>
+			<last_name>Fälltmann</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Corey</first_name_original>
+			<last_name_original>Feldman</last_name_original>
+			<details job="2" gender="1" birthday="1971-07-16" deathday="" country="USA" />
+		</person>
+		<person id="DF-Celebreties-Jerry_O'Connell" tmdb_id="" imdb_id="nm0005278" creator="8782" created_by="DerFronck">
+			<first_name>Cherry</first_name>
+			<last_name>Oh' Konnill</last_name>
+			<nick_name></nick_name>
+			<first_name_original>Jerry</first_name_original>
+			<last_name_original>O'Connell</last_name_original>
+			<details job="2" gender="1" birthday="1974-02-17" deathday="" country="USA" />
+		</person>
+		<person id="DF-Celebreties-David_Benioff" tmdb_id="" imdb_id="nm1125275" creator="8782" created_by="DerFronck">
+			<first_name>Dave</first_name>
+			<last_name>Benniov</last_name>
+			<nick_name></nick_name>
+			<first_name_original>David</first_name_original>
+			<last_name_original>Benioff</last_name_original>
+			<details job="1" gender="1" birthday="1970-09-25" deathday="" country="USA" />
+		</person>
+		<person id="DF-Celebreties-D.B._Weiss" tmdb_id="" imdb_id="nm1888967" creator="8782" created_by="DerFronck">
+			<first_name>Dee Bee</first_name>
+			<last_name>Vice</last_name>
+			<nick_name></nick_name>
+			<first_name_original>D.B.</first_name_original>
+			<last_name_original>Weiss</last_name_original>
+			<details job="1" gender="1" birthday="1971-04-23" deathday="" country="USA" />
+		</person>
 
 
 		<!-- THE WALKING DEAD -->
@@ -2896,36 +2896,36 @@
 		<person id="fee7aeab-0e92-4cbf-82e5-6e456583fa51" first_name="Edward" last_name="Zwigg" nick_name="" first_name_original="Edward" last_name_original="Zwick" birthday="" deathday="" imdb_id="nm0001880" />
 
 
-        <!-- Richard Chamberlain -->
-        <person id="TheRob-TowerTV-RicardoKammerlein" first_name="Ricardo" last_name="Kammerlein" nick_name="" first_name_original="Richard" last_name_original="Chamberlain" birthday="1934-03-31" deathday="" imdb_id="nm0000328" />
-        <!-- Toshirô Mifune -->
-        <person id="TheRob-TowerTV-ToshinoSisune" first_name="Toshino" last_name="Sisune" nick_name="" first_name_original="Toshirô" last_name_original="Mifune" birthday="1920-04-01" deathday="1997-12-24" imdb_id="nm0001536" />
-        <!-- Yôko Shimada -->
-        <person id="TheRob-TowerTV-YokoDiewada" first_name="Yoko" last_name="Diewada" nick_name="" first_name_original="Yôko" last_name_original="Shimada" birthday="1953-05-17" deathday="2022-07-25" imdb_id="nm0793577" />
-        <!-- Jerry London -->
-        <person id="TheRob-TowerTV-JerryHeathrow" first_name="Jerry" last_name="Heathrow" nick_name="" first_name_original="Jerry" last_name_original="London" birthday="1937-01-21" deathday="" imdb_id="nm0518719" />
-        <!-- Sergio Sollima -->
-        <person id="TheRob-TowerTV-SergeWolltihnka" first_name="Serge" last_name="Wolltihnka" nick_name="" first_name_original="Sergio" last_name_original="Sollima" birthday="1921-04-17" deathday="2015-07-01" imdb_id="nm0813177" />
-        <!-- Kabir Bedi -->
-        <person id="TheRob-TowerTV-KabiraWedira" first_name="Kabira" last_name="Wedira" nick_name="" first_name_original="Kabir" last_name_original="Bedi" birthday="1946-01-16" deathday="" imdb_id="nm0001934" />
-        <!-- Adolfo Celi -->
-        <person id="TheRob-TowerTV-RolfoBella" first_name="Rolfo" last_name="Bella" nick_name="" first_name_original="Adolfo" last_name_original="Celi" birthday="1922-07-27" deathday="1986-02-19" imdb_id="nm0148041" />
-        <!-- Philippe Leroy -->
-        <person id="TheRob-TowerTV-PhilliGemoy" first_name="Philli" last_name="Gemoy" nick_name="" first_name_original="Philippe" last_name_original="Leroy" birthday="1930-10-15" deathday="" imdb_id="nm0006573" />
-        <!-- Denys de La Patellière -->
-        <person id="TheRob-TowerTV-DennisPatell" first_name="Dennis" last_name="Patell" nick_name="" first_name_original="Denys" last_name_original="de La Patellière" birthday="1921-03-08" deathday="2013-07-21" imdb_id="nm0478800" />
-        <!-- Louis de Funès -->
-        <person id="TheRob-TowerTV-LouDerFume" first_name="Lou" last_name="Derfume" nick_name="" first_name_original="Louis" last_name_original="de Funès" birthday="1914-07-31" deathday="1983-01-27" imdb_id="nm0000086" />
-        <!-- Jean Gabin -->
-        <person id="TheRob-TowerTV-ReanWarin" first_name="Rean" last_name="Warin" nick_name="" first_name_original="Jean" last_name_original="Gabin" birthday="1904-05-07" deathday="1976-11-15" imdb_id="nm0300064" />
-        <!-- Peter Lorre -->
-        <person id="TheRob-TowerTV-PeteWore" first_name="Pete" last_name="Wore" nick_name="" first_name_original="Peter" last_name_original="Lorre" birthday="1904-06-26" deathday="1964-03-23" imdb_id="nm0000048" />
-        <!-- Edmund Goulding -->
-        <person id="TheRob-TowerTV-EdmundGulden" first_name="Edmund" last_name="Gulden" nick_name="" first_name_original="Edmund" last_name_original="Goulding" birthday="1891-03-20" deathday="1959-12-24" imdb_id="nm0332539" />
-        <!-- Henry Hathaway -->
-        <person id="TheRob-TowerTV-HenryHastAway" first_name="Henry Hast" last_name="Away" nick_name="" first_name_original="Henry" last_name_original="Hathaway" birthday="1898-03-13" deathday="1985-02-11" imdb_id="nm0368871" />
-        <!-- Claudette Colbert -->
-        <person id="TheRob-TowerTV-ClaudiaColgerd" first_name="Claudia" last_name="Colgerd" nick_name="" first_name_original="Claudette" last_name_original="Colbert" birthday="1903-09-13" deathday="1996-07-30" imdb_id="nm0001055" />
+		<!-- Richard Chamberlain -->
+		<person id="TheRob-TowerTV-RicardoKammerlein" first_name="Ricardo" last_name="Kammerlein" nick_name="" first_name_original="Richard" last_name_original="Chamberlain" birthday="1934-03-31" deathday="" imdb_id="nm0000328" />
+		<!-- Toshirô Mifune -->
+		<person id="TheRob-TowerTV-ToshinoSisune" first_name="Toshino" last_name="Sisune" nick_name="" first_name_original="Toshirô" last_name_original="Mifune" birthday="1920-04-01" deathday="1997-12-24" imdb_id="nm0001536" />
+		<!-- Yôko Shimada -->
+		<person id="TheRob-TowerTV-YokoDiewada" first_name="Yoko" last_name="Diewada" nick_name="" first_name_original="Yôko" last_name_original="Shimada" birthday="1953-05-17" deathday="2022-07-25" imdb_id="nm0793577" />
+		<!-- Jerry London -->
+		<person id="TheRob-TowerTV-JerryHeathrow" first_name="Jerry" last_name="Heathrow" nick_name="" first_name_original="Jerry" last_name_original="London" birthday="1937-01-21" deathday="" imdb_id="nm0518719" />
+		<!-- Sergio Sollima -->
+		<person id="TheRob-TowerTV-SergeWolltihnka" first_name="Serge" last_name="Wolltihnka" nick_name="" first_name_original="Sergio" last_name_original="Sollima" birthday="1921-04-17" deathday="2015-07-01" imdb_id="nm0813177" />
+		<!-- Kabir Bedi -->
+		<person id="TheRob-TowerTV-KabiraWedira" first_name="Kabira" last_name="Wedira" nick_name="" first_name_original="Kabir" last_name_original="Bedi" birthday="1946-01-16" deathday="" imdb_id="nm0001934" />
+		<!-- Adolfo Celi -->
+		<person id="TheRob-TowerTV-RolfoBella" first_name="Rolfo" last_name="Bella" nick_name="" first_name_original="Adolfo" last_name_original="Celi" birthday="1922-07-27" deathday="1986-02-19" imdb_id="nm0148041" />
+		<!-- Philippe Leroy -->
+		<person id="TheRob-TowerTV-PhilliGemoy" first_name="Philli" last_name="Gemoy" nick_name="" first_name_original="Philippe" last_name_original="Leroy" birthday="1930-10-15" deathday="" imdb_id="nm0006573" />
+		<!-- Denys de La Patellière -->
+		<person id="TheRob-TowerTV-DennisPatell" first_name="Dennis" last_name="Patell" nick_name="" first_name_original="Denys" last_name_original="de La Patellière" birthday="1921-03-08" deathday="2013-07-21" imdb_id="nm0478800" />
+		<!-- Louis de Funès -->
+		<person id="TheRob-TowerTV-LouDerFume" first_name="Lou" last_name="Derfume" nick_name="" first_name_original="Louis" last_name_original="de Funès" birthday="1914-07-31" deathday="1983-01-27" imdb_id="nm0000086" />
+		<!-- Jean Gabin -->
+		<person id="TheRob-TowerTV-ReanWarin" first_name="Rean" last_name="Warin" nick_name="" first_name_original="Jean" last_name_original="Gabin" birthday="1904-05-07" deathday="1976-11-15" imdb_id="nm0300064" />
+		<!-- Peter Lorre -->
+		<person id="TheRob-TowerTV-PeteWore" first_name="Pete" last_name="Wore" nick_name="" first_name_original="Peter" last_name_original="Lorre" birthday="1904-06-26" deathday="1964-03-23" imdb_id="nm0000048" />
+		<!-- Edmund Goulding -->
+		<person id="TheRob-TowerTV-EdmundGulden" first_name="Edmund" last_name="Gulden" nick_name="" first_name_original="Edmund" last_name_original="Goulding" birthday="1891-03-20" deathday="1959-12-24" imdb_id="nm0332539" />
+		<!-- Henry Hathaway -->
+		<person id="TheRob-TowerTV-HenryHastAway" first_name="Henry Hast" last_name="Away" nick_name="" first_name_original="Henry" last_name_original="Hathaway" birthday="1898-03-13" deathday="1985-02-11" imdb_id="nm0368871" />
+		<!-- Claudette Colbert -->
+		<person id="TheRob-TowerTV-ClaudiaColgerd" first_name="Claudia" last_name="Colgerd" nick_name="" first_name_original="Claudette" last_name_original="Colbert" birthday="1903-09-13" deathday="1996-07-30" imdb_id="nm0001055" />
 
 		<!-- Louis Gossett Jr. -->
 		<person id="TheRob-TowerTV-RuisLosset" first_name="Ruis" last_name="Losset Jr" nick_name="" first_name_original="Louis" last_name_original="Gossett Jr" birthday="1936-05-27" deathday="" imdb_id="nm0001283" creator="8751" created_by="TheRob" />
@@ -3194,24 +3194,24 @@
 		<person id="TheRob-TowerTV-RonnyMcdawoll" first_name="Ronny" last_name="Mc Dawoll" nick_name="" first_name_original="Roddy" last_name_original="McDowall" birthday="1866-01-19" deathday="1949-08-09" imdb_id="nm0003193" creator="8751" created_by="TheRob" />
 		<!-- Yul Brynner -->
 		<person id="TheRob-TowerTV-JulesSinner" first_name="Jules" last_name="Sinner" nick_name="" first_name_original="Yul" last_name_original="Brynner" birthday="1920-07-11" deathday="1985-10-10" imdb_id="nm0000989" creator="8751" created_by="TheRob" />
-        <!-- William C. McGann -->
-        <person id="TheRob-TowerTV-GilianCMcWann" first_name="Gillian C." last_name="Mc Wann" nick_name="" first_name_original="William C." last_name_original="McGann" birthday="1893-04-15" deathday="1977-11-15" imdb_id="nm0568915" creator="8751" created_by="TheRob" />
-        <!-- Buster Keaton -->
-        <person id="TheRob-TowerTV-BlasterWeaton" first_name="Blaster" last_name="Weaton" nick_name="" first_name_original="Buster" last_name_original="Keaton" birthday="1895-10-04" deathday="1966-02-01" imdb_id="nm0000036" creator="8751" created_by="TheRob" />
-        <!-- Dick Van Dyke -->
-        <person id="TheRob-TowerTV-RickvonDeich" first_name="Rick" last_name="von Deich" nick_name="" first_name_original="Dick" last_name_original="Van Dyke" birthday="1925-12-13" deathday="" imdb_id="nm0001813" creator="8751" created_by="TheRob" />
-        <!-- Lando Buzzanca -->
-        <person id="TheRob-TowerTV-RandoBuccaner" first_name="Rando" last_name="Buccaner" nick_name="" first_name_original="Lando" last_name_original="Buzzanca" birthday="1935-08-24" deathday="2022-12-18" imdb_id="nm0125627" creator="8751" created_by="TheRob" />
-        <!-- Cecil B. DeMille -->
-        <person id="TheRob-TowerTV-CecilCderMiller" first_name="Cecil C." last_name="der Miller" nick_name="" first_name_original="Cecil B." last_name_original="DeMille" birthday="1881-08-12" deathday="1959-01-21" imdb_id="nm0001124" creator="8751" created_by="TheRob" />
-        <!-- Andrew L. Stone -->
-        <person id="TheRob-TowerTV-AndiLRock" first_name="Andi L." last_name="Rock" nick_name="" first_name_original="Andrew" last_name_original="L. Stone" birthday="1902-07-16" deathday="1999-06-09" imdb_id="nm0831720" creator="8751" created_by="TheRob" />
-        <!-- Florence Henderson -->
-        <person id="TheRob-TowerTV-FlorineGenderson" first_name="Florine" last_name="Genderson" nick_name="" first_name_original="Florence" last_name_original="Henderson" birthday="1934-02-14" deathday="2016-11-24" imdb_id="nm0001341" creator="8751" created_by="TheRob" />
-        <!-- Micheál MacLiammóir -->
-        <person id="TheRob-TowerTV-MikeMcPiamoir" first_name="Mike" last_name="Mc Piamoir" nick_name="" first_name_original="Micheál" last_name_original="MacLiammóir" birthday="1899-10-25" deathday="1978-03-06" imdb_id="nm0533943" creator="8751" created_by="TheRob" />
-        <!-- Richard Basehart -->
-        <person id="TheRob-TowerTV-RichieBaseyard" first_name="Richie" last_name="Baseyard" nick_name="" first_name_original="Richard" last_name_original="Basehart" birthday="1914-08-31" deathday="1984-09-17" imdb_id="nm0000865" creator="8751" created_by="TheRob" />
+		<!-- William C. McGann -->
+		<person id="TheRob-TowerTV-GilianCMcWann" first_name="Gillian C." last_name="Mc Wann" nick_name="" first_name_original="William C." last_name_original="McGann" birthday="1893-04-15" deathday="1977-11-15" imdb_id="nm0568915" creator="8751" created_by="TheRob" />
+		<!-- Buster Keaton -->
+		<person id="TheRob-TowerTV-BlasterWeaton" first_name="Blaster" last_name="Weaton" nick_name="" first_name_original="Buster" last_name_original="Keaton" birthday="1895-10-04" deathday="1966-02-01" imdb_id="nm0000036" creator="8751" created_by="TheRob" />
+		<!-- Dick Van Dyke -->
+		<person id="TheRob-TowerTV-RickvonDeich" first_name="Rick" last_name="von Deich" nick_name="" first_name_original="Dick" last_name_original="Van Dyke" birthday="1925-12-13" deathday="" imdb_id="nm0001813" creator="8751" created_by="TheRob" />
+		<!-- Lando Buzzanca -->
+		<person id="TheRob-TowerTV-RandoBuccaner" first_name="Rando" last_name="Buccaner" nick_name="" first_name_original="Lando" last_name_original="Buzzanca" birthday="1935-08-24" deathday="2022-12-18" imdb_id="nm0125627" creator="8751" created_by="TheRob" />
+		<!-- Cecil B. DeMille -->
+		<person id="TheRob-TowerTV-CecilCderMiller" first_name="Cecil C." last_name="der Miller" nick_name="" first_name_original="Cecil B." last_name_original="DeMille" birthday="1881-08-12" deathday="1959-01-21" imdb_id="nm0001124" creator="8751" created_by="TheRob" />
+		<!-- Andrew L. Stone -->
+		<person id="TheRob-TowerTV-AndiLRock" first_name="Andi L." last_name="Rock" nick_name="" first_name_original="Andrew" last_name_original="L. Stone" birthday="1902-07-16" deathday="1999-06-09" imdb_id="nm0831720" creator="8751" created_by="TheRob" />
+		<!-- Florence Henderson -->
+		<person id="TheRob-TowerTV-FlorineGenderson" first_name="Florine" last_name="Genderson" nick_name="" first_name_original="Florence" last_name_original="Henderson" birthday="1934-02-14" deathday="2016-11-24" imdb_id="nm0001341" creator="8751" created_by="TheRob" />
+		<!-- Micheál MacLiammóir -->
+		<person id="TheRob-TowerTV-MikeMcPiamoir" first_name="Mike" last_name="Mc Piamoir" nick_name="" first_name_original="Micheál" last_name_original="MacLiammóir" birthday="1899-10-25" deathday="1978-03-06" imdb_id="nm0533943" creator="8751" created_by="TheRob" />
+		<!-- Richard Basehart -->
+		<person id="TheRob-TowerTV-RichieBaseyard" first_name="Richie" last_name="Baseyard" nick_name="" first_name_original="Richard" last_name_original="Basehart" birthday="1914-08-31" deathday="1984-09-17" imdb_id="nm0000865" creator="8751" created_by="TheRob" />
 
 		<!-- von RumpelFreddy -->
 		<!-- Wilfried Elste -->
@@ -3250,6 +3250,8 @@
 		<person id="d0a5479d-736b-430c-a8bc-9dc180184bf3" first_name="R.J.J." last_name="Trollkind" nick_name="" first_name_original="J.R.R." last_name_original="Tolkien" birthday="1892-01-03" deathday="1973-09-02" imdb_id="nm0866058" creator="9551" />
 		<person id="18b28f36-060e-4bcf-a2d9-dc528527b7d8" first_name="Steward" last_name="Sherman" nick_name="" first_name_original="Bernard" last_name_original="Herrmann" birthday="1911-06-29" deathday="1975-12-24" imdb_id="nm0002136" creator="9551" />
 		<person id="db61d8fe-1493-48dd-ab9c-249e4a4b7c35" first_name="Jan" last_name="Fleme" nick_name="" first_name_original="Ian" last_name_original="Fleming" birthday="1908-05-28" deathday="1964-08-12" imdb_id="nm0001220" creator="9551" />
+
+		<person id="a95674d2-d5e1-4911-9300-0e5cea6102d5" first_name="James Bradley" last_name="Long" nick_name="" first_name_original="John Bedford" last_name_original="Lloyd" gender="1" birthday="1956-01-02" deathday="" imdb_id="nm0066023" creator="9551" />
 	</insignificantpeople>
 
 	<exportOptions onlyFakes="true" onlyCustom="false" dataStructure="FakeData" />

--- a/res/database/Default/database_people.xml
+++ b/res/database/Default/database_people.xml
@@ -3250,7 +3250,7 @@
 		<!-- Steven Hilliard Stern -->
 		<person id="Freddy-realperson-stevstar" first_name="Stev" last_name="Star" nick_name="Canadian Star" first_name_original="Steven Hilliard" last_name_original="Stern" fictional="0" birthday="1937-11-01" deathday="2018-06-27" imdb_id="nm0827854" creator="8667" created_by="Rumpelfreddy" />
 
-		<!-- from speedminister.xml - Mostly unused yet, TODO: add related programme, e.g. tt0978537: Ijon Tichy: Raumpilot -->
+		<!-- from speedminister.xml - TODO: add related programme - https://www.gamezworld.de/phpforum/viewtopic.php?pid=79070#p79070 -->
 
 		<person id="SpeedMinister-person-id032" first_name="Hans" last_name="Prielmann" first_name_original="Heinz" last_name_original="Sielmann" creator="8605" birthday="1917-06-02" deathday="2006-10-06" imdb_id="nm0797140" created_by="speedminister" />
 		<person id="SpeedMinister-person-id037" first_name="Den" last_name="Jakobson" first_name_original="Dennis" last_name_original="Jacobsen" gender="1" birthday="" deathday="" imdb_id="nm0414706" creator="8605" created_by="speedminister" />

--- a/res/database/Default/database_people.xml
+++ b/res/database/Default/database_people.xml
@@ -2266,6 +2266,25 @@
 			<details job="2" gender="1" birthday="1962-07-04" deathday="" country="GB" />
 			<data popularity="10" affinity="10" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="0" topgenre="0" />
 		</person>
+
+		<!-- moved from speedminister.xml -->
+
+		<person id="SpeedMinister-celebritypeople-OttokarKahn" tmdb_id="0" imdb_id="nm2579540" creator="8605" created_by="SpeedMinister">
+			<first_name>Ottokar</first_name>
+			<last_name>Kahn</last_name>
+			<first_name_original>Oliver</first_name_original>
+			<last_name_original>Jahn</last_name_original>
+			<details job="3" gender="1" birthday="1969" deathday="" country="D" />
+			<data popularity="7" affinity="20" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="0" topgenre="0" />
+		</person>
+		<person id="SpeedMinister-celebritypeople-CoraSchirmer" tmdb_id="0" imdb_id="nm1160560" creator="8605" created_by="SpeedMinister">
+			<first_name>Cora</first_name>
+			<last_name>Schirmer</last_name>
+			<first_name_original>Nora</first_name_original>
+			<last_name_original>Tschirner</last_name_original>
+			<details job="2" gender="2" birthday="1981-06-12" deathday="" country="D" />
+			<data popularity="25" affinity="35" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="0" topgenre="0" />
+		</person>
 	</celebritypeople>
 
 	<insignificantpeople>
@@ -3231,9 +3250,26 @@
 		<!-- Steven Hilliard Stern -->
 		<person id="Freddy-realperson-stevstar" first_name="Stev" last_name="Star" nick_name="Canadian Star" first_name_original="Steven Hilliard" last_name_original="Stern" fictional="0" birthday="1937-11-01" deathday="2018-06-27" imdb_id="nm0827854" creator="8667" created_by="Rumpelfreddy" />
 
-		<!-- from speedminister.xml - TODO -->
-		
+		<!-- from speedminister.xml - Mostly unused yet, TODO: add related programme, e.g. tt0978537: Ijon Tichy: Raumpilot -->
+
 		<person id="SpeedMinister-person-id032" first_name="Hans" last_name="Prielmann" first_name_original="Heinz" last_name_original="Sielmann" creator="8605" birthday="1917-06-02" deathday="2006-10-06" imdb_id="nm0797140" created_by="speedminister" />
+		<person id="SpeedMinister-person-id037" first_name="Den" last_name="Jakobson" first_name_original="Dennis" last_name_original="Jacobsen" gender="1" birthday="" deathday="" imdb_id="nm0414706" creator="8605" created_by="speedminister" />
+		<person id="SpeedMinister-person-id038" first_name="Lianda" last_name="Mahoud" first_name_original="Randa" last_name_original="Chahoud" gender="2" birthday="" deathday="" imdb_id="nm1216097" creator="8605" created_by="speedminister" />
+		<!-- USA -->
+		<person id="SpeedMinister-person-id033" first_name="Steven" last_name="Kessel" first_name_original="Steve" last_name_original="Ressel" gender="1" birthday="" deathday="" imdb_id="nm0720383" creator="8605" created_by="speedminister" />
+		<person id="SpeedMinister-person-id034" first_name="Johan" last_name="Richcorner" first_name_original="Jordan" last_name_original="Reichek" gender="1" birthday="1967-10-12" deathday="" imdb_id="nm1264053" creator="8605" created_by="speedminister" />
+		<person id="SpeedMinister-person-id035" first_name="Robby" last_name="Bumblebee" first_name_original="Rob" last_name_original="Hummel" gender="1" birthday="" deathday="" imdb_id="nm0401850" creator="8605" created_by="speedminister" />
+		<person id="SpeedMinister-person-id036" first_name="J. Honey" last_name="Busquez" first_name_original="Jhonen" last_name_original="Vasquez" gender="1" birthday="1974-09-01" deathday="" imdb_id="nm0890679" creator="8605" created_by="speedminister" />
+		<!-- Frankreich -->
+		<person id="SpeedMinister-person-id028" first_name="Manuel" last_name="Goldstein" first_name_original="Emmanuel" last_name_original="Gorinstein" gender="1" birthday="" deathday="" imdb_id="nm1900601" creator="8605" created_by="speedminister" />
+		<person id="SpeedMinister-person-id029" first_name="Alex" last_name="de la Palletière" first_name_original="Alexandre" last_name_original="de La Patellière" gender="1" birthday="" deathday="" imdb_id="nm0478799" creator="8605" created_by="speedminister" />
+		<person id="SpeedMinister-person-id030" first_name="Matthias" last_name="Pförtner" first_name_original="Mathieu" last_name_original="Delaporte" gender="1" birthday="1971-09-02" deathday="" imdb_id="nm1141181" creator="8605" created_by="speedminister" />
+		<!-- Belgien -->
+		<person id="SpeedMinister-person-id031" first_name="Rondo" last_name="van Lenk" first_name_original="Romain" last_name_original="van Liemt" gender="1" birthday="" deathday="" imdb_id="nm2956687" creator="8605" created_by="speedminister" />
+		<!-- England -->
+		<person id="SpeedMinister-person-id039" first_name="Ilan J.W." last_name="Bubble Cap" first_name_original="Alan J.W." last_name_original="Bell" gender="1" birthday="1937-11-14" deathday="" imdb_id="nm0068007" creator="8605" created_by="speedminister" />
+		<person id="SpeedMinister-person-id040" first_name="Douggy" last_name="Eves" first_name_original="Douglas" last_name_original="Adams" gender="1" birthday="1952-03-11" deathday="2001-05-11" imdb_id="nm0010930" creator="8605" created_by="speedminister" />
+		<person id="SpeedMinister-person-id041" first_name="Joe" last_name="Nedlloyd" first_name_original="John" last_name_original="Lloyd" gender="1" birthday="1951-09-30" deathday="" imdb_id="nm0516032" creator="8605" created_by="speedminister" />
 
 		<!-- from scr0llbaer - TODO - but here are already the people turned into references in the descriptions of already existing programmes -->
 

--- a/res/database/Default/database_programmes.xml
+++ b/res/database/Default/database_programmes.xml
@@ -9685,7 +9685,7 @@ Dream scenes and sentiments warp the storyline.</en>
 				</programme>
 					<programme id="TheRob-serie-Sanddornkahn-Episode002" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1306737" creator="8751" created_by="TheRob">
 					<title>
-						<de>Der Geheimnisvolle Prinz</de>
+						<de>Der geheimnisvolle Prinz</de>
 						<en>The Foreign Prince</en>
 					</title>
 					<title_original>
@@ -11016,7 +11016,7 @@ Dream scenes and sentiments warp the storyline.</en>
 			<ratings critics="83" speed="69" outcome="84" />
 		</programme>
 
-		<programme id="TheRob-serie-adv-RobinWusoe" product="2" licence_type="3" tmdb_id="0" imdb_id="tt0167516" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-adv-RobinWusoe" product="2" fictional="0" licence_type="3" tmdb_id="0" imdb_id="tt0167516" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Robinson Crusoe, Abenteuer -->
 				<de>Robin Wusoe</de>
@@ -11039,7 +11039,7 @@ Dream scenes and sentiments warp the storyline.</en>
 			<data country="D/F" year="1964" distribution="2" maingenre="1" subgenre="" flags="8" blocks="2" price_mod="1.00" />
 			<ratings critics="67" speed="44" outcome="" />
 			<children>
-				<programme id="TheRob-serie-RobinWusoe-Ep001" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-RobinWusoe-Ep001" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Wie es begann</de>
 						<en>How it began</en>
@@ -11053,7 +11053,7 @@ Dream scenes and sentiments warp the storyline.</en>
 						<en>The protagonist tells about the start of his journey and about his wishes and dreams.</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-RobinWusoe-Ep002" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-RobinWusoe-Ep002" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Freitag?</de>
 						<en>Friday?</en>
@@ -11067,7 +11067,7 @@ Dream scenes and sentiments warp the storyline.</en>
 						<en>Stranded on an island, R. meets a stranger.</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-RobinWusoe-Ep003" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-RobinWusoe-Ep003" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Kannibalen!</de>
 						<en>Cannibals!</en>
@@ -11081,7 +11081,7 @@ Dream scenes and sentiments warp the storyline.</en>
 						<en>R. and F. slowly understand that they share the island with some very unfriendly people.</en>
 					</description>
 				</programme>
-				<programme id="TheRob-serie-RobinWusoe-Ep004" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
+				<programme id="TheRob-serie-RobinWusoe-Ep004" product="2" fictional="1" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
 						<de>Endlich Heimat</de>
 						<en>Home! Sweet Home</en>
@@ -11337,7 +11337,7 @@ Dream scenes and sentiments warp the storyline.</en>
 		<!-- from speedminister.xml -->
 
 		<!-- ***** Serie: Expeditionen ins Tierreich, Dokumentation (Originaltitel der Episoden nicht mehr verfügbar) (real) ***** -->
-		<programme id="SpeedMinister-Serie-Expeditionen-01" product="4" licence_type="3" imdb_id="tt0305025" creator="8605" created_by="SpeedMinister" comment="The series started in 1965. As this programme was tagged with 1985, contributors are supposedly welcome to add more 'seasons'.">
+		<programme id="SpeedMinister-Serie-Expeditionen-01" product="4" licence_type="3" fictional="0" imdb_id="tt0305025" creator="8605" created_by="SpeedMinister" comment="The series started in 1965. As this programme was tagged with 1985, contributors are supposedly welcome to add more 'seasons'.">
 			<title>
 				<de>Ausflüge ins Tierreich (1985)</de>
 				<en>Excursions into the Animal Kingdom (1985)</en>
@@ -11361,7 +11361,7 @@ Dream scenes and sentiments warp the storyline.</en>
 			<ratings critics="75" speed="45" />
 			<!-- Episodes -->
 			<children>
-				<programme id="SpeedMinister-Serie-Expeditionen-01-ep-01" product="4" licence_type="2" creator="8605" created_by="SpeedMinister">
+				<programme id="SpeedMinister-Serie-Expeditionen-01-ep-01" product="4" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
 					<title>
 						<de>Deutschlands Wälder</de>
 						<en>The forests of Germany</en>
@@ -11376,7 +11376,7 @@ Dream scenes and sentiments warp the storyline.</en>
 					</description>
 					<ratings critics="65" speed="40" />
 				</programme>
-				<programme id="SpeedMinister-Serie-Expeditionen-01-ep-02" product="4" licence_type="2" creator="8605" created_by="SpeedMinister">
+				<programme id="SpeedMinister-Serie-Expeditionen-01-ep-02" product="4" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
 					<title>
 						<de>Die Alpen</de>
 						<en>The Alps</en>
@@ -11391,7 +11391,7 @@ Dream scenes and sentiments warp the storyline.</en>
 					</description>
 					<ratings critics="60" speed="35" />
 				</programme>
-				<programme id="SpeedMinister-Serie-Expeditionen-01-ep-03" product="4" licence_type="2" creator="8605" created_by="SpeedMinister">
+				<programme id="SpeedMinister-Serie-Expeditionen-01-ep-03" product="4" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
 					<title>
 						<de>Die Alligatoren der Everglades</de>
 						<en>Alligators of the Everglades</en>
@@ -11406,7 +11406,7 @@ Dream scenes and sentiments warp the storyline.</en>
 					</description>
 					<ratings critics="80" speed="50" />
 				</programme>
-				<programme id="SpeedMinister-Serie-Expeditionen-01-ep-04" product="4" licence_type="2" creator="8605" created_by="SpeedMinister">
+				<programme id="SpeedMinister-Serie-Expeditionen-01-ep-04" product="4" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
 					<title>
 						<de>Die Füchse Londons</de>
 						<en>Foxes of London</en>
@@ -11421,7 +11421,7 @@ Dream scenes and sentiments warp the storyline.</en>
 					</description>
 					<ratings critics="76" speed="45" />
 				</programme>
-				<programme id="SpeedMinister-Serie-Expeditionen-01-ep-05" product="4" licence_type="2" creator="8605" created_by="SpeedMinister">
+				<programme id="SpeedMinister-Serie-Expeditionen-01-ep-05" product="4" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
 					<title>
 						<de>Madagaskar</de>
 						<en>Madagascar</en>
@@ -11436,7 +11436,7 @@ Dream scenes and sentiments warp the storyline.</en>
 					</description>
 					<ratings critics="75" speed="48" />
 				</programme>
-				<programme id="SpeedMinister-Serie-Expeditionen-01-ep-06" product="4" licence_type="2" creator="8605" created_by="SpeedMinister">
+				<programme id="SpeedMinister-Serie-Expeditionen-01-ep-06" product="4" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
 					<title>
 						<de>Die Schmetterlinge Südamerikas</de>
 						<en>The butterflies of South America</en>
@@ -11451,7 +11451,7 @@ Dream scenes and sentiments warp the storyline.</en>
 					</description>
 					<ratings critics="77" speed="39" />
 				</programme>
-				<programme id="SpeedMinister-Serie-Expeditionen-01-ep-07" product="4" licence_type="2" creator="8605" created_by="SpeedMinister">
+				<programme id="SpeedMinister-Serie-Expeditionen-01-ep-07" product="4" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
 					<title>
 						<de>Das Great Barrier Riff</de>
 						<en>The Great Barrier Reef</en>
@@ -11466,7 +11466,7 @@ Dream scenes and sentiments warp the storyline.</en>
 					</description>
 					<ratings critics="76" speed="42" />
 				</programme>
-				<programme id="SpeedMinister-Serie-Expeditionen-01-ep-0de8" product="4" licence_type="2" creator="8605" created_by="SpeedMinister">
+				<programme id="SpeedMinister-Serie-Expeditionen-01-ep-0de8" product="4" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
 					<title>
 						<de>Die Bären Alaskas</de>
 						<en>The bears of Alaska</en>
@@ -11481,7 +11481,7 @@ Dream scenes and sentiments warp the storyline.</en>
 					</description>
 					<ratings critics="75" speed="40" />
 				</programme>
-				<programme id="SpeedMinister-Serie-Expeditionen-01-ep-09" product="4" licence_type="2" creator="8605" created_by="SpeedMinister">
+				<programme id="SpeedMinister-Serie-Expeditionen-01-ep-09" product="4" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
 					<title>
 						<de>Haie</de>
 						<en>Sharks</en>
@@ -11496,7 +11496,7 @@ Dream scenes and sentiments warp the storyline.</en>
 					</description>
 					<ratings critics="80" speed="52" />
 				</programme>
-				<programme id="SpeedMinister-Serie-Expeditionen-01-ep-10" product="4" licence_type="2" creator="8605" created_by="SpeedMinister">
+				<programme id="SpeedMinister-Serie-Expeditionen-01-ep-10" product="4" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
 					<title>
 						<de>Wale</de>
 						<en>Whales</en>

--- a/res/database/Default/database_programmes.xml
+++ b/res/database/Default/database_programmes.xml
@@ -1463,7 +1463,7 @@ Bloody spectacle for genre fans and dimwits.</en>
 				<member index="3" function="2">ca543b12-8e37-4f9c-8800-af4f9e44b488</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="1998" distribution="1" maingenre="2" subgenre="" flags="64" blocks="3" price_mod="1" />
+			<data country="USA" year="1998" distribution="1" maingenre="2" subgenre="12,16" flags="64" blocks="3" price_mod="1" />
 			<ratings critics="4" speed="51" outcome="51" />
 		</programme>
 		<programme id="a48d3913-b963-465c-b41d-cfa55046f6da" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0187738" creator="">
@@ -1488,7 +1488,7 @@ Successful continuation of the scare.</en>
 				<member index="3" function="2">1c82f854-c349-4dc4-aa15-7cda8594d803</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="2002" distribution="1" maingenre="2" subgenre="" flags="64" blocks="2" price_mod="1" />
+			<data country="USA" year="2002" distribution="1" maingenre="2" subgenre="12,16" flags="64" blocks="2" price_mod="1" />
 			<ratings critics="0" speed="65" outcome="56" />
 		</programme>
 		<programme id="88593448-151d-4928-88af-19507cbbbbb1" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0049293" creator="">
@@ -8266,7 +8266,7 @@ Weary of the twins' constant pranks, his helping-out sister also strongly recomm
 					</description>
 					<ratings critics="73" speed="53" />
 				</programme>
-				<programme id="TheRob-serie-WunderderMeere-Ep002" product="4" fictional="1" licence_type="2" tmdb_id="0" imdb_id="tt0854057" creator="7430" created_by="TheRob">
+				<programme id="TheRob-serie-WunderderMeere-Ep002" product="4" licence_type="2" tmdb_id="0" imdb_id="tt0854057" creator="7430" created_by="TheRob">
 					<title>
 						<de>Die Wale</de>
 						<en>The whales</en>
@@ -9645,7 +9645,7 @@ Dream scenes and sentiments warp the storyline.</en>
 			</children>
 		</programme>
 
-		<programme id="TheRob-serie-Sanddornkahn" product="2" fictional="1" licence_type="3" tmdb_id="0" imdb_id="tt0074050" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-Sanddornkahn" product="2" fictional="0" licence_type="3" tmdb_id="0" imdb_id="tt0074050" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Sandokan, Action -->
 				<de>Sanddornkahn</de>
@@ -9666,60 +9666,59 @@ Dream scenes and sentiments warp the storyline.</en>
 				<member index="3" function="2">TheRob-TowerTV-PhilliGemoy</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="I" year="1976" distribution="2" maingenre="2" subgenre="" flags="0" blocks="1" price_mod="1.00" />
+			<data country="I" year="1976" distribution="2" maingenre="2" subgenre="1,7" flags="0" blocks="1" price_mod="1.00" />
 			<ratings critics="42" speed="46" outcome="" />
 			<children>
-				<!-- No official original German episode titles found, applying translation from original English -->
 				<programme id="TheRob-serie-Sanddornkahn-Episode001" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1306736" creator="8751" created_by="TheRob">
 					<title>
-						<de>Episode 1.1</de>
-						<en>Episode 1.1</en>
+						<de>Die Entführung</de>
+						<en>The Conquest</en>
 					</title>
 					<title_original>
-						<de>Die Entführung</de>
+						<de>Die Eroberer</de>
 						<en>The Kidnapping</en>
 					</title_original>
 					<description>
-						<de>S. erkennt die Ungerechtigkeiten der Briten und entscheidet sich für den Kampf.</de>
-						<en>S. recognizes the injustices of the British and decides to fight.</en>
+						<de>S. erkennt die Ungerechtigkeiten der Briten und entscheidet sich für den Kampf. Eine chinesische Dschunke unter Kontrolle der Engländer wird versenkt.</de>
+						<en>S. recognizes the injustices of the British and decides to fight. A Chinese junk under British control is sunk.</en>
 					</description>
 				</programme>
 					<programme id="TheRob-serie-Sanddornkahn-Episode002" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1306737" creator="8751" created_by="TheRob">
 					<title>
-						<de>Episode 1.2</de>
-						<en>Episode 1.2</en>
-					</title>
-					<title_original>
 						<de>Der Geheimnisvolle Prinz</de>
-						<en>The Mysterious Prince</en>
-					</title_original>
-					<description>
-						<de>S. jagt das erste britische Schiff und versenkt es.</de>
-						<en>S. chases the first British ship and destroys it.</en>
-					</description>
-				</programme>
-				<programme id="TheRob-serie-Sanddornkahn-Episode003" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1306738" creator="8751" created_by="TheRob">
-					<title>
-						<de>Episode 1.3</de>
-						<en>Episode 1.3</en>
+						<en>The Foreign Prince</en>
 					</title>
 					<title_original>
-						<de>Die Tigerjagd</de>
-						<en>The Tiger Hunt</en>
+						<de>Der fremde Prinz</de>
+						<en>The Mysterious Prince</en>
 					</title_original>
 					<description>
 						<de>Ausgerechnet in eine britische Lady verliebt sich S. und bringt sich dadurch in Gefahr.</de>
 						<en>S. falls in love with a British lady, of all people, and thus puts himself in danger.</en>
 					</description>
+				</programme>
+				<programme id="TheRob-serie-Sanddornkahn-Episode003" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1306738" creator="8751" created_by="TheRob">
+					<title>
+						<de>Verfolgung des Tigers</de>
+						<en>Chasing the Tiger</en>
+					</title>
+					<title_original>
+						<de>Tigerjagd</de>
+						<en>The Tiger Hunt</en>
+					</title_original>
+					<description>
+						<de>Auf einer angesetzten Tigerjagd tötet ein junger Jäger einen Tiger, aber es ist noch ein zweites Tier in der Nähe. S. stellt sich der Bestie nur mit dem Messer bewaffnet entgegen.</de>
+						<en>On a scheduled tiger hunt, a young hunter kills a tiger, but there is a second one nearby. S. confronts the beast armed only with a knife.</en>
+					</description>
 					<ratings critics="54" speed="30" />
 				</programme>
 				<programme id="TheRob-serie-Sanddornkahn-Episode004" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1306739" creator="8751" created_by="TheRob">
 					<title>
-						<de>Episode 1.4</de>
-						<en>Episode 1.4</en>
+						<de>Das Angebot</de>
+						<en>The Sacrifice</en>
 					</title>
 					<title_original>
-						<de>Das Angebot</de>
+						<de>Das Opfer</de>
 						<en>The Offer</en>
 					</title_original>
 					<description>
@@ -9729,11 +9728,11 @@ Dream scenes and sentiments warp the storyline.</en>
 				</programme>
 				<programme id="TheRob-serie-Sanddornkahn-Episode005" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1306740" creator="8751" created_by="TheRob">
 					<title>
-						<de>Episode 1.5</de>
-						<en>Episode 1.5</en>
+						<de>Der Treuebruch</de>
+						<en>Defection</en>
 					</title>
 					<title_original>
-						<de>Verrat</de>
+						<de>Der Verrat</de>
 						<en>Betrayal</en>
 					</title_original>
 					<description>
@@ -9744,8 +9743,8 @@ Dream scenes and sentiments warp the storyline.</en>
 				</programme>
 				<programme id="TheRob-serie-Sanddornkahn-Episode006" product="2" licence_type="2" tmdb_id="0" imdb_id="tt1306741" creator="8751" created_by="TheRob">
 					<title>
-						<de>Episode 1.6</de>
-						<en>Episode 1.6</en>
+						<de>Der Kampf</de>
+						<en>The Combat</en>
 					</title>
 					<title_original>
 						<de>Die Schlacht</de>

--- a/res/database/Default/user/kasi.xml
+++ b/res/database/Default/user/kasi.xml
@@ -1243,7 +1243,7 @@
 			<studio_size min="1" max="2" slope="60" />
 		</scripttemplate>
 
-		<!--Episoden gekürzt, kein optionaler Kult-->
+		<!--Episoden gekürzt (TODO: Klären Warum?), kein optionaler Kult-->
 		<scripttemplate licence_type="3" product="2" guid="Kasi-script-Metalsucher">
 			<title>
 				<de>%name1%%name2% in Alaska</de>

--- a/res/database/Default/user/kasi.xml
+++ b/res/database/Default/user/kasi.xml
@@ -1243,7 +1243,7 @@
 			<studio_size min="1" max="2" slope="60" />
 		</scripttemplate>
 
-		<!--Episoden gekürzt (TODO: Klären Warum?), kein optionaler Kult-->
+		<!--Episoden gekürzt (TODO: evtl wieder aktivieren), kein optionaler Kult-->
 		<scripttemplate licence_type="3" product="2" guid="Kasi-script-Metalsucher">
 			<title>
 				<de>%name1%%name2% in Alaska</de>
@@ -1379,8 +1379,8 @@
 			</children>
 			<variables>
 				<name1>
-					<de>Gold|Silber|Platin|Uran|Plutinium</de>
-					<en>Gold|Silver|Platinum|Uranium|Plutinium</en>
+					<de>Gold|Silber|Platin|Uran|Plutonium</de>
+					<en>Gold|Silver|Platinum|Uranium|Plutonium</en>
 				</name1>
 				<name2>
 					<de>funde|sichtungen|stätten|sucher|verstecke</de>

--- a/res/database/Default/user/speedminister.xml
+++ b/res/database/Default/user/speedminister.xml
@@ -21,10 +21,10 @@
         <person id="SpeedMinister-person-id019" first_name="Prof. Dr. Raimund" last_name="Holzner" creator="8605" created_by="speedminister" fictional="1" gender="1" country="D" />
         <person id="SpeedMinister-person-id027" first_name="Dirk" last_name="Kipling" creator="8605" created_by="speedminister" fictional="1" gender="1" country="D" />
 
-        <!-- TODO: Most non-fictional people in this file seem to be unused? -->
-        
-        <person id="SpeedMinister-person-id037" first_name="Den" last_name="Jakobson" first_name_original="Dennis" last_name_original="Jacobsen" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id038" first_name="Lianda" last_name="Mahoud" first_name_original="Randa" last_name_original="Chahoud" creator="8605" created_by="speedminister" />
+        <!-- TODO: Most non-fictional people in this file seem to be unused? Update: IMDB data added, TODO: move entries, TODO: add related programme, e.g. tt0978537: Ijon Tichy: Raumpilot -->
+
+        <person id="SpeedMinister-person-id037" first_name="Den" last_name="Jakobson" first_name_original="Dennis" last_name_original="Jacobsen" gender="1" birthday="" deathday="" imdb_id="nm0414706" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id038" first_name="Lianda" last_name="Mahoud" first_name_original="Randa" last_name_original="Chahoud" gender="2" birthday="" deathday="" imdb_id="nm1216097" creator="8605" created_by="speedminister" />
         <!-- Österreich -->
         <person id="SpeedMinister-person-id007" first_name="Frauke" last_name="Hasenhüttl" creator="8605" created_by="speedminister" fictional="1" gender="2" country="A" />
         <person id="SpeedMinister-person-id009" first_name="Karl" last_name="Schneck" creator="8605" created_by="speedminister" fictional="1" gender="1" country="A" />
@@ -40,43 +40,43 @@
         <!-- USA -->
         <person id="SpeedMinister-person-id025" first_name="C. J." last_name="Harper" creator="8605" created_by="speedminister" fictional="1" gender="" country="USA" />
         <person id="SpeedMinister-person-id026" first_name="Franny" last_name="Tucker" creator="8605" created_by="speedminister" fictional="1" gender="2" country="USA" />
-        <person id="SpeedMinister-person-id033" first_name="Steven" last_name="Kessel" first_name_original="Steve" last_name_original="Ressel" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id034" first_name="Johan" last_name="Richcorner" first_name_original="Jordan" last_name_original="Reichek" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id035" first_name="Robby" last_name="Bumblebee" first_name_original="Rob" last_name_original="Hummel" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id036" first_name="J. Honey" last_name="Busquez" first_name_original="Jhonen" last_name_original="Vasquez" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id033" first_name="Steven" last_name="Kessel" first_name_original="Steve" last_name_original="Ressel" gender="1" birthday="" deathday="" imdb_id="nm0720383" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id034" first_name="Johan" last_name="Richcorner" first_name_original="Jordan" last_name_original="Reichek" gender="1" birthday="1967-10-12" deathday="" imdb_id="nm1264053" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id035" first_name="Robby" last_name="Bumblebee" first_name_original="Rob" last_name_original="Hummel" gender="1" birthday="" deathday="" imdb_id="nm0401850" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id036" first_name="J. Honey" last_name="Busquez" first_name_original="Jhonen" last_name_original="Vasquez" gender="1" birthday="1974-09-01" deathday="" imdb_id="nm0890679" creator="8605" created_by="speedminister" />
         <!-- Frankreich -->
-        <person id="SpeedMinister-person-id028" first_name="Manuel" last_name="Goldstein" first_name_original="Emmanuel" last_name_original="Gorinstein" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id029" first_name="Alex" last_name="de la Palletière" first_name_original="Alexandre" last_name_original="de La Patellière" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id030" first_name="Matthias" last_name="Pförtner" first_name_original="Mathieu" last_name_original="Delaporte" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id028" first_name="Manuel" last_name="Goldstein" first_name_original="Emmanuel" last_name_original="Gorinstein" gender="1" birthday="" deathday="" imdb_id="nm1900601" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id029" first_name="Alex" last_name="de la Palletière" first_name_original="Alexandre" last_name_original="de La Patellière" gender="1" birthday="" deathday="" imdb_id="nm0478799" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id030" first_name="Matthias" last_name="Pförtner" first_name_original="Mathieu" last_name_original="Delaporte" gender="1" birthday="1971-09-02" deathday="" imdb_id="nm1141181" creator="8605" created_by="speedminister" />
         <!-- Belgien -->
-        <person id="SpeedMinister-person-id031" first_name="Rondo" last_name="van Lenk" first_name_original="Romain" last_name_original="van Liemt" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id031" first_name="Rondo" last_name="van Lenk" first_name_original="Romain" last_name_original="van Liemt" gender="1" birthday="" deathday="" imdb_id="nm2956687" creator="8605" created_by="speedminister" />
         <!-- England -->
-        <person id="SpeedMinister-person-id039" first_name="Ilan J.W." last_name="Bubble Cap" first_name_original="Alan J.W." last_name_original="Bell" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id040" first_name="Douggy" last_name="Eves" first_name_original="Douglas" last_name_original="Adams" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id041" first_name="Joe" last_name="Nedlloyd" first_name_original="John" last_name_original="Lloyd" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id039" first_name="Ilan J.W." last_name="Bubble Cap" first_name_original="Alan J.W." last_name_original="Bell" gender="1" birthday="1937-11-14" deathday="" imdb_id="nm0068007" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id040" first_name="Douggy" last_name="Eves" first_name_original="Douglas" last_name_original="Adams" gender="1" birthday="1952-03-11" deathday="2001-05-11" imdb_id="nm0010930" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id041" first_name="Joe" last_name="Nedlloyd" first_name_original="John Bedford" last_name_original="Lloyd" gender="1" birthday="1951-09-30" deathday="" imdb_id="nm0516032" creator="8605" created_by="speedminister" />
     </insignificantpeople>
 
     <celebritypeople>
-        <person id="SpeedMinister-celebritypeople-KarlHeinzDorfmichel" tmdb_id="0" imdb_id="" creator="8605" created_by="SpeedMinister">
+        <person id="SpeedMinister-celebritypeople-KarlHeinzDorfmichel" fictional="1" tmdb_id="0" imdb_id="" creator="8605" created_by="SpeedMinister">
             <first_name>Karlheinz</first_name>
             <last_name>Dorfmichel</last_name>
             <details job="2" gender="1"  birthday="1941" deathday="" country="D" />
             <data popularity="7" affinity="15" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="0" topgenre="0" />
         </person>
-        <person id="SpeedMinister-celebritypeople-OttokarKahn" tmdb_id="0" imdb_id="" creator="8605" created_by="SpeedMinister">
+        <person id="SpeedMinister-celebritypeople-OttokarKahn" tmdb_id="0" imdb_id="nm2579540" creator="8605" created_by="SpeedMinister">
             <first_name>Ottokar</first_name>
             <last_name>Kahn</last_name>
             <first_name_original>Oliver</first_name_original>
             <last_name_original>Jahn</last_name_original>
-            <details job="3" gender="1"  birthday="1969" deathday="" country="D" />
+            <details job="3" gender="1" birthday="1969" deathday="" country="D" />
             <data popularity="7" affinity="20" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="0" topgenre="0" />
         </person>
-        <person id="SpeedMinister-celebritypeople-CoraSchirmer" tmdb_id="0" imdb_id="" creator="8605" created_by="SpeedMinister">
+        <person id="SpeedMinister-celebritypeople-CoraSchirmer" tmdb_id="0" imdb_id="nm1160560" creator="8605" created_by="SpeedMinister">
             <first_name>Cora</first_name>
             <last_name>Schirmer</last_name>
             <first_name_original>Nora</first_name_original>
             <last_name_original>Tschirner</last_name_original>
-            <details job="2" gender="1"  birthday="1981" deathday="" country="D" />
+            <details job="2" gender="2" birthday="1981-06-12" deathday="" country="D" />
             <data popularity="25" affinity="35" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="0" topgenre="0" />
         </person>
     </celebritypeople>
@@ -195,7 +195,7 @@
             </children>
         </programme>
         <!-- ***** Talkrunde, Serie: Andauernd Käse (fiktiv) ***** -->
-        <programme id="SpeedMinister-Serie-andauernd-käse-01" product="4" licence_type="3" creator="8605" created_by="SpeedMinister">
+        <programme id="SpeedMinister-Serie-andauernd-käse-01" product="4" licence_type="3" fictional="1" creator="8605" created_by="SpeedMinister">
             <title>
                 <de>Andauernd Käse</de>
                 <en>Cheese all the time</en>
@@ -389,7 +389,7 @@
             </children>
         </programme>
         <!-- ***** Serie: Soldaten, Paviane und Co. (fiktiv) ***** -->
-        <programme id="SpeedMinister-Serie-SoldatenPavianeCo-01" product="4" licence_type="3" creator="8605" created_by="SpeedMinister">
+        <programme id="SpeedMinister-Serie-SoldatenPavianeCo-01" product="4" licence_type="3" fictional="1" creator="8605" created_by="SpeedMinister">
             <title>
                 <de>Soldaten, Paviane und Co.</de>
                 <en>Soldiers, baboons, and co.</en>

--- a/res/database/Default/user/speedminister.xml
+++ b/res/database/Default/user/speedminister.xml
@@ -21,10 +21,6 @@
         <person id="SpeedMinister-person-id019" first_name="Prof. Dr. Raimund" last_name="Holzner" creator="8605" created_by="speedminister" fictional="1" gender="1" country="D" />
         <person id="SpeedMinister-person-id027" first_name="Dirk" last_name="Kipling" creator="8605" created_by="speedminister" fictional="1" gender="1" country="D" />
 
-        <!-- TODO: Most non-fictional people in this file seem to be unused? Update: IMDB data added, TODO: move entries, TODO: add related programme, e.g. tt0978537: Ijon Tichy: Raumpilot -->
-
-        <person id="SpeedMinister-person-id037" first_name="Den" last_name="Jakobson" first_name_original="Dennis" last_name_original="Jacobsen" gender="1" birthday="" deathday="" imdb_id="nm0414706" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id038" first_name="Lianda" last_name="Mahoud" first_name_original="Randa" last_name_original="Chahoud" gender="2" birthday="" deathday="" imdb_id="nm1216097" creator="8605" created_by="speedminister" />
         <!-- Österreich -->
         <person id="SpeedMinister-person-id007" first_name="Frauke" last_name="Hasenhüttl" creator="8605" created_by="speedminister" fictional="1" gender="2" country="A" />
         <person id="SpeedMinister-person-id009" first_name="Karl" last_name="Schneck" creator="8605" created_by="speedminister" fictional="1" gender="1" country="A" />
@@ -40,20 +36,6 @@
         <!-- USA -->
         <person id="SpeedMinister-person-id025" first_name="C. J." last_name="Harper" creator="8605" created_by="speedminister" fictional="1" gender="" country="USA" />
         <person id="SpeedMinister-person-id026" first_name="Franny" last_name="Tucker" creator="8605" created_by="speedminister" fictional="1" gender="2" country="USA" />
-        <person id="SpeedMinister-person-id033" first_name="Steven" last_name="Kessel" first_name_original="Steve" last_name_original="Ressel" gender="1" birthday="" deathday="" imdb_id="nm0720383" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id034" first_name="Johan" last_name="Richcorner" first_name_original="Jordan" last_name_original="Reichek" gender="1" birthday="1967-10-12" deathday="" imdb_id="nm1264053" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id035" first_name="Robby" last_name="Bumblebee" first_name_original="Rob" last_name_original="Hummel" gender="1" birthday="" deathday="" imdb_id="nm0401850" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id036" first_name="J. Honey" last_name="Busquez" first_name_original="Jhonen" last_name_original="Vasquez" gender="1" birthday="1974-09-01" deathday="" imdb_id="nm0890679" creator="8605" created_by="speedminister" />
-        <!-- Frankreich -->
-        <person id="SpeedMinister-person-id028" first_name="Manuel" last_name="Goldstein" first_name_original="Emmanuel" last_name_original="Gorinstein" gender="1" birthday="" deathday="" imdb_id="nm1900601" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id029" first_name="Alex" last_name="de la Palletière" first_name_original="Alexandre" last_name_original="de La Patellière" gender="1" birthday="" deathday="" imdb_id="nm0478799" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id030" first_name="Matthias" last_name="Pförtner" first_name_original="Mathieu" last_name_original="Delaporte" gender="1" birthday="1971-09-02" deathday="" imdb_id="nm1141181" creator="8605" created_by="speedminister" />
-        <!-- Belgien -->
-        <person id="SpeedMinister-person-id031" first_name="Rondo" last_name="van Lenk" first_name_original="Romain" last_name_original="van Liemt" gender="1" birthday="" deathday="" imdb_id="nm2956687" creator="8605" created_by="speedminister" />
-        <!-- England -->
-        <person id="SpeedMinister-person-id039" first_name="Ilan J.W." last_name="Bubble Cap" first_name_original="Alan J.W." last_name_original="Bell" gender="1" birthday="1937-11-14" deathday="" imdb_id="nm0068007" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id040" first_name="Douggy" last_name="Eves" first_name_original="Douglas" last_name_original="Adams" gender="1" birthday="1952-03-11" deathday="2001-05-11" imdb_id="nm0010930" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id041" first_name="Joe" last_name="Nedlloyd" first_name_original="John" last_name_original="Lloyd" gender="1" birthday="1951-09-30" deathday="" imdb_id="nm0516032" creator="8605" created_by="speedminister" />
     </insignificantpeople>
 
     <celebritypeople>
@@ -62,22 +44,6 @@
             <last_name>Dorfmichel</last_name>
             <details job="2" gender="1"  birthday="1941" deathday="" country="D" />
             <data popularity="7" affinity="15" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="0" topgenre="0" />
-        </person>
-        <person id="SpeedMinister-celebritypeople-OttokarKahn" tmdb_id="0" imdb_id="nm2579540" creator="8605" created_by="SpeedMinister">
-            <first_name>Ottokar</first_name>
-            <last_name>Kahn</last_name>
-            <first_name_original>Oliver</first_name_original>
-            <last_name_original>Jahn</last_name_original>
-            <details job="3" gender="1" birthday="1969" deathday="" country="D" />
-            <data popularity="7" affinity="20" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="0" topgenre="0" />
-        </person>
-        <person id="SpeedMinister-celebritypeople-CoraSchirmer" tmdb_id="0" imdb_id="nm1160560" creator="8605" created_by="SpeedMinister">
-            <first_name>Cora</first_name>
-            <last_name>Schirmer</last_name>
-            <first_name_original>Nora</first_name_original>
-            <last_name_original>Tschirner</last_name_original>
-            <details job="2" gender="2" birthday="1981-06-12" deathday="" country="D" />
-            <data popularity="25" affinity="35" fame="0" scandalizing="0" price_mod="1" power="0" humor="0" charisma="0" appearance="0" topgenre="0" />
         </person>
     </celebritypeople>
 

--- a/res/database/Default/user/speedminister.xml
+++ b/res/database/Default/user/speedminister.xml
@@ -53,7 +53,7 @@
         <!-- England -->
         <person id="SpeedMinister-person-id039" first_name="Ilan J.W." last_name="Bubble Cap" first_name_original="Alan J.W." last_name_original="Bell" gender="1" birthday="1937-11-14" deathday="" imdb_id="nm0068007" creator="8605" created_by="speedminister" />
         <person id="SpeedMinister-person-id040" first_name="Douggy" last_name="Eves" first_name_original="Douglas" last_name_original="Adams" gender="1" birthday="1952-03-11" deathday="2001-05-11" imdb_id="nm0010930" creator="8605" created_by="speedminister" />
-        <person id="SpeedMinister-person-id041" first_name="Joe" last_name="Nedlloyd" first_name_original="John Bedford" last_name_original="Lloyd" gender="1" birthday="1951-09-30" deathday="" imdb_id="nm0516032" creator="8605" created_by="speedminister" />
+        <person id="SpeedMinister-person-id041" first_name="Joe" last_name="Nedlloyd" first_name_original="John" last_name_original="Lloyd" gender="1" birthday="1951-09-30" deathday="" imdb_id="nm0516032" creator="8605" created_by="speedminister" />
     </insignificantpeople>
 
     <celebritypeople>

--- a/res/database/Default/user/therob.xml
+++ b/res/database/Default/user/therob.xml
@@ -1774,7 +1774,7 @@
 			</children>
 		</programme>
 
-		<programme id="TheRob-serie-Moumental-BestofTVTower" product="7" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
+		<programme id="TheRob-serie-Moumental-BestofTVTower" product="7" fictional="1" licence_type="3" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 			<title>
 				<!-- Best of TVTower, Show 204 Wieder gleiche Wertung für alle Folgen. -->
 				<de>Best of TVTower</de>


### PR DESCRIPTION
A few more things can be done in this phase.

* Fix wrong values for fictional resp. add the tag in user files where it was missing, as discussed
* Fix long-standing indentation/whitespace issues in `database_people.xml`
* Some minor content corrections
* Add missing IMDB data to the remain real-people entries in [speedminister.xml](https://github.com/TVTower/TVTower/compare/master...scr0llbaer9000:TVTower:res-update-2b-fix-fictional?expand=1#diff-7de15ca888e729f8e17e4435b2e4ff1d7a850b7ee060d9cca8a336fe6b583bf2), to be moved in subsequent step.

No entries have have been moved in this commit.