### PR TITLE
Anpassung Filmpreis(reduktion) und Ausstrahlungsattraktivität

### DIFF
--- a/source/game.broadcastmaterial.base.bmx
+++ b/source/game.broadcastmaterial.base.bmx
@@ -407,6 +407,12 @@ Type TBroadcastMaterialDefaultImpl extends TBroadcastMaterial {_exposeToLua="sel
 
 
 	'default implementation
+	Method GetTopicalityModifier:Float()
+		Return 1.0
+	End Method
+
+
+	'default implementation
 	Method GetQualityOverTimeEffectMod:Float(quality:Float, block:Int )
 		If (block <= 1) Then Return 0
 		If (quality < 0.5)
@@ -538,9 +544,9 @@ Type TBroadcastMaterialDefaultImpl extends TBroadcastMaterial {_exposeToLua="sel
 		audienceAttraction.BroadcastType = Self.materialType
 		audienceAttraction.GenreDefinition = GetGenreDefinition()
 
-		'1 - Quality of the broadcast
+		'1 - Quality of the broadcast (including topicality loss impact)
 		'store it regardless of block or previous broadcast
-		audienceAttraction.Quality = GetQuality()
+		audienceAttraction.Quality = GetQuality() * GetTopicalityModifier()
 
 		If block = 1 Or Not lastProgrammeBlockAttraction Or usedAsType = TVTBroadcastMaterialType.NEWS
 			'Genre-targetgroup-fit
@@ -572,9 +578,9 @@ Type TBroadcastMaterialDefaultImpl extends TBroadcastMaterial {_exposeToLua="sel
 		audienceAttraction.BroadcastType = Self.materialType
 		audienceAttraction.GenreDefinition = GetGenreDefinition()
 
-		'1 - Quality of the broadcast
+		'1 - Quality of the broadcast  (including topicality loss impact)
 		'store it regardless of block or previous broadcast
-		audienceAttraction.Quality = GetQuality()
+		audienceAttraction.Quality = GetQuality() * GetTopicalityModifier()
 
 		'begin of a programme, begin of broadcast - or news show
 		If block = 1 Or Not lastProgrammeBlockAttraction Or usedAsType = TVTBroadcastMaterialType.NEWS

--- a/source/game.broadcastmaterial.programme.bmx
+++ b/source/game.broadcastmaterial.programme.bmx
@@ -347,6 +347,23 @@ Type TProgramme Extends TBroadcastMaterialDefaultImpl {_exposeToLua="selected"}
 		Return data.GetQuality()
 	End Method
 
+	'override
+	'reduce movie quality if not sent with maximal topicality
+	Method GetTopicalityModifier:Float()
+		Local topicality:Float = data.GetTopicality()
+		Local diff:Float = data.maxTopicalityCache - topicality
+		If diff <= 0
+			Return 1.05
+		ElseIf diff > 0.2
+			Return 0.6
+		ElseIf diff > 0.1
+			Return 0.75
+		ElseIf diff > 0.05
+			Return 0.9
+		EndIf
+		Return 1.0
+	End Method
+
 
 	'override
 	Method GetCastMod:Float()


### PR DESCRIPTION
In der aktuellen Filmpreisberechnung ist der Wertverlust aufgrund nicht maximaler Aktualität implizit (quality). Die vorgeschlagene Änderung berechnet den Basispreis aufgrund der maximalen Aktualität (ohne Anpassung) und zieht davon einen Wertverlust ab (wodurch sich diese Preisdifferenzen zum aktuellen Stand ändern). Erster Vorschlag ist, den Preisverlust auf die Hälfte des Ausgangspreises zu beschränke und von der Differenz zur maximalen Aktualität abhängig zu machen.
Grundsätzlich werden durch diese Änderung weitere Balancinganpassungen der Filmpreise erleichtert, da Basispreis und Wertverlust separat bearbeitbar sind.

Besonders teure Filme sind dadurch (weiter) nicht unmittelbar rentabel, da der Wertverlust der ersten Ausstrahlung (zur Primetime) durch Werbeeinnahmen nicht ausgeglichen werden kann. Entweder man behält den Film dann und strahlt ihne später nochmal aus oder verbucht den Verlust als "Investition in die Senderbeliebtheit" (aufgrund der hohen Einschaltquoten).

Die zweite Änderung betrifft die Berechnung der Einschaltquoten. Ein grundsätzliches Balancing-Ziel ist ja, den Kauf neuer Filme attraktiv zu machen und das dauerhafte Senden des alternden Fundus unattraktiver zu machen. Ein Aspekt dabei ist das Senden von Programmen, die nicht die maximale Aktualität haben. Deren Qualität wird für die Berechnung der Attraktivität mit einem "Malus" versehen.

Zusammen mit einer sich langsamer erholenden Aktualität (andere PRs) soll erreicht werden, dass es attraktiver wird (gerade in der Anfangsphase des Spiels), gerade gesendete Programme lieber wieder zu verkaufen und dafür neue Programme zu holen.