### PR TITLE
Zielgruppenattraktivität für Drehbuchvorlagen

### DIFF
--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -1861,6 +1861,9 @@ Type TDatabaseLoader
 			'source.SetModifier(modifierData.GetString("name"), modifierData.GetFloat("value"))
 		Next
 
+		'=== TARGETGROUP ATTRACTIVITY MOD ===
+		scriptTemplate.targetGroupAttractivityMod = GetV3TargetgroupAttractivityModFromNode(null, node, xml)
+
 		'=== EPISODES ===
 		'load children _after_ element is configured
 		Local nodeChildren:TxmlNode = xml.FindChild(node, "children")

--- a/source/game.production.bmx
+++ b/source/game.production.bmx
@@ -1099,6 +1099,7 @@ endrem
 
 		programmeData.blocks = script.GetBlocks()
 		programmeData.flags = script.flags
+		If script.targetGroupAttractivityMod Then programmeData.targetGroupAttractivityMod = script.targetGroupAttractivityMod
 
 		programmeData.genre = script.mainGenre
 		If script.subGenres

--- a/source/game.production.script.base.bmx
+++ b/source/game.production.script.base.bmx
@@ -2,6 +2,7 @@ SuperStrict
 Import "Dig/base.util.localization.bmx"
 Import "Dig/base.util.string.bmx"
 Import "Dig/base.util.logger.bmx"
+Import "game.broadcast.audience.bmx"
 Import "game.world.worldtime.bmx"
 Import "game.gameobject.bmx"
 Import "game.gameconstants.bmx" 'to access type-constants
@@ -23,6 +24,7 @@ Type TScriptBase Extends TNamedGameObject
 	Field fixedLiveTime:Long = -1
 
 	Field programmeDataModifiers:TData
+	Field targetGroupAttractivityMod:TAudience = Null
 
 	'scripts of series are parent of episode scripts
 	Field parentScriptID:int = 0

--- a/source/game.production.script.bmx
+++ b/source/game.production.script.bmx
@@ -401,6 +401,7 @@ Type TScript Extends TScriptBase {_exposeToLua="selected"}
 		script.potential = template.GetPotential()
 		script.blocks = template.GetBlocks()
 		script.price = template.GetPrice()
+		If template.targetGroupAttractivityMod Then script.targetGroupAttractivityMod = template.targetGroupAttractivityMod.Copy()
 
 		script.flags = template.GetFinalFlags()
 		script.targetGroup = template.GetFinalTargetGroup()


### PR DESCRIPTION
Aktuell sind feingranulare Anpassungen für Programme und Nachrichten möglich. Mit dieser Änderung kann auch für Drehbuchvorlagen die Zielgruppenattraktivität in der Datenbank hinterlegt werden.
Die Werte werden 1:1 von der Vorlage ans Drehbuch an die Programmdaten weitergegeben. Für Wertebereiche sehe ich hier keine Notwendigkeit. Für das Ergebnis gibt es genügend andere Zufallseinflüssen.