### PR TITLE
Unterstützung eigener Filmbilder

### DIFF
--- a/source/game.ingameinterface.bmx
+++ b/source/game.ingameinterface.bmx
@@ -337,7 +337,14 @@ Type TInGameInterface
 						'real programme
 						If TProgramme(obj)
 							Local programme:TProgramme = TProgramme(obj)
-							CurrentProgramme = GetSpriteFromRegistry("gfx_interface_tv_programme_genre_" + TVTProgrammeGenre.GetAsString(programme.data.GetGenre()), "gfx_interface_tv_programme_none")
+							If programme.licence
+								CurrentProgramme = GetSpriteFromRegistry("gfx_interface_tv_programme_" +programme.licence.GetGUID() , True)
+								If CurrentProgramme.GetName() = "defaultsprite"
+									CurrentProgramme = GetSpriteFromRegistry("gfx_interface_tv_programme_genre_" + TVTProgrammeGenre.GetAsString(programme.data.GetGenre()), "gfx_interface_tv_programme_none")
+								EndIf
+							Else
+								CurrentProgramme = GetSpriteFromRegistry("gfx_interface_tv_programme_genre_" + TVTProgrammeGenre.GetAsString(programme.data.GetGenre()), "gfx_interface_tv_programme_none")
+							EndIf
 							If (programme.IsSeriesEpisode() or programme.IsCollectionElement()) and programme.licence.parentLicenceGUID
 								CurrentProgrammeText = programme.licence.GetParentLicence().GetTitle() + " ("+ programme.GetEpisodeNumber() + "/" + programme.GetEpisodeCount()+"): " + programme.GetTitle() + " (" + getLocale("BLOCK") + " " + programmePlan.GetProgrammeBlock() + "/" + programme.GetBlocks() + ")"
 							Else


### PR DESCRIPTION
Proof of concept:
Mit dieser Anpassung können Sprites für eigene Film GUIDs hinterlegt werden. Registriert man mit dem Präfix "gfx_interface_tv_programme_" plus GUID ein Bild (z.B. in interface.xml) wird dieses Bild anstatt des Standard-Genre-Sprites angezeigt.

Ich habe keine Ahnung welche Auswirkung das bei massenhaft hinzugefügten Bildern bezüglich des Speichers haben würde.

see #1140