### PR TITLE
Titelbehandlung für Drehbücher mit mehreren Produktionen

### DIFF
--- a/source/game.programmeproducer.bmx
+++ b/source/game.programmeproducer.bmx
@@ -531,8 +531,10 @@ Type TProgrammeProducer Extends TProgrammeProducerBase
 		If Not script Then script = CreateScript()
 		'add the script to the collection?
 		'...
-		'or just protect the title of being used again
-		GetScriptCollection().AddTitleProtection(script.title, -1)
+		'or just protect the title (for non-multi-production script) of being used again
+		If script.GetProductionLimitMax() <= 1
+			GetScriptCollection().AddTitleProtection(script.title, -1)
+		EndIf
 
 		'Print "CreateProductionConcept():"
 

--- a/source/game.roomhandler.studio.bmx
+++ b/source/game.roomhandler.studio.bmx
@@ -881,9 +881,9 @@ Type RoomHandler_Studio Extends TRoomHandler
 			For local p:TProgrammeLicence = EachIn GetProgrammeLicenceCollection().licences.Values()
 				conceptTitles.addLast(p.getTitle().toLower())
 			Next
-			If conceptTitles.contains(pc.getTitle().toLower())
+			If conceptTitles.contains(pc.getTitle().toLower()) Or Not pc.getTitle().Contains("#")
 				Local newTitle:String
-				For Local i:Int = 2 Until 50
+				For Local i:Int = 1 Until 1000
 					newTitle = pc.script.GetTitle()+  " - #" + i
 					If Not conceptTitles.contains(newTitle.toLower()) Then Exit
 				Next


### PR DESCRIPTION
Für Drehbuchvorlagen ohne Kindelemente aber mit mehreren möglichen Produktionen gibt (Showformate), wurden sinnvolle Änderungen vorgeschlagen.

* Einzelfolgen immer mit Nummer (auch erste Folge: `X #1, X #2, ...`)
* selber Drehbuchname wird geschützt, so lange noch ein aktives Drehbuch existiert (d.h. bis zurückgegeben oder abgedreht)
* Drehbuchname kann wiederverwendet werden, wenn der "Schutz" erloschen ist (Show mit demselben Namen kann durch jemand anderen weitergeführt werden)

see #552