### PR TITLE
Minor content corrections

### DIFF
--- a/res/database/Default/database_programmes.xml
+++ b/res/database/Default/database_programmes.xml
@@ -299,8 +299,8 @@ Modest joke concatenations after the comics of [1|Full].</en>
 				<en>American History X</en>
 			</title_original>
 			<description>
-				<de>Harter Film über Rassenunterschiede und -rivalitäten mit überzeugendem Ende</de>
-				<en>Tough film about racial differences and rivalries with compelling ending</en>
+				<de>Harter Film über Rassenunterschiede und -rivalitäten mit überzeugendem Ende.</de>
+				<en>Tough film about racial differences and rivalries with compelling ending.</en>
 			</description>
 			<staff>
 				<member index="0" function="1">03704ead-958f-4739-950d-7a01bd027d03</member>
@@ -6456,7 +6456,7 @@ El Mariachi fans were utterly disappointed by [0|Last].</en>
 				<member index="5" function="2">c39a70f6-b8fd-40fe-96cd-9dcb0e460e53</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="USA" year="2003" distribution="1" maingenre="2" subgenre="" flags="64" blocks="2" price_mod="1.33" />
+			<data country="MEX/USA" year="2003" distribution="1" maingenre="2" subgenre="" flags="64" blocks="2" price_mod="1.33" />
 			<ratings critics="14" speed="84" outcome="37" />
 		</programme>
 		<programme id="6bda71ba-e56a-46c3-9762-9ae18c587839" product="1" licence_type="1" tmdb_id="0" imdb_id="tt0258000" creator="">
@@ -9143,7 +9143,7 @@ Dream scenes and sentiments warp the storyline.</en>
 				<member index="2" function="2">TheRob-TowerTV-ErlandoJoschkason</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<data country="CH" year="1986" distribution="1" maingenre="16" subgenre="7" flags="0" blocks="3" price_mod="1.00" />
+			<data country="S/GB/F" year="1986" distribution="1" maingenre="7" subgenre="" flags="0" blocks="3" price_mod="1.00" />
 			<ratings critics="86" speed="26" outcome="71" />
 		</programme>
 
@@ -12591,7 +12591,7 @@ Dream scenes and sentiments warp the storyline.</en>
 				<en>[0|First] - The Feature</en>
 			</title>
 			<title_original>
-				<de>Otto - The Film</de>
+				<de>Otto - Der Film</de>
 				<en>Holly - The Movie</en>
 			</title_original>
 			<description>
@@ -12599,11 +12599,10 @@ Dream scenes and sentiments warp the storyline.</en>
 				<en>A young East Frisian comes to Hamburg to try his luck. Above all, he is preoccupied with two problems: How can he impress Silvia, a rich young girl, and where can he get DM 9876.50 to pay off a loan shark?</en>
 			</description>
 			<staff>
-				<member index="0" function="1">Stukov_OttoWaalkes</member>
-				<member index="1" function="2">Stukov_OttoWaalkes</member>
-				<member index="2" function="2">868c1f51-3974-4690-9168-e97509ba94bf</member>
-				<member index="3" function="2">2043dc99-f378-49fe-863d-53329e014edd</member>
-				<member index="4" function="2">2dc70f52-f4e3-4514-9282-b28220b45be6</member>
+				<member index="0" function="7">Stukov_OttoWaalkes</member>
+				<member index="1" function="2">868c1f51-3974-4690-9168-e97509ba94bf</member>
+				<member index="2" function="2">2043dc99-f378-49fe-863d-53329e014edd</member>
+				<member index="3" function="2">2dc70f52-f4e3-4514-9282-b28220b45be6</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
 			<data country="D" distribution="1" maingenre="5" subgenre="15" flags="" blocks="2" />

--- a/res/database/Default/database_programmes.xml
+++ b/res/database/Default/database_programmes.xml
@@ -14675,8 +14675,8 @@ Dream scenes and sentiments warp the storyline.</en>
 			</description>
 			<staff>
 				<member index="0" function="1">04e5ecc5-fd17-4d24-a170-5ef3537342ca</member>
-				<member index="1" function="5">d7aac1f9-c0c1-42ed-83c8-6c6944ea410e</member>
-				<member index="2" function="5">966bcb56-3332-4c0f-9e8a-1714aebeff1a</member>
+				<member index="1" function="6">d7aac1f9-c0c1-42ed-83c8-6c6944ea410e</member>
+				<member index="2" function="6">966bcb56-3332-4c0f-9e8a-1714aebeff1a</member>
 				<member index="3" function="2">a1943cde-0332-4706-8130-9c7a69e52efd</member>
 				<member index="4" function="2">96cd5e3e-d8e8-49ab-992b-dade2dc37067</member>
 				<member index="5" function="2">34eb3aad-b365-4c89-bdff-f6fa235618dc</member>
@@ -14704,8 +14704,8 @@ Dream scenes and sentiments warp the storyline.</en>
 			</description>
 			<staff>
 				<member index="0" function="1">04e5ecc5-fd17-4d24-a170-5ef3537342ca</member>
-				<member index="1" function="5">d7aac1f9-c0c1-42ed-83c8-6c6944ea410e</member>
-				<member index="2" function="5">966bcb56-3332-4c0f-9e8a-1714aebeff1a</member>
+				<member index="1" function="6">d7aac1f9-c0c1-42ed-83c8-6c6944ea410e</member>
+				<member index="2" function="6">966bcb56-3332-4c0f-9e8a-1714aebeff1a</member>
 				<member index="3" function="2">a1943cde-0332-4706-8130-9c7a69e52efd</member>
 				<member index="4" function="2">96cd5e3e-d8e8-49ab-992b-dade2dc37067</member>
 				<member index="5" function="2">34eb3aad-b365-4c89-bdff-f6fa235618dc</member>
@@ -15898,7 +15898,7 @@ Fifth and final part. Not so good.</en>
 				<member index="4" function="2">4ee6f0cd-942c-4b0c-90b7-9395c84d55c1</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" />
-			<targetgroupattractivity children="1.5" teenagers_male="1" teenagers_female="1.5" housewives_male="1" housewives_female="1.2" employees_male="1" employees_female="1.2" unemployed_male="1" unemployed_female="1.2" managers_male="1" managers_female="1.2" pensioners_male="1" pensioners_female="1.2" />
+			<targetgroupattractivity children="1.25" teenagers_male="1" teenagers_female="1.5" housewives_male="1" housewives_female="1.2" employees_male="1" employees_female="1.2" unemployed_male="1" unemployed_female="1.2" managers_male="1" managers_female="1.2" pensioners_male="1" pensioners_female="1.2" />
 			<data country="USA" year="1989" distribution="2" maingenre="2" subgenre="1,4" flags="8" blocks="1" price_mod="0.8" />
 			<ratings critics="45" speed="61" outcome="67" />
 			<children>
@@ -16009,7 +16009,7 @@ Fifth and final part. Not so good.</en>
 				<member index="4" function="2">4ee6f0cd-942c-4b0c-90b7-9395c84d55c1</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" />
-			<targetgroupattractivity children="1.5" teenagers_male="1" teenagers_female="1.5" housewives_male="1" housewives_female="1.2" employees_male="1" employees_female="1.2" unemployed_male="1" unemployed_female="1.2" managers_male="1" managers_female="1.2" pensioners_male="1" pensioners_female="1.2" />
+			<targetgroupattractivity children="1.25" teenagers_male="1" teenagers_female="1.5" housewives_male="1" housewives_female="1.2" employees_male="1" employees_female="1.2" unemployed_male="1" unemployed_female="1.2" managers_male="1" managers_female="1.2" pensioners_male="1" pensioners_female="1.2" />
 			<data country="USA" year="1991" distribution="2" maingenre="2" subgenre="1,4" flags="8" blocks="1" price_mod="0.8" />
 			<ratings critics="37" speed="59" outcome="74" />
 			<children>
@@ -16120,7 +16120,7 @@ Fifth and final part. Not so good.</en>
 				<member index="4" function="2">4ee6f0cd-942c-4b0c-90b7-9395c84d55c1</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" />
-			<targetgroupattractivity children="1.5" teenagers_male="1" teenagers_female="1.5" housewives_male="1" housewives_female="1.2" employees_male="1" employees_female="1.2" unemployed_male="1" unemployed_female="1.2" managers_male="1" managers_female="1.2" pensioners_male="1" pensioners_female="1.2" />
+			<targetgroupattractivity children="1.25" teenagers_male="1" teenagers_female="1.5" housewives_male="1" housewives_female="1.2" employees_male="1" employees_female="1.2" unemployed_male="1" unemployed_female="1.2" managers_male="1" managers_female="1.2" pensioners_male="1" pensioners_female="1.2" />
 			<data country="USA" year="1992" distribution="2" maingenre="2" subgenre="1,4" flags="0" blocks="1" price_mod="0.8" />
 			<ratings critics="43" speed="64" outcome="81" />
 			<children>
@@ -16231,7 +16231,7 @@ Fifth and final part. Not so good.</en>
 				<member index="4" function="2">20c24fd7-cb02-411d-aa9d-2dd8e2a231ec</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" />
-			<targetgroupattractivity children="1.5" teenagers_male="1" teenagers_female="1.5" housewives_male="1" housewives_female="1.2" employees_male="1" employees_female="1.2" unemployed_male="1" unemployed_female="1.2" managers_male="1" managers_female="1.2" pensioners_male="1" pensioners_female="1.2" />
+			<targetgroupattractivity children="1.25" teenagers_male="1" teenagers_female="1.5" housewives_male="1" housewives_female="1.2" employees_male="1" employees_female="1.2" unemployed_male="1" unemployed_female="1.2" managers_male="1" managers_female="1.2" pensioners_male="1" pensioners_female="1.2" />
 			<data country="USA" year="1993" distribution="2" maingenre="2" subgenre="1,4" flags="0" blocks="1" price_mod="0.8" />
 			<ratings critics="42" speed="62" outcome="82" />
 			<children>
@@ -16342,7 +16342,7 @@ Fifth and final part. Not so good.</en>
 				<member index="4" function="2">20c24fd7-cb02-411d-aa9d-2dd8e2a231ec</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" />
-			<targetgroupattractivity children="1.5" teenagers_male="1" teenagers_female="1.5" housewives_male="1" housewives_female="1.2" employees_male="1" employees_female="1.2" unemployed_male="1" unemployed_female="1.2" managers_male="1" managers_female="1.2" pensioners_male="1" pensioners_female="1.2" />
+			<targetgroupattractivity children="1.25" teenagers_male="1" teenagers_female="1.5" housewives_male="1" housewives_female="1.2" employees_male="1" employees_female="1.2" unemployed_male="1" unemployed_female="1.2" managers_male="1" managers_female="1.2" pensioners_male="1" pensioners_female="1.2" />
 			<data country="USA" year="1994" distribution="2" maingenre="2" subgenre="1,4" flags="0" blocks="1" price_mod="0.8" />
 			<ratings critics="41" speed="61" outcome="89" />
 			<children>
@@ -16454,7 +16454,7 @@ Fifth and final part. Not so good.</en>
 				<!-- index 5 used for episode guest star -->
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" />
-			<targetgroupattractivity children="1.5" teenagers_male="1" teenagers_female="1.5" housewives_male="1" housewives_female="1.2" employees_male="1" employees_female="1.2" unemployed_male="1" unemployed_female="1.2" managers_male="1" managers_female="1.2" pensioners_male="1" pensioners_female="1.2" />
+			<targetgroupattractivity children="1.25" teenagers_male="1" teenagers_female="1.5" housewives_male="1" housewives_female="1.2" employees_male="1" employees_female="1.2" unemployed_male="1" unemployed_female="1.2" managers_male="1" managers_female="1.2" pensioners_male="1" pensioners_female="1.2" />
 			<data country="USA" year="1995" distribution="2" maingenre="2" subgenre="1,4" flags="0" blocks="1" price_mod="0.8" />
 			<ratings critics="48" speed="71" outcome="92" />
 			<children>
@@ -16549,7 +16549,7 @@ Fifth and final part. Not so good.</en>
 		</programme>
 		<programme id="2273036d-1dfa-4990-be2d-fbf2fabd1fd6" product="2" licence_type="3" creator="9551" imdb_id="tt0083437" comment="Only a few episodes have been picked to map 22 real episodes to 6 in the game.">
 			<title>
-				<de>Night-Ryder (Staffel 1)</de>
+				<de>Neid-Reiter (Staffel 1)</de>
 				<en>Night-Ryder (Season 1)</en>
 			</title>
 			<title_original>
@@ -16661,7 +16661,7 @@ A young loner on a crusade to champion the cause of the innocent, the helpless, 
 		</programme>
 		<programme id="a8cefae5-ed3d-463b-8723-175a57243d67" product="2" licence_type="3" creator="9551" imdb_id="tt0083437" comment="Only a few episodes have been picked to map 22 real episodes to 6 in the game. Liberties taken in ordering.">
 			<title>
-				<de>Night-Ryder (Staffel 2)</de>
+				<de>Neid-Reiter (Staffel 2)</de>
 				<en>Night-Ryder (Season 2)</en>
 			</title>
 			<title_original>
@@ -16775,7 +16775,7 @@ A young loner on a crusade to champion the cause of the innocent, the helpless, 
 		</programme>
 		<programme id="9cceb45a-b97b-40e1-95d2-d03a272d69fc" product="2" licence_type="3" creator="9551" imdb_id="tt0083437" comment="Only a few episodes have been picked to map 22 real episodes to 6 in the game.">
 			<title>
-				<de>Night-Ryder (Staffel 3)</de>
+				<de>Neid-Reiter (Staffel 3)</de>
 				<en>Night-Ryder (Season 3)</en>
 			</title>
 			<title_original>
@@ -16801,7 +16801,7 @@ A young loner on a crusade to champion the cause of the innocent, the helpless, 
 			<children>
 				<programme id="d6512f69-ab73-4b81-91e5-f6e3a441e067" product="2" licence_type="2" imdb_id="tt0620844" creator="9551">
 					<title>
-						<de>Nachtreiter der Drohnen</de>
+						<de>Neid-Reiter der Drohnen</de>
 						<en>A Mysterious Robot</en>
 					</title>
 					<title_original>
@@ -16829,7 +16829,7 @@ A young loner on a crusade to champion the cause of the innocent, the helpless, 
 				</programme>
 				<programme id="4bbf7885-acbc-4e67-ac0b-e5dfb88eac14" product="2" licence_type="2" imdb_id="tt0620809" creator="9551">
 					<title>
-						<de>Ritter der tiefsten Nacht</de>
+						<de>Reiter des tiefsten Neids</de>
 						<en>Deadly Orchids</en>
 					</title>
 					<title_original>
@@ -16887,7 +16887,7 @@ A young loner on a crusade to champion the cause of the innocent, the helpless, 
 		</programme>
 		<programme id="f7800e12-4a73-4618-8c72-52f335d6873e" product="2" licence_type="3" creator="9551" imdb_id="tt0083437" comment="Only a few episodes have been picked to map 22 real episodes to 6 in the game. Liberties taken in ordering.">
 			<title>
-				<de>Night-Ryder (Staffel 4)</de>
+				<de>Neid-Reiter (Staffel 4)</de>
 				<en>Night-Ryder (Season 4)</en>
 			</title>
 			<title_original>
@@ -16911,7 +16911,7 @@ A young loner on a crusade to champion the cause of the innocent, the helpless, 
 			<children>
 				<programme id="2b32de06-4277-4772-80a9-a16ccca256bf" product="2" licence_type="2" imdb_id="tt0620846" creator="9551">
 					<title>
-						<de>Nachtritter und der Moloch</de>
+						<de>Neid-Reiter und der Moloch</de>
 						<en>K.I.T.T.'s Accident with Consequences</en>
 					</title>
 					<title_original>
@@ -20366,7 +20366,7 @@ This became one of the most common catchphrases of the 1970s. The show's end seq
 				<en>From Germany comes the mother of all traffic education shows. One whole hour of [1|Full], and that in 4 episodes! The most important tips for careful drivers and all adult road users in everyday traffic, compiled from the many years of broadcasting.</en>
 			</description>
 			<staff>
-				<member index="0" function="21">f41917ee-82d1-4c42-9bf9-dda00db1f72d</member>
+				<member index="0" function="21">dda26fcf-74fc-4ac4-94bb-a69d6b1c048d</member>
 				<member index="1" function="8">f41917ee-82d1-4c42-9bf9-dda00db1f72d</member>
 			</staff>
 			<groups target_groups="0" target_groups_optional="8" pro_pressure_groups="0" />
@@ -20449,7 +20449,7 @@ This became one of the most common catchphrases of the 1970s. The show's end seq
 				<member index="0" function="152">6eed09f6-ddfb-403a-bfe1-6870bc0c374e</member>
 			</staff>
 			<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-			<targetgroupattractivity children_male="2" teenagers_male="2" housewives_male="1.25" housewives_female="0.25" employees_male="1.5" employees_female="0.75" unemployed_male="1.5" unemployed_female="0.5" managers="1.5" pensioners_female="0.25" />
+			<targetgroupattractivity children_male="1.5" teenagers_male="1.5" housewives_male="1.25" housewives_female="0.25" employees_male="1.5" employees_female="0.75" unemployed_male="1.5" unemployed_female="0.5" managers="1.5" pensioners_female="0.25" />
 			<data country="GB" year="2005" distribution="2" maingenre="6" subgenre="300" flags="0" blocks="1" price_mod="0.2" />
 			<ratings critics="57" speed="67" outcome="41" />
 			<children>

--- a/res/database/Default/database_programmes_fictional.xml
+++ b/res/database/Default/database_programmes_fictional.xml
@@ -1118,10 +1118,8 @@ Exciting entertainment and brain-teasing trivia questions.</en>
 					</title>
 					<description>
 						<de>Zum Auftakt der neuen Show zu Gast: Lothar Molch, Vorsitzender der graumelierten Panther und Sabine Filz vom Amt für Soziales.
-
 Bieten die beiden genügend Stoff für eine spannende Runde?</de>
 						<en>Guests at the start of the new show: Landon Newt, Chairman of the Graytinged Panthers, and Sabrina Sleaze from the Office of Social Affairs.
-
 Do the two offer enough material for an exciting panel?</en>
 					</description>
 					<staff>
@@ -1189,7 +1187,7 @@ Do the two offer enough material for an exciting panel?</en>
 			</description>
 			<staff>
 				<member index="0" function="1">cebd1a68-cf97-4b93-b3f9-ac34bda4bdcc</member>
-				<member index="1" function="2">88ba23dc-d4f1-4c77-9ddf-8dbf4a4ce3b2</member>
+				<member index="1" function="8">88ba23dc-d4f1-4c77-9ddf-8dbf4a4ce3b2</member>
 				<member index="2" function="64">28fe86a0-74ca-43a7-bc49-d3bd4df7c4d3</member>
 				<member index="3" function="64">4623935a-750a-4e5a-9d1b-6875062ff2a8</member>
 			</staff>

--- a/res/database/Default/user/jorgaeff.xml
+++ b/res/database/Default/user/jorgaeff.xml
@@ -1004,12 +1004,12 @@
 
 		<news id="news-jorgaeff-dyson-05" type="2" thread_id="news-jorgaeff-dyson" creator="8936" created_by="jorgaeff">
 			<title>
-				<de>Dyson vs. Klatschkowski: Tumulte</de>
-				<en>Dyson vs. Klatschkowski: turmoil</en>
+				<de>Dyson vs. Klatschkowski: Tumulte vor Boxkampf</de>
+				<en>Dyson vs. Klatschkowski: Riots before boxing</en>
 			</title>
 			<description>
-				<de>Tumulte vor Boxkampf: Das Wiegen vor dem Fight zwischen Spike Dyson und Eugen Klatschkowski hat sich zum Spektakel entwickelt. Während die Kontrahenten auf die Waage traten, eskalierte Dysons Sohn Shawn und trat Klatschkowski mit Anlauf in die Klöten.</de>
-				<en>Turmoil before boxing match: The weigh-in before the fight between Spike Dyson and Eugen Klatschkowski turned into a spectacle. While the competitors stepped on the scales, Dyson's son Shawn escalated and ran up and kicked Klatschkowski in the nuts.</en>
+				<de>Das Wiegen vor dem Fight zwischen Spike Dyson und Eugen Klatschkowski hat sich zum Spektakel entwickelt. Während die Kontrahenten auf die Waage traten, eskalierte Dysons Sohn Shawn und trat Klatschkowski mit Anlauf in die Klöten.</de>
+				<en>The weigh-in before the fight between Spike Dyson and Eugen Klatschkowski turned into a spectacle. While the competitors stepped on the scales, Dyson's son Shawn escalated and ran up and kicked Klatschkowski in the nuts.</en>
 			</description>
 			<data genre="2" price="0.55" quality="55" fictional="1" />
 			<effects>

--- a/res/database/Default/user/jorgaeff.xml
+++ b/res/database/Default/user/jorgaeff.xml
@@ -1005,11 +1005,11 @@
 		<news id="news-jorgaeff-dyson-05" type="2" thread_id="news-jorgaeff-dyson" creator="8936" created_by="jorgaeff">
 			<title>
 				<de>Dyson vs. Klatschkowski: Tumulte vor Boxkampf</de>
-				<en>Dyson vs. Klatschkowski: Riots before boxing</en>
+				<en>Dyson vs. Klatschkowski: Riots before match</en>
 			</title>
 			<description>
 				<de>Das Wiegen vor dem Fight zwischen Spike Dyson und Eugen Klatschkowski hat sich zum Spektakel entwickelt. Während die Kontrahenten auf die Waage traten, eskalierte Dysons Sohn Shawn und trat Klatschkowski mit Anlauf in die Klöten.</de>
-				<en>The weigh-in before the fight between Spike Dyson and Eugen Klatschkowski turned into a spectacle. While the competitors stepped on the scales, Dyson's son Shawn escalated and ran up and kicked Klatschkowski in the nuts.</en>
+				<en>The weigh-in before the boxing match between Spike Dyson and Eugen Klatschkowski turned into a spectacle. While the competitors stepped on the scales, Dyson's son Shawn escalated and ran up and kicked Klatschkowski in the nuts.</en>
 			</description>
 			<data genre="2" price="0.55" quality="55" fictional="1" />
 			<effects>

--- a/res/database/Default/user/kasi.xml
+++ b/res/database/Default/user/kasi.xml
@@ -390,8 +390,8 @@
 				<en>Talk with %NAME%</en>
 			</title>
 			<description>
-				<de>Typisches Talkshowformat, bei dem die Verzweiflung des Moderators mit jeder einzelnen Sendung zunimmt. Begleiten Sie %NAME% bei schrecklichen Gesprächen mit willkürlich auf der Straße aufgelesenen Menschen, die für eine Sekunde Berühmtheit praktisch alles sagen würden.</de>
-				<en>Typical talk show format where the desperation of the host increases with each show. Join %NAME% as he has horrible conversations with random people picked up on the street who will say practically anything for a second of fame.</en>
+				<de>Talkshowformat, bei dem die Verzweiflung des Moderators mit jeder einzelnen Sendung zunimmt. Begleiten Sie %NAME% bei schrecklichen Gesprächen mit willkürlich aufgelesenen Menschen, die für eine Sekunde Berühmtheit praktisch alles sagen würden.</de>
+				<en>Talk show format where the desperation of the host increases with each show. Join %NAME% as he has horrible conversations with people picked up at random who will say practically anything for a second of fame.</en>
 			</description>
 			<children>
 				<scripttemplate licence_type="2" product="3" index="0" guid="Kasi-script-Talkshow-Ep1">

--- a/res/database/Default/user/ronny.xml
+++ b/res/database/Default/user/ronny.xml
@@ -159,8 +159,8 @@ Contains an exclusive interview with investor Mark Mikikulla.</en>
 				<en>Truly henpecked</en>
 			</title>
 			<description>
-				<de>Gudrun erbt die Pantoffelfabrik ihres Vaters - der Bürgermeister intrigiert und die Stadt braucht ...wahre Pantoffelhelden um die Fabrik zu retten.</de>
-				<en>Gudrun inherits the chicken run of her father. The major is scheming and the city needs ... true hen-peckers.</en>
+				<de>Gudrun erbt die Pantoffelfabrik ihres Vaters - der Bürgermeister intrigiert und die Stadt braucht ... wahre Pantoffelhelden um die Fabrik zu retten.</de>
+				<en>Gudrun inherits the chicken run of her father. The major is scheming and the city needs ... true hen-peckers to save the chicken run.</en>
 			</description>
 			<staff>
 				<member index="0" function="1">cebd1a68-cf97-4b93-b3f9-ac34bda4bdcc</member>

--- a/res/database/Default/user/scr0llbaer.xml
+++ b/res/database/Default/user/scr0llbaer.xml
@@ -1338,7 +1338,7 @@ So that's 4120 per episode.</en>
 				<en>%dead% %winter% in %sarajevo%</en>
 			</title>
 			<description>
-				<de>Kriegsdrama über den jungen, enthusiastischen und leicht beeindruckbaren Stevan auf der einen, und die warmherzige, aber resolute Kara auf der anderen Seite der Front in Jugoslawien, und einem Teufels-Cellisten dazwischen.</de>
+				<de>Kriegsdrama über den jungen, enthusiastischen und leicht beeindruckbaren Stevan auf der einen, und die warmherzige, aber resolute Kara auf der anderen Seite der Front in Jugoslawien, und einen Teufels-Cellisten dazwischen.</de>
 				<en>War drama about the young, enthusiastic and impressionable Stevan on one side, and the warm-hearted but resolute Kara on the other side of the front in Yugoslavia, and a devil's cellist in between.</en>
 			</description>
 
@@ -1440,8 +1440,8 @@ So that's 4120 per episode.</en>
 				</scripttemplate>
 				<scripttemplate index="8" product="2" licence_type="2" guid="1bbdafb5-6df5-4939-bf3c-1cb7ce4cee11">
 					<title>
-						<de>The Child</de>
-						<en>Das Kind</en>
+						<de>Das Kind</de>
+						<en>The Child</en>
 					</title>
 					<description>
 						<de>Es ist eine Sache, Granaten in einen Mörser zu stecken, und eine ganz andere, zu sehen, wo sie landen. Stevan gehen die Gesichter der Kinder nicht aus dem Kopf. Er fasst einen Entschluss...</de>

--- a/res/database/Default/user/therob.xml
+++ b/res/database/Default/user/therob.xml
@@ -913,8 +913,8 @@
 				<en>Curves of the world - Know them all</en>
 			</title>
 			<description>
-				<de>Die schönsten Brüste der Welt. Dezent verpackt. Nichts und doch viel zu sehen. Die anspruchsvolle Erotikshow mit Einlagen über die Kultur des jeweiligen Landes. Selbst Kritiker konnten sich damit anfreunden. Präsentiert von einer schwedischen Schönheit</de>
-				<en>The most beautiful breasts in the world. Discreetly packaged. Nothing and yet much to see. The sophisticated erotic show with interludes about the culture of the respective country. Even critics were able to make friends with it. Presented by a Swedish beauty</en>
+				<de>Die schönsten Brüste der Welt. Dezent verpackt. Nichts und doch viel zu sehen. Die anspruchsvolle Erotikshow mit Einlagen über die Kultur des jeweiligen Landes. Selbst Kritiker konnten sich damit anfreunden. Präsentiert von einer schwedischen Schönheit.</de>
+				<en>The most beautiful breasts in the world. Discreetly packaged. Nothing and yet much to see. The sophisticated erotic show with interludes about the culture of the respective country. Even critics were able to make friends with it. Presented by a Swedish beauty.</en>
 			</description>
 			<staff>
 				<member index="0" function="1">Per_custom_Freddy_42</member>

--- a/res/database/Default/user/therob.xml
+++ b/res/database/Default/user/therob.xml
@@ -295,8 +295,8 @@
 				<en>RatTV - Quo Vadis</en>
 			</title>
 			<description>
-				<de>[1|Full] und [2|Full] von der Firma Regenbogen Wünsche sprechen über ihr Werk. [3|Full] berichtet was ihn an dem Spiel begeistert. OneHitWonder oder doch lange in Erinnerung bleibend?. Ein Klasse Sonstiges! [3|Full] wagt die Prognose: Es kommen Nachfolger!</de>
-				<en>[1|Full] and [2|Full] from the company Rainbow Wishes talk about their work. [3|Full] reports what inspires him about the game. One-hit wonder or lasting in memory for a long time? A superb 'Various'! [3|Full] dares the prognosis: There will be successors!</en>
+				<de>[1|Full] und [2|Full] von RegenbogenWünsche sprechen über ihr Werk. [3|Full] berichtet was ihn an dem Spiel begeistert. OneHitWonder oder doch lange in Erinnerung bleibend? Er wagt die Prognose: Es kommen Nachfolger! Ein Klasse Sonstiges!</de>
+				<en>[1|Full] and [2|Full] from RainbowWishes talk about their work. [3|Full] reports what inspires him about the game. One-hit wonder or lasting in memory for a long time? He dares to predict: There will be successors! A superb 'Various'!</en>
 			</description>
 			<staff>
 				<member index="0" function="1">Per_custom_Freddy_368</member>


### PR DESCRIPTION
Some minor things I found during playtesting.

Some `staff` `function` corrections.

Some adjustments to some `targetgroupattractivity` values.

`Neid-Reiter` for consistency (had long already been used in news items, I had forgotten about the German version; though I don't find that spoof title all too good).

Shortened some too long descriptions (of old items) to fit into the available space.