### PR TITLE
Sammy weniger häufig, geringerer Imagegewinn; Report Yoshi

### DIFF
--- a/source/game.award.base.bmx
+++ b/source/game.award.base.bmx
@@ -139,7 +139,7 @@ Type TAwardCollection Extends TGameObjectCollection
 			'set time to the next 0:00 coming _after the waiting
 			'time is gone (or use that midnight if exactly 0:00)
 			'set random waiting time for next award 
-			Local startTimeExact:Long = previousEndTime + TWorldTime.HOURLENGTH * RandRange(12,36)
+			Local startTimeExact:Long = previousEndTime + TWorldTime.HOURLENGTH * RandRange(24,96)
 			If GetWorldTime().GetDayHour(startTimeExact) = 0 And GetWorldTime().GetDayMinute(startTimeExact) = 0
 				startTime = GetWorldTime().GetTimeGoneForGameTime(0, GetWorldTime().GetDay(startTimeExact), 0, 0)
 			Else
@@ -151,7 +151,13 @@ Type TAwardCollection Extends TGameObjectCollection
 		Local award:TAward = CreateAward(awardType)
 		award.SetStartTime( startTime )
 		award.SetEndTime( award.CalculateEndTime(startTime) )
-
+		If lastAwards
+			Local awardCount:Int = 0
+			For Local a:TAward = EachIn lastAwards
+				If a.awardType = awardType then awardCount:+ 1
+			Next
+			award.priceImage = Max(0.5, award.priceImage - awardCount * 0.25)
+		EndIf
 		AddUpcoming( award )
 		TLogger.Log("TAwardCollection.GenerateUpcomingAward()", "Generated ~qupcoming~q award: type="+TVTAwardType.GetAsString(award.awardType)+" ["+award.awardType+"] "+"  timeframe="+GetWorldTime().GetFormattedGameDate(award.GetStartTime()) +"  -  " + GetWorldTime().GetFormattedGameDate(award.GetEndTime()) +"  now="+GetWorldTime().GetFormattedGameDate(), LOG_DEBUG)
 	End Method
@@ -238,7 +244,7 @@ Type TAward Extends TGameObject
 	Field duration:Long = -1
 	'basic prices all awards offer
 	Field priceMoney:Int = 50000
-	Field priceImage:Float = 2.5
+	Field priceImage:Float = 1.5
 	Field priceBettyLove:Int = 0
 
 	Field _scoreSum:Int = -1 {nosave}

--- a/source/game.award.culture.bmx
+++ b/source/game.award.culture.bmx
@@ -25,9 +25,9 @@ Type TAwardCulture extends TAward
 		awardType = TVTAwardType.CULTURE
 
 		priceMoney = 40000
-		priceImage = 2.5
-		'for now this is 50/10000 so 0.5% but this is an absolute value 
-		priceBettyLove = 50
+		priceImage = 1.5
+		'for now this is 75/10000 so 0.75% but this is an absolute value 
+		priceBettyLove = 75
 
 
 		'=== REGISTER EVENTS ===

--- a/source/game.award.news.bmx
+++ b/source/game.award.news.bmx
@@ -15,7 +15,7 @@ Type TAwardNews extends TAward
 		awardType = TVTAwardType.NEWS
 
 		priceMoney = 25000
-		priceImage = 2.0
+		priceImage = 1.5
 
 		'=== REGISTER EVENTS ===
 		EventManager.UnregisterListenersArray(_eventListeners)


### PR DESCRIPTION
* Erhöhung des Zufallszeitfensters zwischen 2 Sammys
* grundsätzlich geringerer Imagezuwachs für News/Kultur
* der mögliche Imagegewinn sinkt mit jeder Ausschreibung eines Sammy