### PR TITLE
Fahrstuhlplan nicht immer betretbar; Report Paneologe

### DIFF
--- a/source/game.game.bmx
+++ b/source/game.game.bmx
@@ -365,7 +365,10 @@ Type TGame Extends TGameBase {_exposeToLua="selected"}
 			'mark porter, elevatorplan, ... as fake rooms
 			If room.GetOwner() <= 0
 				Select room.GetNameRaw().ToLower()
-					Case "porter", "building", "elevatorplan", "credits", "roomboard"
+					Case "elevatorplan"
+						room.SetFlag(TVTRoomFlag.FAKE_ROOM, True)
+						room.SetFlag(TVTRoomFlag.NEVER_RESTRICT_OCCUPANT_NUMBER, True)
+					Case "porter", "building", "credits", "roomboard"
 						room.SetFlag(TVTRoomFlag.FAKE_ROOM, True)
 				End Select
 			EndIf

--- a/source/game.gameconstants.bmx
+++ b/source/game.gameconstants.bmx
@@ -1387,6 +1387,9 @@ Type TVTRoomFlag
 	'can the rental state of a room be changed in this moment
 	'(eg. an object in the room blocks rental cancelation)
 	Const RENTAL_CHANGE_BLOCKED:Int = 64
+	'room/view can be entered by anybody at any time
+	'even if the figures would "disallow each other"
+	Const NEVER_RESTRICT_OCCUPANT_NUMBER:Int = 128
 End Type
 
 

--- a/source/game.room.base.bmx
+++ b/source/game.room.base.bmx
@@ -787,10 +787,8 @@ Type TRoomBase extends TOwnedGameObject {_exposeToLua="selected"}
 		'is already "nobody" in the room)
 		if HasFlag(TVTRoomFlag.RESTRICT_TO_SINGLE_OCCUPANT)
 			return False
-		'elevatorplan can always be entered
-		elseif getName() = "elevatorplan"
-			'on certain occasions the HasOccupantDisallowingEnteringEntity
-			'prevented player from entering the elevator plan
+		'room/view can be entered even if figures disallow each other
+		elseif HasFlag(TVTRoomFlag.NEVER_RESTRICT_OCCUPANT_NUMBER)
 			return True
 		'else all can enter as there is no limit...
 		else

--- a/source/game.room.base.bmx
+++ b/source/game.room.base.bmx
@@ -787,6 +787,11 @@ Type TRoomBase extends TOwnedGameObject {_exposeToLua="selected"}
 		'is already "nobody" in the room)
 		if HasFlag(TVTRoomFlag.RESTRICT_TO_SINGLE_OCCUPANT)
 			return False
+		'elevatorplan can always be entered
+		elseif getName() = "elevatorplan"
+			'on certain occasions the HasOccupantDisallowingEnteringEntity
+			'prevented player from entering the elevator plan
+			return True
 		'else all can enter as there is no limit...
 		else
 			'except at least one other entity in the room disallows it


### PR DESCRIPTION
Meldung im Forum, dass die Zielauswahl nicht immer betretbar ist (schon jemand im Raum).
Ich konnte das Problem bei mir sporadisch reproduzieren. Gelegentlich war er auch betretbar, obwohl die Ausgaben hätten erwareten lassen, dass die Meldung kommen müsste (canEnterRoom liefert False, weil ein anderer Spieler gerade im Raum ist).

Ursache für das Verhalten dürften die KI-Änderungen zur Terroristenanalyse sein. Da habe ich ja eingebaut, dass gelegentlich im Plan geschaut wird, ob die Räume verschoben sind. Zuvor hat wahrscheinlich keine andere Figur den Plan überhaupt betreten...

Die vorgeschlagene Änderung ist eine Sonderbehandlung des Plans bezüglich "kann betreten werden".