### PR TITLE
Kosten der Produktionsfirma von Blockanzahl abhängig machen

### DIFF
--- a/source/game.production.productioncompany.base.bmx
+++ b/source/game.production.productioncompany.base.bmx
@@ -222,8 +222,9 @@ Type TProductionCompanyBase Extends TGameObject
 
 
 	'base might differ depending on sympathy for channel
-	Method GetFee:Int(channel:Int=-1, blocks:Int)
+	Method GetFee:Int(channel:Int=-1, blocks:Int = 1, broadCastLimit: Int = 0)
 		Local blocksMod:Float = 0.3 + blocks * 0.7
+		If broadCastLimit Then blocksMod = 0.7 + blocks * 0.3
 		Local sympathyMod:Float = 1.0
 		'modify by up to 50% ...
 		If channel >= 0 Then sympathyMod :- 0.5 * GetChannelSympathy(channel)

--- a/source/game.production.productioncompany.base.bmx
+++ b/source/game.production.productioncompany.base.bmx
@@ -222,7 +222,8 @@ Type TProductionCompanyBase Extends TGameObject
 
 
 	'base might differ depending on sympathy for channel
-	Method GetFee:Int(channel:Int=-1)
+	Method GetFee:Int(channel:Int=-1, blocks:Int)
+		Local blocksMod:Float = 0.3 + blocks * 0.7
 		Local sympathyMod:Float = 1.0
 		'modify by up to 50% ...
 		If channel >= 0 Then sympathyMod :- 0.5 * GetChannelSympathy(channel)
@@ -231,7 +232,7 @@ Type TProductionCompanyBase Extends TGameObject
 		'up to "* 100" -> 100% xp means 2000*100 = 200000
 		xpMod :+ 100 * GetExperiencePercentage()
 
-		Return sympathyMod * priceModifier * (20000 + Floor(Int(10000 * xpMod)/100)*100)
+		Return sympathyMod * priceModifier * (20000 + Floor(Int(10000 * xpMod)/100)*100) * blocksMod
 	End Method
 
 

--- a/source/game.production.productionconcept.bmx
+++ b/source/game.production.productionconcept.bmx
@@ -1160,7 +1160,7 @@ endrem
 
 	Method GetProductionCost:Int()
 		If productionCompany
-			local fee:int = productionCompany.GetFee(owner, script.GetBlocks()) ' script.owner)
+			local fee:int = productionCompany.GetFee(owner, script.GetBlocks(), script.productionBroadCastLimit) ' script.owner)
 			'for each category the cost per point doubles
 			For local focusIndex:Int = EachIn productionFocus.activeFocusIndices
 				Local focusPoints:Int = productionFocus.GetFocus(focusIndex)

--- a/source/game.production.productionconcept.bmx
+++ b/source/game.production.productionconcept.bmx
@@ -1160,7 +1160,7 @@ endrem
 
 	Method GetProductionCost:Int()
 		If productionCompany
-			local fee:int = productionCompany.GetFee(owner) ' script.owner)
+			local fee:int = productionCompany.GetFee(owner, script.GetBlocks()) ' script.owner)
 			'for each category the cost per point doubles
 			For local focusIndex:Int = EachIn productionFocus.activeFocusIndices
 				Local focusPoints:Int = productionFocus.GetFocus(focusIndex)

--- a/source/game.programmeproducer.bmx
+++ b/source/game.programmeproducer.bmx
@@ -478,12 +478,13 @@ Type TProgrammeProducer Extends TProgrammeProducerBase
 			Local bestFee:Int
 			Local bestCompany:TProductionCompanyBase = Null
 			For Local p:TProductionCompanyBase = EachIn GetProductionCompanyBaseCollection().entries.Values()
+				Local companyFee:Int = p.GetFee(script.owner, script.GetBlocks())
 				'better than what we found ?
 				if bestCompany
-					If p.GetFocusPoints() > bestFocusPoints and p.GetFee() < budget * 0.7
+					If p.GetFocusPoints() > bestFocusPoints and companyFee < budget * 0.7
 						'if company is more far from requirements than 
 						'current and also more expensive!
-						If abs(p.GetFocusPoints() - requiredFocusPoints) > abs(bestFocusPoints - requiredFocusPoints) and p.GetFee() > bestFee Then Continue
+						If abs(p.GetFocusPoints() - requiredFocusPoints) > abs(bestFocusPoints - requiredFocusPoints) and companyFee > bestFee Then Continue
 						'ignore company to give others a chance
 						If RandRange(0, 100) > 75 Then Continue
 						'alternative: if more than required, then only if cheaper
@@ -494,12 +495,12 @@ Type TProgrammeProducer Extends TProgrammeProducerBase
 
 						bestCompany = p
 						bestFocusPoints = p.GetFocusPoints()
-						bestFee = p.GetFee()
+						bestFee = companyFee
 					Endif
 				Else
 					bestCompany = p
 					bestFocusPoints = p.GetFocusPoints()
-					bestFee = p.GetFee()
+					bestFee = companyFee
 				EndIf
 			Next
 			

--- a/source/game.programmeproducer.bmx
+++ b/source/game.programmeproducer.bmx
@@ -478,7 +478,7 @@ Type TProgrammeProducer Extends TProgrammeProducerBase
 			Local bestFee:Int
 			Local bestCompany:TProductionCompanyBase = Null
 			For Local p:TProductionCompanyBase = EachIn GetProductionCompanyBaseCollection().entries.Values()
-				Local companyFee:Int = p.GetFee(script.owner, script.GetBlocks())
+				Local companyFee:Int = p.GetFee(script.owner,  script.GetBlocks(), script.productionBroadCastLimit)
 				'better than what we found ?
 				if bestCompany
 					If p.GetFocusPoints() > bestFocusPoints and companyFee < budget * 0.7


### PR DESCRIPTION
see #907 
Prototyp für das Abhängigmachen der Firmenkosten von der Blockanzahl (analog Besetzung). Ebenfalls werden die Fokuspunkte nach hinten deutlich teurer.

Für ein Problem mit diesem Ansatz gibt es noch keinen Hebel. Es gibt aktuell noch keine Möglichkeit, die Produktionskosten zu beeinflussen (außer dass der Spieler nur Amateure wählt). Das siebenstündige Nachtprogramm wird mit dieser Änderung noch unattraktiver. Aufgrund der hohen Blockzahl explodieren die Kosten, die Beschränkung der Ausstrahlungszeit (wenigste Zuschauer) und der Ausstrahlungshäufigkeit (einmal) verhindern aber, dass man die Kosten überhaupt reinbekommen kann.