### PR TITLE
Spielstandreparatur Call-In

### DIFF
--- a/source/main.bmx
+++ b/source/main.bmx
@@ -2467,6 +2467,13 @@ Type TSaveGame Extends TGameState
 				EndIf
 			Next
 
+			For local licence:TProgrammeLicence = EachIn GetProgrammeLicenceCollection().licences.Values()
+				If licence.isPaid() And licence.data and licence.data.releaseTime < 0
+					licence.data.releaseTime = 0
+					TLogger.Log("RepairData()", "Fix release date for "+ licence.getTitle(), LOG_LOADING)
+				EndIf
+			Next
+
 		EndIf
 
 		If savegameVersion < 18


### PR DESCRIPTION
Mit #1167 sind nicht alle Call-In-Programme automatisch verfügbar (released). Wenn sie allerdings in einem früheren Spielstand kein explizites Veröffentlichungsdatum hatten (-1) wären sie nun grundsätzlich nicht mehr auswählbar.

Mit dieser Datenbankreparatur bekommen solche Einträge 0 Veröffentlichungszeit und fallen damit unter "released".