### PR TITLE
Randomisierung Werbung

### DIFF
--- a/config/DEV.xml
+++ b/config/DEV.xml
@@ -34,6 +34,9 @@
 
 			<!-- AD CONTRACTS -->
 			<!-- ============ -->
+			<!-- Randomize profit/penalty values-->
+			<DEV_ADCONTRACT_RANDOMIZE value="TRUE" />
+
 			<!-- Print debug screen ad contract statistic as csv, not as table
 				<DEV_ADCONTRACT_STAT_CSV value="1" />
 			-->

--- a/source/game.game.bmx
+++ b/source/game.game.bmx
@@ -336,11 +336,11 @@ Type TGame Extends TGameBase {_exposeToLua="selected"}
 		If startNewGame
 			'initialize variables too
 			TLogger.Log("Game.PrepareStart()", "GameRules initialization + override with DEV values.", LOG_DEBUG)
-			GameRules.Reset()
+			GameRules.AssignFromData( GameRules.devConfigBackup )
 		Else
-			'just load the dev-values into the game rules
-			TLogger.Log("Game.PrepareStart()", "GameRules override with DEV values.", LOG_DEBUG)
-			GameRules.AssignFromData( GameRules.devConfig )
+			'just reset the rules, value assignment is done on loading the gameload the dev-values into the game rules
+			TLogger.Log("Game.PrepareStart()", "resetting GameRules values.", LOG_DEBUG)
+			GameRules.Reset()
 		EndIf
 
 

--- a/source/game.gamerules.bmx
+++ b/source/game.gamerules.bmx
@@ -114,9 +114,6 @@ Type TGameRules {_exposeToLua}
 
 		adContractInstancesMax = 1
 		adContractsPerPlayerMax = 12
-
-
-		AssignFromData(devConfig)
 	End Method
 
 

--- a/source/game.gamerules.bmx
+++ b/source/game.gamerules.bmx
@@ -83,6 +83,8 @@ Type TGameRules {_exposeToLua}
 	'how many contracts of the same contractBase can exist at the
 	'same time? (0 disables any limit)
 	Field adContractInstancesMax:int = 1
+	'randomize profit/penalty
+	Field adContractRandomize:int= 0
 
 	'=== ADAGENCY ===
 	Field adagencySortContractsBy:string = "minaudience"
@@ -114,6 +116,7 @@ Type TGameRules {_exposeToLua}
 
 		adContractInstancesMax = 1
 		adContractsPerPlayerMax = 12
+		adContractRandomize = 0
 	End Method
 
 
@@ -124,6 +127,7 @@ Type TGameRules {_exposeToLua}
 
 		adContractInstancesMax = data.GetInt("DEV_ADCONTRACT_INSTANCES_MAX", adContractInstancesMax)
 		adContractsPerPlayerMax = data.GetInt("DEV_ADCONTRACTS_PER_PLAYER_MAX", adContractsPerPlayerMax)
+		adContractRandomize = data.GetBool("DEV_ADCONTRACT_RANDOMIZE", False)
 
 		'=== ADAGENCY ===
 		adagencySortContractsBy = data.GetString("DEV_ADAGENCY_SORT_CONTRACTS_BY", adagencySortContractsBy).Trim().ToLower()

--- a/source/game.programme.adcontract.bmx
+++ b/source/game.programme.adcontract.bmx
@@ -718,6 +718,9 @@ Type TAdContract Extends TBroadcastMaterialSource {_exposeToLua="selected"}
 	' 4,5 - best daytime + primetime
 	Field adAgencyClassification:Int = 0
 
+	Field profitRandomMod:Float = 0.0
+	Field penaltyRandomMod:Float = 0.0
+
 	'for statistics
 	Field stateTime:Long = -1
 	Field state:Int = 0
@@ -754,6 +757,14 @@ Type TAdContract Extends TBroadcastMaterialSource {_exposeToLua="selected"}
 		Self.base = baseContract
 	End Method
 
+
+	Method Randomize()
+		Local count:Int = GetSpotsToSend()
+		Local dev:Float = 0.3 + (count) * 0.05
+		profitRandomMod = GaussRandRange(0.8,1.2,0.5, dev)
+		penaltyRandomMod = GaussRandRange(0.8,1.2,0.5, dev)
+		'print GetTitle() +" "+dev+" "+profitRandomMod+" "+penaltyRandomMod
+	End Method
 
 	Function SortByName:Int(o1:Object, o2:Object)
 		Local a1:TAdContract = TAdContract(o1)
@@ -1235,11 +1246,13 @@ Type TAdContract Extends TBroadcastMaterialSource {_exposeToLua="selected"}
 		'limiting to specific flags change the price too
 		If GetLimitedToProgrammeFlag() > 0 Then price :* limitedToProgrammeFlagMultiplier
 
-		'adjust by a player difficulty
+		'adjust by a player difficulty and randomize
 		If priceType = PRICETYPE_PROFIT
 			price :* difficulty.adcontractProfitMod
+			If profitRandomMod > 0 Then price :* profitRandomMod
 		ElseIf priceType = PRICETYPE_PENALTY
 			price :* difficulty.adcontractPenaltyMod
+			If penaltyRandomMod > 0 Then price :* penaltyRandomMod
 		ElseIf priceType = PRICETYPE_INFOMERCIALPROFIT
 			price :* difficulty.adcontractInfomercialProfitMod
 		EndIf

--- a/source/game.roomhandler.adagency.bmx
+++ b/source/game.roomhandler.adagency.bmx
@@ -945,6 +945,7 @@ endrem
 					'set classification so contract knows its "origin"
 					contract.adAgencyClassification = classification
 					contract.SetOwner(contract.OWNER_VENDOR)
+					If GameRules.adContractRandomize Then contract.Randomize()
 
 					GetContractsInStock().AddLast(contract)
 					'add afterwards as "GetContractsInStock()" might create
@@ -1057,6 +1058,7 @@ endrem
 				If contract
 					'set classification so contract knows its "origin"
 					contract.adAgencyClassification = classification
+					If GameRules.adContractRandomize Then contract.Randomize()
 
 					contract.SetOwner(contract.OWNER_VENDOR)
 					GetContractsInStock().AddLast(contract)

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -2241,7 +2241,12 @@ Type TGameState
 		_Assign(_WorldWeather, TWorld._instance.weather, "WorldWeather", MODE_LOAD)
 		_Assign(_WorldTime, TWorldTime._instance, "WorldTime", MODE_LOAD)
 		_Assign(_BuildingTime, TBuildingTime._instance, "BuildingTime", MODE_LOAD)
+
+		Local backup:TData = GameRules.devConfigBackup
+		GameRules.Reset()
 		_Assign(_GameRules, GameRules, "GameRules", MODE_LOAD)
+		If backup Then GameRules.devConfigBackup = backup
+
 		_Assign(_GameConfig, GameConfig, "GameConfig", MODE_LOAD)
 		_Assign(_AuctionProgrammeBlocksList, TAuctionProgrammeBlocks.list, "AuctionProgrammeBlocks", MODE_LOAD)
 


### PR DESCRIPTION
Initialer Vorschlag für die Randomisierung der Werbewerte. Damit Debug-Export die Werte nicht verfälscht werden, erfolgt die Randomisierung erst beim Hinzufügen in der Werbeagentur.

Der erste Commit wäre nochmal zu diskutieren. Ich habe mich daran gestört, dass nicht die Dev-Werte des gespeicherten Spielstands verwendet werden (alter Spielstand ohne Randomisierung, nach Laden in neuer Version wird plötzlich randomisiert - die Datenbank wird ja auch nicht auf den neusten Stand gebracht). Wenn man die neuen dev-Werte verwenden möchte, kann man ja das Chat-Kommando verwenden.

closes #1070 