### PR TITLE
Beliebtheitseffekt von Ausstrahlungen etwas reduzieren

### DIFF
--- a/source/game.popularity.genre.bmx
+++ b/source/game.popularity.genre.bmx
@@ -61,17 +61,17 @@ Type TGenrePopularity Extends TPopularity
 
 		Local wholeMarketQuote:Float = data.GetFloat("audienceWholeMarketQuote")
 		'do not count as broadcast if audience was too small
-		If Not wholeMarketQuote Or wholeMarketQuote >= 0.005
+		If Not wholeMarketQuote Or wholeMarketQuote >= 0.01
 			broadCastCountSinceUpdate:+ 1
 
 			'decrease popularity a bit with each broadcast
 			If Popularity > -5
-				Local diff:Float = 0.8^(broadCastCountSinceUpdate-1)
+				Local diff:Float = 0.7^(broadCastCountSinceUpdate-1)
 				Popularity:- diff
 			EndIf
 		EndIf
-		'decrease long term popularity with first broadcast
-		If broadCastCountSinceUpdate = 1 And LongTermPopularity > -5 Then SetLongTermPopularity(LongTermPopularity - 1)
+		'decrease long term popularity if genre was broadcasted too often
+		If broadCastCountSinceUpdate = 3 And LongTermPopularity > -5 Then SetLongTermPopularity(LongTermPopularity - 1)
 	End Method
 
 
@@ -98,19 +98,19 @@ Type TGenrePopularity Extends TPopularity
 	End Method
 
 	Method UpdatePopularity() override
-		'Increase popularity of programme genres not broadcasted
-		If broadCastCountSinceUpdate = 0 And referenceGUID.startsWith("moviegenre")
+		'Increase popularity of programme genres not broadcasted (exclude erotic)
+		If broadCastCountSinceUpdate < 3 And referenceGUID.startsWith("moviegenre") And referenceGUID <> "moviegenre-8"
 			If Popularity < 0
-				Popularity:+ 5
+				Popularity:+ (7 - broadCastCountSinceUpdate)
 			ElseIf Popularity < 20
-				Popularity:+ 3
+				Popularity:+ (4 - broadCastCountSinceUpdate)
 			Else
 				Popularity:+ 1
 			EndIf
 			If LongTermPopularity < 0
-				SetLongTermPopularity(LongTermPopularity + 5)
+				SetLongTermPopularity(LongTermPopularity + (5 - broadCastCountSinceUpdate))
 			ElseIf LongTermPopularity < 10
-				SetLongTermPopularity(LongTermPopularity + 3)
+				SetLongTermPopularity(LongTermPopularity + (3 - broadCastCountSinceUpdate))
 			ElseIf LongTermPopularity < 20
 				SetLongTermPopularity(LongTermPopularity + 1)
 			EndIf


### PR DESCRIPTION
* Schwellwert für das Zählen einer Ausstrahlung etwas erhöht
* Beliebtheit nicht sofort bei erster Ausstrahlung des Genres reduzieren
* Beliebtheit nicht nur bei gar keiner Ausstrahlung erhöhen