### PR TITLE
Episoden-Genre, Report Der Baum

### DIFF
--- a/res/database/Default/database_programmes.xml
+++ b/res/database/Default/database_programmes.xml
@@ -8471,7 +8471,7 @@ Ermattet von den ständigen Streichen der Zwillinge empfiehlt auch seine aushelf
 						<en>Rolle and Ralle reveal the limits of their working father's parenting skills.
 Weary of the twins' constant pranks, his helping-out sister also strongly recommends remarriage.</en>
 					</description>
-					<data country="DDR" year="1974" price_mod="1.00" />
+					<data year="1974" />
 					<ratings critics="79" speed="36" />
 				</programme>
 				<programme id="therob-programme-famser-AlsoPapa-ep102" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751/7430" created_by="Sjaele/TheRob">
@@ -8487,7 +8487,7 @@ Weary of the twins' constant pranks, his helping-out sister also strongly recomm
 						<de>Mit vereinten Kräften versuchen die Zwillinge unterstützt von Onkel und Tante Vati von der Zweckmäßigkeit eine Brautschau zu überzeugen. Ob die Karusselbesitzerin das Rennen macht?</de>
 						<en>With combined forces, the twins, supported by uncle and aunt, try to convince daddy of the usefulness of the pursuit of looking for a wife. Will the carousel owner make the race?</en>
 					</description>
-					<data country="DDR" year="1974" />
+					<data year="1974" />
 					<ratings critics="77" speed="36" />
 				</programme>
 				<programme id="therob-programme-famser-AlsoPapa-ep103" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751/7430" created_by="Sjaele/TheRob">
@@ -8503,7 +8503,7 @@ Weary of the twins' constant pranks, his helping-out sister also strongly recomm
 						<de>Die Rummelplatzfee war nur zur Aushilfe bei ihrem Vater, ist für eine LPG unabdingbar. Raus aus Berlin auf's Dorf?</de>
 						<en>The fairground maiden was only there to help out her father, but she is indispensable for an Agricultural Production Cooperative. Out of Berlin and into the village?</en>
 					</description>
-					<data country="DDR" year="1974" />
+					<data year="1974" />
 					<ratings critics="77" speed="38" />
 				</programme>
 				<programme id="therob-programme-famser-AlsoPapa-ep104" product="2" licence_type="2" tmdb_id="0" imdb_id="" creator="8751/7430" created_by="Sjaele/TheRob">
@@ -9020,7 +9020,7 @@ Weary of the twins' constant pranks, his helping-out sister also strongly recomm
 						<de>Petra nimmt Wolfgang nur zurück, wenn er sich beweist und erwachsen wird. Erst dann ist sie für eine gemeinsame Zukunft bereit.</de>
 						<en>Petra will only accept Wolfgang back if he can prove himself and grow up. Not until then will she be open to a future together.</en>
 					</description>
-					<data country="DDR" year="1964" distribution="1" maingenre="13" subgenre="" flags="8" blocks="3" price_mod="1.00" />
+					<data subgenre="13" blocks="3" />
 					<ratings critics="67" speed="53" />
 				</programme>
 			</children>
@@ -11634,7 +11634,7 @@ Dream scenes and sentiments warp the storyline.</en>
 						<de>Auf nach Hause. Wie gelingt die Flucht?</de>
 						<en>On the way home. How to make the escape?</en>
 					</description>
-					<data country="D/F" year="1964" distribution="0" maingenre="13" subgenre="1" flags="8" blocks="4" price_mod="1.00" />
+					<data subgenre="13" blocks="4" />
 					<ratings critics="67" speed="53" />
 				</programme>
 			</children>

--- a/res/database/Default/user/therob.xml
+++ b/res/database/Default/user/therob.xml
@@ -743,7 +743,7 @@
 						<de>Nach einigen abstrusen Abteuern mit geflügelten Menschen, entscheidet sich Sinbad mit seiner neu Angetrauten nach Bagdad zurück zu kehren.</de>
 						<en>After some abstruse adventures with winged people, Sinbad decides to return to Baghdad with his newly wedded wife.</en>
 					</description>
-					<data year="1979" distribution="2"  blocks="2" price_mod="1.00" />
+					<data year="1979" blocks="2" />
 					<ratings critics="47" speed="47" />
 				</programme>
 			</children>
@@ -1479,7 +1479,7 @@
 						<de>Ralle und Rolle entdecken die Wahrheit und lernen sich kennen. Freude über den unerwarteten Bruder und blankes Entsetzen über den Beruf sorgen für Unterhaltung.</de>
 						<en>Ralle and Rolle discover the truth and get to know each other. Joy about the unexpected brother and sheer horror about the job provide entertainment.</en>
 					</description>
-					<data country="DDR" year="1980" distribution="0" maingenre="4" subgenre="7,5" flags="0" blocks="2" price_mod="1.00" />
+					<data blocks="2" />
 					<ratings critics="52" speed="28" />
 				</programme>
 			</children>
@@ -1816,7 +1816,6 @@
 					<member index="3" function="8">3d37e02e-78f2-4749-9de5-429e31b5590b</member>
 					</staff>
 					<groups target_groups="0" />
-					<data country="D" distribution="0" maingenre="204" subgenre="" flags="8" blocks="4" price_mod="1.0" />
 				</programme>
 				<programme id="TheRob-serie-BestofTVTower-Ep002" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
@@ -1834,7 +1833,6 @@
 						<member index="3" function="2">Per_custom_Freddy_429</member>
 						<member index="4" function="8">3d37e02e-78f2-4749-9de5-429e31b5590b</member>
 					</staff>
-					<data country="D" distribution="0" maingenre="204" subgenre="" flags="8" blocks="4" price_mod="1.00" />
 				</programme>
 				<programme id="TheRob-serie-BestofTVTower-Ep003" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
@@ -1852,7 +1850,6 @@
 						<member index="3" function="8">21e88c65-0cc6-4bd1-bd14-b48b6ce25402</member>
 						<member index="4" function="8">3d37e02e-78f2-4749-9de5-429e31b5590b</member>
 					</staff>
-					<data country="D" distribution="0" maingenre="204" subgenre="" flags="8" blocks="4" price_mod="1.00" />
 				</programme>
 				<programme id="TheRob-serie-BestofTVTower-Ep004" product="7" licence_type="2" tmdb_id="0" imdb_id="tt0072443" creator="Sjaele/TheRob">
 					<title>
@@ -1875,7 +1872,7 @@
 						<member index="4" function="8">3d37e02e-78f2-4749-9de5-429e31b5590b</member>
 					</staff>
 					<groups target_groups="0" pro_pressure_groups="0" contra_pressure_groups="0" />
-					<data country="SU" distribution="0" maingenre="204" subgenre="" flags="0" blocks="3" price_mod="1.00" />
+					<data country="SU" blocks="3" />
 				</programme>
 			</children>
 		</programme>


### PR DESCRIPTION
Im Forum wurde angemerkt, dass bei Fuchs unter Füchsen in der letzten Serie das falsche Fernsehbild gezeigt wurde. Tatsächlich war das Hauptgenre der letzten Folge als "Monumental" angegeben. Für "überlange" Finalfolgen würde ich "Monumental" nicht als Hauptgenre verwenden sondern als Untergenre.

Ich habe die Datenbank mal nach Stellen durchsucht, an denen Einzelfolgen die data-Tags enthalten und damit die Daten des Haupteintrags überschreiben. In diesem PR wurden diese z.T. angepasst:
* Löschen von duplizierten Einträgen
* Löschen von Einzelattributen, die keine Änderung bewirken
* Anpassung Subgenre statt Hauptgenre für lange Finalfolgen einer Serie