### PR TITLE
Reparatur Sammy-Zeiten; Report Streuner

### DIFF
--- a/source/main.bmx
+++ b/source/main.bmx
@@ -6435,7 +6435,7 @@ endrem
 		EndIf
 
 		'=== UPDATE AWARDS / SAMMYS ===
-		'when updating awards onHour, onDayBegins would fire before the last day's award was handled
+		'ensure awards finish on the correct day (usually 23:59); ending an award on the next day could cause
 		'fail of mission possible although the award is won/wrong award count
 		If minute = 59 Then GetAwardCollection().UpdateAwards()
 
@@ -6656,6 +6656,11 @@ endrem
 				Next
 			Next
 		EndIf
+
+		'=== UPDATE AWARDS / SAMMYS ===
+		'in particular start award on the beginning of the day
+		'otherwise it might start 00:59 and and at that time on the next day...
+		GetAwardCollection().UpdateAwards()
 
 		Return True
 	End Function


### PR DESCRIPTION
Beim Einbau der Missionen wurde die Zeit, zu der die Sammy-Updates angestoßen wurden geändert (Minute 59, damit die Auswertung am richtigen Tag stattfindet).
Das hat aber auch dazu geführt, dass die Sammys auch nur zu dieser Zeit gestartet werden (0:59) und zu dieser Zeit am nächsten Tag enden.

Mit dieser Reparatur werden die Sammys am Tagesbeginn gestartet (und enden damit 23:59) und werden am Tagesende abgeschlossen.