### PR TITLE
Nächstes Element einer Mehrfachproduktion bei shift anbieten

### DIFF
--- a/source/game.production.bmx
+++ b/source/game.production.bmx
@@ -649,6 +649,7 @@ Type TProduction Extends TOwnedGameObject
 
 		If Not programmeData.extra Then programmeData.extra = New TData
 		programmeData.extra.AddInt("productionID", self.GetID())
+		programmeData.extra.addInt("scriptID", productionConcept.script.GetId())
 
 		If owner <> 0 Then programmeData.extra.AddInt("producerID", owner)
 

--- a/source/game.screen.programmeplanner.bmx
+++ b/source/game.screen.programmeplanner.bmx
@@ -1662,6 +1662,22 @@ endrem
 					'for "single licences" we cannot fetch a "next sublicence"
 					else
 						createFromLicence = TProgramme(item.broadcastMaterial).licence
+						'but for multi-productions we can look for the "next" one
+						If createFromLicence.IsCustomProduction() And createFromLicence.GetData().extra
+							Local scriptId:Int = createFromLicence.GetData().extra.GetInt("scriptID")
+							Local origReleaseDate:Long = createFromLicence.GetData().GetReleaseTime()
+							Local replaced:Int = False
+							If scriptId
+								For Local t:TProgrammeLicence = EachIn GetPlayerProgrammeCollection(createFromLicence.GetOwner()).GetProgrammeLicences()
+									If t.IsCustomProduction() And t.GetData().extra And scriptId = t.GetData().extra.GetInt("scriptID")
+										If t.GetData().GetReleaseTime() > origReleaseDate And (Not replaced Or t.GetData().GetReleaseTime() < createFromLicence.GetData().GetReleaseTime())  
+											createFromLicence = t
+											replaced = True
+										EndIf
+									EndIf
+								Next
+							EndIf
+						EndIf
 					endif
 				EndIf
 


### PR DESCRIPTION
Mehrfachproduktionen werden anders als Serien behandelt (kein Container). Daher kann man im Programmplaner auch nicht sofort mit shift die nächste "Folge" planen.
Ich habe mit den Bestandsdaten keine Möglichkeit gefunden, Lizenzen, die aus demselben Script entstanden sind, zu extrahieren (Ansatz Counter aus Titel rausschneiden habe ich nicht verfolgt). Daher habe ich die script-ID an die Programmdaten gepackt und hole bei shift alle Lizenzen derselben ID und "kopiere" die mit dem nächsten Veröffentlichungsdatum.