### PR TITLE
Verkaufspreis von Eigenproduktionen soll Preisfaktor ignorieren

### DIFF
--- a/source/game.production.bmx
+++ b/source/game.production.bmx
@@ -781,6 +781,9 @@ Type TProduction Extends TOwnedGameObject
 			programmeLicence.getData().releaseTime = GetWorldTime().GetTimeGone()
 		EndIf
 
+		'difficulty price modifier shall not apply to custom productions
+		If programmeLicence.IsAPlayersCustomProduction() Then programmeLicence.SetBroadcastFlag(TVTBroadcastMaterialSourceFlag.IGNORE_PLAYERDIFFICULTY, True)
+
 		GetProgrammeDataCollection().Add(programmeLicence.data)
 		GetProgrammeLicenceCollection().AddAutomatic(programmeLicence)
 
@@ -973,6 +976,9 @@ endrem
 			'production done - but for the child elements)
 			'parentLicence.GetData().productionID = - self.GetID() 
 			parentLicence.GetData().SetFlag(TVTProgrammeDataFlag.CUSTOMPRODUCTION, True)
+
+			'difficulty price modifier shall not apply to custom productions
+			If parentLicence.IsAPlayersCustomProduction() Then parentLicence.SetBroadcastFlag(TVTBroadcastMaterialSourceFlag.IGNORE_PLAYERDIFFICULTY, True)
 
 			'if the template header does not define all licence flags, the ones
 			'set for the header heavily depend on the production order of episodes!

--- a/source/game.roomhandler.movieagency.bmx
+++ b/source/game.roomhandler.movieagency.bmx
@@ -960,6 +960,8 @@ Type RoomHandler_MovieAgency Extends TRoomHandler
 					'set owner (and automatically remove from offerPlan-lists)
 					licence.SetOwner(licence.OWNER_VENDOR)
 					lists[listIndex][entryIndex] = licence
+					'once a custom production is sold, the player difficulty should be considered
+					If licence.IsAPlayersCustomProduction() Then licence.SetBroadcastFlag(TVTBroadcastMaterialSourceFlag.IGNORE_PLAYERDIFFICULTY, False)
 				Else
 					If Not warnedOfMissingLicence
 						TLogger.Log("MovieAgency.RefillBlocks()", "Not enough licences to refill slot["+entryIndex+"+] in list["+listIndex+"]", LOG_WARNING | LOG_DEBUG)


### PR DESCRIPTION
Ist aufgrund des Schwierigkeitsgrades der Filmpreisfaktor hoch, soll dieser nicht für den Verkauf von Eigenproduktionen angewandt werden (höherer Verkaufspreis).

see #784 