### PR TITLE
Unterstützung Effekte in Drehbuchvorlagen

### DIFF
--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -1950,6 +1950,21 @@ Type TDatabaseLoader
 			)
 		EndIf
 
+
+		'=== EFFECTS ===
+		'add effects after processing the children
+		'as script template does not extend TBroadcastMaterialSourceBase,
+		'propagating parent effects is to big an effort here
+		'it will be done when creating the script from the template
+		'at this point each template gets exactly the effects defined in the database
+		Local nodeEffects:TxmlNode = xml.FindChild(node, "effects")
+		If nodeEffects
+			Local tmpSource:TBroadcastMaterialSourceBase = new TBroadcastMaterialSourceBase()
+			LoadV3EffectsFromNode(tmpSource, node, xml)
+			If tmpSource.effects Then scriptTemplate.effects = tmpSource.effects.Copy()
+			If scriptTemplate.effects Then print scriptTemplate.GetTitle() +" has effects"
+		EndIf
+
 		'=== ADD TO COLLECTION ===
 		GetScriptTemplateCollection().Add(scriptTemplate)
 

--- a/source/game.production.bmx
+++ b/source/game.production.bmx
@@ -739,6 +739,9 @@ Type TProduction Extends TOwnedGameObject
 			if not programmeData.modifiers Then programmeData.modifiers = New TData
 			programmeData.modifiers.Append(productionConcept.script.programmeDataModifiers)
 		EndIf
+		If productionConcept.script.effects
+			programmeLicence.effects = productionConcept.script.effects.Copy()
+		EndIf
 		Return programmeLicence
 	End Method
 	

--- a/source/game.production.script.base.bmx
+++ b/source/game.production.script.base.bmx
@@ -7,6 +7,7 @@ Import "game.world.worldtime.bmx"
 Import "game.gameobject.bmx"
 Import "game.gameconstants.bmx" 'to access type-constants
 Import "game.gamerules.bmx"
+Import "game.modifier.base.bmx"
 Import "game.player.difficulty.bmx"
 
 Type TScriptBase Extends TNamedGameObject
@@ -25,6 +26,8 @@ Type TScriptBase Extends TNamedGameObject
 
 	Field programmeDataModifiers:TData
 	Field targetGroupAttractivityMod:TAudience = Null
+	'effects both for scripts and the produced programme
+	Field effects:TGameModifierGroup
 
 	'scripts of series are parent of episode scripts
 	Field parentScriptID:int = 0

--- a/source/game.production.script.bmx
+++ b/source/game.production.script.bmx
@@ -467,6 +467,10 @@ Type TScript Extends TScriptBase {_exposeToLua="selected"}
 			script.subGenres :+ [subGenre]
 		Next
 
+		If template.effects
+			script.effects=template.effects.Copy()
+		EndIf
+
 		'add children
 		If includingEpisodes
 			If template.programmeDataModifiers
@@ -533,8 +537,26 @@ Type TScript Extends TScriptBase {_exposeToLua="selected"}
 
 			If script.subScripts
 				'#440 propagate final optional header flags to episodes
+				'also propagate parent effects
 				For Local subScript:TScript = EachIn script.subScripts
 					subScript.flags :| script.flags
+					If script.effects
+						If subScript.effects
+							'appending parent effects to existing subscript entries
+							Local node:TNode = script.effects.entries._FirstNode()
+							While node And node <> TGameModifierGroup._nilNode
+								Local l:TList = TList(node._value)
+								If Not l Then Continue
+								For Local m:TGameModifierBase = EachIn l
+									subScript.effects.AddEntry(String(node._key), m)
+								Next
+								'move on to next node
+								node = node.NextNode()
+							Wend
+						Else
+							subScript.effects = script.effects.Copy()
+						EndIf
+					EndIf
 				Next
 
 				'#424 script with children is live (only) if any of the children is live


### PR DESCRIPTION
Im ersten Schritt werden Effekte aus der Datenbank gelesen und an die erzeugten Lizenzen weitergegeben. Auf diese Weise kann z.B. durch die Ausstrahlung einer selbstgedrehten Staffel 1 die Drehbuchvorlage für Staffel 2 freigeschaltet werden.

In einem zweiten Schritt könnten auch Produktionseffekte implementiert werden (Effekt, wenn Produktion gestartet/abgeschlossen wurde). Ich glaube aber fast, dass der Großteil des gewünschten Verhaltens schon mit diesem Stand erreicht werden kann.

closes #1058
closes #972