### PR TITLE
[Balancing] Anpassung der Aktualitätserholung

### DIFF
--- a/res/database/Default/user/ronny.xml
+++ b/res/database/Default/user/ronny.xml
@@ -969,7 +969,7 @@ Illustrious guests and music by [3|Nick].</en>
 			<data flags="4" />
 			<programme_data_modifiers>
 				<modifier name="price" value="0.15" />
-				<modifier name="topicality::refresh" value="0.25" />
+				<modifier name="topicality::refresh" value="0.65" />
 				<modifier name="topicality::age" value="0.3" />
 				<modifier name="topicality::wearoff" value="1.5" />
 				<modifier name="topicality::firstBroadcastDone" value="0.03" />
@@ -1136,7 +1136,7 @@ Illustrious guests and music by [3|Nick].</en>
 			<data flags="4" />
 			<programme_data_modifiers>
 				<modifier name="price" value="0.15" />
-				<modifier name="topicality::refresh" value="0.25" />
+				<modifier name="topicality::refresh" value="0.65" />
 				<modifier name="topicality::age" value="0.3" />
 				<modifier name="topicality::wearoff" value="1.5" />
 				<modifier name="topicality::firstBroadcastDone" value="0.03" />
@@ -1269,7 +1269,7 @@ Illustrious guests and music by [3|Nick].</en>
 			<data flags="4" />
 			<programme_data_modifiers>
 				<modifier name="price" value="0.15" />
-				<modifier name="topicality::refresh" value="0.25" />
+				<modifier name="topicality::refresh" value="0.65" />
 				<modifier name="topicality::age" value="0.3" />
 				<modifier name="topicality::wearoff" value="1.5" />
 				<modifier name="topicality::firstBroadcastDone" value="0.03" />

--- a/res/database/Default/user/scr0llbaer.xml
+++ b/res/database/Default/user/scr0llbaer.xml
@@ -899,7 +899,7 @@ So that's 4120 per episode.</en>
 			<speed min="20" max="50" />
 			<programme_data_modifiers> <!-- Idea is that while the content itself may be kind of ageless and could reach Discovery Channel-like quality, the episodes are nevertheless meant to be discarded quickly (only 2 broadcasts) as there are too many gods to cover, and as to not spam one's archive. -->
 				<modifier name="topicality::age" value="0.1" />
-				<modifier name="topicality::refresh" value="0.5" />
+				<modifier name="topicality::refresh" value="0.7" />
 			</programme_data_modifiers>
 		</scripttemplate>
 


### PR DESCRIPTION
* Berechnung nur wenn nötig (aktuell<max)
* Genrepopularität bei der Erholung berücksichtigen (auch für Min-Werte)
* langsamere Erholung