### PR TITLE
Nachrichten: Randomisierung wiederkehrender Nachrichten

### DIFF
--- a/source/game.programme.newsevent.template.bmx
+++ b/source/game.programme.newsevent.template.bmx
@@ -540,7 +540,13 @@ Type TNewsEventTemplate extends TBroadcastMaterialSourceBase
 	Method GetQuality:Float()
 		If qualityMin >= 0 And qualityMax >= 0
 			return 0.001 * BiasedRandRange(int(1000*qualityMin), int(1000*qualityMax), qualitySlope)
-		Endif
+		ElseIf Not HasFlag(TVTNewsFlag.UNIQUE_EVENT)
+			'for reusable news randomize a bit (+/- 15%) 
+			'do not go below 10% / above 90% (or the defined quality in case it is beyond these thresholds)
+			Local diff:Float = 0.01 * BiasedRandRange(-15, 15, 0.5)
+			Local result:Float = MathHelper.Clamp(quality + diff, Min(0.1, quality), Max(0.9, quality))
+			return result
+		EndIf
 
 		Return quality
 	End Method


### PR DESCRIPTION
Die Datenbank sieht für Nachrichtentemplates zwar Qualitäts-Wertebereiche vor. Diese werden jedoch aktuell nicht genutzt. Für Einmalnachrichten ist das nicht so problematisch. Wiederkehrende Nachrichten sollten jedoch nicht immer dieselben Werte haben.
Daher wird, wenn Flag 2 nicht gesetzt ist und kein Qualtiätsbereich definiert ist, der Qualitätswert randomisiert.