### PR TITLE
Datenbank: Programmdatenwiederverwendung

### DIFF
--- a/res/database/Default/user/ronny.xml
+++ b/res/database/Default/user/ronny.xml
@@ -436,7 +436,7 @@ Illustrious guests and music by [3|Nick].</en>
 			<ratings critics="18" speed="35" />
 		</programme>
 
-		<programme id="ronny-programme-betonfuerdenclan-01" product="4" licence_type="1" fictional="1" creator="5578" created_by="Ronny">
+		<programme id="ronny-programme-beton01" product="4" licence_type="1" fictional="1" creator="5578" created_by="Ronny">
 			<title>
 				<de>Beton für den Clan</de>
 				<en>Concrete for the Clans</en>
@@ -459,6 +459,19 @@ Illustrious guests and music by [3|Nick].</en>
 			<releaseTime year_relative="-5" year_relative_min="1980" year_relative_max="1995" />
 			<ratings critics="25" speed="20" />
 		</programme>
+
+		<programme id="ronny-programme-beton02" programmedata_id="ronny-programme-beton01" product="4" licence_type="1" fictional="1" creator="5578" created_by="Ronny">
+			<data licence_broadcast_limit="1" licence_flags="4" />
+			<title>
+				<de>Beton für den Clan - Director's cut</de>
+				<en>Concrete for the Clans</en>
+			</title>
+			<modifiers>
+				<!-- the programme ages slower than average -->
+				<modifier name="price" value="0.25" />
+			</modifiers>
+		</programme>
+
 	</allprogrammes>
 
 	<allnews>
@@ -673,7 +686,6 @@ Illustrious guests and music by [3|Nick].</en>
 				- Interesse an Liebesfilmen steigern
 			-->
 			<effects>
-				<effect trigger="happen" type="modifyPersonPopularity" guid="21e88c65-0cc6-4bd1-bd14-b48b6ce25402" valueMin="0.1" valueMax="0.2" />
 				<effect trigger="happen" type="modifyMovieGenrePopularity" genre="15" valueMin="0.5" valueMax="2.0" />
 			</effects>
 

--- a/source/game.broadcastmaterial.programme.bmx
+++ b/source/game.broadcastmaterial.programme.bmx
@@ -686,7 +686,7 @@ Type TProgramme Extends TBroadcastMaterialDefaultImpl {_exposeToLua="selected"}
 
 	'get the title
 	Method GetTitle:String() {_exposeToLua}
-		Return data.GetTitle()
+		Return licence.GetTitle()
 	End Method
 
 

--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -1415,7 +1415,13 @@ Type TDatabaseLoader
 
 		'=== MODIFIERS ===
 		'take over modifiers from parent (if episode)
-		LoadV3ModifiersFromNode(programmeData, node, xml)
+		If TXmlHelper.FindValue(node,"programmedata_id", "")
+			'for referenced data, store modifiers in the licence,
+			'so they do not change the global data
+			LoadV3ModifiersFromNode(programmeLicence, node, xml)
+		Else
+			LoadV3ModifiersFromNode(programmeData, node, xml)
+		EndIf
 
 
 


### PR DESCRIPTION
closes #1047 

Insb. für den in der Dokumentation genannten Fall Speziallizenz mit eingeschränkter Ausstrahlungsanzahl und geringerem Preis sollten Modifier für wiederverwendete Programmdaten nicht in den Daten sondern nur für die neue Lizenz verwendet werden.