### PR TITLE
Produzent soll Drehbuch mit mehr als einer Produktion ignorieren

### DIFF
--- a/source/game.programmeproducer.bmx
+++ b/source/game.programmeproducer.bmx
@@ -238,11 +238,13 @@ Type TProgrammeProducer Extends TProgrammeProducerBase
 			scriptTemplate = GetScriptTemplateCollection().GetRandomByFilter(True, True)
 			Local rnd:Int = RandRange(0, 100)
 			'print "contemplating "+ scriptTemplate.getTitle() +" with random "+ rnd
-			If scriptTemplate.IsLive() 
+			If scriptTemplate.productionLimit <> 1
+				'ignore script
+			ElseIf scriptTemplate.IsLive() 
 				If rnd > 95 Then Return scriptTemplate
 			ElseIf scriptTemplate.IsSeries() 
 				If rnd > 90 Then Return scriptTemplate
-			ElseIf scriptTemplate.productionLimit = 1
+			Else
 				'it is not the outcome that will be used for the production, but it is an indicator
 				Local outcome:Int = 100 * scriptTemplate.Getoutcome()
 				If rnd > outcome Then Return scriptTemplate


### PR DESCRIPTION
Um die Verschwendung von Drehbüchern mit mehreren möglichen Produktionen zu vermeiden (oder der Dauerproduktion einer einzigen Sendung), sollen die In-Game Produzenten solche Drehbücher bei der Auswahl ignorieren.