### PR TITLE
Auffüllstrategie Drehbuchagentur

### DIFF
--- a/source/game.production.script.bmx
+++ b/source/game.production.script.bmx
@@ -154,8 +154,16 @@ Type TScriptCollection Extends TGameObjectCollection
 
 
 	Method GetRandomAvailable:TScript(avoidTemplateIDs:Int[] = Null)
-		'if no script is available, create (and return) some a new one
-		If GetAvailableScriptList().Count() = 0 Then Return GenerateRandom(avoidTemplateIDs)
+		Local availableCount:Int = GetAvailableScriptList().Count()
+		'if no script is available, create (and return) a new one
+		If availableCount = 0 Then Return GenerateRandom(avoidTemplateIDs)
+
+		'with a low chance, create a random script rather than using one from pool
+		If availableCount < 10
+			If randRange(1,100) > 70 Then Return GenerateRandom(avoidTemplateIDs)
+		Else
+			If randRange(1,100) > 90 Then Return GenerateRandom(avoidTemplateIDs)
+		EndIf
 
 		'fetch a random script
 		If Not avoidTemplateIDs Or avoidTemplateIDs.length = 0

--- a/source/game.roomhandler.scriptagency.bmx
+++ b/source/game.roomhandler.scriptagency.bmx
@@ -720,11 +720,16 @@ Type RoomHandler_ScriptAgency extends TRoomHandler
 				'if exists and is valid...skip it
 				if lists[j][i] then continue
 
+				'prevent cheat of buying scripts to get good ones
+				'on normal refill, only offer pool scripts or none-prime ones
+				Local preventNewGoodScript:Int = Not replaceOffer And (GetScriptCollection().GetAvailableScriptList().Count() = 0)
 				'get a new script - but avoid having multiple scripts
 				'of the same base template (high similarity)
 				For Local i:Int = 0 Until 10
 					script = GetScriptCollection().GetRandomAvailable(usedTemplateIDs)
-					If script.getTitle().contains("#") and i < 10
+					If preventNewGoodScript And script.GetPotential() > 0.3 Then
+						GetScriptCollection().Remove(script)
+					ElseIf script.getTitle().contains("#") and i < 10
 						GetScriptCollection().Remove(script)
 					Else
 						Exit


### PR DESCRIPTION
Beim reinen Auffüllen (z.B. nach Drehbuchkauf) sollen möglichst keine Super-Drehbücher erzeugt werden. Es soll nicht mehr so einfach sein, durch Kauf von Drehbüchern und anschließendem Wiederbetreten der Agentur an neu erzeugte gute Drehbücher zu kommen. Die Änderung ist nur wirksam, wenn keine Drehbücher mehr im Pool sind, wenn also alle Drehbücher neu erzeugt werden müssten.

Auch gab es im Forum die Anmerkung, dass sich das Angebot in der Agentur zu selten ändert. GetRandomAvailable hat immer eins aus dem Pool geliefert, solange noch Drehbücher im Pool vorhanden waren (d.h. es gab nur wirklich neue, wenn beim Auffüllen wieder alle aus dem Pool entfernt wurden).
Mit einer gewissen Wahrscheinlichkeit wird nun ein Drehbuch auch neu erzeugt, wenn der Pool noch nicht leer ist.