### PR TITLE
Kosten- und Zeiteinfluss der Fokuspunkte

### DIFF
--- a/source/game.production.productionconcept.bmx
+++ b/source/game.production.productionconcept.bmx
@@ -1158,19 +1158,20 @@ endrem
 	End Method
 
 
-	Method GetProductionCost:int()
-		if productionCompany
+	Method GetProductionCost:Int()
+		If productionCompany
 			local fee:int = productionCompany.GetFee(owner) ' script.owner)
-
-			'each set point costs a bit more than the previous
-			local focusPoints:int = productionFocus.GetFocusPointsSet()
-			For local i:int = 1 until focusPoints
-				fee :+ 500*i
+			'for each category the cost per point doubles
+			For local focusIndex:Int = EachIn productionFocus.activeFocusIndices
+				Local focusPoints:Int = productionFocus.GetFocus(focusIndex)
+				For Local i:Int = 0 until focusPoints
+					fee :+ 1000 * (2 ^ i)
+				Next
 			Next
-			return fee
-		endif
+			Return fee
+		EndIf
 
-		return 0
+		Return 0
 	End Method
 
 
@@ -1212,18 +1213,18 @@ endrem
 
 
 			'POINTS ADD TO TIME !
-			local focusPoints:int = productionFocus.GetFocusPointsSet()
-			'ignore points without penalty
-			focusPoints :- (teamPoints + speedPoints)
-			if focusPoints > 0
-				For local i:int = 0 until focusPoints
-					if script.IsFictional()
-						base :+ (15 + i*7) * TWorldTime.MINUTELENGTH
-					else
-						base :+ (10 + i*5) * TWorldTime.MINUTELENGTH
-					endif
-				Next
-			endif
+			For Local focusIndex:Int = EachIn productionFocus.activeFocusIndices
+				If focusIndex <> TVTProductionFocus.TEAM And focusIndex <> TVTProductionFocus.PRODUCTION_SPEED
+					Local focusPoints:Int = productionFocus.GetFocus(focusIndex)
+					For Local i:Int = 0 until focusPoints
+						if script.IsFictional()
+							base :+ (45 * (i+1) + 3 * 2^i) * TWorldTime.MINUTELENGTH
+						else
+							base :+ (30 * (i+1) + 2 * 2^i) * TWorldTime.MINUTELENGTH
+						endif
+					Next
+				EndIf
+ 			Next
 		endif
 
 		base :* speedPointTimeMod


### PR DESCRIPTION
Bislang wurden die Kosten und die Zeit aufgrund der Gesamtfokuspunktanzahl berechnet. Es erscheint aber sinnvoller, diese Werte pro Kategorie zu ermitteln. Je mehr Punkte in einer Kategorie vergeben werden, desto länger und teurer wird es (immer mehr Aufwand für etwas Verbesserung).

Außerdem sollten Zeit und Kosten wesentlich stärker als linear steigen. Bei den Kosten muss man sich überlegen, ob sich der zusätzliche Punkt lohnt. Bei der Zeit muss man sich überlegen, ob man Punkte für das Produktionstempo vergibt, um das Studio nicht so lange zu blockieren.

Achtung. Am Script gibt es das Flag "fictional", was wohl eine andere Bedeutung hat als das fictional an Nachrichten oder Programmen ("Sachbuch vs Roman"?). Es wird in der Datenbank aktuell nicht verwendet!