### PR TITLE
Debug-Ansicht Senderkarte

### DIFF
--- a/source/game.debug.screen.page.bmx
+++ b/source/game.debug.screen.page.bmx
@@ -254,29 +254,34 @@ Type TDebugControlsButton
 	Method Render:Int(offsetX:Int=0, offsetY:Int=0)
 		If Not visible Then Return False
 
+		RenderButton(offsetX + x, offsetY + y, w, h, text, enabled, selected)
+	End Method
+	
+	
+	Function RenderButton(x:Int, y:Int, w:Int, h:int, text:String, enabled:Int = True, selected:Int = False)
 		Local oldColA:Float = GetAlpha()
 		If Not enabled Then SetAlpha oldColA * 0.5 
 
 		SetColor 150,150,150
-		DrawRect(offsetX + x,offsetY + y,w,h)
+		DrawRect(x,y,w,h)
 		If selected
-			If THelper.MouseIn(offsetX + x,offsetY + y,w,h)
+			If THelper.MouseIn(x,y,w,h)
 				SetColor 120,110,100
 			Else
 				SetColor 80,70,50
 			EndIf
-		ElseIf THelper.MouseIn(offsetX + x,offsetY + y,w,h)
+		ElseIf THelper.MouseIn(x,y,w,h)
 			SetColor 50,50,50
 		Else
 			SetColor 0,0,0
 		EndIf
 
-		DrawRect(offsetX + x+1,offsetY + y+1,w-2,h-2)
+		DrawRect(x+1,y+1,w-2,h-2)
 		SetColor 255,255,255
-		GetBitmapFont("default", 11).DrawBox(text, offsetX + x,offsetY + y,w,h, sALIGN_CENTER_CENTER, SColor8.White)
+		GetBitmapFont("default", 11).DrawBox(text, x,y,w,h, sALIGN_CENTER_CENTER, SColor8.White)
 		
 		SetAlpha(oldColA)
-	End Method
+	End Function
 
 
 	Method onClick()

--- a/source/game.debug.screen.page.stationmap.bmx
+++ b/source/game.debug.screen.page.stationmap.bmx
@@ -3,14 +3,13 @@ Import "game.debug.screen.page.bmx"
 Import "game.game.bmx"
 Import "game.stationmap.bmx"
 
-
-
+'TODO: * data sheet when overing
+'      * lazy init - obtain data when opening, on "map" change, on player selection
+'      * sorting (by section, by audience count, by "name", running cost (absolute/per 1000 viewers))
+'      * switch show population, show running costs
 Type TDebugScreenPage_Stationmap extends TDebugScreenPage
 	Field buttons:TDebugControlsButton[]
-	Field playerStationsListHeight:Int[4]
-	Field playerStationsListOffsetY:Int[4]
-	Field playerStationsListButtonHeight:Int = 20
-	
+
 	Method Init:TDebugScreenPage_Stationmap()
 		Local texts:String[] = ["Destroy", "Add"]
 		Local button:TDebugControlsButton
@@ -20,11 +19,11 @@ Type TDebugScreenPage_Stationmap extends TDebugScreenPage
 
 			buttons :+ [button]
 		Next
-		
+
 		Return self
 	End Method
-	
-	
+
+
 	Method SetPosition(x:Int, y:Int)
 		position = new SVec2I(x, y)
 
@@ -34,12 +33,12 @@ Type TDebugScreenPage_Stationmap extends TDebugScreenPage
 			b.y = y + b.dataInt * (b.h + 3)
 		Next
 	End Method
-	
-	
+
+
 	Method Reset()
 	End Method
-	
-	
+
+
 	Method Activate()
 	End Method
 
@@ -50,38 +49,24 @@ Type TDebugScreenPage_Stationmap extends TDebugScreenPage
 
 	Method Update()
 		Local playerID:Int = GetShownPlayerID()
-
-
-		'move buttons
-		if buttons.length >= 6
-			buttons[ 0].SetXY(position.x + 510 + 70, position.y + 0 * 18 + 5).SetWH( 43, 15)
-			buttons[ 1].SetXY(position.x + 510 + 90 + 47, position.y + 0 * 18 + 5).SetWH( 26, 15)
-		endif
-
-
 		For Local b:TDebugControlsButton = EachIn buttons
 			b.Update()
-		Next
-
-		For local i:int = 1 to 4
-			UpdateBlock_PlayerStationsList(playerID, position.x + 5 * (i-1) * 135, position.y + 50, 130, 250)
 		Next
 	End Method
 
 
 	Method Render()
-		DrawOutlineRect(position.x + 510, 13, 160, 150)
-		textFont.Draw("Satellites", position.x + 510, position.y + 0 * 18 + 5)
+		Local playerID:Int = GetShownPlayerID()
 
 		For Local i:Int = 0 Until buttons.length
 			buttons[i].Render()
 		Next
-		
+		Local boxWidth:Int = 130
+		Local boxHeight:Int = 330
+		Local fistBlockOffset:Int = 15
 
-		For local i:int = 1 to 4
-			RenderBlock_PlayerStations(i, position.x + 5 + (i-1) * 135, position.y)
-			RenderBlock_PlayerStationsList(i, position.x + 5 + (i-1) * 135, position.y + 50, 130, 250)
-		Next
+		RenderBlock_PlayerStations(playerID, position.x + 5, position.y, boxWidth, boxHeight)
+		RenderBlock_PlayerStationsList(playerID, fistBlockOffset, position.x + 5, position.y, boxWidth, boxHeight)
 rem
 		Local headerText:String = GetLocale("COUNTRYNAME_ISO3166_"+GetStationMapCollection().GetMapISO3166Code())
 
@@ -98,83 +83,82 @@ rem
 		skin.fontNormal.DrawBox(GetLocale("CABLE_NETWORK_RECEIVERS")+":", col3, textY + 3*lineH, col3W,  overviewLineH, sALIGN_LEFT_TOP, skin.textColorNeutral, EDrawTextEffect.Shadow, 0.2)
 		skin.fontNormal.DrawBox(MathHelper.NumberToString(GetStationMapCollection().GetAveragePopulationCableShare()*100, 2)+"%", col4, textY + 3*lineH, col4W,  overviewLineH, sALIGN_RIGHT_TOP, skin.textColorNeutral)
 endrem
-
-
 	End Method
 
 
-	Method RenderBlock_PlayerStations(playerID:Int, x:Int, y:Int)
+	Method RenderBlock_PlayerStations(playerID:Int, x:Int, y:Int, w:Int, h:Int)
 		Local player:TPlayer = GetPlayer(playerID)
-		Local boxWidth:Int = 130
-		Local boxHeight:Int = 330
 
-		SetColor 40,40,40
-		DrawRect(x, y, boxWidth, boxHeight)
-		SetColor 50,50,40
-		DrawRect(x+1, y+1, boxWidth-2, boxHeight)
-		SetColor 255,255,255
+		For Local i:Int = 0 Until 4
+			SetColor 40,40,40
+			DrawRect(x + i*135, y, w, h)
+			SetColor 50,50,40
+			DrawRect(x + 1 + i*135, y+1, w-2, h)
+			SetColor 255,255,255
+		Next
 
 		Local textX:Int = x + 3
 		Local textY:Int = y + 3 - 1
 		Local map:TStationMap = GetStationMap(playerID)
 		textFont.Draw("Player: " + playerID, textX, textY)
-		textFont.DrawBox("Reach: " + MathHelper.DottedValue(map.GetReach()), textX, textY, boxWidth - 6, 16, sALIGN_RIGHT_TOP, SColor8.WHITE)
-		textY :+ 15
+		textFont.DrawBox("Reach: " + MathHelper.DottedValue(map.GetReach()), textX, textY, w - 6, 16, sALIGN_RIGHT_TOP, SColor8.WHITE)
 	End Method
 
 
-	Method UpdateBlock_PlayerStationsList(playerID:Int, x:Int, y:Int, w:Int, h:int)
-		if THelper.MouseIn(x, y + h - 50, w/2, 50)
-			If MouseManager.IsClicked(1)
-				playerStationsListOffsetY[playerID - 1] :- 50
-				MouseManager.SetClickHandled(1)
-			EndIf
-		Elseif THelper.MouseIn(x + w/2, y + h - 50, w/2, 50)
-			If MouseManager.IsClicked(1)
-				playerStationsListOffsetY[playerID - 1] :+ 50
-				MouseManager.SetClickHandled(1)
-			EndIf
-		EndIf
-		'clamp
-		if playerStationsListHeight[playerID - 1] > h
-			playerStationsListOffsetY[playerID - 1] = Min(Max(0, playerStationsListOffsetY[playerID - 1]), playerStationsListHeight[playerID - 1] - h + playerStationsListButtonHeight)
-		else
-			playerStationsListOffsetY[playerID - 1] = Min(Max(0, playerStationsListOffsetY[playerID - 1]), playerStationsListHeight[playerID - 1] - h)
-		endif
-	End Method
-
-
-	Method RenderBlock_PlayerStationsList(playerID:Int, x:Int, y:Int, w:Int, h:int)
+	Method RenderBlock_PlayerStationsList(playerID:Int, firstBlockOffset:Int, x:Int, y:Int, w:Int, h:int)
 		Local player:TPlayer = GetPlayer(playerID)
 		Local map:TStationMap = GetStationMap(playerID)
 
-		Local vpx:Int, vpy:Int, vpw:Int, vph:Int
-		GetViewport(vpx, vpy, vpw, vph)
-		SetViewport(x, y, w, h)
-
-		SetColor 40,40,40
-		DrawRect(x, y, w, h)
-		SetColor 50,50,40
-		DrawRect(x+1, y+1, w-2, h)
-		SetColor 255,255,255
-
 		Local textX:Int = x + 3
-		Local textY:Int = y + 3 - 1
-		textY :- playerStationsListOffsetY[playerID-1]
+		Local textY:Int = y + firstBlockOffset + 3 - 1
 		Local textYStart:Int = textY
 
-		'do not render over buttons
-		if playerStationsListHeight[playerID-1] > h
-			SetViewport(x, y, w, h - playerStationsListButtonHeight)
-		EndIf
+		textFont.Draw("Sat Uplinks: " + map.GetStationCount(TVTStationType.SATELLITE_UPLINK), textX, textY)
+		textFont.DrawBox(MathHelper.DottedValue(GetStationMapCollection().GetSatelliteUplinkAudienceSum(playerID)), textX, textY, w - 6, 16, sALIGN_RIGHT_TOP, SColor8.WHITE)
+		textY :+ 12
+		For local satellite:TStationMap_Satellite = EachIn GetStationMapCollection().satellites
+			Local station:TStationBase = map.GetSatelliteUplinkBySatellite(satellite)
+			If station
+				textFont.Draw( Chr(9654) + " " + satellite.GetName(), textX + 5, textY)
+				textFont.DrawBox(MathHelper.DottedValue(station.GetExclusiveReach()), textX, textY, w - 6, 16, sALIGN_RIGHT_TOP, SColor8.WHITE)
+				textY :+ 10
+			EndIf
+		Next
+		textY :+ 3
+
+		textFont.Draw("Cable Uplinks: " + map.GetStationCount(TVTStationType.CABLE_NETWORK_UPLINK), textX, textY)
+		textFont.DrawBox(MathHelper.DottedValue(GetStationMapCollection().GetCableNetworkUplinkAudienceSum(playerID)), textX, textY, w - 6, 16, sALIGN_RIGHT_TOP, SColor8.WHITE)
+		textY :+ 12
+		For local section:TStationMapSection = EachIn GetStationMapCollection().sections
+			Local sectionName:String = section.name
+			Local station:TStationBase = map.GetCableNetworkUplinkStationBySectionName(sectionName)
+			If station
+				Local iso:String = station.GetSectionISO3166Code()
+				Local n:String = GetLocale("MAP_COUNTRY_"+iso+"_LONG")
+				if n.length > 11 then n = n[.. 10]+".."
+				Local c:SColor8 = SColor8.WHITE
+				if not station.IsActive() then c = SColor8.GRAY
+				textFont.DrawBox( Chr(9654) + " " + n, textX + 5, textY, 90, 16, sALIGN_LEFT_TOP, c)
+				textFont.DrawBox(MathHelper.DottedValue(station.GetExclusiveReach()), textX, textY, w - 6, 16, sALIGN_RIGHT_TOP, c)
+				textY :+ 10
+			EndIf
+		Next
+		textY :+ 3
+
 		textFont.Draw("Antennas: " + map.GetStationCount(TVTStationType.ANTENNA), textX, textY)
 		textFont.DrawBox(MathHelper.DottedValue(GetStationMapCollection().GetAntennaAudienceSum(playerID)), textX, textY, w - 6, 16, sALIGN_RIGHT_TOP, SColor8.WHITE)
 
 		textY :+ 12
 		For local section:TStationMapSection = EachIn GetStationMapCollection().sections
-			Local sectionName:String = section.GetName()
+			Local sectionName:String = section.name
 			For local station:TStationAntenna = EachIn map.GetStationsBySectionName(sectionName)
-				Local n:String = GetLocale("MAP_COUNTRY_"+sectionName)
+				If textY >= y + h - 1
+					x = x + 135
+					textX:Int = x + 3
+					textY:Int = y - 1
+				EndIf
+				Local iso:String = station.GetSectionISO3166Code()
+				Local n:String = GetLocale("MAP_COUNTRY_"+iso+"_SHORT")
 				if n.length > 11 then n = n[.. 10]+".."
 				Local c:SColor8 = SColor8.WHITE
 				if not station.IsActive() then c = SColor8.GRAY
@@ -183,61 +167,6 @@ endrem
 				textY :+ 10
 			Next
 		Next
-		textY :+ 3
-
-		textFont.Draw("Cable Uplinks: " + map.GetStationCount(TVTStationType.CABLE_NETWORK_UPLINK), textX, textY)
-		textFont.DrawBox(MathHelper.DottedValue(GetStationMapCollection().GetCableNetworkUplinkAudienceSum(playerID)), textX, textY, w - 6, 16, sALIGN_RIGHT_TOP, SColor8.WHITE)
-		textY :+ 12
-		For local section:TStationMapSection = EachIn GetStationMapCollection().sections
-			Local sectionName:String = section.GetName()
-			Local station:TStationBase = map.GetCableNetworkUplinkStationBySectionName(sectionName)
-			If station
-				Local n:String = GetLocale("MAP_COUNTRY_"+sectionName)
-				if n.length > 11 then n = n[.. 10]+".."
-				Local c:SColor8 = SColor8.WHITE
-				if not station.IsActive() then c = SColor8.GRAY
-				textFont.DrawBox( Chr(9654) + " " + n +": " + station.GetName(), textX + 5, textY, 90, 16, sALIGN_LEFT_TOP, c)
-				textFont.DrawBox(MathHelper.DottedValue(station.GetExclusiveReach()), textX, textY, w - 6, 16, sALIGN_RIGHT_TOP, c)
-				textY :+ 10
-			EndIf
-		Next
-		textY :+ 3
-
-		textFont.Draw("Sat Uplinks: " + map.GetStationCount(TVTStationType.SATELLITE_UPLINK), textX, textY)
-		textFont.DrawBox(MathHelper.DottedValue(GetStationMapCollection().GetSatelliteUplinkAudienceSum(playerID)), textX, textY, w - 6, 16, sALIGN_RIGHT_TOP, SColor8.WHITE)
-		textY :+ 12
-		For local satellite:TStationMap_Satellite = EachIn GetStationMapCollection().satellites
-			Local station:TStationBase = map.GetSatelliteUplinkBySatellite(satellite)
-			If station
-				textFont.Draw( Chr(9654) + " " + satellite.GetName() +": till", textX + 5, textY)
-				textFont.DrawBox(MathHelper.DottedValue(station.GetExclusiveReach()), textX, textY, w - 6, 16, sALIGN_RIGHT_TOP, SColor8.WHITE)
-				textY :+ 10
-			EndIf
-		Next
-		textY :+ 3
-		
-		if playerStationsListHeight[playerID-1] > h
-			SetViewport(x, y, w, h)
-
-			Local listH:Int = h - playerStationsListButtonHeight
-			local indicatorHeight:int = listH * (float(listH) / playerStationsListHeight[playerID-1])
-			local indicatorOffset:int = playerStationsListOffsetY[playerID-1] * indicatorHeight/float(listH)
-			SetAlpha 0.5
-			SetColor 100,100,100
-			DrawRect(x + w - 2, y, 2, listH)
-			SetAlpha 0.8
-			SetColor 180,160,150
-			DrawRect(x + w - 2, y  + indicatorOffset, 2, indicatorHeight)
-			SetAlpha 1.0
-			SetColor 255,255,255
-
-			TDebugControlsButton.RenderButton(x + 5, y + h - playerStationsListButtonHeight + 2, w/2 - 10, playerStationsListButtonHeight - 4, chr(9650))
-			TDebugControlsButton.RenderButton(x + w/2 + 10, y + h - playerStationsListButtonHeight + 2, w/2 - 10, playerStationsListButtonHeight - 4, chr(9660))
-		EndIf
-			
-		SetViewport(vpx, vpy, vpw, vph)
-
-		playerStationsListHeight[playerID-1] = textY - textYStart
 	End Method
 
 
@@ -249,34 +178,6 @@ rem
 				GetPublicImage(1).Reset()
 			case 1
 				GetPublicimage(1).ChangeImage(New TAudience.InitValue(-changeValue, -changeValue))
-			case 2
-				GetPublicimage(1).ChangeImage(New TAudience.InitValue(changeValue, changeValue))
-			case 3
-				GetPublicimage(1).ChangeImage(New TAudience.InitValue(changeValue*10, changeValue*10))
-			case 4
-				GetPublicImage(2).Reset()
-			case 5
-				GetPublicimage(2).ChangeImage(New TAudience.InitValue(-changeValue, -changeValue))
-			case 6
-				GetPublicimage(2).ChangeImage(New TAudience.InitValue(changeValue, changeValue))
-			case 7
-				GetPublicimage(2).ChangeImage(New TAudience.InitValue(changeValue*10, changeValue*10))
-			case 8
-				GetPublicImage(3).Reset()
-			case 9
-				GetPublicimage(3).ChangeImage(New TAudience.InitValue(-changeValue, -changeValue))
-			case 10
-				GetPublicimage(3).ChangeImage(New TAudience.InitValue(changeValue, changeValue))
-			case 11
-				GetPublicimage(3).ChangeImage(New TAudience.InitValue(changeValue*10, changeValue*10))
-			case 12
-				GetPublicImage(4).Reset()
-			case 13
-				GetPublicimage(4).ChangeImage(New TAudience.InitValue(-changeValue, -changeValue))
-			case 14
-				GetPublicimage(4).ChangeImage(New TAudience.InitValue(changeValue, changeValue))
-			case 15
-				GetPublicimage(4).ChangeImage(New TAudience.InitValue(changeValue*10, changeValue*10))
 endrem
 		End Select
 

--- a/source/game.debug.screen.page.stationmap.bmx
+++ b/source/game.debug.screen.page.stationmap.bmx
@@ -1,0 +1,287 @@
+SuperStrict
+Import "game.debug.screen.page.bmx"
+Import "game.game.bmx"
+Import "game.stationmap.bmx"
+
+
+
+Type TDebugScreenPage_Stationmap extends TDebugScreenPage
+	Field buttons:TDebugControlsButton[]
+	Field playerStationsListHeight:Int[4]
+	Field playerStationsListOffsetY:Int[4]
+	Field playerStationsListButtonHeight:Int = 20
+	
+	Method Init:TDebugScreenPage_Stationmap()
+		Local texts:String[] = ["Destroy", "Add"]
+		Local button:TDebugControlsButton
+		For Local i:Int = 0 Until texts.length
+			button = CreateActionButton(i, texts[i], position.x, position.y)
+			button._onClickHandler = OnButtonClickHandler
+
+			buttons :+ [button]
+		Next
+		
+		Return self
+	End Method
+	
+	
+	Method SetPosition(x:Int, y:Int)
+		position = new SVec2I(x, y)
+
+		'move buttons
+		For local b:TDebugControlsButton = EachIn buttons
+			b.x = x + 510 + 5
+			b.y = y + b.dataInt * (b.h + 3)
+		Next
+	End Method
+	
+	
+	Method Reset()
+	End Method
+	
+	
+	Method Activate()
+	End Method
+
+
+	Method Deactivate()
+	End Method
+
+
+	Method Update()
+		Local playerID:Int = GetShownPlayerID()
+
+
+		'move buttons
+		if buttons.length >= 6
+			buttons[ 0].SetXY(position.x + 510 + 70, position.y + 0 * 18 + 5).SetWH( 43, 15)
+			buttons[ 1].SetXY(position.x + 510 + 90 + 47, position.y + 0 * 18 + 5).SetWH( 26, 15)
+		endif
+
+
+		For Local b:TDebugControlsButton = EachIn buttons
+			b.Update()
+		Next
+
+		For local i:int = 1 to 4
+			UpdateBlock_PlayerStationsList(playerID, position.x + 5 * (i-1) * 135, position.y + 50, 130, 250)
+		Next
+	End Method
+
+
+	Method Render()
+		DrawOutlineRect(position.x + 510, 13, 160, 150)
+		textFont.Draw("Satellites", position.x + 510, position.y + 0 * 18 + 5)
+
+		For Local i:Int = 0 Until buttons.length
+			buttons[i].Render()
+		Next
+		
+
+		For local i:int = 1 to 4
+			RenderBlock_PlayerStations(i, position.x + 5 + (i-1) * 135, position.y)
+			RenderBlock_PlayerStationsList(i, position.x + 5 + (i-1) * 135, position.y + 50, 130, 250)
+		Next
+rem
+		Local headerText:String = GetLocale("COUNTRYNAME_ISO3166_"+GetStationMapCollection().GetMapISO3166Code())
+
+		skin.fontNormal.DrawBox("|b|"+GetLocale("POPULATION")+":|/b|", col1, textY + 0*lineH, col1W,  overviewLineH, sALIGN_LEFT_TOP, skin.textColorNeutral)
+		skin.fontNormal.DrawBox(TFunctions.DottedValue(GetStationMapCollection().GetPopulation()), col2, textY + 0*lineH, col2W,  overviewLineH, sALIGN_RIGHT_TOP, skin.textColorNeutral)
+		skin.fontNormal.DrawBox("|b|"+GetLocale("STATIONMAP_SECTIONS_NAME")+":|/b|", col1, textY + 1*lineH, col1W,  overviewLineH, sALIGN_LEFT_TOP, skin.textColorNeutral)
+		skin.fontNormal.DrawBox(GetStationMapCollection().GetSectionCount(), col2, textY + 1*lineH, col2W,  overviewLineH, sALIGN_RIGHT_TOP, skin.textColorNeutral)
+
+		skin.fontNormal.DrawBox("|b|"+GetLocale("RECEIVER_SHARE")+"|/b|", col3, textY + 0*lineH, col3W + col4W,  overviewLineH, sALIGN_LEFT_TOP, skin.textColorNeutral)
+		skin.fontNormal.DrawBox(GetLocale("ANTENNA_RECEIVERS")+":", col3, textY + 1*lineH, col3W,  overviewLineH, sALIGN_LEFT_TOP, skin.textColorNeutral, EDrawTextEffect.Shadow, 0.2)
+		skin.fontNormal.DrawBox(MathHelper.NumberToString(GetStationMapCollection().GetAveragePopulationAntennaShare()*100, 2)+"%", col4, textY + 1*lineH, col4W,  overviewLineH, sALIGN_RIGHT_TOP, skin.textColorNeutral)
+		skin.fontNormal.DrawBox(GetLocale("SATELLITE_RECEIVERS")+":", col3, textY + 2*lineH, col3W,  overviewLineH, sALIGN_LEFT_TOP, skin.textColorNeutral, EDrawTextEffect.Shadow, 0.2)
+		skin.fontNormal.DrawBox(MathHelper.NumberToString(GetStationMapCollection().GetAveragePopulationSatelliteShare()*100, 2)+"%", col4, textY + 2*lineH, col4W,  overviewLineH, sALIGN_RIGHT_TOP, skin.textColorNeutral)
+		skin.fontNormal.DrawBox(GetLocale("CABLE_NETWORK_RECEIVERS")+":", col3, textY + 3*lineH, col3W,  overviewLineH, sALIGN_LEFT_TOP, skin.textColorNeutral, EDrawTextEffect.Shadow, 0.2)
+		skin.fontNormal.DrawBox(MathHelper.NumberToString(GetStationMapCollection().GetAveragePopulationCableShare()*100, 2)+"%", col4, textY + 3*lineH, col4W,  overviewLineH, sALIGN_RIGHT_TOP, skin.textColorNeutral)
+endrem
+
+
+	End Method
+
+
+	Method RenderBlock_PlayerStations(playerID:Int, x:Int, y:Int)
+		Local player:TPlayer = GetPlayer(playerID)
+		Local boxWidth:Int = 130
+		Local boxHeight:Int = 330
+
+		SetColor 40,40,40
+		DrawRect(x, y, boxWidth, boxHeight)
+		SetColor 50,50,40
+		DrawRect(x+1, y+1, boxWidth-2, boxHeight)
+		SetColor 255,255,255
+
+		Local textX:Int = x + 3
+		Local textY:Int = y + 3 - 1
+		Local map:TStationMap = GetStationMap(playerID)
+		textFont.Draw("Player: " + playerID, textX, textY)
+		textFont.DrawBox("Reach: " + MathHelper.DottedValue(map.GetReach()), textX, textY, boxWidth - 6, 16, sALIGN_RIGHT_TOP, SColor8.WHITE)
+		textY :+ 15
+	End Method
+
+
+	Method UpdateBlock_PlayerStationsList(playerID:Int, x:Int, y:Int, w:Int, h:int)
+		if THelper.MouseIn(x, y + h - 50, w/2, 50)
+			If MouseManager.IsClicked(1)
+				playerStationsListOffsetY[playerID - 1] :- 50
+				MouseManager.SetClickHandled(1)
+			EndIf
+		Elseif THelper.MouseIn(x + w/2, y + h - 50, w/2, 50)
+			If MouseManager.IsClicked(1)
+				playerStationsListOffsetY[playerID - 1] :+ 50
+				MouseManager.SetClickHandled(1)
+			EndIf
+		EndIf
+		'clamp
+		if playerStationsListHeight[playerID - 1] > h
+			playerStationsListOffsetY[playerID - 1] = Min(Max(0, playerStationsListOffsetY[playerID - 1]), playerStationsListHeight[playerID - 1] - h + playerStationsListButtonHeight)
+		else
+			playerStationsListOffsetY[playerID - 1] = Min(Max(0, playerStationsListOffsetY[playerID - 1]), playerStationsListHeight[playerID - 1] - h)
+		endif
+	End Method
+
+
+	Method RenderBlock_PlayerStationsList(playerID:Int, x:Int, y:Int, w:Int, h:int)
+		Local player:TPlayer = GetPlayer(playerID)
+		Local map:TStationMap = GetStationMap(playerID)
+
+		Local vpx:Int, vpy:Int, vpw:Int, vph:Int
+		GetViewport(vpx, vpy, vpw, vph)
+		SetViewport(x, y, w, h)
+
+		SetColor 40,40,40
+		DrawRect(x, y, w, h)
+		SetColor 50,50,40
+		DrawRect(x+1, y+1, w-2, h)
+		SetColor 255,255,255
+
+		Local textX:Int = x + 3
+		Local textY:Int = y + 3 - 1
+		textY :- playerStationsListOffsetY[playerID-1]
+		Local textYStart:Int = textY
+
+		'do not render over buttons
+		if playerStationsListHeight[playerID-1] > h
+			SetViewport(x, y, w, h - playerStationsListButtonHeight)
+		EndIf
+		textFont.Draw("Antennas: " + map.GetStationCount(TVTStationType.ANTENNA), textX, textY)
+		textFont.DrawBox(MathHelper.DottedValue(GetStationMapCollection().GetAntennaAudienceSum(playerID)), textX, textY, w - 6, 16, sALIGN_RIGHT_TOP, SColor8.WHITE)
+
+		textY :+ 12
+		For local section:TStationMapSection = EachIn GetStationMapCollection().sections
+			Local sectionName:String = section.GetName()
+			For local station:TStationAntenna = EachIn map.GetStationsBySectionName(sectionName)
+				Local n:String = GetLocale("MAP_COUNTRY_"+sectionName)
+				if n.length > 11 then n = n[.. 10]+".."
+				Local c:SColor8 = SColor8.WHITE
+				if not station.IsActive() then c = SColor8.GRAY
+				textFont.DrawBox( Chr(9654) + " " + n +": " + station.GetName(), textX + 5, textY, 90, 16, sALIGN_LEFT_TOP, c)
+				textFont.DrawBox(MathHelper.DottedValue(station.GetExclusiveReach()), textX, textY, w - 6, 16, sALIGN_RIGHT_TOP, c)
+				textY :+ 10
+			Next
+		Next
+		textY :+ 3
+
+		textFont.Draw("Cable Uplinks: " + map.GetStationCount(TVTStationType.CABLE_NETWORK_UPLINK), textX, textY)
+		textFont.DrawBox(MathHelper.DottedValue(GetStationMapCollection().GetCableNetworkUplinkAudienceSum(playerID)), textX, textY, w - 6, 16, sALIGN_RIGHT_TOP, SColor8.WHITE)
+		textY :+ 12
+		For local section:TStationMapSection = EachIn GetStationMapCollection().sections
+			Local sectionName:String = section.GetName()
+			Local station:TStationBase = map.GetCableNetworkUplinkStationBySectionName(sectionName)
+			If station
+				Local n:String = GetLocale("MAP_COUNTRY_"+sectionName)
+				if n.length > 11 then n = n[.. 10]+".."
+				Local c:SColor8 = SColor8.WHITE
+				if not station.IsActive() then c = SColor8.GRAY
+				textFont.DrawBox( Chr(9654) + " " + n +": " + station.GetName(), textX + 5, textY, 90, 16, sALIGN_LEFT_TOP, c)
+				textFont.DrawBox(MathHelper.DottedValue(station.GetExclusiveReach()), textX, textY, w - 6, 16, sALIGN_RIGHT_TOP, c)
+				textY :+ 10
+			EndIf
+		Next
+		textY :+ 3
+
+		textFont.Draw("Sat Uplinks: " + map.GetStationCount(TVTStationType.SATELLITE_UPLINK), textX, textY)
+		textFont.DrawBox(MathHelper.DottedValue(GetStationMapCollection().GetSatelliteUplinkAudienceSum(playerID)), textX, textY, w - 6, 16, sALIGN_RIGHT_TOP, SColor8.WHITE)
+		textY :+ 12
+		For local satellite:TStationMap_Satellite = EachIn GetStationMapCollection().satellites
+			Local station:TStationBase = map.GetSatelliteUplinkBySatellite(satellite)
+			If station
+				textFont.Draw( Chr(9654) + " " + satellite.GetName() +": till", textX + 5, textY)
+				textFont.DrawBox(MathHelper.DottedValue(station.GetExclusiveReach()), textX, textY, w - 6, 16, sALIGN_RIGHT_TOP, SColor8.WHITE)
+				textY :+ 10
+			EndIf
+		Next
+		textY :+ 3
+		
+		if playerStationsListHeight[playerID-1] > h
+			SetViewport(x, y, w, h)
+
+			Local listH:Int = h - playerStationsListButtonHeight
+			local indicatorHeight:int = listH * (float(listH) / playerStationsListHeight[playerID-1])
+			local indicatorOffset:int = playerStationsListOffsetY[playerID-1] * indicatorHeight/float(listH)
+			SetAlpha 0.5
+			SetColor 100,100,100
+			DrawRect(x + w - 2, y, 2, listH)
+			SetAlpha 0.8
+			SetColor 180,160,150
+			DrawRect(x + w - 2, y  + indicatorOffset, 2, indicatorHeight)
+			SetAlpha 1.0
+			SetColor 255,255,255
+
+			TDebugControlsButton.RenderButton(x + 5, y + h - playerStationsListButtonHeight + 2, w/2 - 10, playerStationsListButtonHeight - 4, chr(9650))
+			TDebugControlsButton.RenderButton(x + w/2 + 10, y + h - playerStationsListButtonHeight + 2, w/2 - 10, playerStationsListButtonHeight - 4, chr(9660))
+		EndIf
+			
+		SetViewport(vpx, vpy, vpw, vph)
+
+		playerStationsListHeight[playerID-1] = textY - textYStart
+	End Method
+
+
+	Function OnButtonClickHandler(sender:TDebugControlsButton)
+		Local changeValue:Float = 1.0 '1%
+		Select sender.dataInt
+rem
+			case 0
+				GetPublicImage(1).Reset()
+			case 1
+				GetPublicimage(1).ChangeImage(New TAudience.InitValue(-changeValue, -changeValue))
+			case 2
+				GetPublicimage(1).ChangeImage(New TAudience.InitValue(changeValue, changeValue))
+			case 3
+				GetPublicimage(1).ChangeImage(New TAudience.InitValue(changeValue*10, changeValue*10))
+			case 4
+				GetPublicImage(2).Reset()
+			case 5
+				GetPublicimage(2).ChangeImage(New TAudience.InitValue(-changeValue, -changeValue))
+			case 6
+				GetPublicimage(2).ChangeImage(New TAudience.InitValue(changeValue, changeValue))
+			case 7
+				GetPublicimage(2).ChangeImage(New TAudience.InitValue(changeValue*10, changeValue*10))
+			case 8
+				GetPublicImage(3).Reset()
+			case 9
+				GetPublicimage(3).ChangeImage(New TAudience.InitValue(-changeValue, -changeValue))
+			case 10
+				GetPublicimage(3).ChangeImage(New TAudience.InitValue(changeValue, changeValue))
+			case 11
+				GetPublicimage(3).ChangeImage(New TAudience.InitValue(changeValue*10, changeValue*10))
+			case 12
+				GetPublicImage(4).Reset()
+			case 13
+				GetPublicimage(4).ChangeImage(New TAudience.InitValue(-changeValue, -changeValue))
+			case 14
+				GetPublicimage(4).ChangeImage(New TAudience.InitValue(changeValue, changeValue))
+			case 15
+				GetPublicimage(4).ChangeImage(New TAudience.InitValue(changeValue*10, changeValue*10))
+endrem
+		End Select
+
+		'handled
+		sender.clicked = False
+		sender.selected = False
+	End Function
+End Type

--- a/source/gamefunctions_debug.bmx
+++ b/source/gamefunctions_debug.bmx
@@ -31,6 +31,7 @@ Type TDebugScreen
 	Field scriptAgencyOfferHightlight:TScript
 	
 	
+	Field pageStationmap:TDebugScreenPage_StationMap
 	Field pagePublicImages:TDebugScreenPage_PublicImages
 	Field pagePlayerFinancials:TDebugScreenPage_PlayerFinancials
 	Field pagePlayerBroadcasts:TDebugScreenPage_PlayerBroadcasts
@@ -58,7 +59,7 @@ Type TDebugScreen
 		Local button:TDebugControlsButton
 
 
-		Local texts:String[] = ["Overview", "Player Commands", "Player Financials", "Player Broadcasts", "Public Image", "-", "Ad Agency", "Movie Vendor", "News Agency", "Script Agency", "Room Agency", "-", "Politics Sim", "Custom Production", "Producers", "Sports Sim", "Modifiers", "Misc"]
+		Local texts:String[] = ["Overview", "Player Commands", "Player Financials", "Player Broadcasts", "Public Image", "Stationmap", "-", "Ad Agency", "Movie Vendor", "News Agency", "Script Agency", "Room Agency", "-", "Politics Sim", "Custom Production", "Producers", "Sports Sim", "Modifiers", "Misc"]
 		Local mode:int = 0
 		For Local i:Int = 0 Until texts.length
 			if texts[i] = "-" then continue 'spacer
@@ -84,6 +85,9 @@ Type TDebugScreen
 
 		pagePublicImages = new TDebugScreenPage_PublicImages.Init()
 		pagePublicImages.SetPosition(sideButtonPanelWidth, 20)
+
+		pageStationmap = new TDebugScreenPage_StationMap.Init()
+		pageStationmap.SetPosition(sideButtonPanelWidth, 20)
 
 		pageAdAgency = TDebugScreenPage_AdAgency.GetInstance().Init()
 		pageAdAgency.SetPosition(sideButtonPanelWidth, 20)
@@ -114,6 +118,7 @@ Type TDebugScreen
 	
 	
 	Method Reset()
+		If pageStationmap Then pageStationmap.Reset()
 		If pagePublicImages Then pagePublicImages.Reset()
 		If pagePlayerFinancials Then pagePlayerFinancials.Reset()
 		If pagePlayerBroadcasts Then TDebugScreenPage_PlayerBroadcasts.GetInstance().Reset()
@@ -152,18 +157,19 @@ Type TDebugScreen
 				Case 2	newPage = pagePlayerFinancials
 				Case 3	newPage = pagePlayerBroadcasts
 				Case 4	newPage = pagePublicImages
-				Case 5	newPage = pageAdAgency
-				Case 6	newPage = pageMovieAgency
+				Case 5	newPage = pageStationmap
+				Case 6	newPage = pageAdAgency
+				Case 7	newPage = pageMovieAgency
 
-				'Case 7	UpdateMode_NewsAgency()
-				'Case 8	UpdateMode_ScriptAgency()
-				'Case 9	UpdateMode_RoomAgency()
-				'Case 10	UpdateMode_Politics()
-				Case 11  newPage = pageCustomProductions
-				'Case 12	UpdateMode_Producers()
-				'Case 13	UpdateMode_Sports()
-				Case 14	newPage = pageModifiers
-				'Case 15	UpdateMode_Misc()
+				'Case 8	UpdateMode_NewsAgency()
+				'Case 9	UpdateMode_ScriptAgency()
+				'Case 10	UpdateMode_RoomAgency()
+				'Case 11	UpdateMode_Politics()
+				Case 12  newPage = pageCustomProductions
+				'Case 13	UpdateMode_Producers()
+				'Case 14	UpdateMode_Sports()
+				Case 15	newPage = pageModifiers
+				'Case 16	UpdateMode_Misc()
 				default newPage = Null
 			End Select
 			
@@ -239,13 +245,13 @@ Type TDebugScreen
 			Case 0	UpdateMode_Overview()
 			Case 1	UpdateMode_PlayerCommands()
 
-			Case 7	UpdateMode_NewsAgency()
-			Case 8	UpdateMode_ScriptAgency()
-			Case 9	UpdateMode_RoomAgency()
-			Case 10	UpdateMode_Politics()
-			Case 12	UpdateMode_Producers()
-			Case 13	UpdateMode_Sports()
-			Case 15	UpdateMode_Misc()
+			Case 8	UpdateMode_NewsAgency()
+			Case 9	UpdateMode_ScriptAgency()
+			Case 10	UpdateMode_RoomAgency()
+			Case 11	UpdateMode_Politics()
+			Case 13	UpdateMode_Producers()
+			Case 14	UpdateMode_Sports()
+			Case 16	UpdateMode_Misc()
 			default
 				if currentPage then currentPage.Update()
 		End Select
@@ -287,13 +293,13 @@ Type TDebugScreen
 			Case 0	RenderMode_Overview()
 			Case 1	RenderMode_PlayerCommands()
 
-			Case 7	RenderMode_NewsAgency()
-			Case 8	RenderMode_ScriptAgency()
-			Case 9	RenderMode_RoomAgency()
-			Case 10	RenderMode_Politics()
-			Case 12	RenderMode_Producers()
-			Case 13	RenderMode_Sports()
-			Case 15	RenderMode_Misc()
+			Case 8	RenderMode_NewsAgency()
+			Case 9	RenderMode_ScriptAgency()
+			Case 10	RenderMode_RoomAgency()
+			Case 11	RenderMode_Politics()
+			Case 13	RenderMode_Producers()
+			Case 14	RenderMode_Sports()
+			Case 16	RenderMode_Misc()
 			default
 				if currentPage then currentPage.Render()
 		End Select

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -108,6 +108,7 @@ Import "game.gamescriptexpression.bmx"
 
 Import "game.screen.menu.bmx"
 
+Import "game.debug.screen.page.stationmap.bmx"
 Import "game.debug.screen.page.publicimages.bmx"
 Import "game.debug.screen.page.playerfinancials.bmx"
 Import "game.debug.screen.page.playerbroadcasts.bmx"


### PR DESCRIPTION
Ich habe den Branch zu PR #574 rebased und angepasst. Es werden nicht mehr alle Spieler gleichzeitig angezeigt sondern nur die Daten des aktuellen Spielers. Man kann neben der Reichweite auch Kosten und Kosten pro Zuschauer anzeigen lassen sowie die Sortierung anpassen. Bei Hover über einer Station gibt es eine Detailansicht.

closes #560