### PR TITLE
Anzeige maximale Einschaltquote

### DIFF
--- a/source/game.broadcast.broadcaststatistic.bmx
+++ b/source/game.broadcast.broadcaststatistic.bmx
@@ -10,6 +10,7 @@ Type TBroadcastStatistic
 	Field bestAudienceResult:TAudienceResultBase[][4]
 	'store last audience for each player
 	Field lastAudienceResult:TAudienceResultBase[][4]
+	Field bestAudiencePercantage:Float[4]
 
 
 	Method SetAudienceResult:Int(channelNumber:int, block:int, audienceResult:TAudienceResult)
@@ -31,6 +32,10 @@ Type TBroadcastStatistic
 			if best.audience.GetTotalSum() < audienceResult.audience.GetTotalSum()
 				bestAudienceResult[channelNumber-1][block-1] = audienceResult
 			endif
+			local percentage:Float = audienceResult.GetAudienceQuotePercentage()
+			If Not bestAudiencePercantage[channelNumber-1] Or percentage > bestAudiencePercantage[channelNumber-1]
+				bestAudiencePercantage[channelNumber-1] = percentage
+			EndIf
 		endif
 			
 		return True

--- a/source/game.programme.programmelicence.bmx
+++ b/source/game.programme.programmelicence.bmx
@@ -2552,18 +2552,29 @@ Type TProgrammeLicence Extends TBroadcastMaterialSource {_exposeToLua="selected"
 		'boxes have a top-padding (except with messages)
 		if msgAreaH = 0 then contentY :+ boxAreaPaddingY
 
+		Local shiftDown:Int = KeyManager.IsDown(KEY_LSHIFT) Or KeyManager.IsDown(KEY_RSHIFT)
 
 		'=== BOX LINE 1 ===
 		'blocks
 		skin.RenderBox(contentX + 5, contentY, 47, -1, GetBlocks(), "duration", "neutral", skin.fontBold)
 		'repetitions
-		if useOwner <= 0
+		'TODO total number of broadcasts only when not owned?
+		if useOwner <= 0 Or shiftDown
 			skin.RenderBox(contentX + 5 + 51, contentY, 52, -1, GetTimesBroadcasted(-1), "repetitions", "neutral", skin.fontBold)
 		else
 			skin.RenderBox(contentX + 5 + 51, contentY, 52, -1, GetTimesBroadcasted(useOwner), "repetitions", "neutral", skin.fontBold)
 		endif
 		'record
-		skin.RenderBox(contentX + 5 + 107, contentY, 88, -1, TFunctions.convertValue(GetBroadcastStatistic(useOwner).GetBestAudienceResult(useOwner, -1).audience.GetTotalSum(),2), "maxAudience", "neutral", skin.fontBold)
+		If shiftDown
+			Local show:String = "-"
+			If useOwner
+				Local perc:Float = GetBroadcastStatistic(useOwner).bestAudiencePercantage[useOwner-1]
+				If perc > 0 then show = MathHelper.NumberToString(perc*100.0)+"%"
+			EndIf
+			skin.RenderBox(contentX + 5 + 107, contentY, 88, -1, show, "maxAudience", "neutral", skin.fontBold)
+		Else
+			skin.RenderBox(contentX + 5 + 107, contentY, 88, -1, TFunctions.convertValue(GetBroadcastStatistic(useOwner).GetBestAudienceResult(useOwner, -1).audience.GetTotalSum(),2), "maxAudience", "neutral", skin.fontBold)
+		EndIf
 
 		'price
 		local showPrice:int = not data.hasBroadcastFlag(TVTBroadcastMaterialSourceFlag.HIDE_PRICE)


### PR DESCRIPTION
Im Datenblatt für Programme wird aktuell die maximale Zuschauerzahl angezeigt, was beim Sendegebietsausbau wenig aussagekräftig ist. Mit Shift kann die maximale Einschaltquote angezeigt werden.

Für die Datenhaltung wurde nur diese Zahl zusätzlich abgelegt. Noch mehr AudienceResult-Objekte nur dafür wären meiner Ansicht nach Overkill.