### PR TITLE
Nachrichtenketten mit derselben ID sollen nicht gleichzeitig starten

### DIFF
--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -604,6 +604,7 @@ Type TDatabaseLoader
 
 	Method LoadV3NewsEventTemplateFromNode:TNewsEventTemplate(node:TxmlNode, xml:TXmlHelper)
 		Local GUID:String = xml.FindValue(node,"id", "")
+		Local threadId:String = xml.FindValue(node,"thread_id", "")
 		Local doAdd:Int = True
 
 		'fetch potential meta data
@@ -620,6 +621,7 @@ Type TDatabaseLoader
 			newsEventTemplate.title = New TLocalizedString
 			newsEventTemplate.description = New TLocalizedString
 			newsEventTemplate.GUID = GUID
+			newsEventTemplate.threadId = threadId
 		Else
 			doAdd = False
 


### PR DESCRIPTION
Mit dieser Änderung kann man mehrere Initialnachrichten mit derselben Thread-ID markieren, um anzuzeigen, dass sie zum selben Thema gehören und nicht gleichzeitig gestartet werden sollen.
Wird ein Template verwendet, wird nicht nur das Template selbst als verwendet markiert, sondern auch alle anderen Templates mit derselben Thread-ID.

Bei einem Aufräumen der Nachrichten, sollten Thread-IDs entfernt werden, wenn sie nicht benötigt werden.