### PR TITLE
Strategie für Auffüllen der Werbung

### DIFF
--- a/config/DEV.xml
+++ b/config/DEV.xml
@@ -50,7 +50,7 @@
 			<!-- <DEV_ADAGENCY_SORT_CONTRACTS_BY value="minaudience" /> -->
 
 			<!-- define refill mode when choosing new contracts -->
-			<!-- <DEV_ADAGENCY_REFILL_MODE value="2" /> -->
+			<!-- <DEV_ADAGENCY_REFILL_MODE value="10" /> -->
 
 
 

--- a/source/game.debug.screen.page.adagency.bmx
+++ b/source/game.debug.screen.page.adagency.bmx
@@ -23,7 +23,7 @@ Type TDebugScreenPage_Adagency extends TDebugScreenPage
 
 
 	Method Init:TDebugScreenPage_AdAgency()
-		Local texts:String[] = ["Refill Offers", "Replace Offers", "Change Mode"]
+		Local texts:String[] = ["Refill Offers", "Replace All Offers", "Replace Offers", "Change Mode"]
 		Local button:TDebugControlsButton
 		For Local i:Int = 0 Until texts.length
 			button = CreateActionButton(i, texts[i], position.x, position.y)
@@ -52,11 +52,16 @@ Type TDebugScreenPage_Adagency extends TDebugScreenPage
 			case 1
 				RoomHandler_AdAgency.GetInstance().ReFillBlocks(True, 1.0)
 			case 2
-				if RoomHandler_AdAgency.GetInstance()._setRefillMode = 2
-					RoomHandler_AdAgency.GetInstance().SetRefillMode(1)
+				RoomHandler_AdAgency.GetInstance().ReFillBlocks(True, GameRules.refillAdAgencyPercentage)
+			case 3
+				if RoomHandler_AdAgency.GetInstance()._setRefillMode = 10
+					RoomHandler_AdAgency.GetInstance().SetRefillMode(11)
+					GetInstance().UpdateAdAgencyModeButton()
+				elseif RoomHandler_AdAgency.GetInstance()._setRefillMode = 11
+					RoomHandler_AdAgency.GetInstance().SetRefillMode(12)
 					GetInstance().UpdateAdAgencyModeButton()
 				else
-					RoomHandler_AdAgency.GetInstance().SetRefillMode(2)
+					RoomHandler_AdAgency.GetInstance().SetRefillMode(10)
 					GetInstance().UpdateAdAgencyModeButton()
 				endif
 		End Select
@@ -80,10 +85,11 @@ Type TDebugScreenPage_Adagency extends TDebugScreenPage
 
 
 	Method UpdateAdAgencyModeButton()
-		Select RoomHandler_AdAgency.GetInstance()._setRefillMode
-			case 1	buttons[2].text = "Change Mode: " + RoomHandler_AdAgency.GetInstance()._setRefillMode + "->2"
-			case 2	buttons[2].text = "Change Mode: " + RoomHandler_AdAgency.GetInstance()._setRefillMode + "->1"
-			default	buttons[2].text = "Change Mode: " + RoomHandler_AdAgency.GetInstance()._setRefillMode + "->2"
+		Local cm:Int = RoomHandler_AdAgency.GetInstance()._setRefillMode
+		Select cm
+			case 10 buttons[3].text = "Change Mode "+cm+" -> conservative"
+			case 11 buttons[3].text = "Change Mode "+cm+" -> bold"
+			case 12 buttons[3].text = "Change Mode "+cm+" -> random"
 		End Select
 	End Method
 

--- a/source/game.gamerules.bmx
+++ b/source/game.gamerules.bmx
@@ -86,7 +86,7 @@ Type TGameRules {_exposeToLua}
 
 	'=== ADAGENCY ===
 	Field adagencySortContractsBy:string = "minaudience"
-	Field adagencyRefillMode:int = 1
+	Field adagencyRefillMode:int = 10
 
 	'=== NEWS STUDIO ===
 	Field newsStudioSortNewsBy:string = "age"
@@ -108,7 +108,7 @@ Type TGameRules {_exposeToLua}
 
 
 		adagencySortContractsBy = "minaudience"
-		adagencyRefillMode = 2 'new one
+		adagencyRefillMode = 10 'mixed mode
 
 		newsStudioSortNewsBy = "age"
 


### PR DESCRIPTION
Es gibt zwei fertig implementierte Strategien für das Auffüllen der Werbung. Einmal feingranular nach Image und Einschaltquoten (gut für Tagesprogramm) und einmal grob (Billig und Rest, gefühlt gut für großes Prime-Angebot). Letztere war Default und sorgt dafür, dass das Werbeangebot ziemlich unausgewogen sein konnte (viel Prime-Werbung, kaum was für den Tag).
Ein globales Umschalten war per Dev-Optionen möglich.

Mit diesem PR wird ohne großes Anpassen der Strategien selbst dafür gesorgt, dass beim Austausch von Werbung zufällig eine der beiden Strategien verwendet wird und damit mal mehr Tageswerbung und mal mehr Primewerbung zur Verfügung steht.

closes #920

Edit: ggf. kann man von 50:50 auf 65:35 zugunsten der "aktuellen" Strategie wechseln, damit es nicht so leicht ist, gutes Tagesprogramm zu bekommen.