### PR TITLE
Datenbankfehler abfangen

### DIFF
--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -1230,10 +1230,10 @@ Type TDatabaseLoader
 		programmeData.country = data.GetString("country", programmeData.country)
 
 		programmeData.distributionChannel = data.GetInt("distribution", programmeData.distributionChannel)
-		programmeData.blocks = data.GetInt("blocks", programmeData.blocks)
+		programmeData.blocks = MathHelper.clamp(data.GetInt("blocks", programmeData.blocks), 1, 12)
 
-		programmeData.broadcastTimeSlotStart = data.GetInt("broadcast_time_slot_start", programmeData.broadcastTimeSlotStart)
-		programmeData.broadcastTimeSlotEnd = data.GetInt("broadcast_time_slot_end", programmeData.broadcastTimeSlotEnd)
+		programmeData.broadcastTimeSlotStart = MathHelper.clamp(data.GetInt("broadcast_time_slot_start", programmeData.broadcastTimeSlotStart), 0, 23)
+		programmeData.broadcastTimeSlotEnd = MathHelper.clamp(data.GetInt("broadcast_time_slot_end", programmeData.broadcastTimeSlotEnd), 0, 23)
 		If programmeData.broadcastTimeSlotStart = programmeData.broadcastTimeSlotEnd
 			programmeData.broadcastTimeSlotStart = -1
 			programmeData.broadcastTimeSlotEnd = -1

--- a/source/game.production.scripttemplate.bmx
+++ b/source/game.production.scripttemplate.bmx
@@ -498,8 +498,8 @@ Type TScriptTemplate Extends TScriptBase
 	Method SetBlocksRange(minValue:Int, maxValue:Int=-1, slope:Float=0.5)
 		if maxValue = -1 then maxValue = minValue
 		MathHelper.SortIntValues(minValue, maxValue)
-		minValue = max(1, minValue)
-		maxValue = max(1, maxValue)
+		minValue = MathHelper.clamp(minValue, 1, 12)
+		maxValue = MathHelper.clamp(maxValue, 1, 12)
 
 		blocksMin = minValue
 		blocksMax = maxValue


### PR DESCRIPTION
see #995

Der XML-Errorhandler-Code in main.bmx um Zeile 140 greift nicht. Beim lokalen Einlesen einer Datei, in der ein Attribut doppelt definiert wird, gibt es zwar ein "print" des Fehlers (mit unbrauchbarer Zeilennummer), aber die erwartete Log-Ausgabe kommt nicht.