### PR TITLE
Filter archivierte Nachrichten

### DIFF
--- a/source/game.screen.archivedmessages.bmx
+++ b/source/game.screen.archivedmessages.bmx
@@ -166,10 +166,11 @@ Type TScreenHandler_OfficeArchivedMessages extends TScreenHandler
 
 	Method onChangeShowModeDropdown:Int(triggerEvent:TEventBase)
 		Local list:TGUIDropDown = TGUIDropDown(triggerEvent.GetSender())
+		If list <> _instance.showModeSelect Then return FALSE
 		local item:TGUIDropDownItem = TGUIDropDownItem(list.getSelectedEntry())
 		If not item Then return FALSE
-		local mode:Int=item.data.getInt("showMode")
-		If mode <> showMode
+		local mode:Int=item.data.getInt("showMode", -1)
+		If mode >= 0 And mode <> showMode
 			showMode = mode
 			GetInstance().ReloadMessages()
 		EndIf


### PR DESCRIPTION
Das Event für den Filterwechsel wird hin und wieder wohl auch ohne Nutzerinteraktion gefeuert. Als Ergebnis stimmen mutmaßlich ausgewählte und der tatsächliche Filter nicht mehr zusammen (da "0" von "nicht gesetzt" nicht unterschieden werden kann).
Aus diesem Grund bekommt "alle ausgewählt" einen anderen Wert.