### PR TITLE
[Balancing] Aktualitätsverlust bei Ausstrahlung abhängig vom Schwierigkeitsgrad

### DIFF
--- a/config/gamesettings/default.xml
+++ b/config/gamesettings/default.xml
@@ -4,6 +4,7 @@
 		<startMoney value="750000"/>
 		<startCredit value="250000"/>
 		<programmePriceMod value="0.75"/>
+		<programmeTopicalityCutMod value="0.9"/>
 		<roomRentMod value="0.80"/>
 		<adcontractProfitMod value="1.25"/>
 		<antennaBuyPriceMod value="1.0"/>
@@ -25,6 +26,7 @@
 		<startMoney value="0"/>
 		<creditMinimumOnGameStart value="500000"/>
 		<programmePriceMod value="1.1"/>
+		<programmeTopicalityCutMod value="1.1"/>
 		<roomRentMod value="1.5"/>
 		<adcontractProfitMod value="0.9"/>
 		<adcontractLimitedTargetgroupMod value="1.15"/>
@@ -57,6 +59,7 @@
 		<interestRateNegativeBalance value="0.1"/><!--interest rate to be paid for negative balance; 0.1 = 10%-->
 
 		<programmePriceMod value="1.0"/><!--factor for licence prices-->
+		<programmeTopicalityCutMod value="1.0"/><!--factor for topicaltiy loss after broadcast (smaller value=less topicality loss)-->
 		<newsItemPriceMod value="1.0"/><!--factor for news item prices-->
 		<roomRentMod value="1.0"/><!--factor for room rents-->
 		<productionTimeMod value="1.0"/><!--factor for production time-->

--- a/source/game.broadcastmaterial.programme.bmx
+++ b/source/game.broadcastmaterial.programme.bmx
@@ -309,7 +309,14 @@ Type TProgramme Extends TBroadcastMaterialDefaultImpl {_exposeToLua="selected"}
 		'adjust topicality relative to possible audience
 		'using the maximum of all blocks here (as this is the maximum
 		'audience knowing about that movie)
-		data.CutTopicality(GetTopicalityCutModifier( maxWholeMarketAudiencePercentage ))
+		If TProgrammeLicenceCollection.GetInstance().IsLicenceDataUsedMultipleTimes(data.GetID())
+			print "did non use difficulty for topicality cut because the data is used by multiple licences"
+			data.CutTopicality(GetTopicalityCutModifier(maxWholeMarketAudiencePercentage))
+		Else
+			'If the programme data is unique to the owned licence, use player difficulty modifier
+			Local difficultyMod:Float = GetPlayerDifficulty(GetOwner()).programmeTopicalityCutMod
+			data.CutTopicality(GetTopicalityCutModifier( maxWholeMarketAudiencePercentage ) / difficultyMod)
+		EndIf
 
 
 		'if someone can watch that movie, increase the aired amount

--- a/source/game.player.difficulty.bmx
+++ b/source/game.player.difficulty.bmx
@@ -47,6 +47,7 @@ Type TPlayerDifficultyCollection Extends TGameObjectCollection
 			result.interestRatePositiveBalance = ReadFloat("interestRatePositiveBalance", spec, def, 0.0, 0.3)
 			result.interestRateNegativeBalance = ReadFloat("interestRateNegativeBalance", spec, def, 0.0, 0.3)
 			result.programmePriceMod = ReadFloat("programmePriceMod", spec, def, 0.1, 5.0)
+			result.programmeTopicalityCutMod = ReadFloat("programmeTopicalityCutMod", spec, def, 0.5, 2.0)
 			result.newsItemPriceMod = ReadFloat("newsItemPriceMod", spec, def, 0.1, 5.0)
 			result.roomRentMod = ReadFloat("roomRentMod", spec, def, 0.1, 5.0)
 			result.productionTimeMod = ReadFloat("productionTimeMod", spec, def, 0.1, 5.0)
@@ -140,6 +141,7 @@ Type TPlayerDifficulty extends TGameObject
 	Field interestRatePositiveBalance:Float
 	Field interestRateNegativeBalance:Float
 	Field programmePriceMod:Float = 1.0
+	Field programmeTopicalityCutMod:Float = 1.0
 	Field newsItemPriceMod:Float
 	Field roomRentmod:Float = 1.0
 	Field productionTimeMod:Float

--- a/source/gameDebug/game.debug.screen.page.modifiers.bmx
+++ b/source/gameDebug/game.debug.screen.page.modifiers.bmx
@@ -117,6 +117,7 @@ Type TDebugScreenPage_Modifiers extends TDebugScreenPage
 		'TODO Spieler mit gleichem Level teilen sich wohl dasselbe Objekt - keine spielerindividuellen Difficulty-Werte
 		'programme
 		renderModifier("Programme Price", "licPrice", difficulty.programmePriceMod)
+		renderModifier("Prog. Topicality Cut", "licTopCut", difficulty.programmeTopicalityCutMod)
 		renderModifier("Xrated Penalty", "xPenalty", difficulty.sentXRatedPenalty, 5000)
 		renderModifier("Xrated Confiscate Risk", "xRisk", difficulty.sentXRatedConfiscateRisk)
 
@@ -213,6 +214,8 @@ Type TDebugScreenPage_Modifiers extends TDebugScreenPage
 		Select fieldName
 			Case "licPrice"
 				difficulty.programmePriceMod:+ diff/100.0
+			Case "licTopCut"
+				difficulty.programmeTopicalityCutMod:+ diff/100.0
 			Case "xPenalty"
 				difficulty.sentXRatedPenalty:+ diff
 			Case "xRisk"


### PR DESCRIPTION
Ein größerer Einfluss wäre möglich, wenn man die Aktualitätserholung vom Schwierigkeitsgrad abhängig machen würde. Das ist aber konzeptionell nicht ganz trivial, da die Aktualität ja nicht am Filem sondern an den Daten hängt, die nicht wirklich einen Besitzer haben. Auch im Fall von Programmen, die nach der Ausstrahlung verkauft werden, verpufft der Effekt ggf. (starker Spieler verkauft Programm -> erholt sich schneller, als wenn er es behalten hätte).

Daher als kleiner Ansatz: den Verlust der Aktualität bei Ausstrahlung mit einem schwierigkeitsabhängigen Faktor zu versehen.