### PR TITLE
Datenbank: Auswirkung Reihenfolge des Einlesens der Dateien

### DIFF
--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -1339,7 +1339,9 @@ Type TDatabaseLoader
 			'which are created after that programme
 			If Not member
 				member = New TPersonBase
-				member.SetFlag(TVTPersonFlag.FICTIONAL, True)
+				Local memberFictional:Int = True
+				If mdata Then memberFictional = mdata.GetInt("fictional", 0)
+				member.SetFlag(TVTPersonFlag.FICTIONAL, memberFictional)
 
 				If memberGenerator
 					'generator is "countrycode1 countrycode2, gender, levelup"


### PR DESCRIPTION
closes #1064

Die Reihenfolge des Einlesens der Datenbankdateien hat einen unerwünschten Nebeneffekt auf den möglichen Cast. Ist beim DB-Einlesen eine Person noch nicht bekannt, wird sie als fiktionale Person angelegt und später ggf. durch eine andere DB-Datei erweitert. Zu dem Zeitpunk wird das fiktional-Flag aber nicht wieder auf "0" zurückgesetzt.

Durch diese Härtung bekommt die unbekannte Person das fiktional-Flag des Programms - Programm und Cast passen also "zusammen".