### PR TITLE
Bug bezüglich bookable-Flag; Report scr0llbaer

### DIFF
--- a/res/database/Default/database_people_fictional.xml
+++ b/res/database/Default/database_people_fictional.xml
@@ -167,7 +167,7 @@
 	<insignificantpeople>
 		<person id="common-amateur-actors" first_name="" last_name="Laiendarsteller" nick_name="Laiendarsteller" fictional="1" levelup="0" castable="0" />
 		<person id="common-amateur-director" first_name="" last_name="Regiepraktikant" nick_name="Regiepraktikant" fictional="1" levelup="0" castable="0" />
-		<person id="unnamed-person" first_name="" last_name="Unbekannt" nick_name="Unbekannt" fictional="1" levelup="0" castable="0" />
+		<person id="common-unnamed-person" first_name="" last_name="Unbekannt" nick_name="Unbekannt" fictional="1" levelup="0" castable="0" />
 		<person id="various-voice-artists" first_name="" last_name="versch. Stimmkünstler" fictional="1" levelup="0" castable="0" />
 		<person id="various-puppeteers" first_name="" last_name="versch. Puppenspieler" fictional="1" levelup="0" castable="0" />
 		<person id="various-models" first_name="" last_name="versch. Models" fictional="1" levelup="0" castable="0" />

--- a/res/database/Default/lang/de.xml
+++ b/res/database/Default/lang/de.xml
@@ -4,7 +4,7 @@
 	<persons>
 		<person guid="common-amateur-actors" first_name="" last_name="Laiendarsteller" nick_name="Laiendarsteller" />
 		<person guid="common-amateur-director" first_name="" last_name="Regiepraktikant" nick_name="Regiepraktikant" />
-		<person guid="unnamed-person" first_name="" last_name="Unbekannt" nick_name="Unbekannt" />
+		<person guid="common-unnamed-person" first_name="" last_name="Unbekannt" nick_name="Unbekannt" />
 		<person guid="various-voice-artists" first_name="" last_name="versch. Stimmkünstler" />
 		<person guid="various-puppeteers" first_name="" last_name="versch. Puppenspieler" />
 		<person guid="various-models" first_name="" last_name="versch. Models" />

--- a/res/database/Default/lang/en.xml
+++ b/res/database/Default/lang/en.xml
@@ -23,7 +23,7 @@
 	<persons>
 		<person guid="common-amateur-actors" first_name="" last_name="Amateur Actors" nick_name="Amateur Actors" />
 		<person guid="common-amateur-director" first_name="" last_name="Amateur Director" nick_name="Amateur Director" />
-		<person guid="unnamed-person" first_name="" last_name="Unknown" nick_name="Unknown" />
+		<person guid="common-unnamed-person" first_name="" last_name="Unknown" nick_name="Unknown" />
 		<person guid="various-voice-artists" first_name="" last_name="various voice artists" />
 		<person guid="various-puppeteers" first_name="" last_name="various puppeteers" />
 		<person guid="various-models" first_name="" last_name="various models" />

--- a/res/database/Default/lang_original/de.xml
+++ b/res/database/Default/lang_original/de.xml
@@ -4,7 +4,7 @@
 	<persons>
 		<person guid="common-amateur-actors" first_name="" last_name="Laiendarsteller" nick_name="Laiendarsteller" />
 		<person guid="common-amateur-director" first_name="" last_name="Regiepraktikant" nick_name="Regiepraktikant" />
-		<person guid="unnamed-person" first_name="" last_name="Unbekannt" nick_name="Unbekannt" />
+		<person guid="common-unnamed-person" first_name="" last_name="Unbekannt" nick_name="Unbekannt" />
 		<person guid="various-voice-artists" first_name="" last_name="versch. Stimmkünstler" />
 		<person guid="various-puppeteers" first_name="" last_name="versch. Puppenspieler" />
 		<person guid="various-models" first_name="" last_name="versch. Models" />

--- a/res/database/Default/lang_original/en.xml
+++ b/res/database/Default/lang_original/en.xml
@@ -23,7 +23,7 @@
 	<persons>
 		<person guid="common-amateur-actors" first_name="" last_name="Amateur Actors" nick_name="Amateur Actors" />
 		<person guid="common-amateur-director" first_name="" last_name="Amateur Director" nick_name="Amateur Director" />
-		<person guid="unnamed-person" first_name="" last_name="Unknown" nick_name="Unknown" />
+		<person guid="common-unnamed-person" first_name="" last_name="Unknown" nick_name="Unknown" />
 		<person guid="various-voice-artists" first_name="" last_name="various voice artists" />
 		<person guid="various-puppeteers" first_name="" last_name="various puppeteers" />
 		<person guid="various-models" first_name="" last_name="various models" />

--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -497,6 +497,8 @@ Type TDatabaseLoader
 		'fallback for old database syntax
 		person.SetFlag(TVTPersonFlag.CASTABLE, data.GetBool("bookable", person.IsCastable()) )
 		person.SetFlag(TVTPersonFlag.CASTABLE, data.GetBool("castable", person.IsCastable()) )
+		'cast filtering is mainly done using the bookable flag - not castable implies not bookable
+		If Not person.IsCastable() Then person.SetFlag(TVTPersonFlag.BOOKABLE, false )
 		person.SetFlag(TVTPersonFlag.CAN_LEVEL_UP, data.GetBool("levelup", person.CanLevelUp()) )
 		person.SetJob(data.GetInt("job"))
 		person.countryCode = data.GetString("country", person.countryCode).ToUpper()

--- a/source/game.newsagency.base.bmx
+++ b/source/game.newsagency.base.bmx
@@ -517,8 +517,19 @@ Type TNewsAgency
 		Local localizeTitle:TLocalizedString
 		Local localizeDescription:TLocalizedString
 
+		'prevent anonymous various/common persons to appear in movie news
+		Local actor:TPersonBase = licence.GetData().getActor(1)
+		Local actor2:TPersonBase = licence.GetData().getActor(2)
+		If actor
+			If actor.GetGUID().startsWith("various") Or actor.GetGUID().startsWith("common")
+				actor = Null
+			ElseIf actor2 And actor2.GetGUID().startsWith("various") Or actor2.GetGUID().startsWith("common") 
+				actor = Null
+			EndIf
+		EndIf
+
 		'no director and no actors
-		If licence.GetData().getActor(1) = Null And licence.GetData().getDirector(1) = Null
+		If actor = Null And licence.GetData().getDirector(1) = Null
 			localizeTitle = GetRandomLocalizedString("NEWS_ANNOUNCE_MOVIE_NO_CAST_TITLE")
 			localizeDescription = GetRandomLocalizedString("NEWS_ANNOUNCE_MOVIE_NO_CAST_DESCRIPTION")
 		'no director
@@ -526,11 +537,11 @@ Type TNewsAgency
 			localizeTitle = GetRandomLocalizedString("NEWS_ANNOUNCE_MOVIE_NO_CAST_TITLE")
 			localizeDescription = GetRandomLocalizedString("NEWS_ANNOUNCE_MOVIE_NO_CAST_DESCRIPTION")
 		'no actor named (eg. cartoon)
-		ElseIf licence.GetData().getActor(1) = Null
+		ElseIf actor = Null
 			localizeTitle = GetRandomLocalizedString("NEWS_ANNOUNCE_MOVIE_NO_ACTOR_TITLE")
 			localizeDescription = GetRandomLocalizedString("NEWS_ANNOUNCE_MOVIE_NO_ACTOR_DESCRIPTION")
 		'if same director and main actor...
-		ElseIf licence.GetData().getActor(1) = licence.GetData().getDirector(1)
+		ElseIf actor = licence.GetData().getDirector(1)
 			localizeTitle = GetRandomLocalizedString("NEWS_ANNOUNCE_MOVIE_ACTOR_IS_DIRECTOR_TITLE")
 			localizeDescription = GetRandomLocalizedString("NEWS_ANNOUNCE_MOVIE_ACTOR_IS_DIRECTOR_DESCRIPTION")
 		'default

--- a/source/game.person.base.bmx
+++ b/source/game.person.base.bmx
@@ -462,9 +462,9 @@ Type TPersonBaseCollection Extends TGameObjectCollection
 	End Method
 	
 
-	'useful to fetch a random "amateur" (aka "layman")
-	Method GetRandomInsignificants:TPersonBase[](array:TPersonBase[] = Null, amount:Int, onlyFictional:Int = False, onlyBookable:Int = False, job:Int = 0, gender:Int = -1, alive:Int = -1, countryCode:String="", forbiddenGUIDs:String[] = Null, forbiddenIDs:Int[] = Null)
-		Return GetRandomsFromArrayOrFilter(array, FILTER_INSIGNIFICANT, amount, onlyFictional, onlyBookable, job, gender, alive, countryCode.ToUpper(), forbiddenGUIDs, forbiddenIDs)
+	'useful to fetch a random castable "amateur" (aka "layman")
+	Method GetRandomCastableInsignificants:TPersonBase[](array:TPersonBase[] = Null, amount:Int, onlyFictional:Int = False, onlyBookable:Int = False, job:Int = 0, gender:Int = -1, alive:Int = -1, countryCode:String="", forbiddenGUIDs:String[] = Null, forbiddenIDs:Int[] = Null)
+		Return GetRandomsFromArrayOrFilter(array, FILTER_CASTABLE_INSIGNIFICANT, amount, onlyFictional, onlyBookable, job, gender, alive, countryCode.ToUpper(), forbiddenGUIDs, forbiddenIDs)
 	End Method
 
 
@@ -473,8 +473,8 @@ Type TPersonBaseCollection Extends TGameObjectCollection
 	End Method
 
 
-	Method GetRandomCelebrities:TPersonBase[](array:TPersonBase[] = Null, amount:Int, onlyFictional:Int = False, onlyBookable:Int = False, job:Int = 0, gender:Int = -1, alive:Int = -1, countryCode:String="", forbiddenGUIDs:String[] = Null, forbiddenIDs:Int[] = Null)
-		Return GetRandomsFromArrayOrFilter(array, FILTER_CELEBRITY, amount, onlyFictional, onlyBookable, job, gender, alive, countryCode.ToUpper(), forbiddenGUIDs, forbiddenIDs)
+	Method GetRandomCastableCelebrities:TPersonBase[](array:TPersonBase[] = Null, amount:Int, onlyFictional:Int = False, onlyBookable:Int = False, job:Int = 0, gender:Int = -1, alive:Int = -1, countryCode:String="", forbiddenGUIDs:String[] = Null, forbiddenIDs:Int[] = Null)
+		Return GetRandomsFromArrayOrFilter(array, FILTER_CASTABLE_CELEBRITY, amount, onlyFictional, onlyBookable, job, gender, alive, countryCode.ToUpper(), forbiddenGUIDs, forbiddenIDs)
 	End Method
 
 
@@ -488,13 +488,13 @@ Type TPersonBaseCollection Extends TGameObjectCollection
 	End Method
 
 
-	Method GetFilteredInsignificantsArray:TPersonBase[](onlyFictional:Int = False, onlyBookable:Int = False, job:Int=0, gender:Int=-1, alive:Int = -1, countryCode:String="", forbiddenGUIDs:String[] = Null, forbiddenIDs:Int[] = Null)
-		Return _FilterList( GetFilteredList(FILTER_INSIGNIFICANT), -1, onlyFictional, onlyBookable, job, gender, alive, countryCode.ToUpper(), forbiddenGUIDs, forbiddenIDs)
+	Method GetFilteredCastableInsignificantsArray:TPersonBase[](onlyFictional:Int = False, onlyBookable:Int = False, job:Int=0, gender:Int=-1, alive:Int = -1, countryCode:String="", forbiddenGUIDs:String[] = Null, forbiddenIDs:Int[] = Null)
+		Return _FilterList( GetFilteredList(FILTER_CASTABLE_INSIGNIFICANT), -1, onlyFictional, onlyBookable, job, gender, alive, countryCode.ToUpper(), forbiddenGUIDs, forbiddenIDs)
 	End Method
 
 
-	Method GetFilteredCelebritiesArray:TPersonBase[](onlyFictional:Int = False, onlyBookable:Int = False, job:Int=0, gender:Int=-1, alive:Int = -1, countryCode:String="", forbiddenGUIDs:String[] = Null, forbiddenIDs:Int[] = Null)
-		Return _FilterList( GetFilteredList(FILTER_CELEBRITY), -1, onlyFictional, onlyBookable, job, gender, alive, countryCode.ToUpper(), forbiddenGUIDs, forbiddenIDs)
+	Method GetFilteredCastableCelebritiesArray:TPersonBase[](onlyFictional:Int = False, onlyBookable:Int = False, job:Int=0, gender:Int=-1, alive:Int = -1, countryCode:String="", forbiddenGUIDs:String[] = Null, forbiddenIDs:Int[] = Null)
+		Return _FilterList( GetFilteredList(FILTER_CASTABLE_CELEBRITY), -1, onlyFictional, onlyBookable, job, gender, alive, countryCode.ToUpper(), forbiddenGUIDs, forbiddenIDs)
 	End Method
 
 

--- a/source/game.person.bmx
+++ b/source/game.person.bmx
@@ -123,7 +123,7 @@ Function EnsureEnoughCastableCelebritiesPerJob:Int(amount:int, baseCountryCode:S
 
 	'fetch all fictional and bookable celebs
 	'onlyFictional, onlyBookable, job, gender, alive, countryCode, forbiddenGUIDs, forbiddenIDs
-	local celebrities:TPersonBase[] = GetPersonBaseCollection().GetFilteredCelebritiesArray(True, True, 0, -1, True, "", Null, Null)
+	local celebrities:TPersonBase[] = GetPersonBaseCollection().GetFilteredCastableCelebritiesArray(True, True, 0, -1, True, "", Null, Null)
 	Local castJobIDs:Int[] = TVTPersonJob.GetCastJobs()
 	local addedCelebs:TPersonBase[]
 

--- a/source/game.production.productionmanager.bmx
+++ b/source/game.production.productionmanager.bmx
@@ -483,13 +483,13 @@ Type TProductionManager
 		Local amountWithoutJob:Int = (amateursToInclude * 3) / 10
 		if amateursToInclude > 1 then amountWithoutJob :+ 1
 
-		local amateursWithJob:TPersonBase[] = GetPersonBaseCollection().GetRandomInsignificants(currentAvailableAmateurs, amateursToInclude - amountWithoutJob, True, True, filtertoJobID, filterToGenderID, True, "", null)
+		local amateursWithJob:TPersonBase[] = GetPersonBaseCollection().GetRandomCastableInsignificants(currentAvailableAmateurs, amateursToInclude - amountWithoutJob, True, True, filtertoJobID, filterToGenderID, True, "", null)
 		local amateursWithJobIDs:Int[] = new Int[amateursWithJob.length]
 		For local i:int = 0 until amateursWithJob.length
 			amateursWithJobIDs[i] = amateursWithJob[i].id
 		Next
 		'no job restrictions but other persons than the ones with job
-		local amateursWithoutJob:TPersonBase[] = GetPersonBaseCollection().GetRandomInsignificants(currentAvailableAmateurs, amountWithoutJob, True, True, 0, filterToGenderID, True, "", null, amateursWithJobIDs)
+		local amateursWithoutJob:TPersonBase[] = GetPersonBaseCollection().GetRandomCastableInsignificants(currentAvailableAmateurs, amountWithoutJob, True, True, 0, filterToGenderID, True, "", null, amateursWithJobIDs)
 
 
 		For local i:int = 0 until amateursWithJob.length + amateursWithoutJob.length
@@ -609,8 +609,8 @@ Type TProductionManager
 		
 
 		'1.) fetch all amateurs
-		'    all fictional, bookable, no job restriction, no gender restriction, alive, no country restriction
-		currentAvailableAmateurs = GetPersonBaseCollection().GetFilteredInsignificantsArray(True, True, 0, -1, True, "", null, null)
+		'    all fictional, castable, bookable, no job restriction, no gender restriction, alive, no country restriction
+		currentAvailableAmateurs = GetPersonBaseCollection().GetFilteredCastableInsignificantsArray(True, True, 0, -1, True, "", null, null)
 		'remove celebs? -> should not be needed
 
 

--- a/source/game.programmeproducer.bmx
+++ b/source/game.programmeproducer.bmx
@@ -399,10 +399,10 @@ Type TProgrammeProducer Extends TProgrammeProducerBase
 
 			Local result:TPersonBase = currentChoice
 			'TODO check if these calls give the same set of persons available in the supermarket
-			Local alternatives:TPersonBase[] = GetPersonBaseCollection().GetRandomCelebrities(Null, 20, True, True, job.job, job.gender, True, jobCountry, Null, usedPersonIDs)
+			Local alternatives:TPersonBase[] = GetPersonBaseCollection().GetRandomCastableCelebrities(Null, 20, True, True, job.job, job.gender, True, jobCountry, Null, usedPersonIDs)
 			If alternatives.length < 10
 				'no job restriction if there are too few alternatives
-				alternatives:+ GetPersonBaseCollection().GetRandomCelebrities(Null, 20, True, True, 0, job.gender, True, jobCountry, Null, usedPersonIDs)
+				alternatives:+ GetPersonBaseCollection().GetRandomCastableCelebrities(Null, 20, True, True, 0, job.gender, True, jobCountry, Null, usedPersonIDs)
 			End If
 			Local script:TScript = productionConcept.script
 			Local genreID:Int = script.mainGenre


### PR DESCRIPTION
Die Frage wäre, ob zusätzlich das Filtern in person.base erweitert werden sollte:
Die Producer nutzen nicht die castable-Filter, was zur Folge hat, dass zwar auf bookable geprüft wird, aber wenn alle bookable aber nicht castable sind, rutschen eben trotzdem  ungewollte Einträge durch.

Eine Erweiterung wäre ggf. ohnehin besser, da mit dieser Änderung nur neue Spiele repariert werden. In alten Spielständen haben die Personen ja schon das falsche Flag.

closes #1111