### PR TITLE
KI über korrekten Sendegenehmigungspreis informieren; Report Yoshi

### DIFF
--- a/source/game.ai.bmx
+++ b/source/game.ai.bmx
@@ -982,6 +982,7 @@ endrem
 		Local section:TStationMapSection = GetStationMapCollection().GetSection(x,y)
 		If Not section Then Return Self.RESULT_NOTFOUND
 		If section.HasBroadCastPermission(Self.ME, TVTStationType.ANTENNA) Then Return 0
+		If Not section.NeedsBroadcastPermission(Self.ME, TVTStationType.ANTENNA) Then Return 0
 		If Not section.CanGetBroadcastPermission(Self.ME) Return -1
 		Local price:Int = section.GetBroadcastPermissionPrice(Self.ME, TVTStationType.ANTENNA)
 		Return price


### PR DESCRIPTION
Bei der aktuellen Implementierung wird der Fall nicht berücksichtigt, dass gar keine Sendegenehmigung nötig ist. Das führt ins. bei späterem Spielstart dazu, dass die KI nur im Startland Antennen kauft, obwohl sie sich auch die in anderen Bundesländern leisten könnte.