### PR TITLE
Verbesserung Autosave; Report bol

### DIFF
--- a/source/main.bmx
+++ b/source/main.bmx
@@ -2918,6 +2918,11 @@ endrem
 		'close message window
 		If messageWindow Then messageWindow.Close()
 
+		'reduce game speed for autosave games (saved during fast forward)
+		If saveURI.contains("autosave.") and GetWorldTime().GetTimeFactor() > 200
+			GetGame().SetGameSpeedPreset(0)
+		EndIf
+
 		'call game that game continues/starts now
 		GetGame().StartLoadedSaveGame()
 
@@ -6311,7 +6316,7 @@ endrem
 		If TSaveGame.autoSaveNow and Not GetPlayer().GetFigure().IsInRoom()
 			Local gameName:String = GameConfig.savegame_lastUsedName
 			Local autoSaveName:String = "autosave"
-			If gameName and gameName <> "quicksave" and not gameName.endsWith("_autosave")
+			If gameName and gameName <> "quicksave" and not gameName.endsWith("autosave")
 				autoSaveName = gameName + "_autosave"
 			EndIf
 			Local autoSaveURI:String = TSavegame.GetSavegameURI(autoSaveName)


### PR DESCRIPTION
* Dateiname autosave_autosave vermeiden
* Fast-Forward nach Laden eines Autosave vermeiden

(Wenn man selbst explizit einen Spielstand speichert macht man das zu einem Zeitpunkt, bei dem man die Spielgeschwindigkeit unter Kontrolle hatte. Autosave passiert mit hoher Wahrscheinlichkeit bei einem Fast-Forward-Raumwechsel. Daher sollte beim Laden des Spiels die Geschwindigkeit runtergesetzt werden.)