### PR TITLE
Reparatur Lokalisierungs-Fallback; report scr0llbaer

### DIFF
--- a/source/Dig/base.util.localization.bmx
+++ b/source/Dig/base.util.localization.bmx
@@ -644,21 +644,21 @@ Type TLocalizationLanguage
 		If group Then key = group + "::" + key
 		key = lower(key)
 
-		local availableStrings:int = 1
+		local availableStrings:int = 0
 		local found:int = 0
 		local subKey:string = ""
 		repeat
 			subKey = Key
 			if availableStrings > 0 then subKey :+ availableStrings
 			if map.Contains(subKey)
-				availableStrings :+ 1
 				found :+ 1
 			elseif availableStrings <> 0
 				exit
 			endif
+			availableStrings :+ 1
 		until found > 10
 
-		return availableStrings
+		return found
 	End Method
 End Type
 


### PR DESCRIPTION
Wenn ein Schlüssel nicht vorhanden ist, muss der Fallback verwendet werden. Durch die Initialisierung und Rückgabe von "availableStrings" gab es nie einen Fallback. Änderung bitte genau prüfen.

closes #1005