### PR TITLE
optionale "Pilotfolge" für Seriendrehbuchvorlagen

### DIFF
--- a/source/game.production.script.bmx
+++ b/source/game.production.script.bmx
@@ -476,7 +476,9 @@ Type TScript Extends TScriptBase {_exposeToLua="selected"}
 			Local mainTemplateEpisodeCount:Int = template.getEpisodes()
 			If mainTemplateEpisodeCount > 1 and mainTemplateEpisodeCount < template.subScripts.length
 				'if parent restricts the number of episodes - get a subset of templates
-				For Local subTemplate:TScriptTemplate = EachIn template.GetSubTemplateSubset(mainTemplateEpisodeCount)
+				Local pilot:TScriptTemplate = TScriptTemplate(template.subScripts[0])
+				Local forceIncludePilot:Int = pilot.episodesMin > 0
+				For Local subTemplate:TScriptTemplate = EachIn template.GetSubTemplateSubset(mainTemplateEpisodeCount, forceIncludePilot)
 					Local subScript:TScript = TScript.CreateFromTemplate(subTemplate, False)
 					If subScript
 						If template.programmeDataModifiers

--- a/source/game.production.scripttemplate.bmx
+++ b/source/game.production.scripttemplate.bmx
@@ -576,11 +576,17 @@ Type TScriptTemplate Extends TScriptBase
 		return BiasedRandRange(episodesMin, episodesMax, episodesSlope)
 	End Method
 
-	Method GetSubTemplateSubset:TScriptTemplate[](count:int)
+	Method GetSubTemplateSubset:TScriptTemplate[](count:Int, forceIncludePilot:Int = 0)
 		count = Min(count, subScripts.length)
 		Local result:TScriptTemplate[] = new TScriptTemplate[count]
-		Local keep:Int[] = [0]
-		If count > 1 Then keep :+ RandRangeArray(1, subScripts.length-1, count-1)
+		Local keep:Int[] = []
+		Local startIndex:Int = 0
+		If forceIncludePilot
+			keep:+ [0]
+			count:- 1
+			startIndex = 1
+		EndIf
+		If count > 1 Then keep :+ RandRangeArray(startIndex, subScripts.length-1, count-1)
 		keep.Sort()
 		For local i:Int = 0 until keep.length
 			result[i] = TScriptTemplate(subScripts[keep[i]])


### PR DESCRIPTION
Z.B. in scripttemplate-ron-visiting wird die Möglichkeit verwendet, eine Serie mit wenigen Folgen zu definieren, die aus einer langen Liste möglicher Folgen zufällig ausgewählt wird. Die Annahme der ersten Implementierung war, dass die Serien nichts wirklich miteinander zu tun haben, also immer eine Pilotfolge existiert (erstes Kind).
Möchte man ein solches Template aber nutzen um eine Serie mit mehreren Staffeln zu definieren (wobei die Einzelfolgen für sich selbst stehen sollten), wäre es ungünstig, wenn das erste Kind-Template immer dabei wäre.

Mit der gemachten Anpassung kann die "Pilotfolge" als optional markiert werden.