### PR TITLE
Datenblatt: Anzeige Preis pro Block

### DIFF
--- a/source/game.programme.programmelicence.bmx
+++ b/source/game.programme.programmelicence.bmx
@@ -2625,6 +2625,7 @@ Type TProgrammeLicence Extends TBroadcastMaterialSource {_exposeToLua="selected"
 
 
 		if showPrice
+			if shiftDown then price:/ GetBlocksTotal()
 			if canAfford
 				skin.RenderBox(contentX + 5 + 199, contentY, contentW - 10 - 199 +1, -1, MathHelper.DottedValue( price ), "money", EDatasheetColorStyle.Neutral, skin.fontBold, ALIGN_RIGHT_CENTER)
 			else


### PR DESCRIPTION
Für Vergleiche von Programmen kann der Preis pro Block interessant sein. Insb. bei Serien müssen ja auch nicht alle Folgen dieselbe Länge haben. Daher der Vorschlag bei shift den Preis pro Block anzuzeigen (analog Prämie pro Block bei Werbung).