### PR TITLE
Reparatur Zufallswertinitialisierung; report Paneologe

### DIFF
--- a/source/game.game.base.bmx
+++ b/source/game.game.base.bmx
@@ -114,10 +114,9 @@ Type TGameBase {_exposeToLua="selected"}
 
 	'(re)set everything to default values
 	Method Initialize()
-		SeedRand(MilliSecs())
+		SetRandomizerBase(MilliSecs())
 		gameId = Rand32()
-		SeedRand(0)
-		randomSeedValue = 0
+		SetRandomizerBase(0)
 		title = "MyGame"
 		SetCursor(TGameBase.CURSOR_DEFAULT)
 		gamestate = 1 'mainmenu
@@ -358,7 +357,7 @@ endrem
 
 
 	Method SetRandomizerBase( value:Int=0 )
-		randomSeedValue = value
+		randomSeedValue = Abs(value)
 		'seed the random base for MERSENNE TWISTER (seedrnd for the internal one)
 		SeedRand(randomSeedValue)
 	End Method

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -2251,6 +2251,8 @@ Type TGameState
 		_Assign(_RoomHandler_ScriptAgency, RoomHandler_ScriptAgency._instance, "ScriptAgency", MODE_LOAD)
 		_Assign(_RoomHandler_News, RoomHandler_News._instance, "News", MODE_LOAD)
 		_Assign(_Game, TGame._instance, "Game")
+		'initialize() sets seed to 0, after assign randomSeedValue is correct, but was not used for setting the actual seed
+		GetGame().SetRandomizerBase(GetGame().randomSeedValue)
 
 
 		RoomHandler_AdAgency.ListSortMode = _adAgencySortMode


### PR DESCRIPTION
* korrekte Wiederherstellung des gespeicherten Seeds
* Verhinderung Überlauf bei Spielstart, wenn der Rechner zu lange angeschaltet war (millisecs liefert long, Bibliothek erwaret positiven int)