### PR TITLE
Anzeige Einnahme/Strafe pro Werbespot; report Paneologe

### DIFF
--- a/source/game.programme.adcontract.bmx
+++ b/source/game.programme.adcontract.bmx
@@ -1823,10 +1823,17 @@ Type TAdContract Extends TBroadcastMaterialSource {_exposeToLua="selected"}
 		Else
 			skin.RenderBox(contentX + 5, contentY, 100, -1, TFunctions.convertValue(GetMinAudienceForPlayer(forPlayerID), 2), "minAudience", "neutral", skin.fontBold)
 		EndIf
-		'penalty
-		skin.RenderBox(contentX + 5 + 104, contentY, 96, -1, TFunctions.convertValue(GetPenaltyForPlayer(forPlayerID), 2), "money", "bad", skin.fontBold, ALIGN_RIGHT_CENTER)
-		'profit
-		skin.RenderBox(contentX + 5 + 204, contentY, 96, -1, TFunctions.convertValue(GetProfitForPlayer(forPlayerID), 2), "money", "good", skin.fontBold, ALIGN_RIGHT_CENTER)
+			If KeyManager.IsDown(KEY_LSHIFT) Or KeyManager.IsDown(KEY_RSHIFT)
+			'penalty per spot
+			skin.RenderBox(contentX + 5 + 104, contentY, 96, -1, TFunctions.convertValue(GetPenaltyForPlayer(forPlayerID)/GetSpotCount(), 2), "money", "bad", skin.fontBold, ALIGN_RIGHT_CENTER)
+			'profit per spot
+			skin.RenderBox(contentX + 5 + 204, contentY, 96, -1, TFunctions.convertValue(GetProfitForPlayer(forPlayerID)/GetSpotCount(), 2), "money", "good", skin.fontBold, ALIGN_RIGHT_CENTER)
+		Else
+			'penalty
+			skin.RenderBox(contentX + 5 + 104, contentY, 96, -1, TFunctions.convertValue(GetPenaltyForPlayer(forPlayerID), 2), "money", "bad", skin.fontBold, ALIGN_RIGHT_CENTER)
+			'profit
+			skin.RenderBox(contentX + 5 + 204, contentY, 96, -1, TFunctions.convertValue(GetProfitForPlayer(forPlayerID), 2), "money", "good", skin.fontBold, ALIGN_RIGHT_CENTER)
+		EndIf
 
 
 		'=== DEBUG ===


### PR DESCRIPTION
In der ersten Version habe ich das Datenblatt für Werbung um eine Zeile erweitert, in der die Beträge pro Block angezeigt werden.
Optisch gefällt mir das aber nicht wirklich. Ich wäre eher für ein Umschalten der Anzeige - Gesamtbetrag Default, pro Block bei gedrückter Shift-Taste.