### PR TITLE
Umsetzung Effekte von Programmausstrahlung

### DIFF
--- a/res/database/Default/user/jorgaeff.xml
+++ b/res/database/Default/user/jorgaeff.xml
@@ -479,7 +479,7 @@
 			<effects>
 				<!-- "in 0-3 Stunden" -->
 				<effect trigger="happen" type="triggernews" time="1,0,3" news="news-jorgaeff-drops-06" />
-				<effect trigger="happen" type="modifyPersonPopularity" referenceGUID="21e88c65-0cc6-4bd1-bd14-b48b6ce25402" valueMin="0.05" valueMax="0.075" />
+				<effect trigger="happen" type="modifyPersonPopularity" guid="21e88c65-0cc6-4bd1-bd14-b48b6ce25402" valueMin="0.05" valueMax="0.075" />
 			</effects>
 		</news>
 
@@ -496,7 +496,7 @@
 			<effects>
 				<!-- "übermorgen 17-23 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,2,2,17,23" news="news-jorgaeff-drops-07" />
-				<effect trigger="happen" type="modifyPersonPopularity" referenceGUID="ronny-programmeperson-bennyjameson" valueMin="0.03" valueMax="0.07" />
+				<effect trigger="happen" type="modifyPersonPopularity" guid="ronny-programmeperson-bennyjameson" valueMin="0.03" valueMax="0.07" />
 			</effects>
 		</news>
 
@@ -513,7 +513,7 @@
 			<effects>
 				<!-- "übermorgen 10-16 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,2,2,10,16" news="news-jorgaeff-drops-08" />
-				<effect trigger="happen" type="modifyPersonPopularity" referenceGUID="ronny-programmeperson-bennyjameson" valueMin="-0.07" valueMax="-0.03" />
+				<effect trigger="happen" type="modifyPersonPopularity" guid="ronny-programmeperson-bennyjameson" valueMin="-0.07" valueMax="-0.03" />
 			</effects>
 		</news>
 
@@ -530,7 +530,7 @@
 			<effects>
 				<!-- "in 7 Tagen 0-23 Uhr" -->
 				<effect trigger="happen" type="triggernews" time="2,7,7,0,23" news="news-jorgaeff-drops-09" />
-				<effect trigger="happen" type="modifyPersonPopularity" referenceGUID="ronny-programmeperson-bennyjameson" valueMin="0.01" valueMax="0.03" />
+				<effect trigger="happen" type="modifyPersonPopularity" guid="ronny-programmeperson-bennyjameson" valueMin="0.01" valueMax="0.03" />
 			</effects>
 		</news>
 
@@ -545,7 +545,7 @@
 			</description>
 			<data genre="1" price="0.6" quality="55" fictional="1" />
 			<effects>
-				<effect trigger="happen" type="modifyPersonPopularity" referenceGUID="ronny-programmeperson-bennyjameson" valueMin="0.03" valueMax="0.07" />
+				<effect trigger="happen" type="modifyPersonPopularity" guid="ronny-programmeperson-bennyjameson" valueMin="0.03" valueMax="0.07" />
 			</effects>
 		</news>
 

--- a/res/database/Default/user/ronny.xml
+++ b/res/database/Default/user/ronny.xml
@@ -673,7 +673,7 @@ Illustrious guests and music by [3|Nick].</en>
 				- Interesse an Liebesfilmen steigern
 			-->
 			<effects>
-				<effect trigger="happen" type="modifyPersonPopularity" referenceGUID="21e88c65-0cc6-4bd1-bd14-b48b6ce25402" valueMin="0.1" valueMax="0.2" />
+				<effect trigger="happen" type="modifyPersonPopularity" guid="21e88c65-0cc6-4bd1-bd14-b48b6ce25402" valueMin="0.1" valueMax="0.2" />
 				<effect trigger="happen" type="modifyMovieGenrePopularity" genre="15" valueMin="0.5" valueMax="2.0" />
 			</effects>
 

--- a/source/game.broadcastmaterial.programme.bmx
+++ b/source/game.broadcastmaterial.programme.bmx
@@ -182,6 +182,13 @@ Type TProgramme Extends TBroadcastMaterialDefaultImpl {_exposeToLua="selected"}
 			'store audience for this block
 			licence.GetBroadcastStatistic().SetAudienceResult(owner, currentBlockBroadcasting, audienceResult)
 
+			If licence And licence.effects
+				Local effectParams:TData = New TData.AddInt("programmeId", Self.licence.GetId())
+				licence.effects.Update("broadcast", effectParams)
+				'very first broadcast - not owner dependent
+				If licence.data.GetTimesBroadcasted(-1) = 0 Then licence.effects.Update("broadcastFirstTime", effectParams)
+			EndIf
+
 			'inform others
 			TriggerBaseEvent(GameEventKeys.Broadcast_Programme_BeginBroadcasting, New TData.AddInt("day", day).AddInt("hour", hour).AddInt("minute", minute).Add("audienceData", audienceData), Self)
 		ElseIf usedAsType = TVTBroadcastMaterialType.ADVERTISEMENT
@@ -334,6 +341,13 @@ Type TProgramme Extends TBroadcastMaterialDefaultImpl {_exposeToLua="selected"}
 		'instead of just setting back topicality, just refresh it "once"
 		'data.trailerTopicality = 1.0
 		data.RefreshTrailerTopicality()
+
+		If licence And licence.effects
+			Local effectParams:TData = New TData.AddInt("programmeId", Self.licence.GetId())
+			licence.effects.Update("broadcastDone", effectParams)
+			'very first broadcast - not owner dependent
+			If data.GetTimesBroadcasted(-1) = 1 Then licence.effects.Update("broadcastFirstTimeDone", effectParams)
+		EndIf
 
 		'print "aired programme "+GetTitle()+" "+data.GetTimesAired(owner)+"x."
 		'print self.GetTitle() + "  finished at day="+day+" hour="+hour+" minute="+minute + " aired="+data.timesAired + " topicality="+data.topicality+" oldTop="+oldTop

--- a/source/game.gameconstants.bmx
+++ b/source/game.gameconstants.bmx
@@ -654,8 +654,9 @@ Type TVTScriptFlag {_exposeToLua}
 'currently unused!
 	'more expensive
 	Const REQUIRE_AUDIENCE_DURING_PRODUCTION:Int = 128
+	Const NOT_AVAILABLE:Int = 256
 
-	Const count:Int = 8
+	Const count:Int = 9
 
 
 	Function GetAtIndex:Int(index:Int = 0)
@@ -674,6 +675,7 @@ Type TVTScriptFlag {_exposeToLua}
 			Case  32	Return 6
 			Case  64	Return 7
 			Case 128	Return 8
+			Case 256	Return 9
 		End Select
 		Return 0
 	End Function
@@ -691,6 +693,7 @@ Type TVTScriptFlag {_exposeToLua}
 			Case POOL_REMOVES_TRADEABILITY            Return "pool_removes_tradeability"
 			Case TEXTS_EDITABLE                       Return "texts_editable"
 			Case REQUIRE_AUDIENCE_DURING_PRODUCTION   Return "require_audience_during_production"
+			Case NOT_AVAILABLE                        Return "not_available"
 
 			Default
 				'loop through all entries and add them if contained

--- a/source/game.popularity.bmx
+++ b/source/game.popularity.bmx
@@ -350,7 +350,8 @@ Type TGameModifierPopularity_ModifyPopularity extends TGameModifierBase
 		if extra and extra.GetInt("childIndex") > 0 then index = extra.GetInt("childIndex")
 		popularityID = data.GetInt("id"+index, data.GetInt("id", 0))
 		popularityReferenceID = data.GetInt("referenceID"+index, data.GetInt("referenceID", 0))
-		popularityReferenceGUID = data.GetString("referenceGUID"+index, data.GetString("referenceGUID", ""))
+		popularityReferenceGUID = data.GetString("guid"+index, data.GetString("guid", ""))
+		If Not popularityReferenceGUID Then popularityReferenceGUID = data.GetString("referenceGUID"+index, data.GetString("referenceGUID", ""))
 		if popularityID = 0 and popularityReferenceID = 0 and popularityReferenceGUID = ""
 			TLogger.Log(ToString(), "Init() failed - no popularityID or referenceID/referenceGUID given.", LOG_ERROR)
 			return Null


### PR DESCRIPTION
see #1058

Erster Prototyp:
* ausschließlich Lizenzeffekte - keine globalen Effekte für Daten (was wäre das Anwendungsszenario)
* happen(=broadcastDone), sowie broadcastFirstTimeDone
* zunächst modifyProgrammeAvailability

TODOS:
* aktuellen Stand mit Serien testen (effekt am parent, effekt an Einzelepisode, Freischalten einer Serie aktiviert alle Episoden)
* modifyScriptAvailability (bei Ausstrahlung eines Programms ein Remake-/Fortsetzungstemplate aktivieren)
* Programmeffekte in Drehbüchern umsetzen (Aussenden einer Serie aktiviert Drehbücher für die nächste Staffel; Hauptproblem wird hier, dass das Auffinden selbst produzierter Lizenzen...)