### PR TITLE
Anpassung Lua an neue Kartenlogik

### DIFF
--- a/res/ai/DefaultAIPlayer/TaskAdAgency.lua
+++ b/res/ai/DefaultAIPlayer/TaskAdAgency.lua
@@ -350,7 +350,7 @@ end
 
 function SignRequisitedContracts:Prepare(pParams)
 	self.CurrentSpotIndex = 0
-	self.maxAudience = TVT:getReceivers()
+	self.maxAudience = MY.GetChannelReceivers()
 	self.highAudienceFactor = 0.08
 	self.avgAudienceFactor = 0.045
 	self.lowAudienceFactor = 0.003
@@ -512,7 +512,7 @@ function SignRequisitedContracts:SignMatchingContracts(requisition, guessedAudie
 
 		--TODO optimize
 		--skip all children and some manager ads - too dangerous
-		if adContract.GetLimitedToTargetGroup() == 1 or (hard == true or avg == true and spotCount > 2 and adContract.GetLimitedToTargetGroup() == 32) then
+		if adContract.GetLimitedToTargetGroup() == 1 or ((hard == true or avg == true) and spotCount > 2 and adContract.GetLimitedToTargetGroup() == 32) then
 		-- skip if contract requires too many spots for the given level
 		elseif doSign == true then
 			local minGuessedAudienceValue = minGuessedAudience.GetTotalValue(adContract.GetLimitedToTargetGroup())
@@ -568,7 +568,7 @@ end
 function SignContracts:Prepare(pParams)
 	self.CurrentSpotIndex = 0
 	self.lowAudienceFactor = 0.005
-	self.maxAudience =  TVT:getReceivers()
+	self.maxAudience = MY.GetChannelReceivers()
 	self.ownedContracts = {};
 	--heuristic for licence max price - possible income per spot
 	local maxIncomePerSpot = 0

--- a/source/game.ai.bmx
+++ b/source/game.ai.bmx
@@ -1035,13 +1035,6 @@ endrem
 		EndIf
 		Return Self.RESULT_NOTALLOWED
 	End Method
-	
-	
-	Method of_getReceivers:Int(playerID:Int)
-		If Not _PlayerInRoom("office") Then Return Self.RESULT_WRONGROOM
-
-		Return GetStationMapCollection().GetReceivers(playerID)
-	End Method
 
 
 	Method of_getAudience:Int(day:Int, hour:Int)
@@ -1080,7 +1073,10 @@ endrem
 		Local map:TStationMap = _GetPlayerStationMap()
 		Local station:TStationAntenna = New TStationAntenna.Init(New SVec2I(x, y), self.ME)
 
-		If map.AddStation( station, True )
+		If map.GetAntennaByXY(x,y,True)
+			'prevent buying antenna in same position
+			Return Self.RESULT_FAILED
+		ElseIf map.AddStation( station, True )
 			Return Self.RESULT_OK
 		Else
 			Return Self.RESULT_FAILED

--- a/source/game.stationmap.bmx
+++ b/source/game.stationmap.bmx
@@ -2951,7 +2951,7 @@ Type TStationMap Extends TOwnedGameObject {_exposeToLua="selected"}
 		
 		For Local antenna:TStationAntenna = EachIn stations
 			If exactPosition
-				If antenna.X <> X Or antenna.Y <> Y Then Continue
+				If antenna.X = X And antenna.Y = Y Then Return antenna
 			Else
 				'or x,y outside of station-circle?
 				Local distanceSquared:Int = (X - antenna.X)^2 + (Y - antenna.Y)^2


### PR DESCRIPTION
Für den eigentlichen Kauf von Antennen und Vertragsabschlüsse müssen noch Api-Änderungen vorgenommen werden. Um zu verhindern, dass an derselben Stelle mehrere Antenne gebaut werden, wird "extern" geprüft, dass es dort nicht schon eine Antenne gibt.