### PR TITLE
Drehbuchvorlage nicht bei jeder Verwendung markieren

### DIFF
--- a/source/game.production.script.bmx
+++ b/source/game.production.script.bmx
@@ -86,6 +86,15 @@ Type TScriptCollection Extends TGameObjectCollection
 			RemoveTitleProtection(script.title)
 		EndIf
 
+		If script.basedOnScriptTemplateID
+			Local template:TScriptTemplate = GetScriptTemplateCollection().getById(script.basedOnScriptTemplateID)
+			If template And template.IsUsedForScript(script.GetID())
+				template.RemoveUsedForScript(script.GetID())
+			Else
+				TLogger.log("TScriptCollection.Remove", "Template for script "+script.GetTitle()+ " not found for marking it as unused.", LOG_ERROR)
+			EndIf
+		EndIf
+
 		Return Super.Remove(script)
 	End Method
 

--- a/source/game.production.scripttemplate.bmx
+++ b/source/game.production.scripttemplate.bmx
@@ -257,6 +257,18 @@ Type TScriptTemplate Extends TScriptBase
 		Return True
 	End Method
 
+	Method RemoveUsedForScript:Int(scriptID:int)
+		If IsUsedForScript(scriptID)
+			For Local i:Int = 0 Until usedForScripts.length
+				if usedForScripts[i] = scriptID
+					usedForScripts = usedForScripts[.. i] + usedForScripts[i + 1 ..]
+					Return True
+				EndIf
+			Next
+		EndIf
+		Return False
+	End Method
+
 
 	'set a job to the specific index
 	'the index must be existing already


### PR DESCRIPTION
Aktuell wird eine Vorlage als verwendet markiert, sobald ein Drehbuch erstellt wurde, selbst wenn dieses nie verwendet wird.
Damit das "usedLimit" überhaupt sinnvoll einsetzbar ist, sollte die Vorlage nur dann markiert werden, wenn das Drehbuch verkauft oder vom In-Game-Produzenten verwendet wurde.