### PR TITLE
Türfarbe nach Bankrott aktualisieren; Report engsoz

### DIFF
--- a/source/main.bmx
+++ b/source/main.bmx
@@ -5089,6 +5089,11 @@ endrem
 		If Not player.IsLocalHuman()
 			GetToastMessageCollection().AddMessage(toast, "TOPLEFT")
 		EndIf
+
+		'ensure new color for room signs
+		For Local door:TRoomDoor = EachIn GetRoomDoorCollection().list
+			door._lastOwner = 1000
+		Next
 	End Function
 
 


### PR DESCRIPTION
Der Cache des Sprites wurde bei Bankrott nicht invalidiert - Vorschlag: der Einfachheit halber bei allen Türen.