### PR TITLE
Absturz bei ProductionFinish

### DIFF
--- a/source/game.person.base.bmx
+++ b/source/game.person.base.bmx
@@ -1901,8 +1901,9 @@ Type TPersonProductionBaseData Extends TPersonBaseData
 
 		'add newly done jobs
 		jobsDone[0] :+ 1
-		For Local jobIndex:Int = 1 To TVTPersonJob.count
-			If (job & TVTPersonJob.GetAtIndex(jobIndex)) > 0
+		'TODO rename jobsDone or extend not only to cast jobs
+		For Local jobIndex:Int = 1 To TVTPersonJob.castCount
+			If (job & TVTPersonJob.GetCastJobAtIndex(jobIndex)) > 0
 				jobsDone[jobIndex] :+ 1
 			EndIf
 		Next


### PR DESCRIPTION
Ein Debugspiel ist bei mir an dieser Stelle mit Segmentation-Fault abgestürzt. Die Variable jobsDone ist nur mit der Länge von "castJobs" initialisiert. Hier wird aber bislang über alle Jobs iteriert (ging bislang gut, da es zuvor keine Drehbücher mit Models etc. gab).
Unklar ist, ob das wirklich die richtige Lösung ist (Model-Jobs werden nun nicht gezählt).