### PR TITLE
Werbekoffersortierung

### DIFF
--- a/source/game.programme.adcontract.bmx
+++ b/source/game.programme.adcontract.bmx
@@ -808,10 +808,12 @@ Type TAdContract Extends TBroadcastMaterialSource {_exposeToLua="selected"}
 		Local a2:TAdContract = TAdContract(o2)
 		If Not a1 Then Return -1
 		If Not a2 Then Return 1
-		If a1.GetProfit() = a2.GetProfit()
+		Local p1:Int = a1.GetProfit() / a1.GetSpotsToSend()
+		Local p2:Int = a2.GetProfit() / a2.GetSpotsToSend()
+		If p1 = p2
 			Return a1.GetTitle() > a2.GetTitle()
 		EndIf
-        Return a1.GetProfit() - a2.GetProfit()
+		Return p1 - p2
 	End Function
 
 
@@ -866,7 +868,7 @@ Type TAdContract Extends TBroadcastMaterialSource {_exposeToLua="selected"}
 		If Not a1 Then Return -1
 		If Not a2 Then Return 1
 
-		If a1.GetSpotsSent() = a2.GetSpotsSent()
+		If a1.GetSpotsToSend() = a2.GetSpotsToSend()
 			Return a1.GetTitle() > a2.GetTitle()
 		EndIf
         Return a1.GetSpotsToSend() - a2.GetSpotsToSend()

--- a/source/game.roomhandler.adagency.bmx
+++ b/source/game.roomhandler.adagency.bmx
@@ -731,6 +731,7 @@ Type RoomHandler_AdAgency Extends TRoomHandler
 		Next
 
 		'create missing gui elements for the players contracts
+		SortContracts(programmeCollection.adContracts, ListSortMode)
 		For Local contract:TAdContract = EachIn programmeCollection.adContracts
 			If guiListSuitcase.ContainsContract(contract) Then Continue
 			Local block:TGuiAdContract = New TGuiAdContract.CreateWithContract(contract)


### PR DESCRIPTION
Die Sortierung im Koffer wird der ausgewählten Sortierung in der Werbeagentur angepasst. Vorschlag im zweiten Commit: statt den absoluten Profit für einen Vertrag zu vergleichen sollte der Profit pro Spot verglichen werden.