### PR TITLE
Event für Nachrichtenverfügbarkeit korrekt behandeln

### DIFF
--- a/source/game.newsagency.base.bmx
+++ b/source/game.newsagency.base.bmx
@@ -696,6 +696,11 @@ Type TNewsAgency
 			'skip news events not happening yet
 			If Not newsEvent.HasHappened() Then Continue
 
+			If Not newsEvent.IsAvailable()
+				GetNewsEventCollection().Remove(newsEvent)
+				Continue
+			EndIf
+
 			AnnounceNewsEventToPlayers(newsEvent)
 
 			'attention: RESET_TICKER_TIME is only "useful" for followup news

--- a/source/game.programme.newsevent.bmx
+++ b/source/game.programme.newsevent.bmx
@@ -1188,7 +1188,9 @@ Type TGameModifierNews_ModifyAvailability Extends TGameModifierBase
 					GetNewsEventCollection()._InvalidateCaches()
 				EndIf
 			Next
-			
+
+			'prevent undoing enablement immediately
+			setFlag(TGameModifierBase.FLAG_PERMANENT)
 			Return True
 		Else
 			Local newsEvent:TNewsEvent = GetNewsEvent()
@@ -1201,6 +1203,8 @@ Type TGameModifierNews_ModifyAvailability Extends TGameModifierBase
 				'refresh caches
 				GetNewsEventCollection()._InvalidateCaches()
 
+				'prevent undoing enablement immediately
+				setFlag(TGameModifierBase.FLAG_PERMANENT)
 				Return True
 			EndIf
 		EndIf


### PR DESCRIPTION
Im Zusammenhang mit #955 habe ich den Effekt modifyAvailability für Nachrichten ausprobiert. Der Trigger feuert und setzt das Flag. Wenn die Nachricht dann aber dran war, hatte das Flag allerdings wieder seinen Ausgangswert.
Es stellte sich heraus, dass unmittelbar nach dem RunFunction das UndoFunction lief. Ich denke, das soll nicht sein - wenn das Setzen erfolgreich war, soll der Effekt permanent sein.

Weiterhin fehlte bei Nachfolgenachrichten die Prüfung des Flags, so dass sie trotz "Verbots" verfügbar wären.