### PR TITLE
Berücksichtigung Subgenres

### DIFF
--- a/source/game.broadcastmaterial.advertisement.bmx
+++ b/source/game.broadcastmaterial.advertisement.bmx
@@ -1,4 +1,4 @@
-﻿Rem
+Rem
 	====================================================================
 	code for advertisement-objects in programme planning
 	====================================================================
@@ -97,7 +97,7 @@ Type TAdvertisement Extends TBroadcastMaterialDefaultImpl {_exposeToLua="selecte
 
 	'override - return INFOMERCIAL genre
 	Method GetGenreDefinition:TGenreDefinitionBase()
-		Return GetMovieGenreDefinitionCollection().Get(TVTProgrammeGenre.INFOMERCIAL)
+		Return GetMovieGenreDefinitionCollection().Get([TVTProgrammeGenre.INFOMERCIAL])
 	End Method
 
 

--- a/source/game.production.productionconcept.bmx
+++ b/source/game.production.productionconcept.bmx
@@ -667,7 +667,7 @@ Type TProductionConcept Extends TOwnedGameObject
 	'producers could use this)
 	'returns amount of unspend points
 	Method AssignEffectiveFocusPoints:Int(pointsToSpend:Int)
-		Local genreDefinition:TMovieGenreDefinition = GetMovieGenreDefinition(script.mainGenre)
+		Local genreDefinition:TMovieGenreDefinition = GetMovieGenreDefinition([script.mainGenre]+script.subgenres)
 
 		Local indices:Int[] = productionFocus.GetOrderedFocusIndices()
 		Local priorities:Float[] = new Float[indices.length]
@@ -718,7 +718,7 @@ Type TProductionConcept Extends TOwnedGameObject
 		_effectiveFocusPoints = 0.0
 		_effectiveFocusPointsMax = 0.0
 
-		Local genreDefinition:TMovieGenreDefinition = GetMovieGenreDefinition(script.mainGenre)
+		Local genreDefinition:TMovieGenreDefinition = GetMovieGenreDefinition([script.mainGenre]+script.subGenres)
 
 		For local focusPointID:int = EachIn productionFocus.GetOrderedFocusIndices()
 			'production speed does not add to quality
@@ -841,7 +841,7 @@ Type TProductionConcept Extends TOwnedGameObject
 
 		local castFitSum:Float = 0.0
 		local personCount:int = 0
-		local genreDefinition:TMovieGenreDefinition = GetMovieGenreDefinition(script.mainGenre)
+		local genreDefinition:TMovieGenreDefinition = GetMovieGenreDefinition([script.mainGenre]+script.subgenres)
 
 
 		For local castIndex:int = 0 until cast.length

--- a/source/game.production.script.bmx
+++ b/source/game.production.script.bmx
@@ -932,7 +932,7 @@ Type TScript Extends TScriptBase {_exposeToLua="selected"}
 
 	'mixes main and subgenre criterias
 	Method CalculateTotalGenreCriterias(totalReview:Float Var, totalSpeed:Float Var, totalOutcome:Float Var)
-		Local genreDefinition:TMovieGenreDefinition = GetMovieGenreDefinition(mainGenre)
+		Local genreDefinition:TMovieGenreDefinition = GetMovieGenreDefinition([mainGenre] + subGenres)
 		If Not genreDefinition
 			TLogger.Log("TScript.CalculateTotalGenreCriterias()", "script with wrong movie genre definition, criteria calculation failed.", LOG_ERROR)
 			Return
@@ -941,35 +941,6 @@ Type TScript Extends TScriptBase {_exposeToLua="selected"}
 		totalOutcome = genreDefinition.OutcomeMod
 		totalReview = genreDefinition.ReviewMod
 		totalSpeed = genreDefinition.SpeedMod
-
-		'build subgenre-averages
-		Local subGenreDefinition:TMovieGenreDefinition
-		Local subGenreCount:Int
-		Local subGenreOutcome:Float, subGenreReview:Float, subGenreSpeed:Float
-		For Local i:Int = 0 Until subGenres.length
-			subGenreDefinition = GetMovieGenreDefinition(i)
-			If Not subGenreDefinition Then Continue
-
-			subGenreOutcome :+ subGenreDefinition.OutcomeMod
-			subGenreReview :+ subGenreDefinition.ReviewMod
-			subGenreSpeed :+ subGenreDefinition.SpeedMod
-			subGenreCount :+ 1
-		Next
-		If subGenreCount > 1
-			subGenreOutcome :/ subGenreCount
-			subGenreReview :/ subGenreCount
-			subGenreSpeed :/ subGenreCount
-		EndIf
-
-		'mix maingenre and subgenres by 60:40
-		If subGenreCount > 0
-			'if main genre ignores outcome, ignore for subgenres too!
-			If totalOutcome > 0
-				totalOutcome = totalOutcome*0.6 + subGenreOutcome*0.4
-			EndIf
-			totalReview = totalReview*0.6 + subGenreReview*0.4
-			totalSpeed = totalSpeed*0.6 + subGenreSpeed*0.4
-		EndIf
 	End Method
 
 

--- a/source/game.programme.programmedata.bmx
+++ b/source/game.programme.programmedata.bmx
@@ -1559,7 +1559,7 @@ Type TProgrammeData Extends TBroadcastMaterialSource {_exposeToLua}
 
 	Method GetGenreDefinition:TMovieGenreDefinition()
 		If Not genreDefinitionCache Then
-			genreDefinitionCache = GetMovieGenreDefinitionCollection().Get(Genre)
+			genreDefinitionCache = GetMovieGenreDefinitionCollection().Get([Genre]+subgenres)
 
 			If Not genreDefinitionCache
 				TLogger.Log("GetGenreDefinition()", "Programme ~q"+GetTitle()+"~q: Genre #"+Genre+" misses a genreDefinition. Creating BASIC definition-", LOG_ERROR)

--- a/source/game.programmeproducer.bmx
+++ b/source/game.programmeproducer.bmx
@@ -405,7 +405,7 @@ Type TProgrammeProducer Extends TProgrammeProducerBase
 			End If
 			Local script:TScript = productionConcept.script
 			Local genreID:Int = script.mainGenre
-			Local genreDefinition:TMovieGenreDefinition = GetMovieGenreDefinition( genreID )
+			Local genreDefinition:TMovieGenreDefinition = GetMovieGenreDefinition( [genreID] +script.subgenres)
 
 			For Local i:Int = 0 Until alternatives.length
 				Local alternative:TPersonBase = alternatives[i]

--- a/source/game.screen.supermarket.production.bmx
+++ b/source/game.screen.supermarket.production.bmx
@@ -3010,7 +3010,7 @@ Type TGUICastListItem Extends TGUISelectListItem
 				Local script:TScript = TScreenHandler_SupermarketProduction.GetInstance().currentProductionConcept.script
 				If script 
 					genreID = script.mainGenre
-					genreDefinition = GetMovieGenreDefinition( genreID )
+					genreDefinition = GetMovieGenreDefinition( [genreID] + script.subgenres )
 				EndIf
 			EndIf
 

--- a/unittests/movieGenreDefinitions.bmx
+++ b/unittests/movieGenreDefinitions.bmx
@@ -1,0 +1,92 @@
+SuperStrict
+
+Framework brl.StandardIO
+Import "../source/Dig/base.util.math.bmx"
+Import "../source/game.gameconstants.bmx"
+Import "../source/game.registry.loaders.bmx"
+Import "../source/game.broadcast.genredefinition.movie.bmx"
+
+Local registryLoader:TRegistryLoader = New TRegistryLoader
+registryLoader.LoadFromXML("../config/programmedatamods.xml", true)
+
+Global col:TMovieGenreDefinitionCollection=TMovieGenreDefinitionCollection.GetInstance()
+col.Initialize()
+
+'printDefinition([TVTProgrammeGenre.Adventure])
+
+printDefinition2([TVTProgrammeGenre.Adventure, TVTProgrammeGenre.Erotic])
+
+Function printDefinition(genres:Int[])
+	Local main:TMovieGenreDefinition = col.Get([genres[0]])
+
+	print TVTProgrammeGenre.GetAsString(genres[0])
+	print ""
+	print "  id     : "+n2(main.referenceId)
+	print "  outcome: "+n2(main.outcomeMod)
+	print "  review : "+n2(main.ReviewMod)
+	print "  speed  : "+n2(main.SpeedMod)
+	print ""
+	For Local hour:Int = 0 to 9
+		print "  time  "+hour+": "+n2(main.TimeMods[hour])
+	Next
+	For Local hour:Int = 10 to 23
+		print "  time "+hour+": "+n2(main.TimeMods[hour])
+	Next
+End Function
+
+Function printDefinition2(genres:Int[])
+	If genres.length<>2 Then throw "expecting two genres "
+	Local main:TMovieGenreDefinition = col.Get([genres[0]])
+	Local sub:TMovieGenreDefinition = col.Get([genres[1]])
+	Local agg:TMovieGenreDefinition = col.Get(genres)
+
+	print TVTProgrammeGenre.GetAsString(genres[0]) + "+"+TVTProgrammeGenre.GetAsString(genres[1])
+	print ""
+	print "  id     : "+main.referenceId + " .. " +sub.referenceId + " = " +agg.referenceId
+	print "  outcome: "+n2(main.outcomeMod) + " .. " +n2(sub.outcomeMod) + " = " +n2(agg.outcomeMod)
+	print "  review : "+n2(main.ReviewMod) + " .. " +n2(sub.ReviewMod) + " = " +n2(agg.ReviewMod)
+	print "  speed  : "+n2(main.SpeedMod) + " .. " +n2(sub.SpeedMod) + " = " +n2(agg.SpeedMod)
+	print ""
+	rem
+		For Local hour:Int = 0 to 9
+			print "  time  "+hour+": "+n2(main.TimeMods[hour])+ " .. " +n2(sub.TimeMods[hour]) + " = " +n2(agg.TimeMods[hour])
+		Next
+		For Local hour:Int = 10 to 23
+			print "  time "+hour+": "+n2(main.TimeMods[hour])+ " .. " +n2(sub.TimeMods[hour]) + " = " +n2(agg.TimeMods[hour])
+		Next
+	endrem
+
+	rem
+		print main.AudienceAttraction.ToString()
+		print sub.AudienceAttraction.ToString()
+		print agg.AudienceAttraction.ToString()
+	endrem
+
+	print ""
+	printFocusPoints("main", main)
+	printFocusPoints("sub", sub)
+	printFocusPoints("aggregate", agg)
+
+	print ""
+	printCastAttributes("main", main)
+	printCastAttributes("sub", sub)
+	printCastAttributes("aggregate", agg)
+End Function
+
+Function n2:String(value:Float)
+	return MathHelper.NumberToString(value, 2)
+End Function
+
+Function printFocusPoints(id:String, def:TMovieGenreDefinition)
+	print "focus points "+id
+	For Local key:String = EachIn def.focusPointPriorities.Keys()
+		print key+ " : "+ String(def.focusPointPriorities.ValueForKey(key))
+	Next
+EndFunction
+
+Function printCastAttributes(id:String, def:TMovieGenreDefinition)
+	print "cast attributes "+id
+	For Local key:String = EachIn def.castAttributes.Keys()
+		print key+ " : "+ String(def.castAttributes.ValueForKey(key))
+	Next
+EndFunction


### PR DESCRIPTION
Zunächst Vorschlag für den Lösungsansatz. Anstatt an allen Stellen Haupt- und Subgenres getrennt zu betrachten und Wete zu aggregieren, werden beim Getter alle Genres mitgegeben. Für kombinierte Genres wird dort ggf. ein Aggregat erzeugt und persistiert.
Im ersten Commit wird erstmal nur ausgegeben, dass mehrere Genres angefragt werden und die Definition des Hauptgenres zurückgegeben.

closes #1010