### PR TITLE
Werbefilter Tag 1

### DIFF
--- a/source/game.roomhandler.adagency.bmx
+++ b/source/game.roomhandler.adagency.bmx
@@ -1648,7 +1648,7 @@ Struct SAdContractRefillData
 			'highestChannelQuote = 0.175
 
 			lowestChannelQuoteDayTime:Float = 0.005
-			averageChannelQuoteDayTime:Float = 0.01
+			averageChannelQuoteDayTime:Float = 0.03
 			highestChannelQuoteDayTime:Float = 0.07
 
 			lowestChannelQuotePrimeTime:Float = 0.07


### PR DESCRIPTION
Der niedrige Durchschnittswert für Tag ein sorgt dafür, dass ggf. zu wenige passende Verträge für den Filter existieren und er angepasst wird - auf Mindestquote 0, wodurch Schrottwerbung in der Hauptauswahl erscheint.