### PR TITLE
konsistentere Verwendung des Währungszeichens

### DIFF
--- a/source/basefunctions.bmx
+++ b/source/basefunctions.bmx
@@ -21,8 +21,6 @@ Import "Dig/external/persistence.mod/persistence.bmx"
 ?
 Import "Dig/base.util.mersenne.bmx"
 
-Const CURRENCYSIGN:String = Chr(8364) 'eurosign
-
 
 
 Type TNumberCurveValue

--- a/source/common.misc.plannerlist.contractlist.bmx
+++ b/source/common.misc.plannerlist.contractlist.bmx
@@ -193,7 +193,7 @@ Type TgfxContractlist Extends TPlannerList
 				if contract.GetDaysLeft() <= 0 then SetColor 255,255,255
 
 				if TVTDebugInfo
-					font.DrawBox(contract.GetProfit() +CURRENCYSIGN+" @ "+ contract.GetMinAudience(), currX + 22, currY + 3, 150,15, sALIGN_LEFT_CENTER, SColor8.Black)
+					font.DrawBox(GetFormattedCurrency(contract.GetProfit())+" @ "+ contract.GetMinAudience(), currX + 22, currY + 3, 150,15, sALIGN_LEFT_CENTER, SColor8.Black)
 				else
 					font.DrawBox(contract.GetTitle(), currX + 22, currY + 3, 150,15, sALIGN_LEFT_CENTER, SColor8.Black)
 				endif

--- a/source/game.achievements.bmx
+++ b/source/game.achievements.bmx
@@ -347,7 +347,7 @@ Type TAchievementReward_Money extends TAchievementReward
 	'override
 	Method GetTitle:string()
 		local t:string = Super.GetTitle()
-		if not t then t = MathHelper.DottedValue(money) +" "+ CURRENCYSIGN
+		if not t then t = GetFormattedCurrency(money)
 		return t
 	End Method
 

--- a/source/game.award.base.bmx
+++ b/source/game.award.base.bmx
@@ -294,8 +294,8 @@ Type TAward Extends TGameObject
 
 		If priceMoney <> 0
 			If result <> "" Then result :+ "~n"
-			If priceMoney > 0 Then result :+ Chr(9654) + " " +GetLocale("MONEY")+": |color=0,125,0|+" + MathHelper.DottedValue(priceMoney)+getLocale("CURRENCY")+"|/color|"
-			If priceMoney < 0 Then result :+ Chr(9654) + " " +GetLocale("MONEY")+": |color=125,0,0|" + MathHelper.DottedValue(priceMoney)+getLocale("CURRENCY")+"|/color|"
+			If priceMoney > 0 Then result :+ Chr(9654) + " " +GetLocale("MONEY")+": |color=0,125,0|+" + MathHelper.DottedValue(priceMoney)+CURRENCYSIGN+"|/color|"
+			If priceMoney < 0 Then result :+ Chr(9654) + " " +GetLocale("MONEY")+": |color=125,0,0|" + MathHelper.DottedValue(priceMoney)+CURRENCYSIGN+"|/color|"
 		EndIf
 
 		Return result

--- a/source/game.award.base.bmx
+++ b/source/game.award.base.bmx
@@ -294,8 +294,8 @@ Type TAward Extends TGameObject
 
 		If priceMoney <> 0
 			If result <> "" Then result :+ "~n"
-			If priceMoney > 0 Then result :+ Chr(9654) + " " +GetLocale("MONEY")+": |color=0,125,0|+" + MathHelper.DottedValue(priceMoney)+CURRENCYSIGN+"|/color|"
-			If priceMoney < 0 Then result :+ Chr(9654) + " " +GetLocale("MONEY")+": |color=125,0,0|" + MathHelper.DottedValue(priceMoney)+CURRENCYSIGN+"|/color|"
+			If priceMoney > 0 Then result :+ Chr(9654) + " " +GetLocale("MONEY")+": |color=0,125,0|+" + GetFormattedCurrency(priceMoney)+"|/color|"
+			If priceMoney < 0 Then result :+ Chr(9654) + " " +GetLocale("MONEY")+": |color=125,0,0|" + GetFormattedCurrency(priceMoney)+"|/color|"
 		EndIf
 
 		Return result

--- a/source/game.broadcastmaterial.advertisement.bmx
+++ b/source/game.broadcastmaterial.advertisement.bmx
@@ -177,7 +177,7 @@ Type TAdvertisement Extends TBroadcastMaterialDefaultImpl {_exposeToLua="selecte
 		local audienceResult:TAudienceResult = TAudienceResult(audienceData)
 		Local earn:Int = audienceResult.Audience.GetTotalSum() * contract.GetPerViewerRevenue()
 		if earn > 0
-			TLogger.Log("TAdvertisement.FinishBroadcastingAsProgramme", "Infomercial ~q"+GetTitle()+"~q sent by player "+owner+", earned "+earn+CURRENCYSIGN+" with an audience of " + audienceResult.Audience.GetTotalSum() +". CPV="+contract.GetPerViewerRevenue() , LOG_DEBUG)
+			TLogger.Log("TAdvertisement.FinishBroadcastingAsProgramme", "Infomercial ~q"+GetTitle()+"~q sent by player "+owner+", earned "+GetFormattedCurrency(earn)+" with an audience of " + audienceResult.Audience.GetTotalSum() +". CPV="+contract.GetPerViewerRevenue() , LOG_DEBUG)
 			GetPlayerFinance(owner).EarnInfomercialRevenue(earn, contract)
 		elseif earn = 0
 			TLogger.Log("TAdvertisement.FinishBroadcastingAsProgramme", "Infomercial ~q"+GetTitle()+"~q sent by player "+owner+", earned nothing with an audience of " + audienceResult.Audience.GetTotalSum() +". CPV="+contract.GetPerViewerRevenue(), LOG_DEBUG)

--- a/source/game.gameconstants.bmx
+++ b/source/game.gameconstants.bmx
@@ -14,6 +14,7 @@ Global CopyrightString:String = ""
 
 Global TVTPlayerCount:Int = 4
 
+Const CURRENCYSIGN:String = Chr(8364) 'eurosign
 
 
 Global TVTDebugInfo:Int = False

--- a/source/game.gameconstants.bmx
+++ b/source/game.gameconstants.bmx
@@ -8,6 +8,8 @@ Rem
 EndRem
 SuperStrict
 
+Import "Dig/base.util.math.bmx"
+
 Global VersionDate:String = "unknown"
 Global VersionString:String = ""
 Global CopyrightString:String = ""
@@ -20,6 +22,9 @@ Const CURRENCYSIGN:String = Chr(8364) 'eurosign
 Global TVTDebugInfo:Int = False
 Global TVTGhostBuildingScrollMode:Int = False
 
+Function GetFormattedCurrency:String(money:Long)
+	return MathHelper.DottedValue(money) +" "+ CURRENCYSIGN
+EndFunction
 
 'collection of all constants types (so it could be exposed
 'to LUA in one step)

--- a/source/game.ingameinterface.bmx
+++ b/source/game.ingameinterface.bmx
@@ -481,25 +481,25 @@ Type TInGameInterface
 			If THelper.MouseIn(309,412,178,32)
 				MoneyToolTip.title = getLocale("MONEY")
 				local content:String = ""
-				content	= "|b|"+getLocale("MONEY")+":|/b| "+MathHelper.DottedValue(GetPlayerBase().GetMoney()) + getLocale("CURRENCY")
+				content	= "|b|"+getLocale("MONEY")+":|/b| "+MathHelper.DottedValue(GetPlayerBase().GetMoney()) + CURRENCYSIGN
 				if GetPlayerBase().GetCredit() > 0
 					content	:+ "~n"
-					content	:+ "|b|"+getLocale("DEBT")+":|/b| |color=200,100,100|"+ MathHelper.DottedValue(GetPlayerBase().GetCredit()) + getLocale("CURRENCY")+"|/color|"
+					content	:+ "|b|"+getLocale("DEBT")+":|/b| |color=200,100,100|"+ MathHelper.DottedValue(GetPlayerBase().GetCredit()) +CURRENCYSIGN+"|/color|"
 				else
 					content	:+ "~n"
-					content	:+ "|b|"+getLocale("DEBT")+":|/b| |color=0,200,100|0" + getLocale("CURRENCY")+"|/color|"
+					content	:+ "|b|"+getLocale("DEBT")+":|/b| |color=0,200,100|0" + CURRENCYSIGN+"|/color|"
 				endif
 
 				local profit:int = GetPlayerFinance(GetPlayerBase().playerID).GetCurrentProfit()
 				if profit > 0
 					content	:+ "~n"
-					content	:+ "|b|"+getLocale("FINANCES_TODAYS_INCOME")+":|/b| |color=100,200,100|+"+ MathHelper.DottedValue(profit) + getLocale("CURRENCY")+"|/color|"
+					content	:+ "|b|"+getLocale("FINANCES_TODAYS_INCOME")+":|/b| |color=100,200,100|+"+ MathHelper.DottedValue(profit) + CURRENCYSIGN+"|/color|"
 				elseif profit = 0
 					content	:+ "~n"
-					content	:+ "|b|"+getLocale("FINANCES_TODAYS_INCOME")+":|/b| |color=100,100,100|0" + getLocale("CURRENCY")+"|/color|"
+					content	:+ "|b|"+getLocale("FINANCES_TODAYS_INCOME")+":|/b| |color=100,100,100|0" + CURRENCYSIGN+"|/color|"
 				else
 					content	:+ "~n"
-					content	:+ "|b|"+getLocale("FINANCES_TODAYS_INCOME")+":|/b| |color=200,100,100|"+ MathHelper.DottedValue(profit) + getLocale("CURRENCY")+"|/color|"
+					content	:+ "|b|"+getLocale("FINANCES_TODAYS_INCOME")+":|/b| |color=200,100,100|"+ MathHelper.DottedValue(profit) + CURRENCYSIGN+"|/color|"
 				endif
 
 				MoneyTooltip.SetContent(content)

--- a/source/game.ingameinterface.bmx
+++ b/source/game.ingameinterface.bmx
@@ -481,25 +481,25 @@ Type TInGameInterface
 			If THelper.MouseIn(309,412,178,32)
 				MoneyToolTip.title = getLocale("MONEY")
 				local content:String = ""
-				content	= "|b|"+getLocale("MONEY")+":|/b| "+MathHelper.DottedValue(GetPlayerBase().GetMoney()) + CURRENCYSIGN
+				content	= "|b|"+getLocale("MONEY")+":|/b| "+GetFormattedCurrency(GetPlayerBase().GetMoney())
 				if GetPlayerBase().GetCredit() > 0
 					content	:+ "~n"
-					content	:+ "|b|"+getLocale("DEBT")+":|/b| |color=200,100,100|"+ MathHelper.DottedValue(GetPlayerBase().GetCredit()) +CURRENCYSIGN+"|/color|"
+					content	:+ "|b|"+getLocale("DEBT")+":|/b| |color=200,100,100|"+ GetFormattedCurrency(GetPlayerBase().GetCredit()) +"|/color|"
 				else
 					content	:+ "~n"
-					content	:+ "|b|"+getLocale("DEBT")+":|/b| |color=0,200,100|0" + CURRENCYSIGN+"|/color|"
+					content	:+ "|b|"+getLocale("DEBT")+":|/b| |color=0,200,100|" + GetFormattedCurrency(0)+"|/color|"
 				endif
 
 				local profit:int = GetPlayerFinance(GetPlayerBase().playerID).GetCurrentProfit()
 				if profit > 0
 					content	:+ "~n"
-					content	:+ "|b|"+getLocale("FINANCES_TODAYS_INCOME")+":|/b| |color=100,200,100|+"+ MathHelper.DottedValue(profit) + CURRENCYSIGN+"|/color|"
+					content	:+ "|b|"+getLocale("FINANCES_TODAYS_INCOME")+":|/b| |color=100,200,100|+"+ GetFormattedCurrency(profit) +"|/color|"
 				elseif profit = 0
 					content	:+ "~n"
-					content	:+ "|b|"+getLocale("FINANCES_TODAYS_INCOME")+":|/b| |color=100,100,100|0" + CURRENCYSIGN+"|/color|"
+					content	:+ "|b|"+getLocale("FINANCES_TODAYS_INCOME")+":|/b| |color=100,100,100|" + GetFormattedCurrency(0)+"|/color|"
 				else
 					content	:+ "~n"
-					content	:+ "|b|"+getLocale("FINANCES_TODAYS_INCOME")+":|/b| |color=200,100,100|"+ MathHelper.DottedValue(profit) + CURRENCYSIGN+"|/color|"
+					content	:+ "|b|"+getLocale("FINANCES_TODAYS_INCOME")+":|/b| |color=200,100,100|"+ GetFormattedCurrency(profit) +"|/color|"
 				endif
 
 				MoneyTooltip.SetContent(content)

--- a/source/game.production.productionconcept.gui.bmx
+++ b/source/game.production.productionconcept.gui.bmx
@@ -375,7 +375,7 @@ Type TGuiProductionConceptListItem Extends TGUIGameListItem
 			contentY :+ msgH
 		endif
 		If showMsgDepositPaid
-			skin.RenderMessage(contentX+5, contentY, contentW - 9, -1, getLocale("PRODUCTION_DEPOSIT_PAID").Replace("%MONEY%", MathHelper.DottedValue(productionConcept.GetDepositCost()) + GetLocale("CURRENCY")), "money", "neutral", skin.fontNormal, ALIGN_CENTER_CENTER)
+			skin.RenderMessage(contentX+5, contentY, contentW - 9, -1, getLocale("PRODUCTION_DEPOSIT_PAID").Replace("%MONEY%", MathHelper.DottedValue(productionConcept.GetDepositCost()) + CURRENCYSIGN), "money", "neutral", skin.fontNormal, ALIGN_CENTER_CENTER)
 			contentY :+ msgH
 		endif
 

--- a/source/game.production.productionconcept.gui.bmx
+++ b/source/game.production.productionconcept.gui.bmx
@@ -375,7 +375,7 @@ Type TGuiProductionConceptListItem Extends TGUIGameListItem
 			contentY :+ msgH
 		endif
 		If showMsgDepositPaid
-			skin.RenderMessage(contentX+5, contentY, contentW - 9, -1, getLocale("PRODUCTION_DEPOSIT_PAID").Replace("%MONEY%", MathHelper.DottedValue(productionConcept.GetDepositCost()) + CURRENCYSIGN), "money", "neutral", skin.fontNormal, ALIGN_CENTER_CENTER)
+			skin.RenderMessage(contentX+5, contentY, contentW - 9, -1, getLocale("PRODUCTION_DEPOSIT_PAID").Replace("%MONEY%", GetFormattedCurrency(productionConcept.GetDepositCost())), "money", "neutral", skin.fontNormal, ALIGN_CENTER_CENTER)
 			contentY :+ msgH
 		endif
 

--- a/source/game.programme.adcontract.bmx
+++ b/source/game.programme.adcontract.bmx
@@ -1617,7 +1617,7 @@ Type TAdContract Extends TBroadcastMaterialSource {_exposeToLua="selected"}
 		If forPlayerID > 0
 			'convert back cents to euros and round it
 			'value is "per 1000" - so multiply with that too
-			Local revenue:String = MathHelper.DottedValue(Int(1000 * GetPerViewerRevenueForPlayer(forPlayerID)))+CURRENCYSIGN
+			Local revenue:String = GetFormattedCurrency(Int(1000 * GetPerViewerRevenueForPlayer(forPlayerID)))
 			skin.RenderMessage(contentX+5, contentY, contentW - 9, -1, getLocale("MOVIE_CALLINSHOW").Replace("%PROFIT%", revenue), "money", "good", skin.fontNormal, ALIGN_CENTER_CENTER)
 			contentY :+ msgH
 		EndIf

--- a/source/game.programme.programmelicence.bmx
+++ b/source/game.programme.programmelicence.bmx
@@ -2505,7 +2505,7 @@ Type TProgrammeLicence Extends TBroadcastMaterialSource {_exposeToLua="selected"
 		If showMsgEarnInfo
 			'convert back cents to euros and round it
 			'value is "per 1000" - so multiply with that too
-			local revenue:string = MathHelper.DottedValue(int(1000 * data.GetPerViewerRevenue(useOwner)))+CURRENCYSIGN
+			local revenue:string = GetFormattedCurrency(int(1000 * data.GetPerViewerRevenue(useOwner)))
 
 			skin.RenderMessage(contentX+5, contentY, contentW - 9, -1, getLocale("MOVIE_CALLINSHOW").replace("%PROFIT%", revenue), "money", "good", skin.fontNormal, ALIGN_CENTER_CENTER)
 			contentY :+ msgH
@@ -2514,7 +2514,7 @@ Type TProgrammeLicence Extends TBroadcastMaterialSource {_exposeToLua="selected"
 		if showMsgLiveProductionCost
 			Local productionCostsLeftValue:int
 			if extraData then productionCostsLeftValue = extraData.GetInt("productionCostsLeft")
-			local productionCostsLeft:string = MathHelper.DottedValue(productionCostsLeftValue)+CURRENCYSIGN
+			local productionCostsLeft:string = GetFormattedCurrency(productionCostsLeftValue)
 			skin.RenderMessage(contentX+5, contentY, contentW - 9, -1, getLocale("LIVE_PRODUCTION_FINISH_WILL_COST_X").Replace("%X%", productionCostsLeft) , "money", "warning", skin.fontNormal, ALIGN_CENTER_CENTER)
 			contentY :+ msgH
 		endif

--- a/source/game.roomhandler.movieagency.bmx
+++ b/source/game.roomhandler.movieagency.bmx
@@ -1997,7 +1997,7 @@ Type TAuctionProgrammeBlocks Extends TGameObject {_exposeToLua="selected"}
 			textBlockDrawSettings.data.lineHeight = 13
 			titleFont.DrawBox(licence.GetTitle(), 31,3, 215,36, sALIGN_LEFT_TOP, new SColor8(50,50,50), textBlockDrawSettings, EDrawTextEffect.Emboss, 0.4)
 
-			font.DrawBox("|color=90,90,90|" + GetLocale("AUCTION_MAKE_BID")+":|/color| |b|"+MathHelper.DottedValue(GetNextBid(GetPlayerBase().playerID))+CURRENCYSIGN+"|/b|", 31,30, 212,-1, sALIGN_RIGHT_TOP, new SColor8(50,50,50), EDrawTextEffect.Emboss, 0.4)
+			font.DrawBox("|color=90,90,90|" + GetLocale("AUCTION_MAKE_BID")+":|/color| |b|"+GetFormattedCurrency(GetNextBid(GetPlayerBase().playerID))+"|/b|", 31,30, 212,-1, sALIGN_RIGHT_TOP, new SColor8(50,50,50), EDrawTextEffect.Emboss, 0.4)
 
 			'reset target for fonts
 			TBitmapFont.setRenderTarget(Null)

--- a/source/game.roomhandler.news.bmx
+++ b/source/game.roomhandler.news.bmx
@@ -460,18 +460,18 @@ Type RoomHandler_News extends TRoomHandler
 			if not playersRoom
 				NewsGenreTooltip.content = ""
 			else
-				NewsGenreTooltip.content = getLocale("NEWSSTUDIO_SUBSCRIBE_GENRE_LEVEL")+" 1:~t"+ MathHelper.DottedValue(TNewsAgency.GetNewsAbonnementPrice(room.owner, genre, level+1))+getLocale("CURRENCY")+"/"+getLocale("DAY")
+				NewsGenreTooltip.content = getLocale("NEWSSTUDIO_SUBSCRIBE_GENRE_LEVEL")+" 1:~t"+ MathHelper.DottedValue(TNewsAgency.GetNewsAbonnementPrice(room.owner, genre, level+1))+CURRENCYSIGN+"/"+getLocale("DAY")
 			endif
 		Else
 			NewsGenreTooltip.title = button.caption.GetValue()+" - "+getLocale("NEWSSTUDIO_SUBSCRIPTION_LEVEL")+" "+level
 			if not playersRoom
 				NewsGenreTooltip.content = ""
 			else
-				NewsGenreTooltip.content = getLocale("NEWSSTUDIO_CURRENT_SUBSCRIPTION_LEVEL")+":~t"+ MathHelper.DottedValue(TNewsAgency.GetNewsAbonnementPrice(room.owner, genre, level))+getLocale("CURRENCY")+"/"+getLocale("DAY")+"~n"
+				NewsGenreTooltip.content = getLocale("NEWSSTUDIO_CURRENT_SUBSCRIPTION_LEVEL")+":~t"+ MathHelper.DottedValue(TNewsAgency.GetNewsAbonnementPrice(room.owner, genre, level))+CURRENCYSIGN+"/"+getLocale("DAY")+"~n"
 				if level = GameRules.maxAbonnementLevel
 					NewsGenreTooltip.content :+ getLocale("NEWSSTUDIO_DONT_SUBSCRIBE_GENRE_ANY_LONGER")
 				Else
-					NewsGenreTooltip.content :+ getLocale("NEWSSTUDIO_NEXT_SUBSCRIPTION_LEVEL")+":~t"+ MathHelper.DottedValue(TNewsAgency.GetNewsAbonnementPrice(room.owner, genre, level+1))+getLocale("CURRENCY")+"/"+getLocale("DAY")
+					NewsGenreTooltip.content :+ getLocale("NEWSSTUDIO_NEXT_SUBSCRIPTION_LEVEL")+":~t"+ MathHelper.DottedValue(TNewsAgency.GetNewsAbonnementPrice(room.owner, genre, level+1))+CURRENCYSIGN+"/"+getLocale("DAY")
 				EndIf
 			endif
 		EndIf
@@ -480,7 +480,7 @@ Type RoomHandler_News extends TRoomHandler
 				NewsGenreTooltip.content :+ "~n~n"
 				local tip:String = getLocale("NEWSSTUDIO_YOU_ALREADY_USED_LEVEL_AND_THEREFOR_PAY")
 				tip = tip.Replace("%MAXLEVEL%", GetPlayerBase().GetNewsAbonnementDaysMax(genre))
-				tip = tip.Replace("%TOPAY%", MathHelper.DottedValue(TNewsAgency.GetNewsAbonnementPrice(room.owner, genre, GetPlayerBase().GetNewsAbonnementDaysMax(genre))) + getLocale("CURRENCY"))
+				tip = tip.Replace("%TOPAY%", MathHelper.DottedValue(TNewsAgency.GetNewsAbonnementPrice(room.owner, genre, GetPlayerBase().GetNewsAbonnementDaysMax(genre))) + CURRENCYSIGN)
 				NewsGenreTooltip.content :+ getLocale("HINT")+": " + tip
 			endif
 		endif

--- a/source/game.roomhandler.news.bmx
+++ b/source/game.roomhandler.news.bmx
@@ -460,18 +460,18 @@ Type RoomHandler_News extends TRoomHandler
 			if not playersRoom
 				NewsGenreTooltip.content = ""
 			else
-				NewsGenreTooltip.content = getLocale("NEWSSTUDIO_SUBSCRIBE_GENRE_LEVEL")+" 1:~t"+ MathHelper.DottedValue(TNewsAgency.GetNewsAbonnementPrice(room.owner, genre, level+1))+CURRENCYSIGN+"/"+getLocale("DAY")
+				NewsGenreTooltip.content = getLocale("NEWSSTUDIO_SUBSCRIBE_GENRE_LEVEL")+" 1:~t"+ GetFormattedCurrency(TNewsAgency.GetNewsAbonnementPrice(room.owner, genre, level+1))+"/"+getLocale("DAY")
 			endif
 		Else
 			NewsGenreTooltip.title = button.caption.GetValue()+" - "+getLocale("NEWSSTUDIO_SUBSCRIPTION_LEVEL")+" "+level
 			if not playersRoom
 				NewsGenreTooltip.content = ""
 			else
-				NewsGenreTooltip.content = getLocale("NEWSSTUDIO_CURRENT_SUBSCRIPTION_LEVEL")+":~t"+ MathHelper.DottedValue(TNewsAgency.GetNewsAbonnementPrice(room.owner, genre, level))+CURRENCYSIGN+"/"+getLocale("DAY")+"~n"
+				NewsGenreTooltip.content = getLocale("NEWSSTUDIO_CURRENT_SUBSCRIPTION_LEVEL")+":~t"+ GetFormattedCurrency(TNewsAgency.GetNewsAbonnementPrice(room.owner, genre, level))+"/"+getLocale("DAY")+"~n"
 				if level = GameRules.maxAbonnementLevel
 					NewsGenreTooltip.content :+ getLocale("NEWSSTUDIO_DONT_SUBSCRIBE_GENRE_ANY_LONGER")
 				Else
-					NewsGenreTooltip.content :+ getLocale("NEWSSTUDIO_NEXT_SUBSCRIPTION_LEVEL")+":~t"+ MathHelper.DottedValue(TNewsAgency.GetNewsAbonnementPrice(room.owner, genre, level+1))+CURRENCYSIGN+"/"+getLocale("DAY")
+					NewsGenreTooltip.content :+ getLocale("NEWSSTUDIO_NEXT_SUBSCRIPTION_LEVEL")+":~t"+ GetFormattedCurrency(TNewsAgency.GetNewsAbonnementPrice(room.owner, genre, level+1))+"/"+getLocale("DAY")
 				EndIf
 			endif
 		EndIf
@@ -480,7 +480,7 @@ Type RoomHandler_News extends TRoomHandler
 				NewsGenreTooltip.content :+ "~n~n"
 				local tip:String = getLocale("NEWSSTUDIO_YOU_ALREADY_USED_LEVEL_AND_THEREFOR_PAY")
 				tip = tip.Replace("%MAXLEVEL%", GetPlayerBase().GetNewsAbonnementDaysMax(genre))
-				tip = tip.Replace("%TOPAY%", MathHelper.DottedValue(TNewsAgency.GetNewsAbonnementPrice(room.owner, genre, GetPlayerBase().GetNewsAbonnementDaysMax(genre))) + CURRENCYSIGN)
+				tip = tip.Replace("%TOPAY%", GetFormattedCurrency(TNewsAgency.GetNewsAbonnementPrice(room.owner, genre, GetPlayerBase().GetNewsAbonnementDaysMax(genre))))
 				NewsGenreTooltip.content :+ getLocale("HINT")+": " + tip
 			endif
 		endif

--- a/source/game.roomhandler.roomagency.bmx
+++ b/source/game.roomhandler.roomagency.bmx
@@ -587,7 +587,7 @@ Type RoomHandler_RoomAgency extends TRoomHandler
 
 			if room.GetOwner() <= 0
 				if not room.IsRented() ' and room.IsRentable()
-					adText :+ GetLocale("ROOMAGENCY_AVAILABLE_FOR_RENT_OF_X_PER_DAY").Replace("%X%", MathHelper.DottedValue(room.GetRentForPlayer(currentPlayerID)) +" "+GetLocale("CURRENCY"))
+					adText :+ GetLocale("ROOMAGENCY_AVAILABLE_FOR_RENT_OF_X_PER_DAY").Replace("%X%", MathHelper.DottedValue(room.GetRentForPlayer(currentPlayerID)) +" "+CURRENCYSIGN)
 				else
 					adText :+ "~n~n" + GetRandomLocale("ROOMAGENCY_ROOM_CURRENTLY_NOT_AVAILABLE_BUT_THIS_MIGHT_CHANGE")
 				endif
@@ -598,7 +598,7 @@ Type RoomHandler_RoomAgency extends TRoomHandler
 		if adText then t :+ "~n"
 
 		if room.IsRentable() and room.GetOwner() <> currentPlayerID
-			t :+ GetLocale("ROOMAGENCY_SIGNING_WILL_COST_A_SINGLE_PAYMENT_OF_X").Replace("%X%", MathHelper.DottedValue( GetRoomAgency().GetCourtageForOwner(room, currentPlayerID) ) +" "+GetLocale("CURRENCY"))
+			t :+ GetLocale("ROOMAGENCY_SIGNING_WILL_COST_A_SINGLE_PAYMENT_OF_X").Replace("%X%", MathHelper.DottedValue( GetRoomAgency().GetCourtageForOwner(room, currentPlayerID) ) +" "+CURRENCYSIGN)
 		endif
 		skin.fontNormal.DrawBox(t, contentX + 5, contentY, contentW - 10, descriptionH, sALIGN_LEFT_TOP, skin.textColorNeutral, skin.textBlockDrawSettings)
 		contentY :+ descriptionH

--- a/source/game.roomhandler.roomagency.bmx
+++ b/source/game.roomhandler.roomagency.bmx
@@ -587,7 +587,7 @@ Type RoomHandler_RoomAgency extends TRoomHandler
 
 			if room.GetOwner() <= 0
 				if not room.IsRented() ' and room.IsRentable()
-					adText :+ GetLocale("ROOMAGENCY_AVAILABLE_FOR_RENT_OF_X_PER_DAY").Replace("%X%", MathHelper.DottedValue(room.GetRentForPlayer(currentPlayerID)) +" "+CURRENCYSIGN)
+					adText :+ GetLocale("ROOMAGENCY_AVAILABLE_FOR_RENT_OF_X_PER_DAY").Replace("%X%", GetFormattedCurrency(room.GetRentForPlayer(currentPlayerID)))
 				else
 					adText :+ "~n~n" + GetRandomLocale("ROOMAGENCY_ROOM_CURRENTLY_NOT_AVAILABLE_BUT_THIS_MIGHT_CHANGE")
 				endif
@@ -598,7 +598,7 @@ Type RoomHandler_RoomAgency extends TRoomHandler
 		if adText then t :+ "~n"
 
 		if room.IsRentable() and room.GetOwner() <> currentPlayerID
-			t :+ GetLocale("ROOMAGENCY_SIGNING_WILL_COST_A_SINGLE_PAYMENT_OF_X").Replace("%X%", MathHelper.DottedValue( GetRoomAgency().GetCourtageForOwner(room, currentPlayerID) ) +" "+CURRENCYSIGN)
+			t :+ GetLocale("ROOMAGENCY_SIGNING_WILL_COST_A_SINGLE_PAYMENT_OF_X").Replace("%X%", GetFormattedCurrency( GetRoomAgency().GetCourtageForOwner(room, currentPlayerID) ))
 		endif
 		skin.fontNormal.DrawBox(t, contentX + 5, contentY, contentW - 10, descriptionH, sALIGN_LEFT_TOP, skin.textColorNeutral, skin.textBlockDrawSettings)
 		contentY :+ descriptionH

--- a/source/game.screen.financials.bmx
+++ b/source/game.screen.financials.bmx
@@ -163,8 +163,8 @@ global LS_officeFinancialScreen:TLowerString = TLowerString.Create("officeFinanc
 			Endif
 			'ronny: do not "abs()" the value - this helps color-blind
 			'       people to distinguish positive and negative
-			logFont.DrawBox("|"+logCol+"|"+MathHelper.DottedValue(history.GetMoney())+" "+getLocale("CURRENCY")+"|/color| "+history.GetDescription(), 501 + screenOffsetX + 5, 40 + screenOffsetY + logSlot*logH, 258 - 2*5, logH, sALIGN_LEFT_CENTER, clLog)
-			'logFont.DrawBlock("|"+logCol+"|"+MathHelper.DottedValue(abs(history.GetMoney()))+" "+getLocale("CURRENCY")+"|/color| "+history.GetDescription(), 501 + screenOffsetX + 5, 41 + screenOffsetY + logSlot*logH, 258 - 2*5, logH, ALIGN_LEFT_CENTER, clLog)
+			logFont.DrawBox("|"+logCol+"|"+MathHelper.DottedValue(history.GetMoney())+" "+CURRENCYSIGN+"|/color| "+history.GetDescription(), 501 + screenOffsetX + 5, 40 + screenOffsetY + logSlot*logH, 258 - 2*5, logH, sALIGN_LEFT_CENTER, clLog)
+			'logFont.DrawBlock("|"+logCol+"|"+MathHelper.DottedValue(abs(history.GetMoney()))+" "+CURRENCYSIGN+"|/color| "+history.GetDescription(), 501 + screenOffsetX + 5, 41 + screenOffsetY + logSlot*logH, 258 - 2*5, logH, ALIGN_LEFT_CENTER, clLog)
 			logSlot:+1
 		Next
 

--- a/source/game.screen.financials.bmx
+++ b/source/game.screen.financials.bmx
@@ -163,8 +163,8 @@ global LS_officeFinancialScreen:TLowerString = TLowerString.Create("officeFinanc
 			Endif
 			'ronny: do not "abs()" the value - this helps color-blind
 			'       people to distinguish positive and negative
-			logFont.DrawBox("|"+logCol+"|"+MathHelper.DottedValue(history.GetMoney())+" "+CURRENCYSIGN+"|/color| "+history.GetDescription(), 501 + screenOffsetX + 5, 40 + screenOffsetY + logSlot*logH, 258 - 2*5, logH, sALIGN_LEFT_CENTER, clLog)
-			'logFont.DrawBlock("|"+logCol+"|"+MathHelper.DottedValue(abs(history.GetMoney()))+" "+CURRENCYSIGN+"|/color| "+history.GetDescription(), 501 + screenOffsetX + 5, 41 + screenOffsetY + logSlot*logH, 258 - 2*5, logH, ALIGN_LEFT_CENTER, clLog)
+			logFont.DrawBox("|"+logCol+"|"+GetFormattedCurrency(history.GetMoney())+"|/color| "+history.GetDescription(), 501 + screenOffsetX + 5, 40 + screenOffsetY + logSlot*logH, 258 - 2*5, logH, sALIGN_LEFT_CENTER, clLog)
+			'logFont.DrawBlock("|"+logCol+"|"+GetFormattedCurrency(abs(history.GetMoney()))+"|/color| "+history.GetDescription(), 501 + screenOffsetX + 5, 41 + screenOffsetY + logSlot*logH, 258 - 2*5, logH, ALIGN_LEFT_CENTER, clLog)
 			logSlot:+1
 		Next
 

--- a/source/game.screen.stationmap.bmx
+++ b/source/game.screen.stationmap.bmx
@@ -771,7 +771,7 @@ Type TGameGUIAntennaPanel Extends TGameGUIBasicStationmapPanel
 
 			If showPermissionText And section And selectedStation
 				If Not section.HasBroadcastPermission(selectedStation.owner)
-					skin.fontNormal.DrawBox(getLocale("PRICE_INCLUDES_X_FOR_BROADCAST_PERMISSION").Replace("%X%", "|b|"+TFunctions.convertValue(section.GetBroadcastPermissionPrice(selectedStation.owner), 2, 0) + " " + CURRENCYSIGN+"|/b|"), contentX + 5, currentY, contentW - 10, permissionTextH, sALIGN_CENTER_CENTER, subHeaderColor, EDrawTextEffect.Emboss, 0.5)
+					skin.fontNormal.DrawBox(getLocale("PRICE_INCLUDES_X_FOR_BROADCAST_PERMISSION").Replace("%X%", "|b|"+GetFormattedCurrency(section.GetBroadcastPermissionPrice(selectedStation.owner)) +"|/b|"), contentX + 5, currentY, contentW - 10, permissionTextH, sALIGN_CENTER_CENTER, subHeaderColor, EDrawTextEffect.Emboss, 0.5)
 				Else
 					currentY :- 1 'align it a bit better
 					skin.fontNormal.DrawBox(getLocale("BROADCAST_PERMISSION_EXISTING"), contentX + 5, currentY, contentW - 10, permissionTextH, sALIGN_CENTER_CENTER, subHeaderColor, EDrawTextEffect.Emboss, 0.5)
@@ -974,13 +974,13 @@ Type TGameGUICableNetworkPanel Extends TGameGUIBasicStationmapPanel
 						local runningCostChange:int = selectedStation.GetCurrentRunningCosts() - selectedStation.GetRunningCosts()
 						if runningCostChange < 0
 							renewContractTooltips[1].contentColor = skin.textColorGood
-							renewContractTooltips[1].SetContent( TFunctions.convertValue(runningCostChange, 2, 0) + " " + CURRENCYSIGN )
+							renewContractTooltips[1].SetContent( GetFormattedCurrency(runningCostChange))
 						elseif runningCostChange = 0
 							renewContractTooltips[1].contentColor = skin.textColorNeutral
-							renewContractTooltips[1].SetContent( "+/- 0 " + CURRENCYSIGN )
+							renewContractTooltips[1].SetContent( "+/- " + GetFormattedCurrency(0))
 						else
 							renewContractTooltips[1].contentColor = skin.textColorBad
-							renewContractTooltips[1].SetContent( "+"+TFunctions.convertValue(runningCostChange, 2, 0) + " " + CURRENCYSIGN )
+							renewContractTooltips[1].SetContent( "+" + GetFormattedCurrency(runningCostChange))
 						endif
 
 					EndIf
@@ -1098,7 +1098,7 @@ Type TGameGUICableNetworkPanel Extends TGameGUIBasicStationmapPanel
 
 			If showPermissionText And section And selectedStation
 				If Not section.HasBroadcastPermission(selectedStation.owner)
-					skin.fontNormal.DrawBox(getLocale("PRICE_INCLUDES_X_FOR_BROADCAST_PERMISSION").Replace("%X%", "|b|"+TFunctions.convertValue(section.GetBroadcastPermissionPrice(selectedStation.owner), 2, 0) + " " + CURRENCYSIGN+"|/b|"), contentX + 5, currentY, contentW - 10, permissionTextH, sALIGN_CENTER_CENTER, subHeaderColor, EDrawTextEffect.Emboss, 0.5)
+					skin.fontNormal.DrawBox(getLocale("PRICE_INCLUDES_X_FOR_BROADCAST_PERMISSION").Replace("%X%", "|b|"+GetFormattedCurrency(section.GetBroadcastPermissionPrice(selectedStation.owner)) +"|/b|"), contentX + 5, currentY, contentW - 10, permissionTextH, sALIGN_CENTER_CENTER, subHeaderColor, EDrawTextEffect.Emboss, 0.5)
 				Else
 					currentY :- 1 'align it a bit better
 					skin.fontNormal.DrawBox(getLocale("BROADCAST_PERMISSION_EXISTING"), contentX + 5, currentY, contentW - 10, permissionTextH, sALIGN_CENTER_CENTER, subHeaderColor, EDrawTextEffect.Emboss, 0.5)
@@ -1378,13 +1378,13 @@ endrem
 							local runningCostChange:int = selectedStation.GetCurrentRunningCosts() - selectedStation.GetRunningCosts()
 							if runningCostChange < 0
 								renewContractTooltips[1].contentColor = skin.textColorGood
-								renewContractTooltips[1].SetContent( TFunctions.convertValue(runningCostChange, 2, 0) + " " + CURRENCYSIGN )
+								renewContractTooltips[1].SetContent( GetFormattedCurrency(runningCostChange))
 							elseif runningCostChange = 0
 								renewContractTooltips[1].contentColor = skin.textColorNeutral
-								renewContractTooltips[1].SetContent( "+/- 0 " + CURRENCYSIGN )
+								renewContractTooltips[1].SetContent( "+/- " +GetFormattedCurrency(0))
 							else
 								renewContractTooltips[1].contentColor = skin.textColorBad
-								renewContractTooltips[1].SetContent( "+"+TFunctions.convertValue(runningCostChange, 2, 0) + " " + CURRENCYSIGN )
+								renewContractTooltips[1].SetContent( "+"+GetFormattedCurrency(runningCostChange))
 							endif
 
 							price = TFunctions.convertValue(selectedStation.GetSellPrice(), 2, 0)
@@ -1516,7 +1516,8 @@ endrem
 
 
 			If showIncludesHardwareText
-				skin.fontNormal.DrawBox(getLocale("PRICE_INCLUDES_X_FOR_HARDWARE").Replace("%X%", "|b|"+TFunctions.convertValue(123, 2, 0) + " " + CURRENCYSIGN+"|/b|"), contentX + 5, currentY, contentW - 10, includesHardwareTextH, sALIGN_CENTER_CENTER, subHeaderColor, EDrawTextEffect.Emboss, 0.55)
+				'TODO constant value 123?
+				skin.fontNormal.DrawBox(getLocale("PRICE_INCLUDES_X_FOR_HARDWARE").Replace("%X%", "|b|"+ GetFormattedCurrency(123) +"|/b|"), contentX + 5, currentY, contentW - 10, includesHardwareTextH, sALIGN_CENTER_CENTER, subHeaderColor, EDrawTextEffect.Emboss, 0.55)
 			EndIf
 		EndIf
 
@@ -2267,7 +2268,7 @@ Type TStationMapInformationFrame
 
 			skin.fontSmallCaption.DrawBox(GetLocale("BROADCAST_PERMISSION")+":", col3, textY + 0*lineH, col3W+col4W, -1, sALIGN_LEFT_TOP, skin.textColorNeutral)
 			skin.fontNormal.DrawBox(GetLocale("PRICE")+":", col3, textY + 1*lineH, col3W, -1, sALIGN_LEFT_TOP, skin.textColorNeutral, EDrawTextEffect.Shadow, 0.4)
-			skin.fontNormal.DrawBox(TFunctions.DottedValue(selectedSection.GetBroadcastPermissionPrice(owner))+" " +CURRENCYSIGN, col4, textY + 1*lineH, col4W, -1, sALIGN_RIGHT_TOP, skin.textColorNeutral)
+			skin.fontNormal.DrawBox(GetFormattedCurrency(selectedSection.GetBroadcastPermissionPrice(owner)), col4, textY + 1*lineH, col4W, -1, sALIGN_RIGHT_TOP, skin.textColorNeutral)
 			skin.fontNormal.DrawBox(GetLocale("CHANNEL_IMAGE")+":", col3, textY + 2*lineH, col3W,  -1, sALIGN_LEFT_TOP, skin.textColorNeutral, EDrawTextEffect.Shadow, 0.4)
 			skin.fontNormal.DrawBox(GetLocale("MIN_VALUEX").Replace("%VALUEX%", MathHelper.NumberToString(selectedSection.broadcastPermissionMinimumChannelImage, 1, True)+"%"), col4, textY + 2*lineH, col4W,  -1, sALIGN_RIGHT_TOP, skin.textColorNeutral)
 			if selectedSection.HasBroadcastPermission(owner)

--- a/source/game.screen.stationmap.bmx
+++ b/source/game.screen.stationmap.bmx
@@ -771,7 +771,7 @@ Type TGameGUIAntennaPanel Extends TGameGUIBasicStationmapPanel
 
 			If showPermissionText And section And selectedStation
 				If Not section.HasBroadcastPermission(selectedStation.owner)
-					skin.fontNormal.DrawBox(getLocale("PRICE_INCLUDES_X_FOR_BROADCAST_PERMISSION").Replace("%X%", "|b|"+TFunctions.convertValue(section.GetBroadcastPermissionPrice(selectedStation.owner), 2, 0) + " " + GetLocale("CURRENCY")+"|/b|"), contentX + 5, currentY, contentW - 10, permissionTextH, sALIGN_CENTER_CENTER, subHeaderColor, EDrawTextEffect.Emboss, 0.5)
+					skin.fontNormal.DrawBox(getLocale("PRICE_INCLUDES_X_FOR_BROADCAST_PERMISSION").Replace("%X%", "|b|"+TFunctions.convertValue(section.GetBroadcastPermissionPrice(selectedStation.owner), 2, 0) + " " + CURRENCYSIGN+"|/b|"), contentX + 5, currentY, contentW - 10, permissionTextH, sALIGN_CENTER_CENTER, subHeaderColor, EDrawTextEffect.Emboss, 0.5)
 				Else
 					currentY :- 1 'align it a bit better
 					skin.fontNormal.DrawBox(getLocale("BROADCAST_PERMISSION_EXISTING"), contentX + 5, currentY, contentW - 10, permissionTextH, sALIGN_CENTER_CENTER, subHeaderColor, EDrawTextEffect.Emboss, 0.5)
@@ -974,13 +974,13 @@ Type TGameGUICableNetworkPanel Extends TGameGUIBasicStationmapPanel
 						local runningCostChange:int = selectedStation.GetCurrentRunningCosts() - selectedStation.GetRunningCosts()
 						if runningCostChange < 0
 							renewContractTooltips[1].contentColor = skin.textColorGood
-							renewContractTooltips[1].SetContent( TFunctions.convertValue(runningCostChange, 2, 0) + " " + GetLocale("CURRENCY") )
+							renewContractTooltips[1].SetContent( TFunctions.convertValue(runningCostChange, 2, 0) + " " + CURRENCYSIGN )
 						elseif runningCostChange = 0
 							renewContractTooltips[1].contentColor = skin.textColorNeutral
-							renewContractTooltips[1].SetContent( "+/- 0 " + GetLocale("CURRENCY") )
+							renewContractTooltips[1].SetContent( "+/- 0 " + CURRENCYSIGN )
 						else
 							renewContractTooltips[1].contentColor = skin.textColorBad
-							renewContractTooltips[1].SetContent( "+"+TFunctions.convertValue(runningCostChange, 2, 0) + " " + GetLocale("CURRENCY") )
+							renewContractTooltips[1].SetContent( "+"+TFunctions.convertValue(runningCostChange, 2, 0) + " " + CURRENCYSIGN )
 						endif
 
 					EndIf
@@ -1098,7 +1098,7 @@ Type TGameGUICableNetworkPanel Extends TGameGUIBasicStationmapPanel
 
 			If showPermissionText And section And selectedStation
 				If Not section.HasBroadcastPermission(selectedStation.owner)
-					skin.fontNormal.DrawBox(getLocale("PRICE_INCLUDES_X_FOR_BROADCAST_PERMISSION").Replace("%X%", "|b|"+TFunctions.convertValue(section.GetBroadcastPermissionPrice(selectedStation.owner), 2, 0) + " " + GetLocale("CURRENCY")+"|/b|"), contentX + 5, currentY, contentW - 10, permissionTextH, sALIGN_CENTER_CENTER, subHeaderColor, EDrawTextEffect.Emboss, 0.5)
+					skin.fontNormal.DrawBox(getLocale("PRICE_INCLUDES_X_FOR_BROADCAST_PERMISSION").Replace("%X%", "|b|"+TFunctions.convertValue(section.GetBroadcastPermissionPrice(selectedStation.owner), 2, 0) + " " + CURRENCYSIGN+"|/b|"), contentX + 5, currentY, contentW - 10, permissionTextH, sALIGN_CENTER_CENTER, subHeaderColor, EDrawTextEffect.Emboss, 0.5)
 				Else
 					currentY :- 1 'align it a bit better
 					skin.fontNormal.DrawBox(getLocale("BROADCAST_PERMISSION_EXISTING"), contentX + 5, currentY, contentW - 10, permissionTextH, sALIGN_CENTER_CENTER, subHeaderColor, EDrawTextEffect.Emboss, 0.5)
@@ -1378,13 +1378,13 @@ endrem
 							local runningCostChange:int = selectedStation.GetCurrentRunningCosts() - selectedStation.GetRunningCosts()
 							if runningCostChange < 0
 								renewContractTooltips[1].contentColor = skin.textColorGood
-								renewContractTooltips[1].SetContent( TFunctions.convertValue(runningCostChange, 2, 0) + " " + GetLocale("CURRENCY") )
+								renewContractTooltips[1].SetContent( TFunctions.convertValue(runningCostChange, 2, 0) + " " + CURRENCYSIGN )
 							elseif runningCostChange = 0
 								renewContractTooltips[1].contentColor = skin.textColorNeutral
-								renewContractTooltips[1].SetContent( "+/- 0 " + GetLocale("CURRENCY") )
+								renewContractTooltips[1].SetContent( "+/- 0 " + CURRENCYSIGN )
 							else
 								renewContractTooltips[1].contentColor = skin.textColorBad
-								renewContractTooltips[1].SetContent( "+"+TFunctions.convertValue(runningCostChange, 2, 0) + " " + GetLocale("CURRENCY") )
+								renewContractTooltips[1].SetContent( "+"+TFunctions.convertValue(runningCostChange, 2, 0) + " " + CURRENCYSIGN )
 							endif
 
 							price = TFunctions.convertValue(selectedStation.GetSellPrice(), 2, 0)
@@ -1516,7 +1516,7 @@ endrem
 
 
 			If showIncludesHardwareText
-				skin.fontNormal.DrawBox(getLocale("PRICE_INCLUDES_X_FOR_HARDWARE").Replace("%X%", "|b|"+TFunctions.convertValue(123, 2, 0) + " " + GetLocale("CURRENCY")+"|/b|"), contentX + 5, currentY, contentW - 10, includesHardwareTextH, sALIGN_CENTER_CENTER, subHeaderColor, EDrawTextEffect.Emboss, 0.55)
+				skin.fontNormal.DrawBox(getLocale("PRICE_INCLUDES_X_FOR_HARDWARE").Replace("%X%", "|b|"+TFunctions.convertValue(123, 2, 0) + " " + CURRENCYSIGN+"|/b|"), contentX + 5, currentY, contentW - 10, includesHardwareTextH, sALIGN_CENTER_CENTER, subHeaderColor, EDrawTextEffect.Emboss, 0.55)
 			EndIf
 		EndIf
 
@@ -2267,7 +2267,7 @@ Type TStationMapInformationFrame
 
 			skin.fontSmallCaption.DrawBox(GetLocale("BROADCAST_PERMISSION")+":", col3, textY + 0*lineH, col3W+col4W, -1, sALIGN_LEFT_TOP, skin.textColorNeutral)
 			skin.fontNormal.DrawBox(GetLocale("PRICE")+":", col3, textY + 1*lineH, col3W, -1, sALIGN_LEFT_TOP, skin.textColorNeutral, EDrawTextEffect.Shadow, 0.4)
-			skin.fontNormal.DrawBox(TFunctions.DottedValue(selectedSection.GetBroadcastPermissionPrice(owner))+" " + GetLocale("CURRENCY"), col4, textY + 1*lineH, col4W, -1, sALIGN_RIGHT_TOP, skin.textColorNeutral)
+			skin.fontNormal.DrawBox(TFunctions.DottedValue(selectedSection.GetBroadcastPermissionPrice(owner))+" " +CURRENCYSIGN, col4, textY + 1*lineH, col4W, -1, sALIGN_RIGHT_TOP, skin.textColorNeutral)
 			skin.fontNormal.DrawBox(GetLocale("CHANNEL_IMAGE")+":", col3, textY + 2*lineH, col3W,  -1, sALIGN_LEFT_TOP, skin.textColorNeutral, EDrawTextEffect.Shadow, 0.4)
 			skin.fontNormal.DrawBox(GetLocale("MIN_VALUEX").Replace("%VALUEX%", MathHelper.NumberToString(selectedSection.broadcastPermissionMinimumChannelImage, 1, True)+"%"), col4, textY + 2*lineH, col4W,  -1, sALIGN_RIGHT_TOP, skin.textColorNeutral)
 			if selectedSection.HasBroadcastPermission(owner)

--- a/source/game.screen.supermarket.presents.bmx
+++ b/source/game.screen.supermarket.presents.bmx
@@ -112,7 +112,7 @@ Type TScreenHandler_SupermarketPresents extends TScreenHandler
 		If presentButtons[0]
 			For local i:int = 0 to 9
 				local present:TBettyPresent = TBettyPresent.GetPresent(i)
-				presentButtons[i].SetValue( MathHelper.DottedValue(present.price) + CURRENCYSIGN + " ("+GetBetty().getPresentGivenCount(present)+"x)")
+				presentButtons[i].SetValue( GetFormattedCurrency(present.price) +" ("+GetBetty().getPresentGivenCount(present)+"x)")
 			Next
 		End If
 	End function

--- a/source/game.screen.supermarket.presents.bmx
+++ b/source/game.screen.supermarket.presents.bmx
@@ -112,7 +112,7 @@ Type TScreenHandler_SupermarketPresents extends TScreenHandler
 		If presentButtons[0]
 			For local i:int = 0 to 9
 				local present:TBettyPresent = TBettyPresent.GetPresent(i)
-				presentButtons[i].SetValue( MathHelper.DottedValue(present.price) + getLocale("CURRENCY") + " ("+GetBetty().getPresentGivenCount(present)+"x)")
+				presentButtons[i].SetValue( MathHelper.DottedValue(present.price) + CURRENCYSIGN + " ("+GetBetty().getPresentGivenCount(present)+"x)")
 			Next
 		End If
 	End function

--- a/source/game.screen.supermarket.production.bmx
+++ b/source/game.screen.supermarket.production.bmx
@@ -238,11 +238,11 @@ Type TScreenHandler_SupermarketProduction Extends TScreenHandler
 				finishProductionConcept.Disable()
 				finishProductionConcept.SetSpriteName("gfx_gui_button.datasheet.negative")
 			EndIf
-			finishProductionConcept.SetValue("|b|"+GetLocale("FINISH_PLANNING")+"|/b|~n" + GetLocale("AND_PAY_DOWN_MONEY").Replace("%money%", "|b|"+MathHelper.DottedValue(currentProductionConcept.GetDepositCost())+" " + CURRENCYSIGN+"|/b|"))
+			finishProductionConcept.SetValue("|b|"+GetLocale("FINISH_PLANNING")+"|/b|~n" + GetLocale("AND_PAY_DOWN_MONEY").Replace("%money%", "|b|"+GetFormattedCurrency(currentProductionConcept.GetDepositCost())+"|/b|"))
 		Else
 			finishProductionConcept.Disable()
 			finishProductionConcept.SetSpriteName("gfx_gui_button.datasheet")
-			finishProductionConcept.SetValue("|b|"+GetLocale("PLANNING")+"|/b|~n(" + GetLocale("MONEY_TO_PAY_DOWN").Replace("%money%", "|b|"+MathHelper.DottedValue(currentProductionConcept.GetDepositCost())+" " + CURRENCYSIGN+"|/b|") +")")
+			finishProductionConcept.SetValue("|b|"+GetLocale("PLANNING")+"|/b|~n(" + GetLocale("MONEY_TO_PAY_DOWN").Replace("%money%", "|b|"+GetFormattedCurrency(currentProductionConcept.GetDepositCost())+"|/b|") +")")
 		EndIf
 	End Method
 

--- a/source/game.screen.supermarket.production.bmx
+++ b/source/game.screen.supermarket.production.bmx
@@ -238,11 +238,11 @@ Type TScreenHandler_SupermarketProduction Extends TScreenHandler
 				finishProductionConcept.Disable()
 				finishProductionConcept.SetSpriteName("gfx_gui_button.datasheet.negative")
 			EndIf
-			finishProductionConcept.SetValue("|b|"+GetLocale("FINISH_PLANNING")+"|/b|~n" + GetLocale("AND_PAY_DOWN_MONEY").Replace("%money%", "|b|"+MathHelper.DottedValue(currentProductionConcept.GetDepositCost())+" " + GetLocale("CURRENCY")+"|/b|"))
+			finishProductionConcept.SetValue("|b|"+GetLocale("FINISH_PLANNING")+"|/b|~n" + GetLocale("AND_PAY_DOWN_MONEY").Replace("%money%", "|b|"+MathHelper.DottedValue(currentProductionConcept.GetDepositCost())+" " + CURRENCYSIGN+"|/b|"))
 		Else
 			finishProductionConcept.Disable()
 			finishProductionConcept.SetSpriteName("gfx_gui_button.datasheet")
-			finishProductionConcept.SetValue("|b|"+GetLocale("PLANNING")+"|/b|~n(" + GetLocale("MONEY_TO_PAY_DOWN").Replace("%money%", "|b|"+MathHelper.DottedValue(currentProductionConcept.GetDepositCost())+" " + GetLocale("CURRENCY")+"|/b|") +")")
+			finishProductionConcept.SetValue("|b|"+GetLocale("PLANNING")+"|/b|~n(" + GetLocale("MONEY_TO_PAY_DOWN").Replace("%money%", "|b|"+MathHelper.DottedValue(currentProductionConcept.GetDepositCost())+" " + CURRENCYSIGN+"|/b|") +")")
 		EndIf
 	End Method
 

--- a/source/game.stationmap.bmx
+++ b/source/game.stationmap.bmx
@@ -3465,11 +3465,11 @@ Type TStationBase Extends TOwnedGameObject {_exposeToLua="selected"}
 				totalPrice = GetBuyPrice()
 			Else
 				font.Draw(GetTypeName()+": ", textX, textY)
-				fontBold.DrawBox(TFunctions.DottedValue(GetBuyPrice()) + " " + CURRENCYSIGN, textX, textY-1, textW, 20, sALIGN_RIGHT_TOP, SColor8.White)
+				fontBold.DrawBox(GetFormattedCurrency(GetBuyPrice()) , textX, textY-1, textW, 20, sALIGN_RIGHT_TOP, SColor8.White)
 				textY:+ textH
 
 				font.Draw(GetLocale("BROADCAST_PERMISSION")+": ", textX, textY)
-				fontBold.DrawBox(TFunctions.DottedValue(section.GetBroadcastPermissionPrice(owner, stationType)) + " " + CURRENCYSIGN, textX, textY-1, textW, 20, sALIGN_RIGHT_TOP, SColor8.White)
+				fontBold.DrawBox(GetFormattedCurrency(section.GetBroadcastPermissionPrice(owner, stationType)), textX, textY-1, textW, 20, sALIGN_RIGHT_TOP, SColor8.White)
 				textY:+ textH
 
 				'always request the _current_ (refreshed) price
@@ -3478,9 +3478,9 @@ Type TStationBase Extends TOwnedGameObject {_exposeToLua="selected"}
 
 			font.Draw(GetLocale("PRICE")+": ", textX, textY)
 			If Not GetPlayerFinance(owner).CanAfford(totalPrice)
-				fontBold.DrawBox(TFunctions.DottedValue(totalPrice) + " " + CURRENCYSIGN, textX, textY-1, textW, 20, sALIGN_RIGHT_TOP, New SColor8(255,150,150))
+				fontBold.DrawBox(GetFormattedCurrency(totalPrice), textX, textY-1, textW, 20, sALIGN_RIGHT_TOP, New SColor8(255,150,150))
 			Else
-				fontBold.DrawBox(TFunctions.DottedValue(totalPrice) + " " + CURRENCYSIGN, textX, textY-1, textW, 20, sALIGN_RIGHT_TOP, SColor8.White)
+				fontBold.DrawBox(GetFormattedCurrency(totalPrice), textX, textY-1, textW, 20, sALIGN_RIGHT_TOP, SColor8.White)
 			EndIf
 		EndIf
 

--- a/source/game.stationmap.bmx
+++ b/source/game.stationmap.bmx
@@ -3465,11 +3465,11 @@ Type TStationBase Extends TOwnedGameObject {_exposeToLua="selected"}
 				totalPrice = GetBuyPrice()
 			Else
 				font.Draw(GetTypeName()+": ", textX, textY)
-				fontBold.DrawBox(TFunctions.DottedValue(GetBuyPrice()) + " " + GetLocale("CURRENCY"), textX, textY-1, textW, 20, sALIGN_RIGHT_TOP, SColor8.White)
+				fontBold.DrawBox(TFunctions.DottedValue(GetBuyPrice()) + " " + CURRENCYSIGN, textX, textY-1, textW, 20, sALIGN_RIGHT_TOP, SColor8.White)
 				textY:+ textH
 
 				font.Draw(GetLocale("BROADCAST_PERMISSION")+": ", textX, textY)
-				fontBold.DrawBox(TFunctions.DottedValue(section.GetBroadcastPermissionPrice(owner, stationType)) + " " + GetLocale("CURRENCY"), textX, textY-1, textW, 20, sALIGN_RIGHT_TOP, SColor8.White)
+				fontBold.DrawBox(TFunctions.DottedValue(section.GetBroadcastPermissionPrice(owner, stationType)) + " " + CURRENCYSIGN, textX, textY-1, textW, 20, sALIGN_RIGHT_TOP, SColor8.White)
 				textY:+ textH
 
 				'always request the _current_ (refreshed) price
@@ -3478,9 +3478,9 @@ Type TStationBase Extends TOwnedGameObject {_exposeToLua="selected"}
 
 			font.Draw(GetLocale("PRICE")+": ", textX, textY)
 			If Not GetPlayerFinance(owner).CanAfford(totalPrice)
-				fontBold.DrawBox(TFunctions.DottedValue(totalPrice) + " " + GetLocale("CURRENCY"), textX, textY-1, textW, 20, sALIGN_RIGHT_TOP, New SColor8(255,150,150))
+				fontBold.DrawBox(TFunctions.DottedValue(totalPrice) + " " + CURRENCYSIGN, textX, textY-1, textW, 20, sALIGN_RIGHT_TOP, New SColor8(255,150,150))
 			Else
-				fontBold.DrawBox(TFunctions.DottedValue(totalPrice) + " " + GetLocale("CURRENCY"), textX, textY-1, textW, 20, sALIGN_RIGHT_TOP, SColor8.White)
+				fontBold.DrawBox(TFunctions.DottedValue(totalPrice) + " " + CURRENCYSIGN, textX, textY-1, textW, 20, sALIGN_RIGHT_TOP, SColor8.White)
 			EndIf
 		EndIf
 

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -5190,11 +5190,11 @@ endrem
 		If triggerEvent.GetEventKey() = GameEventKeys.PlayerBoss_OnPlayerTakesCredit
 			toast.SetMessageType(2) 'positive
 			toast.SetCaption(StringHelper.UCFirst(GetLocale("CREDIT_TAKEN")))
-			toast.SetText(StringHelper.UCFirst(GetLocale("ACCOUNT_BALANCE"))+": |b||color=0,125,0|+ "+ MathHelper.DottedValue(value) + " " + CURRENCYSIGN + "|/color||/b|")
+			toast.SetText(StringHelper.UCFirst(GetLocale("ACCOUNT_BALANCE"))+": |b||color=0,125,0|+ "+ GetFormattedCurrency(value) + "|/color||/b|")
 		Else
 			toast.SetMessageType(3) 'negative
 			toast.SetCaption(StringHelper.UCFirst(GetLocale("CREDIT_REPAID")))
-			toast.SetText(StringHelper.UCFirst(GetLocale("ACCOUNT_BALANCE"))+": |b||color=125,0,0|- "+ MathHelper.DottedValue(value) + " " + CURRENCYSIGN + "|/color||/b|")
+			toast.SetText(StringHelper.UCFirst(GetLocale("ACCOUNT_BALANCE"))+": |b||color=125,0,0|- "+ GetFormattedCurrency(value) + "|/color||/b|")
 		EndIf
 
 		'play a special sound instead of the default one
@@ -5233,7 +5233,7 @@ endrem
 		toast.SetCaption(GetLocale("AUTHORITIES_STOPPED_BROADCAST"))
 		toast.SetText( ..
 			GetLocale("BROADCAST_OF_XRATED_PROGRAMME_X_NOT_ALLOWED_DURING_DAYTIME").Replace("%TITLE%", "|b|"+programme.GetTitle()+"|/b|") + " " + ..
-			GetLocale("PENALTY_OF_X_WAS_PAID").Replace("%MONEY%", "|b|"+MathHelper.DottedValue(penalty)+CURRENCYSIGN+"|/b|") ..
+			GetLocale("PENALTY_OF_X_WAS_PAID").Replace("%MONEY%", "|b|"+GetFormattedCurrency(penalty)+"|/b|") ..
 		)
 		toast.GetData().AddNumber("playerID", programme.owner)
 
@@ -5507,7 +5507,7 @@ endrem
 					Local cost:Int = triggerEvent.GetData().GetInt("renovationBaseCost")
 					If cost > 0
 						cost = TFunctions.RoundToBeautifulValue(cost * 1.2^ (player.GetAudienceReachLevel()-1))
-						text:+ " "+ GetRandomLocale("TOASTMESSAGE_BOMB_RENOVATION_COST_TEXT").Replace("%COST%", MathHelper.DottedValue(cost)+CURRENCYSIGN)
+						text:+ " "+ GetRandomLocale("TOASTMESSAGE_BOMB_RENOVATION_COST_TEXT").Replace("%COST%", GetFormattedCurrency(cost))
 						player.GetFinance().PayMisc(cost)
 					EndIf
 					If room.GetNameRaw() = "archive"
@@ -5579,7 +5579,7 @@ endrem
 
 		toast.SetText( ..
 			GetLocale("SOMEONE_BID_MORE_THAN_YOU_FOR_X").Replace("%TITLE%", licence.GetTitle()) + " " + ..
-			GetLocale("YOUR_PREVIOUS_BID_OF_X_WAS_REFUNDED").Replace("%MONEY%", "|b|"+MathHelper.DottedValue(previousBestBid)+CURRENCYSIGN+"|/b|") ..
+			GetLocale("YOUR_PREVIOUS_BID_OF_X_WAS_REFUNDED").Replace("%MONEY%", "|b|"+GetFormattedCurrency(previousBestBid)+"|/b|") ..
 		)
 		'play a special sound instead of the default one
 		toast.GetData().AddString("onAddMessageSFX", "positiveMoneyChange")
@@ -5664,11 +5664,11 @@ endrem
 			If GameRules.payLiveProductionInAdvance
 				toast.SetText(GetLocale("THE_LIVE_PRODUCTION_OF_X_JUST_FINISHED").Replace("%TITLE%", "|b|"+title+"|/b|"))
 			Else
-				toast.SetText((GetLocale("THE_LIVE_PRODUCTION_OF_X_JUST_FINISHED") + "~n" + GetLocale("TOTAL_PRODUCTION_COSTS_WERE_X")).Replace("%TITLE%", "|b|"+title+"|/b|").Replace("%TOTALCOST%", "|b|" + MathHelper.DottedValue(production.productionConcept.GetTotalCost()) + CURRENCYSIGN + "|/b|" ))
+				toast.SetText((GetLocale("THE_LIVE_PRODUCTION_OF_X_JUST_FINISHED") + "~n" + GetLocale("TOTAL_PRODUCTION_COSTS_WERE_X")).Replace("%TITLE%", "|b|"+title+"|/b|").Replace("%TOTALCOST%", "|b|" + GetFormattedCurrency(production.productionConcept.GetTotalCost()) + "|/b|" ))
 			EndIf
 		Else
 			toast.SetCaption(GetLocale("SHOOTING_FINISHED"))
-			toast.SetText((GetLocale("THE_LICENCE_OF_X_IS_NOW_AT_YOUR_DISPOSAL") + "~n" + GetLocale("TOTAL_PRODUCTION_COSTS_WERE_X")).Replace("%TITLE%", "|b|"+title+"|/b|").Replace("%TOTALCOST%", "|b|" + MathHelper.DottedValue(production.productionConcept.GetTotalCost()) + CURRENCYSIGN + "|/b|" ))
+			toast.SetText((GetLocale("THE_LICENCE_OF_X_IS_NOW_AT_YOUR_DISPOSAL") + "~n" + GetLocale("TOTAL_PRODUCTION_COSTS_WERE_X")).Replace("%TITLE%", "|b|"+title+"|/b|").Replace("%TOTALCOST%", "|b|" + GetFormattedCurrency(production.productionConcept.GetTotalCost()) + "|/b|" ))
 		EndIf
 
 		toast.GetData().AddNumber("playerID", production.owner)
@@ -5706,7 +5706,7 @@ endrem
 		toast.SetMessageCategory(TVTMessageCategory.MISC)
 		toast.SetCaption(GetLocale("PREPRODUCTION_FINISHED"))
 		If GameRules.payLiveProductionInAdvance
-			toast.SetText((GetLocale("THE_LICENCE_OF_X_IS_NOW_AT_YOUR_DISPOSAL") + "~n" + GetLocale("TOTAL_PRODUCTION_COSTS_WERE_X")).Replace("%TITLE%", "|b|"+title+"|/b|").Replace("%TOTALCOST%", "|b|" + MathHelper.DottedValue(production.productionConcept.GetTotalCost()) + CURRENCYSIGN + "|/b|" ))
+			toast.SetText((GetLocale("THE_LICENCE_OF_X_IS_NOW_AT_YOUR_DISPOSAL") + "~n" + GetLocale("TOTAL_PRODUCTION_COSTS_WERE_X")).Replace("%TITLE%", "|b|"+title+"|/b|").Replace("%TOTALCOST%", "|b|" + GetFormattedCurrency(production.productionConcept.GetTotalCost()) + "|/b|" ))
 		Else
 			toast.SetText(GetLocale("THE_LICENCE_OF_X_IS_NOW_AT_YOUR_DISPOSAL").Replace("%TITLE%", "|b|"+title+"|/b|"))
 		EndIf
@@ -5803,7 +5803,7 @@ endrem
 		toast.SetCaption(GetLocale("ADCONTRACT_FINISHED"))
 		toast.SetText( ..
 			GetLocale("ADCONTRACT_X_SUCCESSFULLY_FINISHED").Replace("%TITLE%", contract.GetTitle()) + " " + ..
-			GetLocale("PROFIT_OF_X_GOT_CREDITED").Replace("%MONEY%", "|b|"+MathHelper.DottedValue(contract.GetProfit())+CURRENCYSIGN+"|/b|") ..
+			GetLocale("PROFIT_OF_X_GOT_CREDITED").Replace("%MONEY%", "|b|"+GetFormattedCurrency(contract.GetProfit())+"|/b|") ..
 		)
 		'play a special sound instead of the default one
 		toast.GetData().AddString("onAddMessageSFX", "positiveMoneyChange")
@@ -5837,7 +5837,7 @@ endrem
 		toast.SetCaption(GetLocale("ADCONTRACT_FAILED"))
 		toast.SetText( ..
 			GetLocale("ADCONTRACT_X_FAILED").Replace("%TITLE%", contract.GetTitle()) + " " + ..
-			GetLocale("PENALTY_OF_X_WAS_PAID").Replace("%MONEY%", "|b|"+MathHelper.DottedValue(contract.GetPenalty())+CURRENCYSIGN+"|/b|") ..
+			GetLocale("PENALTY_OF_X_WAS_PAID").Replace("%MONEY%", "|b|"+GetFormattedCurrency(contract.GetPenalty())+"|/b|") ..
 		)
 
 		toast.GetData().AddNumber("playerID", contract.owner)

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -5190,11 +5190,11 @@ endrem
 		If triggerEvent.GetEventKey() = GameEventKeys.PlayerBoss_OnPlayerTakesCredit
 			toast.SetMessageType(2) 'positive
 			toast.SetCaption(StringHelper.UCFirst(GetLocale("CREDIT_TAKEN")))
-			toast.SetText(StringHelper.UCFirst(GetLocale("ACCOUNT_BALANCE"))+": |b||color=0,125,0|+ "+ MathHelper.DottedValue(value) + " " + getLocale("CURRENCY") + "|/color||/b|")
+			toast.SetText(StringHelper.UCFirst(GetLocale("ACCOUNT_BALANCE"))+": |b||color=0,125,0|+ "+ MathHelper.DottedValue(value) + " " + CURRENCYSIGN + "|/color||/b|")
 		Else
 			toast.SetMessageType(3) 'negative
 			toast.SetCaption(StringHelper.UCFirst(GetLocale("CREDIT_REPAID")))
-			toast.SetText(StringHelper.UCFirst(GetLocale("ACCOUNT_BALANCE"))+": |b||color=125,0,0|- "+ MathHelper.DottedValue(value) + " " + getLocale("CURRENCY") + "|/color||/b|")
+			toast.SetText(StringHelper.UCFirst(GetLocale("ACCOUNT_BALANCE"))+": |b||color=125,0,0|- "+ MathHelper.DottedValue(value) + " " + CURRENCYSIGN + "|/color||/b|")
 		EndIf
 
 		'play a special sound instead of the default one
@@ -5233,7 +5233,7 @@ endrem
 		toast.SetCaption(GetLocale("AUTHORITIES_STOPPED_BROADCAST"))
 		toast.SetText( ..
 			GetLocale("BROADCAST_OF_XRATED_PROGRAMME_X_NOT_ALLOWED_DURING_DAYTIME").Replace("%TITLE%", "|b|"+programme.GetTitle()+"|/b|") + " " + ..
-			GetLocale("PENALTY_OF_X_WAS_PAID").Replace("%MONEY%", "|b|"+MathHelper.DottedValue(penalty)+getLocale("CURRENCY")+"|/b|") ..
+			GetLocale("PENALTY_OF_X_WAS_PAID").Replace("%MONEY%", "|b|"+MathHelper.DottedValue(penalty)+CURRENCYSIGN+"|/b|") ..
 		)
 		toast.GetData().AddNumber("playerID", programme.owner)
 
@@ -5507,7 +5507,7 @@ endrem
 					Local cost:Int = triggerEvent.GetData().GetInt("renovationBaseCost")
 					If cost > 0
 						cost = TFunctions.RoundToBeautifulValue(cost * 1.2^ (player.GetAudienceReachLevel()-1))
-						text:+ " "+ GetRandomLocale("TOASTMESSAGE_BOMB_RENOVATION_COST_TEXT").Replace("%COST%", MathHelper.DottedValue(cost)+getLocale("CURRENCY"))
+						text:+ " "+ GetRandomLocale("TOASTMESSAGE_BOMB_RENOVATION_COST_TEXT").Replace("%COST%", MathHelper.DottedValue(cost)+CURRENCYSIGN)
 						player.GetFinance().PayMisc(cost)
 					EndIf
 					If room.GetNameRaw() = "archive"
@@ -5579,7 +5579,7 @@ endrem
 
 		toast.SetText( ..
 			GetLocale("SOMEONE_BID_MORE_THAN_YOU_FOR_X").Replace("%TITLE%", licence.GetTitle()) + " " + ..
-			GetLocale("YOUR_PREVIOUS_BID_OF_X_WAS_REFUNDED").Replace("%MONEY%", "|b|"+MathHelper.DottedValue(previousBestBid)+getLocale("CURRENCY")+"|/b|") ..
+			GetLocale("YOUR_PREVIOUS_BID_OF_X_WAS_REFUNDED").Replace("%MONEY%", "|b|"+MathHelper.DottedValue(previousBestBid)+CURRENCYSIGN+"|/b|") ..
 		)
 		'play a special sound instead of the default one
 		toast.GetData().AddString("onAddMessageSFX", "positiveMoneyChange")
@@ -5664,11 +5664,11 @@ endrem
 			If GameRules.payLiveProductionInAdvance
 				toast.SetText(GetLocale("THE_LIVE_PRODUCTION_OF_X_JUST_FINISHED").Replace("%TITLE%", "|b|"+title+"|/b|"))
 			Else
-				toast.SetText((GetLocale("THE_LIVE_PRODUCTION_OF_X_JUST_FINISHED") + "~n" + GetLocale("TOTAL_PRODUCTION_COSTS_WERE_X")).Replace("%TITLE%", "|b|"+title+"|/b|").Replace("%TOTALCOST%", "|b|" + MathHelper.DottedValue(production.productionConcept.GetTotalCost()) + GetLocale("CURRENCY") + "|/b|" ))
+				toast.SetText((GetLocale("THE_LIVE_PRODUCTION_OF_X_JUST_FINISHED") + "~n" + GetLocale("TOTAL_PRODUCTION_COSTS_WERE_X")).Replace("%TITLE%", "|b|"+title+"|/b|").Replace("%TOTALCOST%", "|b|" + MathHelper.DottedValue(production.productionConcept.GetTotalCost()) + CURRENCYSIGN + "|/b|" ))
 			EndIf
 		Else
 			toast.SetCaption(GetLocale("SHOOTING_FINISHED"))
-			toast.SetText((GetLocale("THE_LICENCE_OF_X_IS_NOW_AT_YOUR_DISPOSAL") + "~n" + GetLocale("TOTAL_PRODUCTION_COSTS_WERE_X")).Replace("%TITLE%", "|b|"+title+"|/b|").Replace("%TOTALCOST%", "|b|" + MathHelper.DottedValue(production.productionConcept.GetTotalCost()) + GetLocale("CURRENCY") + "|/b|" ))
+			toast.SetText((GetLocale("THE_LICENCE_OF_X_IS_NOW_AT_YOUR_DISPOSAL") + "~n" + GetLocale("TOTAL_PRODUCTION_COSTS_WERE_X")).Replace("%TITLE%", "|b|"+title+"|/b|").Replace("%TOTALCOST%", "|b|" + MathHelper.DottedValue(production.productionConcept.GetTotalCost()) + CURRENCYSIGN + "|/b|" ))
 		EndIf
 
 		toast.GetData().AddNumber("playerID", production.owner)
@@ -5706,7 +5706,7 @@ endrem
 		toast.SetMessageCategory(TVTMessageCategory.MISC)
 		toast.SetCaption(GetLocale("PREPRODUCTION_FINISHED"))
 		If GameRules.payLiveProductionInAdvance
-			toast.SetText((GetLocale("THE_LICENCE_OF_X_IS_NOW_AT_YOUR_DISPOSAL") + "~n" + GetLocale("TOTAL_PRODUCTION_COSTS_WERE_X")).Replace("%TITLE%", "|b|"+title+"|/b|").Replace("%TOTALCOST%", "|b|" + MathHelper.DottedValue(production.productionConcept.GetTotalCost()) + GetLocale("CURRENCY") + "|/b|" ))
+			toast.SetText((GetLocale("THE_LICENCE_OF_X_IS_NOW_AT_YOUR_DISPOSAL") + "~n" + GetLocale("TOTAL_PRODUCTION_COSTS_WERE_X")).Replace("%TITLE%", "|b|"+title+"|/b|").Replace("%TOTALCOST%", "|b|" + MathHelper.DottedValue(production.productionConcept.GetTotalCost()) + CURRENCYSIGN + "|/b|" ))
 		Else
 			toast.SetText(GetLocale("THE_LICENCE_OF_X_IS_NOW_AT_YOUR_DISPOSAL").Replace("%TITLE%", "|b|"+title+"|/b|"))
 		EndIf
@@ -5803,7 +5803,7 @@ endrem
 		toast.SetCaption(GetLocale("ADCONTRACT_FINISHED"))
 		toast.SetText( ..
 			GetLocale("ADCONTRACT_X_SUCCESSFULLY_FINISHED").Replace("%TITLE%", contract.GetTitle()) + " " + ..
-			GetLocale("PROFIT_OF_X_GOT_CREDITED").Replace("%MONEY%", "|b|"+MathHelper.DottedValue(contract.GetProfit())+getLocale("CURRENCY")+"|/b|") ..
+			GetLocale("PROFIT_OF_X_GOT_CREDITED").Replace("%MONEY%", "|b|"+MathHelper.DottedValue(contract.GetProfit())+CURRENCYSIGN+"|/b|") ..
 		)
 		'play a special sound instead of the default one
 		toast.GetData().AddString("onAddMessageSFX", "positiveMoneyChange")
@@ -5837,7 +5837,7 @@ endrem
 		toast.SetCaption(GetLocale("ADCONTRACT_FAILED"))
 		toast.SetText( ..
 			GetLocale("ADCONTRACT_X_FAILED").Replace("%TITLE%", contract.GetTitle()) + " " + ..
-			GetLocale("PENALTY_OF_X_WAS_PAID").Replace("%MONEY%", "|b|"+MathHelper.DottedValue(contract.GetPenalty())+getLocale("CURRENCY")+"|/b|") ..
+			GetLocale("PENALTY_OF_X_WAS_PAID").Replace("%MONEY%", "|b|"+MathHelper.DottedValue(contract.GetPenalty())+CURRENCYSIGN+"|/b|") ..
 		)
 
 		toast.GetData().AddNumber("playerID", contract.owner)


### PR DESCRIPTION
closes #822

Vorschlag ist, eine Konstante statt einer lokalisierten Währung zu verwenden. Falls wir das so machen wollen könnten wir noch überlegen, ob ein Leerzeichen vor dem Währungssymbol stehen soll oder nicht (z.B. auch indem dieses Leerzeichen Teil der Konstante ist und nicht bei jeder Verwendung einzeln ergänzt werden muss).