### PR TITLE
Propagieren targetGroupAttractivityMod für Serienfolgen

### DIFF
--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -1116,9 +1116,12 @@ Type TDatabaseLoader
 
 		If Not programmeLicence
 			If Not programmeData
-				'try to clone the parent's data - if that fails, create
-				'a new instance
-				If parentLicence Then programmeData = TProgrammeData(THelper.CloneObject(parentLicence.data, "id"))
+				'try to clone the parent's data - if that fails, create a new instance;
+				'Attention: do not clone target group attractivity as it contains structs.
+				'Currently, struct data cannot be cloned with clone().
+				'For a series this means that the episodes' attractivity would be 0.0
+				'for all target groups due to default struct values.
+				If parentLicence programmeData = TProgrammeData(THelper.CloneObject(parentLicence.data, "id targetGroupAttractivityMod"))
 				'if failed, create new data
 				If Not programmeData Then programmeData = New TProgrammeData
 


### PR DESCRIPTION
Wenn beim Einlesen die Parentdaten des Felds targetGroupAttractivityMod für eine Folge übernommen werden, sind die Werte hinterher 0. Könnte am "falschen" Clonen Struct liegen.
Jedenfalls passt es ohne die Übernahme des Felds.