### PR TITLE
dynamischere Genre-Beliebtheit

### DIFF
--- a/source/Dig/base.util.mersenne.bmx
+++ b/source/Dig/base.util.mersenne.bmx
@@ -116,7 +116,7 @@ Function GaussRandRange:Double(minValue:Double, maxValue:Double, mean:Float, sta
 	local v1:Float = mt_RandRange(0,1000000) / 1000000.0
 	local v2:Float = mt_RandRange(0,1000000) / 1000000.0
 
-	return minValue + (maxValue - minValue) * mean * abs(1.0 + sqr(-2.0 * log(v1)) * cos(2.0 * pi * v2) * standardDerivation)
+	return minValue + (maxValue - minValue) * mean * abs(1.0 + sqr(-2.0 * log(v1)) * cos(360 * v2) * standardDerivation)
 End Function
 
 

--- a/source/game.broadcast.genredefinition.movie.bmx
+++ b/source/game.broadcast.genredefinition.movie.bmx
@@ -1,4 +1,4 @@
-﻿SuperStrict
+SuperStrict
 Import "Dig/base.util.registry.bmx"
 Import "game.broadcast.genredefinition.base.bmx"
 Import "game.popularity.bmx"
@@ -173,7 +173,12 @@ Type TMovieGenreDefinition Extends TGenreDefinitionBase
 
 
 	Method GetPopularity:TGenrePopularity()
-		return TGenrePopularity(Super.GetPopularity())
+		Local result:TGenrePopularity=TGenrePopularity(Super.GetPopularity())
+		If Not result.referenceGUID
+			result.referenceGUID = "moviegenre-"+referenceID
+'			print "  popularity for " +referenceID +": "+ result.referenceID
+		EndIf
+		Return result
 	End Method
 
 

--- a/source/game.popularity.bmx
+++ b/source/game.popularity.bmx
@@ -228,15 +228,21 @@ Type TPopularity
 	'Passt die LongTermPopularity mit einigen Wahrscheinlichkeiten an
 	'oder ändert sie komplett
 	Method AdjustTrendDirectionRandomly()
+		Local rnd:Int = RandRange(1,100)
+		'Local oldVal:Float = longTermPopularity
 		'2%-Chance das der langfristige Trend komplett umschwenkt
-		If RandRange(1,100) <= ChanceToChangeCompletely Then
+		If rnd <= ChanceToChangeCompletely Then
 			SetLongTermPopularity(RandRange(LongTermPopularityLowerBound, LongTermPopularityUpperBound))
+			'print "changing popularity completely "+referenceGUID +": "+oldVal+"->"+longTermPopularity
 		'10%-Chance das der langfristige Trend umschwenkt
-		ElseIf RandRange(1,100) <= ChanceToChange Then
-			SetLongTermPopularity(LongTermPopularity + RandRange(ChangeLowerBound, ChangeUpperBound))
+		ElseIf rnd <= ChanceToChange Then
+			'favour small changes
+			SetLongTermPopularity(LongTermPopularity + Int(GaussRandRange(ChangeLowerBound, ChangeUpperBound, 0.5, 0.25)))
+			'print "changing Long Term popularity "+referenceGUID+": "+oldVal+"->"+longTermPopularity
 		'25%-Chance das sich die langfristige Popularität etwas dem aktuellen Trend/Popularität anpasst
-		Elseif RandRange(1,100) <= ChanceToAdjustLongTermPopularity Then
+		Elseif rnd <= ChanceToAdjustLongTermPopularity Then
 			SetLongTermPopularity(LongTermPopularity + ((Popularity-LongTermPopularity)/2) + Trend)
+			'print "adjust trend popularity "+referenceGUID+": "+oldVal+"->"+longTermPopularity +" Pop:"+Popularity+ " Trend:"+Trend
 		Endif
 	End Method
 

--- a/source/gameDebug/gamefunctions_debug.bmx
+++ b/source/gameDebug/gamefunctions_debug.bmx
@@ -422,6 +422,7 @@ Type TDebugAudienceInfo
 		Local y:Int = 25
 		Local font:TBitmapFont = GetBitmapFontManager().baseFontSmall
 
+		GetBitmapFontManager().baseFontBold.DrawSimple("Spieler: "+playerID, 25, 25, SColor8.Red)
 		font.DrawBox("Gesamt", x, y, 65, 25, sALIGN_RIGHT_TOP, SColor8.Red)
 		font.DrawBox("Kinder", x + (70*1), y, 65, 25, sALIGN_RIGHT_TOP, SColor8.White)
 		font.DrawBox("Jugendliche", x + (70*2), y, 65, 25, sALIGN_RIGHT_TOP, SColor8.White)
@@ -472,10 +473,14 @@ Type TDebugAudienceInfo
 
 		Local attraction:TAudienceAttraction = audienceResult.AudienceAttraction
 		Local genre:String = "kein Genre"
+		Local popularity:String = ""
 		Select attraction.BroadcastType
 			Case TVTBroadcastMaterialType.PROGRAMME
 				If (attraction.BaseAttraction <> Null And attraction.genreDefinition)
 					genre = GetLocale("PROGRAMME_GENRE_"+TVTProgrammeGenre.GetAsString(attraction.genreDefinition.referenceID))
+					If attraction.GenrePopularityMod
+						popularity = "Popularity "+genre+ ": " + MathHelper.NumberToString(attraction.GenrePopularityMod,2) +"; Long Term: "+MathHelper.NumberToString(1+ attraction.genreDefinition._popularity.LongTermPopularity/100.0,2)
+					EndIf
 				EndIf
 			Case TVTBroadcastMaterialType.ADVERTISEMENT
 				If (attraction.BaseAttraction <> Null)
@@ -489,7 +494,10 @@ Type TDebugAudienceInfo
 
 		Local offset:Int = 110
 
-		GetBitmapFontManager().baseFontBold.DrawSimple("Sendung: " + audienceResult.GetTitle() + "     (" + genre + ") [Spieler: "+playerID+"]", 25, offset, SColor8.Red)
+		GetBitmapFontManager().baseFontBold.DrawSimple("Sendung (" + genre + "): " + audienceResult.GetTitle(), 25, offset, SColor8.Red)
+		If popularity
+			font.DrawBox(popularity, 455, offset, 300, 25, sALIGN_RIGHT_TOP, SColor8.White)
+		EndIf
 		offset :+ 20
 
 		font.DrawSimple("1. Programmqualität & Aktual.", 25, offset, SColor8.White)


### PR DESCRIPTION
Ich habe mir mal den Einfluss der Genre-Beliebtheit (Film) etwas genauer angeschaut. Der Wert taucht ja aktuell in der Quotenansicht nicht auf, hat aber einen nicht zu vernachlässigenden Einfluss.
Mit dem aktuellen PR soll folgendes erreicht werden:

* Genre, die seit einer Aktualisierung nicht ausgestrahlt wurden beliebter machen
* Genre, die ausgestrahlt werden weniger beliebt machen (unmittelbare Sättigung) - nicht nur beim "Update"

Dabei sind die Anpassungen nach oben und unten beschränkt und ergänzen die bestehende Berechnung lediglich.