### PR TITLE
Datenbankeinträge mit nicht unterstützter Sprache ignorieren; report Scr0llbaer

### DIFF
--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -2376,8 +2376,12 @@ Type TDatabaseLoader
 			If value <> ""
 				Local languageID:Int = TLocalization.GetLanguageID( nodeLangEntry.GetName().ToLower() )
 
-				localized.Set(value, languageID)
-				foundEntry = True
+				If languageID <> -1
+					localized.Set(value, languageID)
+					foundEntry = True
+				Else
+					TLogger.Log("TDATABASE.LOAD()", "Found and ignored localization entry for unsupported language " + nodeLangEntry.GetName().ToLower(), LOG_LOADING|LOG_WARNING)
+				EndIf
 			EndIf
 		Next
 


### PR DESCRIPTION
Beim Datenbankeinlesen wird für Einträge mit unbekannter Sprache die ID -1 verwendet. Beim Setzen des Eintrags wird dann die aktuelle Sprache verwendet. Stattdessen sollten diese Einträge ignoriert werden.

closes #987