### PR TITLE
[Balancing] Komödien etwas weniger attraktiv machen

### DIFF
--- a/config/programmedatamods.xml
+++ b/config/programmedatamods.xml
@@ -275,8 +275,8 @@
 					<timeMod time="17" value="0.05"/>
 					<timeMod time="18" value="0.1"/>
 					<timeMod time="19" value="0.1"/>
-					<timeMod time="20" value="0.2"/>
-					<timeMod time="21" value="0.2"/>
+					<timeMod time="20" value="0.15"/>
+					<timeMod time="21" value="0.15"/>
 					<timeMod time="22" value="0.1"/>
 					<timeMod time="23" value="0.05"/>
 				</timeMods>
@@ -460,16 +460,16 @@
 					<timeMod time="16" value="0.1"/>
 					<timeMod time="17" value="0.1"/>
 					<timeMod time="18" value="0.1"/>
-					<timeMod time="19" value="0.15"/>
-					<timeMod time="20" value="0.2"/>
-					<timeMod time="21" value="0.15"/>
+					<timeMod time="19" value="0.1"/>
+					<timeMod time="20" value="0.15"/>
+					<timeMod time="21" value="0.1"/>
 					<timeMod time="22" value="0.05"/>
 					<timeMod time="23" value="0"/>
 				</timeMods>
 				<audienceAttractions>
 					<audienceAttraction id="Children" value="1" />
 					<audienceAttraction id="Teenagers" value="0.2" />
-					<audienceAttraction id="HouseWives" men="1" women="1.5" />
+					<audienceAttraction id="HouseWives" men="0.7" women="1.2" />
 					<audienceAttraction id="Employees" men="0.5" women="1" />
 					<audienceAttraction id="Unemployed" men="0" women="0.3" />
 					<audienceAttraction id="Managers" value="-1" />

--- a/res/database/Default/user/ronny.xml
+++ b/res/database/Default/user/ronny.xml
@@ -436,10 +436,10 @@ Illustrious guests and music by [3|Nick].</en>
 			<ratings critics="18" speed="35" />
 		</programme>
 
-		<programme id="ronny-programme-betonfuerdenclan-01" product="4" licence_type="1" fictional="1" creator="5578" created_by="Ronny">
+		<programme id="beton1" product="1" licence_type="1" fictional="1" creator="5578" created_by="Ronny">
 			<title>
-				<de>Beton für den Clan</de>
-				<en>Concrete for the Clans</en>
+				<de>Beton für den Clan 1</de>
+				<en>Concrete for the Clans 1</en>
 			</title>
 			<description>
 				<de>Gibt es wichtige Unterschiede zwischen Bau-Beton und Mafia-Beton?
@@ -451,14 +451,71 @@ Illustrious guests and music by [3|Nick].</en>
 				<member index="0" function="1">ronny-programmeperson-gertkalischke</member>
 				<member index="1" function="128">ronny-programmeperson-samuelloew</member>
 			</staff>
-			<modifiers>
-				<!-- the programme ages slower than average -->
-				<modifier name="topicality::age" value="0.75" />
-			</modifiers>
-			<data country="D" distribution="2" maingenre="300" subgenre="6" blocks="1" />
+			<data country="D" distribution="2" maingenre="0" blocks="1" />
 			<releaseTime year_relative="-5" year_relative_min="1980" year_relative_max="1995" />
-			<ratings critics="25" speed="20" />
+			<ratings critics="30" speed="30" outcome="30"/>
 		</programme>
+
+		<programme id="beton2" product="1" licence_type="1" fictional="1" creator="5578" created_by="Ronny">
+			<title>
+				<de>Beton für den Clan 2</de>
+				<en>Concrete for the Clans 2</en>
+			</title>
+			<description>
+				<de>Gibt es wichtige Unterschiede zwischen Bau-Beton und Mafia-Beton?
+5 Betonsorten im großen Hafenbecken-Test.</de>
+				<en>Are there any significant differences between construction concrete and mafia concrete?
+5 concrete types in the big port basin test.</en>
+			</description>
+			<staff>
+				<member index="0" function="1">ronny-programmeperson-gertkalischke</member>
+				<member index="1" function="128">ronny-programmeperson-samuelloew</member>
+			</staff>
+			<data country="D" distribution="2" maingenre="5" blocks="1" />
+			<releaseTime year_relative="-5" year_relative_min="1980" year_relative_max="1995" />
+			<ratings critics="30" speed="30" outcome="30"/>
+		</programme>
+
+		<programme id="beton3" product="1" licence_type="1" fictional="1" creator="5578" created_by="Ronny">
+			<title>
+				<de>Beton für den Clan 3</de>
+				<en>Concrete for the Clans 3</en>
+			</title>
+			<description>
+				<de>Gibt es wichtige Unterschiede zwischen Bau-Beton und Mafia-Beton?
+5 Betonsorten im großen Hafenbecken-Test.</de>
+				<en>Are there any significant differences between construction concrete and mafia concrete?
+5 concrete types in the big port basin test.</en>
+			</description>
+			<staff>
+				<member index="0" function="1">ronny-programmeperson-gertkalischke</member>
+				<member index="1" function="128">ronny-programmeperson-samuelloew</member>
+			</staff>
+			<data country="D" distribution="2" maingenre="7" blocks="1" />
+			<releaseTime year_relative="-5" year_relative_min="1980" year_relative_max="1995" />
+			<ratings critics="30" speed="30" outcome="30"/>
+		</programme>
+
+		<programme id="beton4" product="1" licence_type="1" fictional="1" creator="5578" created_by="Ronny">
+			<title>
+				<de>Beton für den Clan 4</de>
+				<en>Concrete for the Clans 4</en>
+			</title>
+			<description>
+				<de>Gibt es wichtige Unterschiede zwischen Bau-Beton und Mafia-Beton?
+5 Betonsorten im großen Hafenbecken-Test.</de>
+				<en>Are there any significant differences between construction concrete and mafia concrete?
+5 concrete types in the big port basin test.</en>
+			</description>
+			<staff>
+				<member index="0" function="1">ronny-programmeperson-gertkalischke</member>
+				<member index="1" function="128">ronny-programmeperson-samuelloew</member>
+			</staff>
+			<data country="D" distribution="2" maingenre="9" blocks="1" />
+			<releaseTime year_relative="-5" year_relative_min="1980" year_relative_max="1995" />
+			<ratings critics="30" speed="30" outcome="30"/>
+		</programme>
+
 	</allprogrammes>
 
 	<allnews>


### PR DESCRIPTION
Die Unterschiede zwischen zwei Programmen, die sich nur im Genre unterscheiden, können ziemlich dramatisch sein (lokal mit Beton für den Clan ausprobiert - kopiert, nur Genre angepasst und zur selben Sendezeit gesendet).
Genre 0 (sonstiges): ca 16% Einschaltquote
Genre 5 (Comedy): ca 26% Einschaltquote

Genre, die insgesamt relativ durchgängig beliebt sind, sind Komödien, Familie, Drama. Komödien stechen dabei besonders hervor, da es davon besonders viele gibt.
In diese PR habe ich erstmal nur den Modifier für die Prime-Time leicht reduziert. Offen ist, ob die Werte für die Zielgruppenattraktivität generell etwas näher an 0 (neutral) gebracht werden sollten, um die Abweichungen zwischen "eigentlich qualitätiv gleichen" Filmen etwas zu reduzieren.
