### PR TITLE
Rollenreferenzen jobindexbasiert machen

### DIFF
--- a/res/database/Default/database_scripts.xml
+++ b/res/database/Default/database_scripts.xml
@@ -143,8 +143,8 @@
 				<en>${ADJECTIVE} ${OBJECT}</en>
 			</title>
 			<description>
-				<de>${JOB} ${.self:"role":0:"firstname"} ${ACTION} ${ENEMY}. Sie wollen ${VICTIM} ${ACTION2}.</de>
-				<en>${JOB} ${.self:"role":0:"firstname"} ${ACTION} ${ENEMY} who want to ${ACTION2}.</en>
+				<de>${JOB} ${.self:"role":1:"firstname"} ${ACTION} ${ENEMY}. Sie wollen ${VICTIM} ${ACTION2}.</de>
+				<en>${JOB} ${.self:"role":1:"firstname"} ${ACTION} ${ENEMY} who want to ${ACTION2}.</en>
 			</description>
 
 			<variables>
@@ -175,8 +175,8 @@
 					<en>a Mexican drug cartel|a secret CIA group|Aliens|a confused sect|the own family|pirates</en>
 				</enemy>
 				<victim>
-					<de>den Präsidenten der USA|den Familienhund|den Sohn von ${.self:"role":0:"firstname"}|den Nachbar von ${.self:"role":0:"firstname"}</de>
-					<en>the president of the USA|the family dog|the son of ${.self:"role":0:"firstname"}|the neighbor of ${.self:"role":0:"firstname"}</en>
+					<de>den Präsidenten der USA|den Familienhund|den Sohn von ${.self:"role":1:"firstname"}|den Nachbar von ${.self:"role":1:"firstname"}</de>
+					<en>the president of the USA|the family dog|the son of ${.self:"role":1:"firstname"}|the neighbor of ${.self:"role":1:"firstname"}</en>
 				</victim>
 			</variables>
 
@@ -1890,8 +1890,8 @@ Exciting entertainment and brain-teasing trivia questions.</en>
 				<en>Creature Rider</en>
 			</title>
 			<description>
-				<de>Da junge Helden, die Drachen reiten, inzwischen Mainstream geworden sind, ist ein Remake des 1964er Fantasy-Films über ${.self:"role":0:"firstname"}, der Fantasiewesen dressiert und reitet, einen Versuch wert.</de>
-				<en>As young heroes who ride dragons have become mainstream, a remake of the 1964 fantasy film about ${.self:"role":0:"firstname"} training and riding fantasy creatures is worth a try.</en>
+				<de>Da junge Helden, die Drachen reiten, inzwischen Mainstream geworden sind, ist ein Remake des 1964er Fantasy-Films über ${.self:"role":1:"firstname"}, der Fantasiewesen dressiert und reitet, einen Versuch wert.</de>
+				<en>As young heroes who ride dragons have become mainstream, a remake of the 1964 fantasy film about ${.self:"role":1:"firstname"} training and riding fantasy creatures is worth a try.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />

--- a/res/database/Default/user/eggi_screenplays_adaptations.xml
+++ b/res/database/Default/user/eggi_screenplays_adaptations.xml
@@ -13,8 +13,8 @@
 				<en>Wellness</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"}, ungleiches Paar in der Kunstszene Chicagos, kämpfen gegen Eheprobleme. Zwischen Achtsamkeitsseminaren und Immobilienträumen müssen sie ihre Vergangenheit bewältigen, um ihre Liebe zu retten.</de>
-				<en>${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"}, a mismatched couple in Chicago's art scene, are battling marital problems. Between mindfulness seminars and real estate dreams, they have to come to terms with their past in order to save their love.</en>
+				<de>${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"}, ungleiches Paar in der Kunstszene Chicagos, kämpfen gegen Eheprobleme. Zwischen Achtsamkeitsseminaren und Immobilienträumen müssen sie ihre Vergangenheit bewältigen, um ihre Liebe zu retten.</de>
+				<en>${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"}, a mismatched couple in Chicago's art scene, are battling marital problems. Between mindfulness seminars and real estate dreams, they have to come to terms with their past in order to save their love.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -41,16 +41,16 @@
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="25b61ccf-34c5-4c76-9cc0-ecdab1a10504" creator="discord/eggi72" comment="https://de.wikipedia.org/wiki/Tobias_Goldfarb | https://www.goodreads.com/book/show/205484457-hilda-hasenherz-das-abenteuer-im-fuchswald | english original role names made-up, TODO: watch for actual English version">
 			<title>
-				<de>${.self:"role":0:"fullname"} - Abenteuer Fuchshöhle</de>
-				<en>${.self:"role":0:"fullname"} - Fox Cave Adventures</en>
+				<de>${.self:"role":1:"fullname"} - Abenteuer Fuchshöhle</de>
+				<en>${.self:"role":1:"fullname"} - Fox Cave Adventures</en>
 			</title>
 			<title_original>
 				<de>Hilda Hasenherz - Das Abenteuer im Fuchswald</de>
 				<en>Becki Bunnyheart - The Adventure in the Fox Forest</en>
 			</title_original>
 			<description>
-				<de>Mutiges Hasenmädchen ${.self:"role":0:"firstname"} lebt im Möhrenfeld und entdeckt, dass der tyrannische ${.self:"role":1:"fullname"} die Möhren für sich hortet. Entschlossen, ihn zu stoppen, begibt sie sich auf eine gefährliche Reise, um den legendären ${.self:"role":4:"fullname"} zu finden.</de>
-				<en>Brave bunny girl ${.self:"role":0:"firstname"} lives in the carrot field and discovers that the tyrannical ${.self:"role":1:"fullname"} is hoarding the carrots for himself. Determined to stop him, she sets off on a dangerous journey to find the legendary ${.self:"role":4:"fullname"}.</en>
+				<de>Mutiges Hasenmädchen ${.self:"role":1:"firstname"} lebt im Möhrenfeld und entdeckt, dass der tyrannische ${.self:"role":2:"fullname"} die Möhren für sich hortet. Entschlossen, ihn zu stoppen, begibt sie sich auf eine gefährliche Reise, um den legendären ${.self:"role":5:"fullname"} zu finden.</de>
+				<en>Brave bunny girl ${.self:"role":1:"firstname"} lives in the carrot field and discovers that the tyrannical ${.self:"role":2:"fullname"} is hoarding the carrots for himself. Determined to stop him, she sets off on a dangerous journey to find the legendary ${.self:"role":5:"fullname"}.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />

--- a/res/database/Default/user/scr0llbaer.xml
+++ b/res/database/Default/user/scr0llbaer.xml
@@ -1286,12 +1286,12 @@ Czyli 4120 na odcinek.</pl>
 		</scripttemplate>
 		<scripttemplate product="2" licence_type="3" guid="d26ee4f9-1b61-4b7a-926a-e462256b127b" creator="9551" comment="Making some use of the existing fairytale characters. Descriptions created with help of ChatGPT.">
 			<title>
-				<de>${.self:"role":1:"firstname"} und ${.self:"role":0:"firstname"} im Märchenwald</de>
-				<en>${.self:"role":1:"firstname"} and ${.self:"role":0:"firstname"} in the Woods of Wonder</en>
+				<de>${.self:"role":2:"firstname"} und ${.self:"role":1:"firstname"} im Märchenwald</de>
+				<en>${.self:"role":2:"firstname"} and ${.self:"role":1:"firstname"} in the Woods of Wonder</en>
 			</title>
 			<description>
-				<de>Vor ihrem bekannten Aufeinandertreffen mit dem Bären erleben die heranwachsenden ${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} zusammen mit den Kindern ${.self:"role":2:"firstname"}, ${.self:"role":3:"firstname"} und ${.self:"role":4:"firstname"} Abenteuer im Wald.</de>
-				<en>Before their famous encounter with the bear, the adolescent ${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"} experience adventures in the forest together with the children ${.self:"role":2:"firstname"}, ${.self:"role":3:"firstname"} and ${.self:"role":4:"firstname"}.</en>
+				<de>Vor ihrem bekannten Aufeinandertreffen mit dem Bären erleben die heranwachsenden ${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} zusammen mit den Kindern ${.self:"role":3:"firstname"}, ${.self:"role":4:"firstname"} und ${.self:"role":5:"firstname"} Abenteuer im Wald.</de>
+				<en>Before their famous encounter with the bear, the adolescent ${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"} experience adventures in the forest together with the children ${.self:"role":3:"firstname"}, ${.self:"role":4:"firstname"} and ${.self:"role":5:"firstname"}.</en>
 			</description>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="5bda9699-4cc2-49cd-875a-70e666594d56">
@@ -1300,8 +1300,8 @@ Czyli 4120 na odcinek.</pl>
 						<en>The Whispering Trees</en>
 					</title>
 					<description>
-						<de>${.self:"role":4:"firstname"} bläst sein Horn in den Verwunschenen Wäldern und erweckt flüsternde Bäume, uralte Hüter und tückische Elfen, die die Abenteurer nun kichernd mit Illusionen und falschen Fährten in die Irre führen.</de>
-						<en>${.self:"role":4:"firstname"} blows his horn in the Enchanted Woods and awakens whispering trees, ancient guardians and elusive sprites, who now, while giggling, lead the adventurers astray with illusions and false trails.</en>
+						<de>${.self:"role":5:"firstname"} bläst sein Horn in den Verwunschenen Wäldern und erweckt flüsternde Bäume, uralte Hüter und tückische Elfen, die die Abenteurer nun kichernd mit Illusionen und falschen Fährten in die Irre führen.</de>
+						<en>${.self:"role":5:"firstname"} blows his horn in the Enchanted Woods and awakens whispering trees, ancient guardians and elusive sprites, who now, while giggling, lead the adventurers astray with illusions and false trails.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="f4fddd1c-0f95-4887-8a76-7994b94e26ef">
@@ -1320,8 +1320,8 @@ Czyli 4120 na odcinek.</pl>
 						<en>The Mirror of Truth</en>
 					</title>
 					<description>
-						<de>Noch in der Hütte steckt ${.self:"role":2:"fullname"} seinen Daumen in einen Kuchen und zieht eine Pflaume heraus, aber ein mystischer Spiegel reflektiert etwas anderes - er enthüllt die verborgensten Geheimnisse aller, was mit dem angesprochenen Schatz zu tun haben könnte.</de>
-						<en>Still in the cottage, ${.self:"role":2:"fullname"} puts his thumb into a pie and pulls out a plum, but a mystical mirror reflects something else - it reveals the deepest secrets of everyone, which might have something to do with the treasure mentioned.</en>
+						<de>Noch in der Hütte steckt ${.self:"role":3:"fullname"} seinen Daumen in einen Kuchen und zieht eine Pflaume heraus, aber ein mystischer Spiegel reflektiert etwas anderes - er enthüllt die verborgensten Geheimnisse aller, was mit dem angesprochenen Schatz zu tun haben könnte.</de>
+						<en>Still in the cottage, ${.self:"role":3:"fullname"} puts his thumb into a pie and pulls out a plum, but a mystical mirror reflects something else - it reveals the deepest secrets of everyone, which might have something to do with the treasure mentioned.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="408d1dbe-0887-4249-a7e6-15f206c63082">
@@ -1373,8 +1373,8 @@ Czyli 4120 na odcinek.</pl>
 				<en>Secretaries Report Part 2 - Careers, Coffee &amp; Canoodling</en>
 			</title>
 			<description>
-				<de>Das Büro brodelt! Neue Sekretärin ${.self:"role":0:"fullname"} bringt frischen Schwung, Meetings werden zur Dating-Show, während Chef ${.self:"role":1:"fullname"} hinterm Schreibtisch charmant Chaos stiftet. Und ${.self:"role":2:"fullname"} entdeckt, dass Verträge und Knutschen mehr gemeinsam haben als gedacht.</de>
-				<en>The office is on fire! New secretary ${.self:"role":0:"fullname"} brings fresh energy, meetings turn into a dating show, while boss ${.self:"role":1:"fullname"} charmingly creates chaos behind his desk. And ${.self:"role":2:"fullname"} discovers that contracts and canoodling have more in common than she thought.</en>
+				<de>Das Büro brodelt! Neue Sekretärin ${.self:"role":1:"fullname"} bringt frischen Schwung, Meetings werden zur Dating-Show, während Chef ${.self:"role":2:"fullname"} hinterm Schreibtisch charmant Chaos stiftet. Und ${.self:"role":3:"fullname"} entdeckt, dass Verträge und Knutschen mehr gemeinsam haben als gedacht.</de>
+				<en>The office is on fire! New secretary ${.self:"role":1:"fullname"} brings fresh energy, meetings turn into a dating show, while boss ${.self:"role":2:"fullname"} charmingly creates chaos behind his desk. And ${.self:"role":3:"fullname"} discovers that contracts and canoodling have more in common than she thought.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1404,8 +1404,8 @@ Czyli 4120 na odcinek.</pl>
 				<en>Secretaries Report Part 3 - Shorthand, Stunts &amp; Sensuality</en>
 			</title>
 			<description>
-				<de>Jetzt wird's noch bunter: ${.self:"role":0:"fullname"} wird zur Meisterin der Stenografie und anderer Quickies, Fax und Fon klingeln im Rhythmus der Aktion und ${.self:"role":1:"fullname"}s klappernder Schreibmaschine... Inmitten biederer Bürokratie brodelt feurige Fantasie.</de>
-				<en>Now it all gets extra sparkly: ${.self:"role":0:"fullname"} becomes a master of shorthand and other quickies, fax and phone ring to the rhythm of the action and ${.self:"role":1:"fullname"}'s clattering typewriter.,, In the midst of bland bureaucracy, fiery fantasies are fizzing.</en>
+				<de>Jetzt wird's noch bunter: ${.self:"role":1:"fullname"} wird zur Meisterin der Stenografie und anderer Quickies, Fax und Fon klingeln im Rhythmus der Aktion und ${.self:"role":2:"fullname"}s klappernder Schreibmaschine... Inmitten biederer Bürokratie brodelt feurige Fantasie.</de>
+				<en>Now it all gets extra sparkly: ${.self:"role":1:"fullname"} becomes a master of shorthand and other quickies, fax and phone ring to the rhythm of the action and ${.self:"role":2:"fullname"}'s clattering typewriter.,, In the midst of bland bureaucracy, fiery fantasies are fizzing.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1435,8 +1435,8 @@ Czyli 4120 na odcinek.</pl>
 				<en>Secretaries Report Part 4</en>
 			</title>
 			<description>
-				<de>Die blonde ${.self:"role":0:"firstname"} von der obersten Etage führt ihre zahlreichen Verehrer an der Nase rum, bei Makler Higwig gibt's 'ne Natursekt-Party, der Chef ${.self:"role":2:"fullname"} wird in Fetisch-Ledermontur in der Wäscherei erwischt,.. Moment mal, das ist doch nicht...?</de>
-				<en>Blonde ${.self:"role":0:"firstname"} from the top floor leads her numerous admirers around by the nose, there's a golden shower party at real estate agent Higwig's, the boss ${.self:"role":2:"fullname"} is caught in a fetish leather outfit in the laundry room,... Wait a minute, isn't that...?</en> <!-- TODO: ref last name Higwig -->
+				<de>Die blonde ${.self:"role":1:"firstname"} von der obersten Etage führt ihre zahlreichen Verehrer an der Nase rum, bei Makler Higwig gibt's 'ne Natursekt-Party, der Chef ${.self:"role":3:"fullname"} wird in Fetisch-Ledermontur in der Wäscherei erwischt,.. Moment mal, das ist doch nicht...?</de>
+				<en>Blonde ${.self:"role":1:"firstname"} from the top floor leads her numerous admirers around by the nose, there's a golden shower party at real estate agent Higwig's, the boss ${.self:"role":3:"fullname"} is caught in a fetish leather outfit in the laundry room,... Wait a minute, isn't that...?</en> <!-- TODO: ref last name Higwig -->
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1463,12 +1463,12 @@ Czyli 4120 na odcinek.</pl>
 
 		<scripttemplate product="1" licence_type="1" guid="d31d1720-d567-4479-8ac9-f77d13848f3c" creator="9551" comment="Parody/spoof also in real-title mode of https://en.wikipedia.org/wiki/Charlie_and_the_Chocolate_Factory | TODO: Maybe yet another parody and erotic comedy version: W. Wanker and the Sex Toy Factory">
 			<title>
-				<de>${.self:"role":0:"fullname"} und die Spirituosenfabrik</de>
-				<en>${.self:"role":0:"fullname"} and the Liquor Factory</en>
+				<de>${.self:"role":1:"fullname"} und die Spirituosenfabrik</de>
+				<en>${.self:"role":1:"fullname"} and the Liquor Factory</en>
 			</title>
 			<description>
-				<de>Der stümperhafte Pfandflaschensammler und Alkoholiker ${.self:"role":1:"fullname"} findet auf einer Bierflasche eins der begehrten Tickets für die Trinklieder-Tour des exzentrischen ${.self:"role":0:"fullname"}. Die Stößchen-Stößchen-Adligen dort nerven aber ziemlich rum.</de>
-				<en>The bumbling deposit bottle collector and alcoholic ${.self:"role":1:"fullname"} finds, on a beer bottle, one of the coveted tickets for the drinking-song-tour of the eccentric ${.self:"role":0:"fullname"}. However, the pint-swilling aristocrats there are quite the nuisance.</en>
+				<de>Der stümperhafte Pfandflaschensammler und Alkoholiker ${.self:"role":2:"fullname"} findet auf einer Bierflasche eins der begehrten Tickets für die Trinklieder-Tour des exzentrischen ${.self:"role":1:"fullname"}. Die Stößchen-Stößchen-Adligen dort nerven aber ziemlich rum.</de>
+				<en>The bumbling deposit bottle collector and alcoholic ${.self:"role":2:"fullname"} finds, on a beer bottle, one of the coveted tickets for the drinking-song-tour of the eccentric ${.self:"role":1:"fullname"}. However, the pint-swilling aristocrats there are quite the nuisance.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />

--- a/res/database/Default/user/scr0llbaer_screenplays_adaptations.xml
+++ b/res/database/Default/user/scr0llbaer_screenplays_adaptations.xml
@@ -16,8 +16,8 @@
 				<en>The Catcher in the Rye</en>
 			</title_original>
 			<description>
-				<de>Endlich eine Adaption des 1951er U.S.-Literaturklassikers. Der 16-jährige ${.self:"role":0:"fullname"} fliegt wieder mal von der Schule und versteckt sich in einer New Yorker Absteige, um die Konfrontation mit den Eltern hinauszuzögern.</de>
-				<en>Finally, an adaptation of the 1951 U.S. literary classic. The 16-year-old ${.self:"role":0:"fullname"} once again drops out of school and hides in a New York flophouse to delay the confrontation with his parents.</en>
+				<de>Endlich eine Adaption des 1951er U.S.-Literaturklassikers. Der 16-jährige ${.self:"role":1:"fullname"} fliegt wieder mal von der Schule und versteckt sich in einer New Yorker Absteige, um die Konfrontation mit den Eltern hinauszuzögern.</de>
+				<en>Finally, an adaptation of the 1951 U.S. literary classic. The 16-year-old ${.self:"role":1:"fullname"} once again drops out of school and hides in a New York flophouse to delay the confrontation with his parents.</en>
 			</description>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="a9721a45-2f3d-453d-bae7-3da684a6b1c0">
@@ -30,8 +30,8 @@
 						<en>Saturday</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} kämpft in N.Y. City mit seiner Entfremdung, begegnet verlogenen Erwachsenen, besucht seinen alten Lehrer und erkundet seine eigenen widersprüchlichen Gefühle, während er nach echten Beziehungen sucht.</de>
-						<en>${.self:"role":0:"firstname"} struggles with his alienation in N.Y. City, navigates encounters with phony adults, visits his old teacher, and explores his own conflicted emotions, all while searching for genuine connections.</en>
+						<de>${.self:"role":1:"firstname"} kämpft in N.Y. City mit seiner Entfremdung, begegnet verlogenen Erwachsenen, besucht seinen alten Lehrer und erkundet seine eigenen widersprüchlichen Gefühle, während er nach echten Beziehungen sucht.</de>
+						<en>${.self:"role":1:"firstname"} struggles with his alienation in N.Y. City, navigates encounters with phony adults, visits his old teacher, and explores his own conflicted emotions, all while searching for genuine connections.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="e42dd265-d253-4a1c-9281-17811c775462">
@@ -44,8 +44,8 @@
 						<en>Sunday</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} verbringt einen besinnlichen Vormittag in einem Museum. Später trifft er sich mit seiner kleinen Schwester ${.self:"role":1:"firstname"}, mit der er ein herzliches Gespräch führt und erkennt, wie wichtig es ist, die Unschuld der Kindheit zu bewahren.</de>
-						<en>${.self:"role":0:"firstname"} spends a reflective morning at a museum. Later, he meets up with his little sister ${.self:"role":1:"firstname"}, leading to heartfelt conversations and a revelation about the importance of preserving childhood innocence.</en>
+						<de>${.self:"role":1:"firstname"} verbringt einen besinnlichen Vormittag in einem Museum. Später trifft er sich mit seiner kleinen Schwester ${.self:"role":2:"firstname"}, mit der er ein herzliches Gespräch führt und erkennt, wie wichtig es ist, die Unschuld der Kindheit zu bewahren.</de>
+						<en>${.self:"role":1:"firstname"} spends a reflective morning at a museum. Later, he meets up with his little sister ${.self:"role":2:"firstname"}, leading to heartfelt conversations and a revelation about the importance of preserving childhood innocence.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="fb8e10e3-b13c-452d-902c-ab7d81895657">
@@ -58,8 +58,8 @@
 						<en>Monday</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} wird mit den Konsequenzen seines Handelns konfrontiert. Durch Begegnungen mit einem ehemaligen Klassenkameraden und einer Prostituierten setzt er sich mit seinen Gefühlen von Isolation und Desillusionierung auseinander.</de>
-						<en>${.self:"role":0:"firstname"} faces the consequences of his actions. Through encounters with a former classmate and a prostitute, he grapples with his feelings of isolation and disillusionment.</en>
+						<de>${.self:"role":1:"firstname"} wird mit den Konsequenzen seines Handelns konfrontiert. Durch Begegnungen mit einem ehemaligen Klassenkameraden und einer Prostituierten setzt er sich mit seinen Gefühlen von Isolation und Desillusionierung auseinander.</de>
+						<en>${.self:"role":1:"firstname"} faces the consequences of his actions. Through encounters with a former classmate and a prostitute, he grapples with his feelings of isolation and disillusionment.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -95,8 +95,8 @@
 				<en>A Perfect Day for Bananafish</en>
 			</title_original>
 			<description>
-				<de>Nach Rückkehr aus dem 2. Weltkrieg und Entlassung aus einem Nervensanatorium verbringt ${.self:"role":0:"fullname"} mit Ehefrau ${.self:"role":1:"firstname"} einen Genesungsurlaub in Florida und sinniert beim Angeln mit der kleinen ${.self:"role":3:"firstname"} über die titelgebende Fischart.</de>
-				<en>After returning from World War II and being released from a sanatorium, ${.self:"role":0:"fullname"} spends a convalescent vacation in Florida with his wife ${.self:"role":1:"firstname"} and, while fishing, muses with little ${.self:"role":3:"firstname"} about the eponymous species.</en>
+				<de>Nach Rückkehr aus dem 2. Weltkrieg und Entlassung aus einem Nervensanatorium verbringt ${.self:"role":1:"fullname"} mit Ehefrau ${.self:"role":2:"firstname"} einen Genesungsurlaub in Florida und sinniert beim Angeln mit der kleinen ${.self:"role":4:"firstname"} über die titelgebende Fischart.</de>
+				<en>After returning from World War II and being released from a sanatorium, ${.self:"role":1:"fullname"} spends a convalescent vacation in Florida with his wife ${.self:"role":2:"firstname"} and, while fishing, muses with little ${.self:"role":4:"firstname"} about the eponymous species.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -134,8 +134,8 @@
 				<en>Hapworth 16, 1924</en>
 			</title_original>
 			<description>
-				<de>Prequel über ${.self:"role":2:"fullname"}: Sein Aufenthalt als 7-Jähriger im titulären Camp, seine Eltern, die Varieté-Perfomer ${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"}, und seine Geschwister. Alle 7 Kinder traten in einem Radioquiz für Hochbegabte auf, was sie aufs College brachte.</de>
-				<en>Prequel about ${.self:"role":2:"fullname"}: His stay as a 7-year-old at the titular camp, his parents, vaudeville performers ${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"}, and his siblings. All 7 children performed in a radio quiz for the highly gifted, which got them into college.</en>
+				<de>Prequel über ${.self:"role":3:"fullname"}: Sein Aufenthalt als 7-Jähriger im titulären Camp, seine Eltern, die Varieté-Perfomer ${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"}, und seine Geschwister. Alle 7 Kinder traten in einem Radioquiz für Hochbegabte auf, was sie aufs College brachte.</de>
+				<en>Prequel about ${.self:"role":3:"fullname"}: His stay as a 7-year-old at the titular camp, his parents, vaudeville performers ${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"}, and his siblings. All 7 children performed in a radio quiz for the highly gifted, which got them into college.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -175,8 +175,8 @@
 				<en>Down at the Dinghy</en>
 			</title_original>
 			<description>
-				<de>Teil 3 über die New Yorker Kinder der Varieté-Eltern ${.self:"role":5:"firstname"} und ${.self:"role":6:"fullname"}, diesmal mit ${.self:"role":0:"firstname"} im Mittelpunkt, die das Vertrauen ihres vierjährigen Sohns ${.self:"role":1:"firstname"} zurückgewinnen will, der sich verstört auf das Dingi-Boot seines Vaters zurückgezogen hat.</de>
-				<en>Part 3 about the New York children of the vaudeville parents ${.self:"role":5:"firstname"} und ${.self:"role":6:"fullname"}, this time with ${.self:"role":0:"firstname"} at the center, who wants to win back the trust of her four-year-old son ${.self:"role":1:"firstname"}, who, upset, has withdrawn to his father's dinghy boat.</en>
+				<de>Teil 3 über die New Yorker Kinder der Varieté-Eltern ${.self:"role":6:"firstname"} und ${.self:"role":7:"fullname"}, diesmal mit ${.self:"role":1:"firstname"} im Mittelpunkt, die das Vertrauen ihres vierjährigen Sohns ${.self:"role":2:"firstname"} zurückgewinnen will, der sich verstört auf das Dingi-Boot seines Vaters zurückgezogen hat.</de>
+				<en>Part 3 about the New York children of the vaudeville parents ${.self:"role":6:"firstname"} und ${.self:"role":7:"fullname"}, this time with ${.self:"role":1:"firstname"} at the center, who wants to win back the trust of her four-year-old son ${.self:"role":2:"firstname"}, who, upset, has withdrawn to his father's dinghy boat.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -214,8 +214,8 @@
 				<en>Raise High the Roof Beam, Carpenters</en>
 			</title_original>
 			<description>
-				<de>Vierter Teil über die Kinder der Varieté-Eltern und Rückschau, bei der ${.self:"role":2:"fullname"} die Hochzeit seines Bruders ${.self:"role":0:"firstname"} mit ${.self:"role":1:"firstname"} besucht, welche von ihrem ersten Mann weglief. Doch ${.self:"role":0:"firstname"} taucht nicht auf.</de>
-				<en>Fourth part about the children of the vaudeville parents and retrospective, in which ${.self:"role":2:"fullname"} attends the wedding of his brother ${.self:"role":0:"firstname"} with ${.self:"role":1:"firstname"}, who ran away from her first husband. But ${.self:"role":0:"firstname"} does not appear.</en>
+				<de>Vierter Teil über die Kinder der Varieté-Eltern und Rückschau, bei der ${.self:"role":3:"fullname"} die Hochzeit seines Bruders ${.self:"role":1:"firstname"} mit ${.self:"role":2:"firstname"} besucht, welche von ihrem ersten Mann weglief. Doch ${.self:"role":1:"firstname"} taucht nicht auf.</de>
+				<en>Fourth part about the children of the vaudeville parents and retrospective, in which ${.self:"role":3:"fullname"} attends the wedding of his brother ${.self:"role":1:"firstname"} with ${.self:"role":2:"firstname"}, who ran away from her first husband. But ${.self:"role":1:"firstname"} does not appear.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -248,16 +248,16 @@
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="25903039-a46b-4b97-94b9-49f0c6798887" creator="9551" comment="https://en.wikipedia.org/wiki/J._D._Salinger | https://en.wikipedia.org/wiki/Raise_High_the_Roof_Beam,_Carpenters_and_Seymour:_An_Introduction | auch: Seymour wird vorgestellt">
 			<title>
-				<de>${.self:"role":0:"firstname"} kennenlernen</de>
-				<en>Getting to Know ${.self:"role":0:"firstname"}</en>
+				<de>${.self:"role":1:"firstname"} kennenlernen</de>
+				<en>Getting to Know ${.self:"role":1:"firstname"}</en>
 			</title>
 			<title_original>
 				<de>Seymour, eine Einführung</de>
 				<en>Seymour: An Introduction</en>
 			</title_original>
 			<description>
-				<de>Teil 5 rollt nochmal die Lebensgeschichte von ${.self:"role":0:"fullname"} bis zu seinem Suizid auf, wieder aus der Sicht seines Bruders ${.self:"role":2:"firstname"}, und es werden Themen angeschnitten wie Zen-Buddhismus, Haiku und die hinduistische Philosophie des Vedanta.</de>
-				<en>Part 5 revisits the life story of ${.self:"role":0:"fullname"} up to his suicide, again from the perspective of his brother ${.self:"role":2:"firstname"}, and touches on topics such as Zen Buddhism, haiku and the Hindu philosophy of Vedanta.</en>
+				<de>Teil 5 rollt nochmal die Lebensgeschichte von ${.self:"role":1:"fullname"} bis zu seinem Suizid auf, wieder aus der Sicht seines Bruders ${.self:"role":3:"firstname"}, und es werden Themen angeschnitten wie Zen-Buddhismus, Haiku und die hinduistische Philosophie des Vedanta.</de>
+				<en>Part 5 revisits the life story of ${.self:"role":1:"fullname"} up to his suicide, again from the perspective of his brother ${.self:"role":3:"firstname"}, and touches on topics such as Zen Buddhism, haiku and the Hindu philosophy of Vedanta.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -295,8 +295,8 @@
 				<en>Franny and Zooey</en>
 			</title_original>
 			<description>
-				<de>Teil 6: Die Erlebnisse von ${.self:"role":5:"firstname"} und ${.self:"role":6:"fullname"}' jüngsten beiden Kindern, frühreif und hochintelligent wie die anderen. ${.self:"role":0:"firstname"} ist am College völlig desillusioniert. ${.self:"role":1:"firstname"} versucht, ihr brüderliche Liebe und Verständnis entgegenzubringen.</de>
-				<en>Part 6: The experiences of ${.self:"role":5:"firstname"} and ${.self:"role":6:"fullname"}' youngest two children, precocious and highly intelligent like the others. ${.self:"role":0:"firstname"} is completely disillusioned at college. ${.self:"role":1:"firstname"} tries to show her brotherly love and understanding.</en>
+				<de>Teil 6: Die Erlebnisse von ${.self:"role":6:"firstname"} und ${.self:"role":7:"fullname"}' jüngsten beiden Kindern, frühreif und hochintelligent wie die anderen. ${.self:"role":1:"firstname"} ist am College völlig desillusioniert. ${.self:"role":2:"firstname"} versucht, ihr brüderliche Liebe und Verständnis entgegenzubringen.</de>
+				<en>Part 6: The experiences of ${.self:"role":6:"firstname"} and ${.self:"role":7:"fullname"}' youngest two children, precocious and highly intelligent like the others. ${.self:"role":1:"firstname"} is completely disillusioned at college. ${.self:"role":2:"firstname"} tries to show her brotherly love and understanding.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -346,8 +346,8 @@
 						<en>Malkuth</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"fullname"}s zufällige Begegnung mit ${.self:"role":1:"fullname"} und ${.self:"role":2:"fullname"} in einer Bar offenbart sein Fachwissen über die Geschichte der Templer und weckt ${.self:"role":1:"fullname"}s Interesse.</de>
-						<en>${.self:"role":0:"fullname"}'s chance meeting with ${.self:"role":1:"fullname"} and ${.self:"role":2:"fullname"} at a bar unveils his expertise in Templar history, piquing ${.self:"role":1:"fullname"}'s interest.</en>
+						<de>${.self:"role":1:"fullname"}s zufällige Begegnung mit ${.self:"role":2:"fullname"} und ${.self:"role":3:"fullname"} in einer Bar offenbart sein Fachwissen über die Geschichte der Templer und weckt ${.self:"role":2:"fullname"}s Interesse.</de>
+						<en>${.self:"role":1:"fullname"}'s chance meeting with ${.self:"role":2:"fullname"} and ${.self:"role":3:"fullname"} at a bar unveils his expertise in Templar history, piquing ${.self:"role":2:"fullname"}'s interest.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="b417e099-e34b-400f-a755-1675cac95945">
@@ -360,8 +360,8 @@
 						<en>Yesod</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":1:"fullname"} macht ${.self:"role":0:"fullname"} mit seinem Arbeitgeber Mr. ${.self:"role":3:"fullname"} bekannt, einem einzigartigen Verleger, der für akademische Werke und exzentrische Autoren, einschließlich Spinner, bekannt ist.</de>
-						<en>${.self:"role":1:"fullname"} introduces ${.self:"role":0:"fullname"} to his employer Mr. ${.self:"role":3:"fullname"}, a unique publisher known for academic works and eccentric authors, including crackpots.</en>
+						<de>${.self:"role":2:"fullname"} macht ${.self:"role":1:"fullname"} mit seinem Arbeitgeber Mr. ${.self:"role":4:"fullname"} bekannt, einem einzigartigen Verleger, der für akademische Werke und exzentrische Autoren, einschließlich Spinner, bekannt ist.</de>
+						<en>${.self:"role":2:"fullname"} introduces ${.self:"role":1:"fullname"} to his employer Mr. ${.self:"role":4:"fullname"}, a unique publisher known for academic works and eccentric authors, including crackpots.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="f064c96f-0fbf-4187-93ee-2313f545c259">
@@ -374,8 +374,8 @@
 						<en>Hod</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":4:"fullname"} präsentiert ein mysteriöses und potenziell gefährliches Templer-Manuskript, nur um dann spurlos zu verschwinden.</de>
-						<en>${.self:"role":4:"fullname"} presents a mysterious and potentially dangerous Templar manuscript, only to vanish without a trace.</en>
+						<de>${.self:"role":5:"fullname"} präsentiert ein mysteriöses und potenziell gefährliches Templer-Manuskript, nur um dann spurlos zu verschwinden.</de>
+						<en>${.self:"role":5:"fullname"} presents a mysterious and potentially dangerous Templar manuscript, only to vanish without a trace.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="ec0ad1cd-a4c5-485d-9833-62264469be39">
@@ -388,8 +388,8 @@
 						<en>Netzach</en>
 					</title_original>
 					<description>
-						<de>Auf der Suche nach Trost reist ${.self:"role":0:"fullname"} nach Brasilien, wo er ${.self:"role":6:"fullname"}, einem Experten für das Okkulte, begegnet und sich in die Sozialistin ${.self:"role":5:"fullname"} verliebt.</de>
-						<en>Seeking solace, ${.self:"role":0:"fullname"} moves to Brazil, where he encounters ${.self:"role":6:"fullname"}, an expert in the occult, and falls for socialist ${.self:"role":5:"fullname"}.</en>
+						<de>Auf der Suche nach Trost reist ${.self:"role":1:"fullname"} nach Brasilien, wo er ${.self:"role":7:"fullname"}, einem Experten für das Okkulte, begegnet und sich in die Sozialistin ${.self:"role":6:"fullname"} verliebt.</de>
+						<en>Seeking solace, ${.self:"role":1:"fullname"} moves to Brazil, where he encounters ${.self:"role":7:"fullname"}, an expert in the occult, and falls for socialist ${.self:"role":6:"fullname"}.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="edc649c4-ddc0-4bfa-8447-57b1e4564608">
@@ -402,8 +402,8 @@
 						<en>Tiferet</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"fullname"} kehrt zurück, angezogen von seiner Liebe zu einer Frau namens Lia, und wird als freiberuflicher Forscher mit verschiedenen Projekten betraut.</de>
-						<en>${.self:"role":0:"fullname"} returns, drawn back by his love for woman named Lia, and becomes a freelance researcher, taking on various projects.</en>
+						<de>${.self:"role":1:"fullname"} kehrt zurück, angezogen von seiner Liebe zu einer Frau namens Lia, und wird als freiberuflicher Forscher mit verschiedenen Projekten betraut.</de>
+						<en>${.self:"role":1:"fullname"} returns, drawn back by his love for woman named Lia, and becomes a freelance researcher, taking on various projects.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="5" product="2" licence_type="2" guid="70cdf605-5db8-48d4-9474-1c61c959a500">
@@ -416,8 +416,8 @@
 						<en>Gevurah</en>
 					</title_original>
 					<description>
-						<de>Bei tieferen Ergründungen okkulter Verschwörungen stößt das Trio mit Hilfe von ${.self:"role":6:"fullname"}s Kontakten auf eine bizarre Ansammlung von Verschwörungstheoretikern.</de>
-						<en>Delving deeper into occult conspiracies, the trio, assisted by ${.self:"role":6:"fullname"}'s contacts, encounters a bizarre array of conspiracy theorists.</en>
+						<de>Bei tieferen Ergründungen okkulter Verschwörungen stößt das Trio mit Hilfe von ${.self:"role":7:"fullname"}s Kontakten auf eine bizarre Ansammlung von Verschwörungstheoretikern.</de>
+						<en>Delving deeper into occult conspiracies, the trio, assisted by ${.self:"role":7:"fullname"}'s contacts, encounters a bizarre array of conspiracy theorists.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="6" product="2" licence_type="2" guid="28d6e0e8-19c8-4e8d-b065-0112170448b4">
@@ -444,8 +444,8 @@
 						<en>Binah</en>
 					</title_original>
 					<description>
-						<de>Begeistert von ihrer Schöpfung beginnen ${.self:"role":0:"fullname"} und seine Partner, ${.self:"role":6:"fullname"} gegenüber anzudeuten, dass sie im Besitz verborgenen Wissens sind.</de>
-						<en>Enthralled by their creation, ${.self:"role":0:"fullname"} and his partners begin hinting to ${.self:"role":6:"fullname"} about possessing hidden knowledge.</en>
+						<de>Begeistert von ihrer Schöpfung beginnen ${.self:"role":1:"fullname"} und seine Partner, ${.self:"role":7:"fullname"} gegenüber anzudeuten, dass sie im Besitz verborgenen Wissens sind.</de>
+						<en>Enthralled by their creation, ${.self:"role":1:"fullname"} and his partners begin hinting to ${.self:"role":7:"fullname"} about possessing hidden knowledge.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="8" product="2" licence_type="2" guid="c572b563-808f-42da-9dba-541171f2844a">
@@ -458,8 +458,8 @@
 						<en>Chochmah</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":6:"fullname"} und europäische Okkultisten, die glauben, die Geschichte kontrollieren zu müssen, jagen das Trio unerbittlich wegen der angeblichen Geheimnisse des „Großen Plans“.</de>
-						<en>${.self:"role":6:"fullname"} and European occultists, believing they must control history, relentlessly chase the trio for the supposed secrets of "The Plan".</en>
+						<de>${.self:"role":7:"fullname"} und europäische Okkultisten, die glauben, die Geschichte kontrollieren zu müssen, jagen das Trio unerbittlich wegen der angeblichen Geheimnisse des „Großen Plans“.</de>
+						<en>${.self:"role":7:"fullname"} and European occultists, believing they must control history, relentlessly chase the trio for the supposed secrets of "The Plan".</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="9" product="2" licence_type="2" guid="ebb91722-c6cd-4cc3-87e1-3f60ba0847f4">
@@ -472,8 +472,8 @@
 						<en>Kether</en>
 					</title_original>
 					<description>
-						<de>Als die Verfolgung immer intensiver wird, verzweifeln ${.self:"role":6:"fullname"} und die anderen, was in einem spannenden Höhepunkt gipfelt, an dem Wahrheit und Trug aufeinanderprallen.</de>
-						<en>As the pursuit intensifies, ${.self:"role":6:"fullname"} and others grow desperate, culminating in a thrilling climax where truth and deception collide.</en>
+						<de>Als die Verfolgung immer intensiver wird, verzweifeln ${.self:"role":7:"fullname"} und die anderen, was in einem spannenden Höhepunkt gipfelt, an dem Wahrheit und Trug aufeinanderprallen.</de>
+						<en>As the pursuit intensifies, ${.self:"role":7:"fullname"} and others grow desperate, culminating in a thrilling climax where truth and deception collide.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -514,8 +514,8 @@
 				<it>L'isola del giorno prima</it>
 			</title_original>
 			<description>
-				<de>Die angeblich wahre Geschichte des piemontesischen Landadligen ${.self:"role":0:"fullname"}, der um die Mitte des 17. Jahrhunderts auf der Suche nach der Lösung des Problems der Längengrade an der Datumsgrenze in der Südsee verschollen sein soll.</de>
-				<en>The allegedly true story of the Piedmontese country nobleman ${.self:"role":0:"fullname"}, who is said to have disappeared in the South Seas around the middle of the 17th century while searching for the solution to the secret of longitude at the International Date Line.</en>
+				<de>Die angeblich wahre Geschichte des piemontesischen Landadligen ${.self:"role":1:"fullname"}, der um die Mitte des 17. Jahrhunderts auf der Suche nach der Lösung des Problems der Längengrade an der Datumsgrenze in der Südsee verschollen sein soll.</de>
+				<en>The allegedly true story of the Piedmontese country nobleman ${.self:"role":1:"fullname"}, who is said to have disappeared in the South Seas around the middle of the 17th century while searching for the solution to the secret of longitude at the International Date Line.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -543,8 +543,8 @@
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="ed6652ef-7559-48ab-9ee3-a4fbb26fae59" creator="9551" comment="https://en.wikipedia.org/wiki/Umberto_Eco | https://de.wikipedia.org/wiki/Baudolino">
 			<title>
-				<de>${.self:"role":0:"firstname"}</de>
-				<en>${.self:"role":0:"firstname"}</en>
+				<de>${.self:"role":1:"firstname"}</de>
+				<en>${.self:"role":1:"firstname"}</en>
 			</title>
 			<title_original>
 				<de>Baudolino</de>
@@ -552,8 +552,8 @@
 				<it>Baudolino</it>
 			</title_original>
 			<description>
-				<de>Die Lebensgeschichte eines schelmischen piemontesischen Bauernjungen, der anno 1154 als etwa Dreizehnjähriger von ${.self:"role":1:"fullname"} adoptiert wird, aufsteigt, Kreuzzüge mitmacht und zuletzt irgendwo im Orient verschollen geht.</de>
-				<en>The life story of a roguish Piedmontese peasant boy who, in 1154 when he is about thirteen years old, is adopted by ${.self:"role":1:"fullname"}, rises through the ranks, takes part in crusades and finally goes missing somewhere in the Orient.</en>
+				<de>Die Lebensgeschichte eines schelmischen piemontesischen Bauernjungen, der anno 1154 als etwa Dreizehnjähriger von ${.self:"role":2:"fullname"} adoptiert wird, aufsteigt, Kreuzzüge mitmacht und zuletzt irgendwo im Orient verschollen geht.</de>
+				<en>The life story of a roguish Piedmontese peasant boy who, in 1154 when he is about thirteen years old, is adopted by ${.self:"role":2:"fullname"}, rises through the ranks, takes part in crusades and finally goes missing somewhere in the Orient.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -708,8 +708,8 @@
 				<en>The City and the Stars</en>
 			</title_original>
 			<description>
-				<de>Millionen Jahre in der Zukunft hat sich die Menschheit wieder auf die Erde zurückgezogen und lebt unter einer Kuppel in einer Stadt, die für alles sorgt. Nur ${.self:"role":0:"firstname"} sehnt sich nach draußen...</de>
-				<en>Millions of years in the future, mankind has returned to Earth and lives under a dome in a city that takes care of everything. Only ${.self:"role":0:"firstname"} longs to go outside...</en>
+				<de>Millionen Jahre in der Zukunft hat sich die Menschheit wieder auf die Erde zurückgezogen und lebt unter einer Kuppel in einer Stadt, die für alles sorgt. Nur ${.self:"role":1:"firstname"} sehnt sich nach draußen...</de>
+				<en>Millions of years in the future, mankind has returned to Earth and lives under a dome in a city that takes care of everything. Only ${.self:"role":1:"firstname"} longs to go outside...</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -744,8 +744,8 @@
 				<en>The Last Question</en>
 			</title_original>
 			<description>
-				<de>„Keine ausreichenden Daten für eine sinnvolle Antwort.“ Die ursprünglich von Menschen geschaffene ${.self:"role":0:"firstname"}-AI, nun im Hyperraum, kann Jahrmilliarden lang die „letzte Frage“ des Wärmetods des Universums nicht beantworten, bis schließlich...</de>
-				<en>"Insufficient data for meaningful answer." Originally created by humans, the ${.self:"role":0:"firstname"} AI, now in hyperspace, cannot answer the "last question" of the heat death of the universe for billions of years, until finally...</en>
+				<de>„Keine ausreichenden Daten für eine sinnvolle Antwort.“ Die ursprünglich von Menschen geschaffene ${.self:"role":1:"firstname"}-AI, nun im Hyperraum, kann Jahrmilliarden lang die „letzte Frage“ des Wärmetods des Universums nicht beantworten, bis schließlich...</de>
+				<en>"Insufficient data for meaningful answer." Originally created by humans, the ${.self:"role":1:"firstname"} AI, now in hyperspace, cannot answer the "last question" of the heat death of the universe for billions of years, until finally...</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -787,8 +787,8 @@
 				<en>The First Question</en>
 			</title_original>
 			<description>
-				<de>Ein kleines Prequel zur ${.self:"role":0:"firstname"}-Reihe. Zwei Techniker, die mit der Wartung dieser AI beschäftigt sind, unterhalten sich darüber, ob sie im menschlichen Sinne denken könne und intelligent sei. ${.self:"role":0:"firstname"} beantwortet ihnen diese Frage auf eigene Weise.</de>
-				<en>A little prequel to the ${.self:"role":0:"firstname"} series. Two technicians working on the maintenance of this AI discuss whether it can think in a human sense and is intelligent. ${.self:"role":0:"firstname"} answers this question in its own way.</en>
+				<de>Ein kleines Prequel zur ${.self:"role":1:"firstname"}-Reihe. Zwei Techniker, die mit der Wartung dieser AI beschäftigt sind, unterhalten sich darüber, ob sie im menschlichen Sinne denken könne und intelligent sei. ${.self:"role":1:"firstname"} beantwortet ihnen diese Frage auf eigene Weise.</de>
+				<en>A little prequel to the ${.self:"role":1:"firstname"} series. Two technicians working on the maintenance of this AI discuss whether it can think in a human sense and is intelligent. ${.self:"role":1:"firstname"} answers this question in its own way.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -823,8 +823,8 @@
 				<en>Someday</en>
 			</title_original>
 			<description>
-				<de>Dank dem für alles sorgenden ${.self:"role":0:"firstname"} lernen die Kinder nicht mehr Lesen und Schreiben und haben nur Zugang zu kleinen Märchenerzähl-Computern. Zwei Elfjährige geben sich nicht damit zufrieden und versuchen ein Upgrade...</de>
-				<en>Thanks to the ${.self:"role":0:"firstname"} that takes care of everything, the children no longer learn to read and write and only have access to small fairytale-telling computers. Two eleven-year-olds are not satisfied with this and try to upgrade...</en>
+				<de>Dank dem für alles sorgenden ${.self:"role":1:"firstname"} lernen die Kinder nicht mehr Lesen und Schreiben und haben nur Zugang zu kleinen Märchenerzähl-Computern. Zwei Elfjährige geben sich nicht damit zufrieden und versuchen ein Upgrade...</de>
+				<en>Thanks to the ${.self:"role":1:"firstname"} that takes care of everything, the children no longer learn to read and write and only have access to small fairytale-telling computers. Two eleven-year-olds are not satisfied with this and try to upgrade...</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -861,8 +861,8 @@
 				<en>Franchise</en>
 			</title_original>
 			<description>
-				<de>Es gibt keine Präsidentschaftswahlen mehr. Schließlich stehen ${.self:"role":0:"firstname"} alle Daten zur Verfügung. Der unsichere ${.self:"role":1:"fullname"} soll dieses Jahr den Willen des Volkes repräsentieren, doch die AI-Kommunikation läuft indirekt. Kann das missbraucht werden?</de>
-				<en>There are no more presidential elections. After all, ${.self:"role":0:"firstname"} has all the data at its disposal. The insecure ${.self:"role":1:"fullname"} is to represent the will of the people this year, but the AI communication works indirectly. Can this be misused?</en>
+				<de>Es gibt keine Präsidentschaftswahlen mehr. Schließlich stehen ${.self:"role":1:"firstname"} alle Daten zur Verfügung. Der unsichere ${.self:"role":2:"fullname"} soll dieses Jahr den Willen des Volkes repräsentieren, doch die AI-Kommunikation läuft indirekt. Kann das missbraucht werden?</de>
+				<en>There are no more presidential elections. After all, ${.self:"role":1:"firstname"} has all the data at its disposal. The insecure ${.self:"role":2:"fullname"} is to represent the will of the people this year, but the AI communication works indirectly. Can this be misused?</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -899,8 +899,8 @@
 				<en>Jokester</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":1:"fullname"} ist quasi ein Meister im Prompt-Engineering. Er kennt sich aus mit ${.self:"role":0:"firstname"} und ist zudem ein begnadeter Witze-Erzähler. Das Nachforschen mit der AI, wo Humor eigentlich herkommt, enthüllt eine unheimliche Verschwörung.</de>
-				<en>${.self:"role":1:"fullname"} is, so-to-speak, a master of prompt engineering. He knows his way around ${.self:"role":0:"firstname"} and is also a gifted joke teller. Investigating with the AI where humor actually comes from reveals a bizarre conspiracy.</en>
+				<de>${.self:"role":2:"fullname"} ist quasi ein Meister im Prompt-Engineering. Er kennt sich aus mit ${.self:"role":1:"firstname"} und ist zudem ein begnadeter Witze-Erzähler. Das Nachforschen mit der AI, wo Humor eigentlich herkommt, enthüllt eine unheimliche Verschwörung.</de>
+				<en>${.self:"role":2:"fullname"} is, so-to-speak, a master of prompt engineering. He knows his way around ${.self:"role":1:"firstname"} and is also a gifted joke teller. Investigating with the AI where humor actually comes from reveals a bizarre conspiracy.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -938,8 +938,8 @@
 				<en>The Dead Past</en>
 			</title_original>
 			<description>
-				<de>Dank des ${.self:"role":0:"firstname"} gibt es ein staatlich kontrolliertes Chronoskop, das ${.self:"role":1:"fullname"} für seine Erforschung des antiken Karthago verwenden möchte, doch die Behörden stellen sich quer. Der Nachbau eines solchen Geräts bringt interessante Erkenntnisse...</de>
-				<en>Thanks to the ${.self:"role":0:"firstname"}, there is a state-controlled chronoscope that ${.self:"role":1:"fullname"} wants to use for his research into ancient Carthage, but the authorities are standing in the way. The reproduction of such a device yields interesting findings...</en>
+				<de>Dank des ${.self:"role":1:"firstname"} gibt es ein staatlich kontrolliertes Chronoskop, das ${.self:"role":2:"fullname"} für seine Erforschung des antiken Karthago verwenden möchte, doch die Behörden stellen sich quer. Der Nachbau eines solchen Geräts bringt interessante Erkenntnisse...</de>
+				<en>Thanks to the ${.self:"role":1:"firstname"}, there is a state-controlled chronoscope that ${.self:"role":2:"fullname"} wants to use for his research into ancient Carthage, but the authorities are standing in the way. The reproduction of such a device yields interesting findings...</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1006,8 +1006,8 @@
 				<en>The Orchard Keeper</en>
 			</title_original>
 			<description>
-				<de>In einer kleinen abgelegenen Berggemeinde im Tennessee der Zwischenkriegszeit versucht Anhalter ${.self:"role":4:"firstname"} den ansässigen ${.self:"role":0:"firstname"} auszurauben, der ihn in Notwehr tötet und die Leiche in einer Kiesgrube versenkt. Ehefrau und Sohn schwören Rache.</de>
-				<en>In a small isolated mountain community in Tennessee during the inter-war period, hitchhiker ${.self:"role":4:"firstname"} tries to rob the local ${.self:"role":0:"firstname"}, who kills him in self-defence and dumps his body in a gravel pit. Wife and son swear revenge.</en>
+				<de>In einer kleinen abgelegenen Berggemeinde im Tennessee der Zwischenkriegszeit versucht Anhalter ${.self:"role":5:"firstname"} den ansässigen ${.self:"role":1:"firstname"} auszurauben, der ihn in Notwehr tötet und die Leiche in einer Kiesgrube versenkt. Ehefrau und Sohn schwören Rache.</de>
+				<en>In a small isolated mountain community in Tennessee during the inter-war period, hitchhiker ${.self:"role":5:"firstname"} tries to rob the local ${.self:"role":1:"firstname"}, who kills him in self-defence and dumps his body in a gravel pit. Wife and son swear revenge.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1041,8 +1041,8 @@
 				<en>Suttree</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"fullname"} gibt sein früheres privilegiertes Leben auf, um Fischer am Tennessee River zu werden, versucht, seine wahre Identität inmitten von Verstoßenen und Außenseitern zu finden, und erlebt dabei allerlei Missgeschicke.</de>
-				<en>${.self:"role":0:"fullname"} repudiates his former life of privilege to become a fisherman on the Tennessee River, trying to find his true identity amidst misfits and outcasts while experiencing all sorts of misadventures.</en>
+				<de>${.self:"role":1:"fullname"} gibt sein früheres privilegiertes Leben auf, um Fischer am Tennessee River zu werden, versucht, seine wahre Identität inmitten von Verstoßenen und Außenseitern zu finden, und erlebt dabei allerlei Missgeschicke.</de>
+				<en>${.self:"role":1:"fullname"} repudiates his former life of privilege to become a fisherman on the Tennessee River, trying to find his true identity amidst misfits and outcasts while experiencing all sorts of misadventures.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1113,8 +1113,8 @@
 				<en>Fallwind</en>
 			</title_original>
 			<description>
-				<de>Kommissar ${.self:"role":0:"fullname"} findet sich in einer Windrad-Gondel auf der Nordsee wieder, zusammen mit einer Unbekannten und Vorräten für ein paar Tage. Erst Stück für Stück kommen die Erinnerungen zurück.</de>
-				<en>Inspector ${.self:"role":0:"fullname"} finds himself on the North Sea in the nacelle of a wind turbine, together with a female stranger and supplies for a few days. Only gradually do the memories come back.</en>
+				<de>Kommissar ${.self:"role":1:"fullname"} findet sich in einer Windrad-Gondel auf der Nordsee wieder, zusammen mit einer Unbekannten und Vorräten für ein paar Tage. Erst Stück für Stück kommen die Erinnerungen zurück.</de>
+				<en>Inspector ${.self:"role":1:"fullname"} finds himself on the North Sea in the nacelle of a wind turbine, together with a female stranger and supplies for a few days. Only gradually do the memories come back.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1149,8 +1149,8 @@
 				<en>Nine-Eye</en>
 			</title_original>
 			<description>
-				<de>In Schulkellern in Hamburg werden mumifizierte Tote entdeckt. Ein bekannter Fallanalytiker aus München soll helfen, doch Kommissar ${.self:"role":0:"fullname"} kann ihn nicht ausstehen und zweifelt an der Theorie seines Kollegen.</de>
-				<en>Mummified corpses are discovered in school basements in Hamburg. A popular case analyst from Munich is to help, but Inspector ${.self:"role":0:"fullname"} can't stand him and doubts his colleague's theory.</en>
+				<de>In Schulkellern in Hamburg werden mumifizierte Tote entdeckt. Ein bekannter Fallanalytiker aus München soll helfen, doch Kommissar ${.self:"role":1:"fullname"} kann ihn nicht ausstehen und zweifelt an der Theorie seines Kollegen.</de>
+				<en>Mummified corpses are discovered in school basements in Hamburg. A popular case analyst from Munich is to help, but Inspector ${.self:"role":1:"fullname"} can't stand him and doubts his colleague's theory.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1215,8 +1215,8 @@
 				<en>Caught Stealing</en>
 			</title_original>
 			<description>
-				<de>Teil 1 der Trilogie über ${.self:"role":0:"fullname"}, ein gescheiterter Baseballspieler, der gern Bars aufsucht und trinkt. Plötzlich wird er ständig mit Schlägern konfrontiert und findet sich alsbald in einer Odyssee durch New York wieder.</de>
-				<en>Part 1 of the trilogy about ${.self:"role":0:"fullname"}, a failed baseball player who likes to frequent bars and drink. Suddenly he is constantly confronted with thugs and soon finds himself in an odyssey through New York.</en>
+				<de>Teil 1 der Trilogie über ${.self:"role":1:"fullname"}, ein gescheiterter Baseballspieler, der gern Bars aufsucht und trinkt. Plötzlich wird er ständig mit Schlägern konfrontiert und findet sich alsbald in einer Odyssee durch New York wieder.</de>
+				<en>Part 1 of the trilogy about ${.self:"role":1:"fullname"}, a failed baseball player who likes to frequent bars and drink. Suddenly he is constantly confronted with thugs and soon finds himself in an odyssey through New York.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1250,8 +1250,8 @@
 				<en>Six Bad Things</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"firstname"} ist untergetaucht in Mexiko, mit einer Tasche voller Bargeld, das die russische Mafia zurückhaben will, und mit vielen, vielen Geheimnissen. Er trifft auf einen Rucksacktouristen, der einige von ihnen kennt. Teil 2 der Trilogie.</de>
-				<en>${.self:"role":0:"firstname"} is in hiding in Mexico, with a bag full of cash that the Russian mafia wants back, and with many, many secrets. He meets a backpacker who knows some of them. Part 2 of the trilogy.</en>
+				<de>${.self:"role":1:"firstname"} ist untergetaucht in Mexiko, mit einer Tasche voller Bargeld, das die russische Mafia zurückhaben will, und mit vielen, vielen Geheimnissen. Er trifft auf einen Rucksacktouristen, der einige von ihnen kennt. Teil 2 der Trilogie.</de>
+				<en>${.self:"role":1:"firstname"} is in hiding in Mexico, with a bag full of cash that the Russian mafia wants back, and with many, many secrets. He meets a backpacker who knows some of them. Part 2 of the trilogy.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1285,8 +1285,8 @@
 				<en>A Dangerous Man</en>
 			</title_original>
 			<description>
-				<de>Widerwilliger Auftragskiller ${.self:"role":0:"firstname"} hat sein Leben nicht mehr im Griff, nimmt Schmerzmittel, seine Schusshand zittert. Umso überraschender, dass er von seinem russischen Mafia-Boss den Auftrag bekommt, einen Baseball-Star zu überwachen. Teil 3 der Trilogie.</de>
-				<en>Reluctant hitman ${.self:"role":0:"firstname"} is no longer in control of his life, takes painkillers, his shooting hand trembles. All the more surprising that he gets the order from his Russian mafia boss to monitor a baseball star. Part 3 of the trilogy.</en>
+				<de>Widerwilliger Auftragskiller ${.self:"role":1:"firstname"} hat sein Leben nicht mehr im Griff, nimmt Schmerzmittel, seine Schusshand zittert. Umso überraschender, dass er von seinem russischen Mafia-Boss den Auftrag bekommt, einen Baseball-Star zu überwachen. Teil 3 der Trilogie.</de>
+				<en>Reluctant hitman ${.self:"role":1:"firstname"} is no longer in control of his life, takes painkillers, his shooting hand trembles. All the more surprising that he gets the order from his Russian mafia boss to monitor a baseball star. Part 3 of the trilogy.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1309,16 +1309,16 @@
 		</scripttemplate>
 		<scripttemplate product="2" licence_type="3" guid="ed95c50e-c70b-47db-9083-426fc3ed2757" creator="9551" comment="https://en.wikipedia.org/wiki/Charlie_Huston | https://en.wikipedia.org/wiki/Joe_Pitt_Casebooks | Terms like 'Vampyre', 'Vyrus' are [sic] with the 'y'.">
 			<title>
-				<de>Das ${.self:"role":0:"fullname"} Dossier</de>
-				<en>The ${.self:"role":0:"fullname"} Dossier</en>
+				<de>Das ${.self:"role":1:"fullname"} Dossier</de>
+				<en>The ${.self:"role":1:"fullname"} Dossier</en>
 			</title>
 			<title_original>
 				<de>Die Joe Pitt Casebooks</de>
 				<en>The Joe Pitt Casebooks</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"fullname"}, ein „Vampyre“, schlägt sich im New Yorker Untergrund durch und erledigt im Tausch gegen Blut und Freiheit Aufträge für verschiedene Clans, während sich ein mysteriöser Zombie-„Vyrus“ ausbreitet.</de>
-				<en>${.self:"role":0:"fullname"}, a "Vampyre", struggles in the underground of New York doing jobs for various clans in exchange for blood and freedom, while a mysterious Zombie "Vyrus" is spreading.</en>
+				<de>${.self:"role":1:"fullname"}, ein „Vampyre“, schlägt sich im New Yorker Untergrund durch und erledigt im Tausch gegen Blut und Freiheit Aufträge für verschiedene Clans, während sich ein mysteriöser Zombie-„Vyrus“ ausbreitet.</de>
+				<en>${.self:"role":1:"fullname"}, a "Vampyre", struggles in the underground of New York doing jobs for various clans in exchange for blood and freedom, while a mysterious Zombie "Vyrus" is spreading.</en>
 			</description>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="785812f4-20b6-4821-bb8c-0e2ca1e7dbe3" comment="https://en.wikipedia.org/wiki/Already_Dead_(Huston_novel)">
@@ -1331,8 +1331,8 @@
 						<en>Already Dead</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} hält sein Vampyre-Dasein immer noch vor seiner HIV-positiven menschlichen Freundin ${.self:"role":1:"firstname"} geheim, während er die Gothic-Tochter eines reichen Mannes finden soll.</de>
-						<en>${.self:"role":0:"firstname"} still keeps his Vampyre condition secret from his HIV-positive human girlfriend ${.self:"role":1:"firstname"}, while he is asked to find the gothic daughter of a rich man.</en>
+						<de>${.self:"role":1:"firstname"} hält sein Vampyre-Dasein immer noch vor seiner HIV-positiven menschlichen Freundin ${.self:"role":2:"firstname"} geheim, während er die Gothic-Tochter eines reichen Mannes finden soll.</de>
+						<en>${.self:"role":1:"firstname"} still keeps his Vampyre condition secret from his HIV-positive human girlfriend ${.self:"role":2:"firstname"}, while he is asked to find the gothic daughter of a rich man.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="298f3649-4dc4-47ab-9a1b-ad03cf30d3e9" comment="https://en.wikipedia.org/wiki/No_Dominion">
@@ -1345,8 +1345,8 @@
 						<en>No Dominion</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} ist vom Pech verfolgt, mit der Miete im Rückstand und knapp an Blut. Sein ehemaliger Chef ${.self:"role":2:"fullname"} wirft ihm einen Auftrag zu: die Quelle einer neuen Straßen-Droge aufspüren, so stark, dass alle mit dem Vyrus infizierten durchdrehen.</de>
-						<en>${.self:"role":0:"firstname"} is down on his luck, behind on rent and low on blood. His former boss ${.self:"role":2:"fullname"} tosses him a job: track down the source of a new drug on the streets, powerful enough to cause those infected with the Vyrus to freak out.</en>
+						<de>${.self:"role":1:"firstname"} ist vom Pech verfolgt, mit der Miete im Rückstand und knapp an Blut. Sein ehemaliger Chef ${.self:"role":3:"fullname"} wirft ihm einen Auftrag zu: die Quelle einer neuen Straßen-Droge aufspüren, so stark, dass alle mit dem Vyrus infizierten durchdrehen.</de>
+						<en>${.self:"role":1:"firstname"} is down on his luck, behind on rent and low on blood. His former boss ${.self:"role":3:"fullname"} tosses him a job: track down the source of a new drug on the streets, powerful enough to cause those infected with the Vyrus to freak out.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="f1d77366-53bd-4ac0-99a4-c95b9e811154" comment="https://en.wikipedia.org/wiki/Half_the_Blood_of_Brooklyn">
@@ -1359,8 +1359,8 @@
 						<en>Half the Blood of Brooklyn</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"}, der vorher unabhängig war und sich durchschlagen musste, arbeitet nun für einen Vampyre-Clan mit all dem Geld und Blut, das er braucht. Aber das hat einen hohen Preis: Mörderische Familienfehden und viel Blutvergießen.</de>
-						<en>${.self:"role":0:"firstname"}, formerly independent and struggling, finds himself working for a Vampyre clan with all the cash and blood he needs. But that comes with a high price: Murderous family feuds and lots of spilling blood.</en>
+						<de>${.self:"role":1:"firstname"}, der vorher unabhängig war und sich durchschlagen musste, arbeitet nun für einen Vampyre-Clan mit all dem Geld und Blut, das er braucht. Aber das hat einen hohen Preis: Mörderische Familienfehden und viel Blutvergießen.</de>
+						<en>${.self:"role":1:"firstname"}, formerly independent and struggling, finds himself working for a Vampyre clan with all the cash and blood he needs. But that comes with a high price: Murderous family feuds and lots of spilling blood.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="d99775b9-41db-4353-9bd8-91715190ffa9" comment="https://en.wikipedia.org/wiki/Every_Last_Drop">
@@ -1373,8 +1373,8 @@
 						<en>Every Last Drop</en>
 					</title_original>
 					<description>
-						<de>Natürlich ist ${.self:"role":0:"firstname"} nun wieder auf sich allein gestellt, musste alle Brücken abreißen und ist Freiwild. Clan-Boss ${.self:"role":5:"fullname"} schlägt ihm einen Deal vor: Ein Heilmittel für das Zombie-Vyrus muss unter allen Umständen verhindert werden...</de>
-						<en>Of course, ${.self:"role":0:"firstname"} is now on his own again, has had to burn all his bridges and is free to hunt. Clan boss ${.self:"role":5:"fullname"} offers him a deal: A cure for the Zombie-Vyrus must be prevented at all costs...</en>
+						<de>Natürlich ist ${.self:"role":1:"firstname"} nun wieder auf sich allein gestellt, musste alle Brücken abreißen und ist Freiwild. Clan-Boss ${.self:"role":6:"fullname"} schlägt ihm einen Deal vor: Ein Heilmittel für das Zombie-Vyrus muss unter allen Umständen verhindert werden...</de>
+						<en>Of course, ${.self:"role":1:"firstname"} is now on his own again, has had to burn all his bridges and is free to hunt. Clan boss ${.self:"role":6:"fullname"} offers him a deal: A cure for the Zombie-Vyrus must be prevented at all costs...</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="34934d49-f1e7-44fe-a5b3-24415a0d8f5f" comment="https://en.wikipedia.org/wiki/My_Dead_Body">
@@ -1387,8 +1387,8 @@
 						<en>My Dead Body</en>
 					</title_original>
 					<description>
-						<de>„Niemand lebt ewig. Nicht mal ein Vampyre.“ ${.self:"role":0:"firstname"} ist wieder ein wandelnder toter Mann. Sogar ${.self:"role":1:"firstname"} will jetzt, dass er einen Auftrag annimmt: Suche nach einem vermissten Mädchen, das ein Baby in sich trägt, das das Schicksal aller Vampyres verändern könnte.</de>
-						<en>"Nobody lives forever. Not even a Vampyre." Again, ${.self:"role":0:"firstname"} is a dead man walking. Even ${.self:"role":1:"firstname"} now wants him to take a gig: Search for a missing girl carrying a baby that might change the destiny of Vamyre-kind.</en>
+						<de>„Niemand lebt ewig. Nicht mal ein Vampyre.“ ${.self:"role":1:"firstname"} ist wieder ein wandelnder toter Mann. Sogar ${.self:"role":2:"firstname"} will jetzt, dass er einen Auftrag annimmt: Suche nach einem vermissten Mädchen, das ein Baby in sich trägt, das das Schicksal aller Vampyres verändern könnte.</de>
+						<en>"Nobody lives forever. Not even a Vampyre." Again, ${.self:"role":1:"firstname"} is a dead man walking. Even ${.self:"role":2:"firstname"} now wants him to take a gig: Search for a missing girl carrying a baby that might change the destiny of Vamyre-kind.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -1429,8 +1429,8 @@
 				<en>Survivor</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"fullname"}, der letzte Überlebende einer suizidalen Sekte, der viel mediale Aufmerksamkeit bekommt, hat plötzlich irgendwie ein Flugzeug entführt, das am Abstürzen ist, und erzählt seine Geschichte in den Flugschreiber.</de>
-				<en>${.self:"role":0:"fullname"}, the last survivor of a suicidal cult who gets a lot of media attention, has suddenly somehow hijacked a plane that is about to crash, and tells his story into the flight recorder.</en>
+				<de>${.self:"role":1:"fullname"}, der letzte Überlebende einer suizidalen Sekte, der viel mediale Aufmerksamkeit bekommt, hat plötzlich irgendwie ein Flugzeug entführt, das am Abstürzen ist, und erzählt seine Geschichte in den Flugschreiber.</de>
+				<en>${.self:"role":1:"fullname"}, the last survivor of a suicidal cult who gets a lot of media attention, has suddenly somehow hijacked a plane that is about to crash, and tells his story into the flight recorder.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1462,8 +1462,8 @@
 				<en>Invisible Monsters</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"firstname"} ist trotz familiärer Schwierigkeiten ein attraktives, erfolgreiches Fotomodell - bis ihr der gesamte Unterkiefer weggeschossen wird. Bei der Sprechtherapie lernt sie Dragqueen ${.self:"role":1:"firstname"} kennen, die ihr hilft, ein neues Leben zu beginnen.</de>
-				<en>Despite family difficulties, ${.self:"role":0:"firstname"} is an attractive, successful fashion model - until her entire lower jaw is shot off. During speech therapy, she meets drag queen ${.self:"role":1:"firstname"}, who helps her start a new life.</en>
+				<de>${.self:"role":1:"firstname"} ist trotz familiärer Schwierigkeiten ein attraktives, erfolgreiches Fotomodell - bis ihr der gesamte Unterkiefer weggeschossen wird. Bei der Sprechtherapie lernt sie Dragqueen ${.self:"role":2:"firstname"} kennen, die ihr hilft, ein neues Leben zu beginnen.</de>
+				<en>Despite family difficulties, ${.self:"role":1:"firstname"} is an attractive, successful fashion model - until her entire lower jaw is shot off. During speech therapy, she meets drag queen ${.self:"role":2:"firstname"}, who helps her start a new life.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1492,15 +1492,15 @@
 		<scripttemplate product="1" licence_type="1" guid="7981114a-198d-4a97-9279-107e182e50e9" creator="9551" comment="https://en.wikipedia.org/wiki/Chuck_Palahniuk | https://en.wikipedia.org/wiki/Rant_(novel)">
 			<title>
 				<de>Das Zeichen von Kain</de>
-				<en>${.self:"role":0:"fullname"}: The Verbal Biography</en>
+				<en>${.self:"role":1:"fullname"}: The Verbal Biography</en>
 			</title>
 			<title_original>
 				<de>Das Kainsmal</de>
 				<en>Rant: An Oral Biography of Buster Casey</en>
 			</title_original>
 			<description>
-				<de>Car-Crash-Party-Enthusiast ${.self:"role":0:"firstname"} ist tot. Mehrere Charaktere zeichnen in Rückblenden eine widersprüchliche Biografie über „Rant“, dessen Spitzname vom Geräusch des Erbrechens stammt und der von Bissen der schwarzen Witwe Erektionen bekam.</de>
-				<en>Car Crash Party enthusiast ${.self:"role":0:"firstname"} is dead. In flashbacks, several characters paint a contradictory biography of "Rant", whose nickname comes from the sound of vomiting and who got erections from bites of the black widow.</en>
+				<de>Car-Crash-Party-Enthusiast ${.self:"role":1:"firstname"} ist tot. Mehrere Charaktere zeichnen in Rückblenden eine widersprüchliche Biografie über „Rant“, dessen Spitzname vom Geräusch des Erbrechens stammt und der von Bissen der schwarzen Witwe Erektionen bekam.</de>
+				<en>Car Crash Party enthusiast ${.self:"role":1:"firstname"} is dead. In flashbacks, several characters paint a contradictory biography of "Rant", whose nickname comes from the sound of vomiting and who got erections from bites of the black widow.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1528,15 +1528,15 @@
 		<scripttemplate product="1" licence_type="1" guid="175c3483-c1e0-43cb-bb2c-2bca8087433f" creator="9551" comment="https://en.wikipedia.org/wiki/Chuck_Palahniuk | https://en.wikipedia.org/wiki/Pygmy_(novel)">
 			<title>
 				<de>Knirps</de>
-				<en>${.self:"role":0:"firstname"}</en>
+				<en>${.self:"role":1:"firstname"}</en>
 			</title>
 			<title_original>
 				<de>Bonsai</de>
 				<en>Pygmy</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"firstname"}, ein von einem totalitären Staat ausgebildeter 13-jähriger Supersoldat, wird mit einigen anderen wie ihm als Austauschschüler nach Amerika geschickt, um einen Terroranschlag zu verüben. Die Gastfamilie respektiert er nicht sonderlich.</de>
-				<en>${.self:"role":0:"firstname"}, a 13 year old super soldier trained by a totalitarian state, is sent to America as an exchange student with a few others like him to carry out a terrorist attack. The host family he doesn't respect very much.</en>
+				<de>${.self:"role":1:"firstname"}, ein von einem totalitären Staat ausgebildeter 13-jähriger Supersoldat, wird mit einigen anderen wie ihm als Austauschschüler nach Amerika geschickt, um einen Terroranschlag zu verüben. Die Gastfamilie respektiert er nicht sonderlich.</de>
+				<en>${.self:"role":1:"firstname"}, a 13 year old super soldier trained by a totalitarian state, is sent to America as an exchange student with a few others like him to carry out a terrorist attack. The host family he doesn't respect very much.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1650,8 +1650,8 @@
 				<en>Double Whammy</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"fullname"} wird angeheuert, um einen prominenten Barschfischer als Betrüger zu entlarven, und wird in ein Mordkomplott hineingezogen. Teil 2 der satirischen Krimi-Reihe um ${.self:"role":4:"fullname"}.</de>
-				<en>${.self:"role":0:"fullname"} is hired to expose a celebrity bass fisherman as a cheat and is drawn into a frame-up for murder. Part 2 of the satirical crime thriller series around ${.self:"role":4:"fullname"}.</en>
+				<de>${.self:"role":1:"fullname"} wird angeheuert, um einen prominenten Barschfischer als Betrüger zu entlarven, und wird in ein Mordkomplott hineingezogen. Teil 2 der satirischen Krimi-Reihe um ${.self:"role":5:"fullname"}.</de>
+				<en>${.self:"role":1:"fullname"} is hired to expose a celebrity bass fisherman as a cheat and is drawn into a frame-up for murder. Part 2 of the satirical crime thriller series around ${.self:"role":5:"fullname"}.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1730,8 +1730,8 @@
 				<en>The Anubis Gates</en>
 			</title_original>
 			<description>
-				<de>Der Literat ${.self:"role":0:"fullname"} wird von Millionär ${.self:"role":1:"fullname"} für eine Zeitreise nach 1810 angeheuert, doch er erregt die Aufmerksamkeit alter ägyptischer Zauberer, bleibt stecken und muss sich mit noch vielen weiteren bizarren Gestalten herumschlagen.</de>
-				<en>Literary scholar ${.self:"role":0:"fullname"} is hired by millionaire ${.self:"role":1:"fullname"} to travel back in time to 1810, but he attracts the attention of ancient Egyptian sorcerers, gets stuck and has to deal with many more bizarre characters.</en>
+				<de>Der Literat ${.self:"role":1:"fullname"} wird von Millionär ${.self:"role":2:"fullname"} für eine Zeitreise nach 1810 angeheuert, doch er erregt die Aufmerksamkeit alter ägyptischer Zauberer, bleibt stecken und muss sich mit noch vielen weiteren bizarren Gestalten herumschlagen.</de>
+				<en>Literary scholar ${.self:"role":1:"fullname"} is hired by millionaire ${.self:"role":2:"fullname"} to travel back in time to 1810, but he attracts the attention of ancient Egyptian sorcerers, gets stuck and has to deal with many more bizarre characters.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1770,8 +1770,8 @@
 				<en>To Die in Spring</en>
 			</title_original>
 			<description>
-				<de>Die 17-jährigen Melker ${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} aus Norddeutschland werden 1945 zwangsrekrutiert, nach Ungarn an die Front gebracht und erleben die Gräuel des Krieges. ${.self:"role":1:"firstname"} desertiert und soll erschossen werden.</de>
-				<en>The 17-year-old milkers ${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"} from northern Germany are forcibly recruited in 1945, taken to the front in Hungary and experience the horrors of war. ${.self:"role":1:"firstname"} deserts and is to be shot.</en>
+				<de>Die 17-jährigen Melker ${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} aus Norddeutschland werden 1945 zwangsrekrutiert, nach Ungarn an die Front gebracht und erleben die Gräuel des Krieges. ${.self:"role":2:"firstname"} desertiert und soll erschossen werden.</de>
+				<en>The 17-year-old milkers ${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"} from northern Germany are forcibly recruited in 1945, taken to the front in Hungary and experience the horrors of war. ${.self:"role":2:"firstname"} deserts and is to be shot.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1808,8 +1808,8 @@
 				<en>Bull</en>
 			</title_original>
 			<description>
-				<de>Teil 1 der Ruhrgebietsreihe. Die Jugendkultur der 70er Jahre: Mit Rockmusik, Drogen, wilden Partys und ersten WGs sucht eine kleine Szene von Außenseitern neue Lebenswege. ${.self:"role":0:"fullname"} manövriert zwischen Exzessen und seinem Job als Pflegehelfer.</de>
-				<en>Part 1 of the Ruhr series. The youth culture of the 70s: With rock music, drugs, wild parties and first shared flats, a small scene of outsiders seeks new ways of life. ${.self:"role":0:"fullname"} navigates between excesses and his job as a nursing assistant.</en>
+				<de>Teil 1 der Ruhrgebietsreihe. Die Jugendkultur der 70er Jahre: Mit Rockmusik, Drogen, wilden Partys und ersten WGs sucht eine kleine Szene von Außenseitern neue Lebenswege. ${.self:"role":1:"fullname"} manövriert zwischen Exzessen und seinem Job als Pflegehelfer.</de>
+				<en>Part 1 of the Ruhr series. The youth culture of the 70s: With rock music, drugs, wild parties and first shared flats, a small scene of outsiders seeks new ways of life. ${.self:"role":1:"fullname"} navigates between excesses and his job as a nursing assistant.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1846,8 +1846,8 @@
 				<en>Forest Night</en>
 			</title_original>
 			<description>
-				<de>Teil 2 der Ruhrgebietsreihe. Der Künstler ${.self:"role":0:"fullname"} kehrt in den 90ern auf Einladung eines Mäzens zurück und trifft auf Figuren seiner Jugend, allen voran „${.self:"role":1:"firstname"}“, der als Zuhälter und Dealer versucht, seinen Traum weiterzuleben.</de>
-				<en>Part 2 of the Ruhr series. In the 90s, the artist ${.self:"role":0:"fullname"} returns at the invitation of a patron and meets figures of his youth, first and foremost "${.self:"role":1:"firstname"}", a pimp and dealer trying to continue living his dream.</en>
+				<de>Teil 2 der Ruhrgebietsreihe. Der Künstler ${.self:"role":1:"fullname"} kehrt in den 90ern auf Einladung eines Mäzens zurück und trifft auf Figuren seiner Jugend, allen voran „${.self:"role":2:"firstname"}“, der als Zuhälter und Dealer versucht, seinen Traum weiterzuleben.</de>
+				<en>Part 2 of the Ruhr series. In the 90s, the artist ${.self:"role":1:"fullname"} returns at the invitation of a patron and meets figures of his youth, first and foremost "${.self:"role":2:"firstname"}", a pimp and dealer trying to continue living his dream.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1922,8 +1922,8 @@
 				<en>Young Light</en>
 			</title_original>
 			<description>
-				<de>Teil 4 der Ruhrgebietsreihe. Das Schuljahr endet für ${.self:"role":0:"fullname"} mit Schlägen des Lehrers und der Mutter. Die Ferien zuhause sind demütigend, aber er findet Zufluchtsorte in einem alten Bauwagen und der Baumhütte einer Jugendbande.</de>
-				<en>Part 4 of the Ruhr series. The school year ends for ${.self:"role":0:"fullname"} with beatings from the teacher and the mother. The vacations at home are humiliating, but he finds refuge in an old construction trailer and the tree hut of a youth gang.</en>
+				<de>Teil 4 der Ruhrgebietsreihe. Das Schuljahr endet für ${.self:"role":1:"fullname"} mit Schlägen des Lehrers und der Mutter. Die Ferien zuhause sind demütigend, aber er findet Zufluchtsorte in einem alten Bauwagen und der Baumhütte einer Jugendbande.</de>
+				<en>Part 4 of the Ruhr series. The school year ends for ${.self:"role":1:"fullname"} with beatings from the teacher and the mother. The vacations at home are humiliating, but he finds refuge in an old construction trailer and the tree hut of a youth gang.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1957,8 +1957,8 @@
 				<en>Flee, My Friend!</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"firstname"} lebt in Berlin, ist Sohn von ${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"}, die sich auf einer Anti-Atomkraft-Demonstration kennengelernt haben, und liebt die pummelige ${.self:"role":3:"firstname"}, kann aber nicht ganz dazu stehen. Ihre Mitbewohnerin ${.self:"role":4:"firstname"} verführt ihn.</de>
-				<en>${.self:"role":0:"firstname"} lives in Berlin, is the son of ${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"}, who met at an anti-nuclear protest, and loves the chubby ${.self:"role":3:"firstname"}, but can't quite stand up for it. Her roommate ${.self:"role":4:"firstname"} seduces him.</en>
+				<de>${.self:"role":1:"firstname"} lebt in Berlin, ist Sohn von ${.self:"role":2:"firstname"} und ${.self:"role":3:"firstname"}, die sich auf einer Anti-Atomkraft-Demonstration kennengelernt haben, und liebt die pummelige ${.self:"role":4:"firstname"}, kann aber nicht ganz dazu stehen. Ihre Mitbewohnerin ${.self:"role":5:"firstname"} verführt ihn.</de>
+				<en>${.self:"role":1:"firstname"} lives in Berlin, is the son of ${.self:"role":2:"firstname"} and ${.self:"role":3:"firstname"}, who met at an anti-nuclear protest, and loves the chubby ${.self:"role":4:"firstname"}, but can't quite stand up for it. Her roommate ${.self:"role":5:"firstname"} seduces him.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1992,8 +1992,8 @@
 				<en>Heat</en>
 			</title_original>
 			<description>
-				<de>Der Tod seiner Lebensgefährtin hat ${.self:"role":0:"firstname"} aus der Bahn geworfen. Statt als Kameramann arbeitet er inzwischen in einer Großküche in Berlin-Kreuzberg. Er begegnet einer polnischen Stadtstreicherin, in der er seine tote Frau wiederzuerkennen glaubt.</de>
-				<en>The death of his significant other has thrown ${.self:"role":0:"firstname"} off course. Instead of working as a cameraman, he now works in a canteen kitchen in Berlin-Kreuzberg. He meets a Polish vagrant in whom he believes he recognizes his dead wife.</en>
+				<de>Der Tod seiner Lebensgefährtin hat ${.self:"role":1:"firstname"} aus der Bahn geworfen. Statt als Kameramann arbeitet er inzwischen in einer Großküche in Berlin-Kreuzberg. Er begegnet einer polnischen Stadtstreicherin, in der er seine tote Frau wiederzuerkennen glaubt.</de>
+				<en>The death of his significant other has thrown ${.self:"role":1:"firstname"} off course. Instead of working as a cameraman, he now works in a canteen kitchen in Berlin-Kreuzberg. He meets a Polish vagrant in whom he believes he recognizes his dead wife.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -2026,8 +2026,8 @@
 				<en>Fire Isn't Burning</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"firstname"} ist älter geworden und seine Liebe zu Buchhändlerin ${.self:"role":1:"firstname"} verblasst wie Kreuzberg nach dem Mauerfall. Der Umzug an den Müggelsee soll die Lösung sein - und eine Affäre mit Professorin ${.self:"role":2:"firstname"} - zu der ihn ${.self:"role":1:"firstname"} sogar ermuntert.</de>
-				<en>${.self:"role":0:"firstname"} has grown older and his love to bookseller ${.self:"role":1:"firstname"} is fading like Kreuzberg after the fall of the Berlin Wall. Moving to the Müggelsee should do the trick - and an affair with Professor ${.self:"role":2:"firstname"} - which ${.self:"role":1:"firstname"} even encourages.</en>
+				<de>${.self:"role":1:"firstname"} ist älter geworden und seine Liebe zu Buchhändlerin ${.self:"role":2:"firstname"} verblasst wie Kreuzberg nach dem Mauerfall. Der Umzug an den Müggelsee soll die Lösung sein - und eine Affäre mit Professorin ${.self:"role":3:"firstname"} - zu der ihn ${.self:"role":2:"firstname"} sogar ermuntert.</de>
+				<en>${.self:"role":1:"firstname"} has grown older and his love to bookseller ${.self:"role":2:"firstname"} is fading like Kreuzberg after the fall of the Berlin Wall. Moving to the Müggelsee should do the trick - and an affair with Professor ${.self:"role":3:"firstname"} - which ${.self:"role":2:"firstname"} even encourages.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -2061,8 +2061,8 @@
 				<en>The Corrections</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"fullname"}, seit 50 Jahren Mutter und Hausfrau, und ihr kalter, introvertierter Ehemann ${.self:"role":1:"firstname"} starten eine lange Kampagne, um die ganze dysfunktionale Großfamilie zu einem letzten, wirklich schönen Weihnachtsfest zusammenzubringen.</de>
-				<en>${.self:"role":0:"fullname"}, a mother and housewife for 50 years, and her cold, introverted husband ${.self:"role":1:"firstname"} start a long campaign to bring the whole dysfunctional extended family together for one last, really nice Christmas.</en>
+				<de>${.self:"role":1:"fullname"}, seit 50 Jahren Mutter und Hausfrau, und ihr kalter, introvertierter Ehemann ${.self:"role":2:"firstname"} starten eine lange Kampagne, um die ganze dysfunktionale Großfamilie zu einem letzten, wirklich schönen Weihnachtsfest zusammenzubringen.</de>
+				<en>${.self:"role":1:"fullname"}, a mother and housewife for 50 years, and her cold, introverted husband ${.self:"role":2:"firstname"} start a long campaign to bring the whole dysfunctional extended family together for one last, really nice Christmas.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -2111,8 +2111,8 @@
 						<en>1984</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"fullname"}, von ihrer Mutter und „Salon-Kommunistin“ ${.self:"role":1:"firstname"} damals mit anderen zwecks „Umsturz“ in die USA geschickt, sieht sich vor allem Vorwürfen über illegale Aktivitäten durch Personen aus ihrem Umfeld konfrontiert.</de>
-						<en>${.self:"role":0:"fullname"}, back then sent to the USA together with others by her mother and "champagne socialist" ${.self:"role":1:"firstname"} for an "overthrow", is confronted with accusations of illegal activities on the part of people around her.</en>
+						<de>${.self:"role":1:"fullname"}, von ihrer Mutter und „Salon-Kommunistin“ ${.self:"role":2:"firstname"} damals mit anderen zwecks „Umsturz“ in die USA geschickt, sieht sich vor allem Vorwürfen über illegale Aktivitäten durch Personen aus ihrem Umfeld konfrontiert.</de>
+						<en>${.self:"role":1:"fullname"}, back then sent to the USA together with others by her mother and "champagne socialist" ${.self:"role":2:"firstname"} for an "overthrow", is confronted with accusations of illegal activities on the part of people around her.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="787b2aba-aa8d-4f66-be4f-29d8a1fc69ae">
@@ -2125,8 +2125,8 @@
 						<en>1985</en>
 					</title_original>
 					<description>
-						<de>Ein geplanter Zusamenschluss der Stadt mit dem Bezirk, Teil eines umfassenden Immobilienspekulationsplans ausgeheckt von ${.self:"role":0:"firstname"} und ihren Kohorten, führt zu einer Auseinandersetzung zwischen ihr und ${.self:"role":2:"fullname"}.</de>
-						<en>A proposed merger between the city and county, part of a larger property speculation scheme hatched by ${.self:"role":0:"firstname"} and her cohorts, leads to a clash between her and ${.self:"role":2:"fullname"}.</en>
+						<de>Ein geplanter Zusamenschluss der Stadt mit dem Bezirk, Teil eines umfassenden Immobilienspekulationsplans ausgeheckt von ${.self:"role":1:"firstname"} und ihren Kohorten, führt zu einer Auseinandersetzung zwischen ihr und ${.self:"role":3:"fullname"}.</de>
+						<en>A proposed merger between the city and county, part of a larger property speculation scheme hatched by ${.self:"role":1:"firstname"} and her cohorts, leads to a clash between her and ${.self:"role":3:"fullname"}.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -2165,8 +2165,8 @@
 				<en>Strong Motion</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"fullname"} kommt in Boston an und muss feststellen, dass seine exzentrische Großmutter bei einem leichten Erdbeben ums Leben gekommen ist, was einen Familienstreit um das Erbe auslöst. Am Strand lernt er die Seismologin ${.self:"role":4:"firstname"} kennen.</de>
-				<en>${.self:"role":0:"fullname"} arrives in Boston to find that a minor earthquake has killed his eccentric grandmother, leading to a family struggle over the inheritance. At the beach he meets seismologist ${.self:"role":4:"firstname"}.</en>
+				<de>${.self:"role":1:"fullname"} kommt in Boston an und muss feststellen, dass seine exzentrische Großmutter bei einem leichten Erdbeben ums Leben gekommen ist, was einen Familienstreit um das Erbe auslöst. Am Strand lernt er die Seismologin ${.self:"role":5:"firstname"} kennen.</de>
+				<en>${.self:"role":1:"fullname"} arrives in Boston to find that a minor earthquake has killed his eccentric grandmother, leading to a family struggle over the inheritance. At the beach he meets seismologist ${.self:"role":5:"firstname"}.</en>
 			</description>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="3d7df88b-ac57-45e3-a8bb-781bf5e97580">
@@ -2179,8 +2179,8 @@
 						<en>Default Gender</en>
 					</title_original>
 					<description>
-						<de>Die Erschütterungen wurden anscheinend durch einen Petrochemie- und Waffenkonzern verursacht. Mögliche Ölvorkommen im Untergrund, der Aktienkurs,... ${.self:"role":1:"firstname"}s Verlobter ${.self:"role":5:"fullname"}, Sohn des CEO, plaudert angetrunken über die giftigen Abwässer.</de>
-						<en>The tremors were apparently caused by a petrochemical and weapons company. Potential oil reservoirs deep underground, the share price,... ${.self:"role":1:"firstname"}'s fiancé ${.self:"role":5:"fullname"}, son of the CEO, drunkenly chats about the toxic wastewater.</en>
+						<de>Die Erschütterungen wurden anscheinend durch einen Petrochemie- und Waffenkonzern verursacht. Mögliche Ölvorkommen im Untergrund, der Aktienkurs,... ${.self:"role":2:"firstname"}s Verlobter ${.self:"role":6:"fullname"}, Sohn des CEO, plaudert angetrunken über die giftigen Abwässer.</de>
+						<en>The tremors were apparently caused by a petrochemical and weapons company. Potential oil reservoirs deep underground, the share price,... ${.self:"role":2:"firstname"}'s fiancé ${.self:"role":6:"fullname"}, son of the CEO, drunkenly chats about the toxic wastewater.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="e6744026-0f07-4d46-baa2-259643bf9250">
@@ -2193,8 +2193,8 @@
 						<en>I &lt;3 Life</en> <!-- TODO: Check English original part titles, only German ones are on Wikipedia -->
 					</title_original>
 					<description>
-						<de>${.self:"role":4:"firstname"} hat ein langes Gespräch mit ${.self:"role":6:"fullname"} nach einem Fernsehinterview, in dem sie dessen irrationale Deutungen einer Strafe Gottes kritisierte. Sie will ihr Baby nach der Trennung vom untreuen ${.self:"role":0:"firstname"} abtreiben.</de>
-						<en>${.self:"role":4:"firstname"} has a long conversation with ${.self:"role":6:"fullname"} after a television interview in which she criticizes his irrational interpretations of a God's Punishment. She wants to abort her baby after separating from the unfaithful ${.self:"role":0:"firstname"}.</en>
+						<de>${.self:"role":5:"firstname"} hat ein langes Gespräch mit ${.self:"role":7:"fullname"} nach einem Fernsehinterview, in dem sie dessen irrationale Deutungen einer Strafe Gottes kritisierte. Sie will ihr Baby nach der Trennung vom untreuen ${.self:"role":1:"firstname"} abtreiben.</de>
+						<en>${.self:"role":5:"firstname"} has a long conversation with ${.self:"role":7:"fullname"} after a television interview in which she criticizes his irrational interpretations of a God's Punishment. She wants to abort her baby after separating from the unfaithful ${.self:"role":1:"firstname"}.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="236a2504-d54c-4a10-9dd8-9dd7573e8c13">
@@ -2207,8 +2207,8 @@
 						<en>Argilla Road</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} besucht seinen Vater ${.self:"role":2:"firstname"} in Illinois, ein linksliberaler, ökologisch eingestellter Geschichtsprofessor, und sie sprechen sich aus, u.a. über die kapitalistische ${.self:"role":3:"firstname"}. Er äußert die Vermutung wirtschaftskrimineller Manipulationen.</de>
-						<en>${.self:"role":0:"firstname"} visits his father ${.self:"role":2:"firstname"} in Illinois, a left-liberal, ecologically-minded history professor, and they speak out, among other things, about the capitalist ${.self:"role":3:"firstname"}. He expresses the suspicion of criminal white-collar activity.</en>
+						<de>${.self:"role":1:"firstname"} besucht seinen Vater ${.self:"role":3:"firstname"} in Illinois, ein linksliberaler, ökologisch eingestellter Geschichtsprofessor, und sie sprechen sich aus, u.a. über die kapitalistische ${.self:"role":4:"firstname"}. Er äußert die Vermutung wirtschaftskrimineller Manipulationen.</de>
+						<en>${.self:"role":1:"firstname"} visits his father ${.self:"role":3:"firstname"} in Illinois, a left-liberal, ecologically-minded history professor, and they speak out, among other things, about the capitalist ${.self:"role":4:"firstname"}. He expresses the suspicion of criminal white-collar activity.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="e898fcdd-01ef-446e-87c4-c2433487be70">
@@ -2221,8 +2221,8 @@
 						<en>In the Black</en>
 					</title_original>
 					<description>
-						<de>Nach Boston zurückgekehrt findet ${.self:"role":0:"firstname"} bei ${.self:"role":1:"firstname"} Unterschlupf und erfährt vom Attentat auf ${.self:"role":4:"firstname"} nach deren Schwangerschaftsabbruch. Plötzlich ereignet sich ein starkes Erdbeben. Das Chemiewerk wird zerstört, und der Strom fällt aus.</de>
-						<en>Back in Boston, ${.self:"role":0:"firstname"} finds shelter with ${.self:"role":1:"firstname"} and learns about the assassination attempt on ${.self:"role":4:"firstname"} after her abortion. Suddenly a strong earthquake occurs. The chemical plant is destroyed and the power goes out.</en>
+						<de>Nach Boston zurückgekehrt findet ${.self:"role":1:"firstname"} bei ${.self:"role":2:"firstname"} Unterschlupf und erfährt vom Attentat auf ${.self:"role":5:"firstname"} nach deren Schwangerschaftsabbruch. Plötzlich ereignet sich ein starkes Erdbeben. Das Chemiewerk wird zerstört, und der Strom fällt aus.</de>
+						<en>Back in Boston, ${.self:"role":1:"firstname"} finds shelter with ${.self:"role":2:"firstname"} and learns about the assassination attempt on ${.self:"role":5:"firstname"} after her abortion. Suddenly a strong earthquake occurs. The chemical plant is destroyed and the power goes out.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -2254,29 +2254,29 @@
 		<scripttemplate product="2" licence_type="3" guid="57ad453d-1c0e-4d84-acbb-e06e6ceedd8c" creator="9551" comment="https://en.wikipedia.org/wiki/Jonathan_Franzen | https://en.wikipedia.org/wiki/Purity_(novel)">
 			<title>
 				<de>Reinheit</de>
-				<en>${.self:"role":0:"firstname"}</en>
+				<en>${.self:"role":1:"firstname"}</en>
 			</title>
 			<title_original>
 				<de>Unschuld</de>
 				<en>Purity</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"firstname"} ist 23 und hat 130.000 Dollar Studienkredit-Schulden. Ihre zurückgezogen lebende Mutter weigert sich, ihr etwas über ihren Vater oder gar ihr früheres Leben zu erzählen. Die Suche führt sie nach Bolivien und Denver.</de>
-				<en>${.self:"role":0:"firstname"} is 23 and has $130,000 in student-loan debt. Her reclusive mother refuses to tell her anything about her father or even her previous life. The quest leads her to Bolivia and Denver.</en>
+				<de>${.self:"role":1:"firstname"} ist 23 und hat 130.000 Dollar Studienkredit-Schulden. Ihre zurückgezogen lebende Mutter weigert sich, ihr etwas über ihren Vater oder gar ihr früheres Leben zu erzählen. Die Suche führt sie nach Bolivien und Denver.</de>
+				<en>${.self:"role":1:"firstname"} is 23 and has $130,000 in student-loan debt. Her reclusive mother refuses to tell her anything about her father or even her previous life. The quest leads her to Bolivia and Denver.</en>
 			</description>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="366ea5d1-b85c-46ab-8cfa-15e453e6b519">
 					<title>
-						<de>${.self:"role":0:"firstname"} in der Bay Area</de>
-						<en>${.self:"role":0:"firstname"} in the Bay Area</en>
+						<de>${.self:"role":1:"firstname"} in der Bay Area</de>
+						<en>${.self:"role":1:"firstname"} in the Bay Area</en>
 					</title>
 					<title_original>
 						<de>Purity in Oakland</de>
 						<en>Purity in Oakland</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} arbeitet als Telemarketerin und lebt wegen ihrer heimlichen Liebe zu einem verheirateten Mann mietfrei in einem besetzten Haus. ${.self:"role":5:"firstname"}, eine schöne deutsche Aktivistin, bringt sie nach Bolivien zur Arbeit bei einer Whistleblowing-Plattform.</de>
-						<en>${.self:"role":0:"firstname"} works as a telemarketer and lives in a squat rent-free house because of her secret love for a married man. ${.self:"role":5:"firstname"}, a beautiful German activist, takes her to Bolivia to work for a whistleblowing platform.</en>
+						<de>${.self:"role":1:"firstname"} arbeitet als Telemarketerin und lebt wegen ihrer heimlichen Liebe zu einem verheirateten Mann mietfrei in einem besetzten Haus. ${.self:"role":6:"firstname"}, eine schöne deutsche Aktivistin, bringt sie nach Bolivien zur Arbeit bei einer Whistleblowing-Plattform.</de>
+						<en>${.self:"role":1:"firstname"} works as a telemarketer and lives in a squat rent-free house because of her secret love for a married man. ${.self:"role":6:"firstname"}, a beautiful German activist, takes her to Bolivia to work for a whistleblowing platform.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="f031cc2a-c6d2-4e1e-a513-de2087e4264d">
@@ -2289,8 +2289,8 @@
 						<en>The Republic of Bad Taste</en>
 					</title_original>
 					<description>
-						<de>Die Vorgeschichte von ${.self:"role":1:"fullname"}, Gründer der Whistleblowing-Plattform. 1987 ist er 27 Jahre alt und lebt in Ostdeutschland, wo er als Jugendbetreuer tätig ist und routinemäßig Sex mit den Teenager-Mädchen hat. Er lernt die geplagte 15-jährige ${.self:"role":5:"firstname"} kennen.</de>
-						<en>The back story of ${.self:"role":1:"fullname"}, founder of the whistleblowing platform. In 1987 he is 27, living in East Germany, where he acts as a youth councillor, routinely having sex with the teenaged girls. He meets the troubled 15 year-old ${.self:"role":5:"firstname"}.</en>
+						<de>Die Vorgeschichte von ${.self:"role":2:"fullname"}, Gründer der Whistleblowing-Plattform. 1987 ist er 27 Jahre alt und lebt in Ostdeutschland, wo er als Jugendbetreuer tätig ist und routinemäßig Sex mit den Teenager-Mädchen hat. Er lernt die geplagte 15-jährige ${.self:"role":6:"firstname"} kennen.</de>
+						<en>The back story of ${.self:"role":2:"fullname"}, founder of the whistleblowing platform. In 1987 he is 27, living in East Germany, where he acts as a youth councillor, routinely having sex with the teenaged girls. He meets the troubled 15 year-old ${.self:"role":6:"firstname"}.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="dc424071-e9e4-4e9e-993f-311edf960662">
@@ -2303,8 +2303,8 @@
 						<en>Too Much Information</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":2:"fullname"} ist eine 52-jährige Enthüllungsjournalistin bei einer Zeitung in Denver, wo ${.self:"role":0:"firstname"} jetzt als Praktikantin arbeitet. ${.self:"role":2:"firstname"} ist begeistert von ihr und drängt Gründer und Herausgeber ${.self:"role":3:"fullname"}, ihre Rolle und ihr Gehalt zu erweitern.</de>
-						<en>${.self:"role":2:"fullname"} is a 52-year-old investigative journalist for a newspaper in Denver, where ${.self:"role":0:"firstname"} is now working as an intern. ${.self:"role":2:"firstname"} is enthralled by her und presses founder and editor ${.self:"role":3:"fullname"} to expand her role and salary.</en>
+						<de>${.self:"role":3:"fullname"} ist eine 52-jährige Enthüllungsjournalistin bei einer Zeitung in Denver, wo ${.self:"role":1:"firstname"} jetzt als Praktikantin arbeitet. ${.self:"role":3:"firstname"} ist begeistert von ihr und drängt Gründer und Herausgeber ${.self:"role":4:"fullname"}, ihre Rolle und ihr Gehalt zu erweitern.</de>
+						<en>${.self:"role":3:"fullname"} is a 52-year-old investigative journalist for a newspaper in Denver, where ${.self:"role":1:"firstname"} is now working as an intern. ${.self:"role":3:"firstname"} is enthralled by her und presses founder and editor ${.self:"role":4:"fullname"} to expand her role and salary.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="5ffce4de-85ce-4f57-a74f-0cb4672a0785">
@@ -2317,8 +2317,8 @@
 						<en>Moonglow Dairy</en>
 					</title_original>
 					<description>
-						<de>Rückblick auf die Arbeit von ${.self:"role":0:"firstname"} in Bolivien, die sie liebt, aber sie ist konsterniert über die bizarre Hierarchie. ${.self:"role":1:"firstname"} macht ihr sexuelle Avancen und sagt ihr, dass es unmöglich sei, ihren Vater ausfindig zu machen.</de>
-						<en>Cutback to ${.self:"role":0:"firstname"}'s work in Bolivia, which she loves, but she is dismayed by the bizarre hierarchy. ${.self:"role":1:"firstname"} makes sexual advances and tells her that it is impossible to track down her father.</en>
+						<de>Rückblick auf die Arbeit von ${.self:"role":1:"firstname"} in Bolivien, die sie liebt, aber sie ist konsterniert über die bizarre Hierarchie. ${.self:"role":2:"firstname"} macht ihr sexuelle Avancen und sagt ihr, dass es unmöglich sei, ihren Vater ausfindig zu machen.</de>
+						<en>Cutback to ${.self:"role":1:"firstname"}'s work in Bolivia, which she loves, but she is dismayed by the bizarre hierarchy. ${.self:"role":2:"firstname"} makes sexual advances and tells her that it is impossible to track down her father.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="9aee3548-61c4-4670-b2c5-2ea9e0acf9a8">
@@ -2331,8 +2331,8 @@
 						<en>[le1o9n8a0rd]</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":3:"fullname"}s Hintergrundgeschichte über seine missbräuchliche Ehe und seine Reise nach Ostdeutschland in den 90er Jahren, wo er ${.self:"role":1:"firstname"} trifft und ihm hilft, die Leiche von ${.self:"role":5:"firstname"}s missbräuchlichem Stiefvater zu entsorgen.</de>
-						<en>${.self:"role":3:"fullname"}'s backstory about his abusive marriage and his trip to East Germany in the 90s, where he meets ${.self:"role":1:"firstname"} and helps him dispose of the body of ${.self:"role":5:"firstname"}'s abusive stepfather.</en>
+						<de>${.self:"role":4:"fullname"}s Hintergrundgeschichte über seine missbräuchliche Ehe und seine Reise nach Ostdeutschland in den 90er Jahren, wo er ${.self:"role":2:"firstname"} trifft und ihm hilft, die Leiche von ${.self:"role":6:"firstname"}s missbräuchlichem Stiefvater zu entsorgen.</de>
+						<en>${.self:"role":4:"fullname"}'s backstory about his abusive marriage and his trip to East Germany in the 90s, where he meets ${.self:"role":2:"firstname"} and helps him dispose of the body of ${.self:"role":6:"firstname"}'s abusive stepfather.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="5" product="2" licence_type="2" guid="74a3f68f-fcc7-48c7-8c61-8232f71c2450">
@@ -2345,8 +2345,8 @@
 						<en>The Killer</en>
 					</title_original>
 					<description>
-						<de>Nach zehn Jahren Lieblosigkeit verlässt ${.self:"role":1:"firstname"} ${.self:"role":5:"firstname"} und wird wegen Veröffentlichung von Geheiminformationen zu einem meistgesuchten Mann, der schließlich seine Operationen in einem versteckten Paradies in Bolivien ansiedelt.</de>
-						<en>After ten years of lovelessness, ${.self:"role":1:"firstname"} leaves ${.self:"role":5:"firstname"} and becomes a most-wanted man for his leaking of secrets, eventually basing his operations in a hidden paradise within Bolivia.</en>
+						<de>Nach zehn Jahren Lieblosigkeit verlässt ${.self:"role":2:"firstname"} ${.self:"role":6:"firstname"} und wird wegen Veröffentlichung von Geheiminformationen zu einem meistgesuchten Mann, der schließlich seine Operationen in einem versteckten Paradies in Bolivien ansiedelt.</de>
+						<en>After ten years of lovelessness, ${.self:"role":2:"firstname"} leaves ${.self:"role":6:"firstname"} and becomes a most-wanted man for his leaking of secrets, eventually basing his operations in a hidden paradise within Bolivia.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="6" product="2" licence_type="2" guid="c2e59aee-11a3-477f-90af-6bf1bdbcccb9">
@@ -2359,8 +2359,8 @@
 						<en>The Rain Comes</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} versucht, sich mit dem Wissen, wer sie ist, zu arrangieren. Sie offenbart sich dem Verwalter des Treuhandfonds ihrer Mutter, dem weitgehend die Hände gebunden sind, wenn ${.self:"role":4:"firstname"} keine Freigabeerklärung unterschreibt.</de>
-						<en>${.self:"role":0:"firstname"} is trying to come to terms with the knowledge of who she is. She reveals herself to her mother's trust-fund manager, whose hands are mostly tied if ${.self:"role":4:"firstname"} does not sign a release document.</en>
+						<de>${.self:"role":1:"firstname"} versucht, sich mit dem Wissen, wer sie ist, zu arrangieren. Sie offenbart sich dem Verwalter des Treuhandfonds ihrer Mutter, dem weitgehend die Hände gebunden sind, wenn ${.self:"role":5:"firstname"} keine Freigabeerklärung unterschreibt.</de>
+						<en>${.self:"role":1:"firstname"} is trying to come to terms with the knowledge of who she is. She reveals herself to her mother's trust-fund manager, whose hands are mostly tied if ${.self:"role":5:"firstname"} does not sign a release document.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -2400,8 +2400,8 @@
 				<en>The Shadow of the Wind</en>
 			</title_original>
 			<description>
-				<de>Im Nachbürgerkriegs-Barcelona findet ${.self:"role":0:"fullname"}, Spross einer Buchhändlerdynastie, in einer geheimen Bibliothek einen längst vergessenen Roman. Seine Nachforschungen über die Herkunft bringen ihn ins Visier der Geheimpolizei.</de>
-				<en>In post-Civil War Barcelona, ${.self:"role":0:"fullname"}, scion of a dynasty of book sellers, finds a long-forgotten novel in a secret library. His research into its provenance puts him on the radar of the secret police.</en>
+				<de>Im Nachbürgerkriegs-Barcelona findet ${.self:"role":1:"fullname"}, Spross einer Buchhändlerdynastie, in einer geheimen Bibliothek einen längst vergessenen Roman. Seine Nachforschungen über die Herkunft bringen ihn ins Visier der Geheimpolizei.</de>
+				<en>In post-Civil War Barcelona, ${.self:"role":1:"fullname"}, scion of a dynasty of book sellers, finds a long-forgotten novel in a secret library. His research into its provenance puts him on the radar of the secret police.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -2438,8 +2438,8 @@
 				<en>The Angel's Game</en>
 			</title_original>
 			<description>
-				<de>In einer verlassenen Villa im 1920er Barcelona müht sich ${.self:"role":0:"fullname"} mit dem Schreiben reißerischer Krimis ab. Schließlich erhält er ein unwiderstehliches Angebot, ein Buch zu schreiben, das eine neue Religion begründen soll.</de>
-				<en>In an abandoned villa in 1920s Barcelona, ${.self:"role":0:"fullname"} struggles to write sensationalist crime novels. Finally, he receives an irresistible offer to write a book that is to found a new religion.</en>
+				<de>In einer verlassenen Villa im 1920er Barcelona müht sich ${.self:"role":1:"fullname"} mit dem Schreiben reißerischer Krimis ab. Schließlich erhält er ein unwiderstehliches Angebot, ein Buch zu schreiben, das eine neue Religion begründen soll.</de>
+				<en>In an abandoned villa in 1920s Barcelona, ${.self:"role":1:"fullname"} struggles to write sensationalist crime novels. Finally, he receives an irresistible offer to write a book that is to found a new religion.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -2476,8 +2476,8 @@
 				<en>The Prisoner of Heaven</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"firstname"} hat 1957 inzwischen selbst Familie und hilft seinem Vater in der Buchhandlung. Ein hinkender Alter ersteht eine wertvolle Erstausgabe und schreibt eine geheimnisvolle Widmung an Laden-Assistent ${.self:"role":2:"fullname"} hinein.</de>
-				<en>In 1957, ${.self:"role":0:"firstname"} has a family of his own and helps his father in the bookstore. A limping old man buys a valuable first edition and writes a mysterious dedication to store assistant ${.self:"role":2:"fullname"} into it.</en>
+				<de>${.self:"role":1:"firstname"} hat 1957 inzwischen selbst Familie und hilft seinem Vater in der Buchhandlung. Ein hinkender Alter ersteht eine wertvolle Erstausgabe und schreibt eine geheimnisvolle Widmung an Laden-Assistent ${.self:"role":3:"fullname"} hinein.</de>
+				<en>In 1957, ${.self:"role":1:"firstname"} has a family of his own and helps his father in the bookstore. A limping old man buys a valuable first edition and writes a mysterious dedication to store assistant ${.self:"role":3:"fullname"} into it.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -2514,8 +2514,8 @@
 				<en>The Labyrinth of Spirits</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"firstname"} hat herausgefunden, dass seine Mutter vom bösartigen Gefängnisdirektor ${.self:"role":1:"firstname"} ermordet wurde, nachdem sie gedroht hatte, zu enthüllen, dass er inhaftierte Autoren als Ghostwriter nutzt. Er sinnt nach Rache.</de>
-				<en>${.self:"role":0:"firstname"} has found out that his mother was murdered by vicious prison warden ${.self:"role":1:"firstname"} after she had threatened to reveal his use of imprisoned authors as ghostwriters. He seeks revenge.</en>
+				<de>${.self:"role":1:"firstname"} hat herausgefunden, dass seine Mutter vom bösartigen Gefängnisdirektor ${.self:"role":2:"firstname"} ermordet wurde, nachdem sie gedroht hatte, zu enthüllen, dass er inhaftierte Autoren als Ghostwriter nutzt. Er sinnt nach Rache.</de>
+				<en>${.self:"role":1:"firstname"} has found out that his mother was murdered by vicious prison warden ${.self:"role":2:"firstname"} after she had threatened to reveal his use of imprisoned authors as ghostwriters. He seeks revenge.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -2542,16 +2542,16 @@
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="9eac358b-717a-4a43-a699-71a813833b00" creator="9551" comment="https://en.wikipedia.org/wiki/Carlos_Ruiz_Zaf%C3%B3n | https://en.wikipedia.org/wiki/Marina_(novel)">
 			<title>
-				<de>${.self:"role":0:"firstname"}</de>
-				<en>${.self:"role":0:"firstname"}</en>
+				<de>${.self:"role":1:"firstname"}</de>
+				<en>${.self:"role":1:"firstname"}</en>
 			</title>
 			<title_original>
 				<de>Marina</de>
 				<en>Marina</en>
 			</title_original>
 			<description>
-				<de>Die 15-jährigen ${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} lernen sich kennen, verlieben sich, verfolgen eine schwarze Frau, die regelmäßig auf den Friedhof kommt, und entlarven die Machenschaften des scheinbar untoten Orthopäden ${.self:"role":2:"firstname"}.</de>
-				<en>The 15-year-olds ${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"} get to know each other, fall in love, follow a black woman who regularly comes to the cemetery, and expose the machinations of the seemingly undead orthopaedic surgeon ${.self:"role":2:"firstname"}.</en>
+				<de>Die 15-jährigen ${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} lernen sich kennen, verlieben sich, verfolgen eine schwarze Frau, die regelmäßig auf den Friedhof kommt, und entlarven die Machenschaften des scheinbar untoten Orthopäden ${.self:"role":3:"firstname"}.</de>
+				<en>The 15-year-olds ${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"} get to know each other, fall in love, follow a black woman who regularly comes to the cemetery, and expose the machinations of the seemingly undead orthopaedic surgeon ${.self:"role":3:"firstname"}.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -2579,16 +2579,16 @@
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="19e286f7-0b76-4377-b3c7-34e1887b1fda" creator="9551" comment="https://en.wikipedia.org/wiki/Steven_Millhauser | https://en.wikipedia.org/wiki/Martin_Dressler">
 			<title>
-				<de>${.self:"role":0:"fullname"} - Ein amerikanischer Fantast</de>
-				<en>${.self:"role":0:"fullname"} - The Legend of an American Fantast</en>
+				<de>${.self:"role":1:"fullname"} - Ein amerikanischer Fantast</de>
+				<en>${.self:"role":1:"fullname"} - The Legend of an American Fantast</en>
 			</title>
 			<title_original>
 				<de>Martin Dressler - Ein amerikanischer Träumer</de>
 				<en>Martin Dressler - The Tale of an American Dreamer</en>
 			</title_original>
 			<description>
-				<de>Der deutsche ${.self:"role":0:"firstname"} geht im 1900er New York unaufhaltbar den Weg des amerikanischen Traums, vom Zigarrenverkäufer und Liftboy zum Bauunternehmer, der Luxushotels eröffnet und eine geheimnisvolle Frau heiratet. Doch der Fall droht ständig.</de>
-				<en>In 1900s New York, the German ${.self:"role":0:"firstname"} unstoppably follows the path of the American dream, from cigar salesman and elevator boy to building contractor who opens luxury hotels and marries a mysterious woman. But the fall is constantly looming.</en>
+				<de>Der deutsche ${.self:"role":1:"firstname"} geht im 1900er New York unaufhaltbar den Weg des amerikanischen Traums, vom Zigarrenverkäufer und Liftboy zum Bauunternehmer, der Luxushotels eröffnet und eine geheimnisvolle Frau heiratet. Doch der Fall droht ständig.</de>
+				<en>In 1900s New York, the German ${.self:"role":1:"firstname"} unstoppably follows the path of the American dream, from cigar salesman and elevator boy to building contractor who opens luxury hotels and marries a mysterious woman. But the fall is constantly looming.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -2614,16 +2614,16 @@
 		</scripttemplate>
 		<scripttemplate product="2" licence_type="3" guid="6019f8fc-6df8-4649-a5b4-3eb6a70439e7" creator="9551" comment="https://en.wikipedia.org/wiki/Steven_Millhauser | https://en.wikipedia.org/wiki/Edwin_Mullhouse">
 			<title>
-				<de>${.self:"role":0:"fullname"}, Vita und Ableben eines amerikanischen Autors, 1943-1954, von ${.self:"role":1:"fullname"}</de>
-				<en>${.self:"role":0:"fullname"}, Vita and Demise of an American Author, 1943-1954, by ${.self:"role":1:"fullname"}</en>
+				<de>${.self:"role":1:"fullname"}, Vita und Ableben eines amerikanischen Autors, 1943-1954, von ${.self:"role":2:"fullname"}</de>
+				<en>${.self:"role":1:"fullname"}, Vita and Demise of an American Author, 1943-1954, by ${.self:"role":2:"fullname"}</en>
 			</title>
 			<title_original>
 				<de>Edwin Mullhouse, Leben und Tod eines amerikanischen Schriftstellers, 1943-1954, von Jeffrey Cartwright</de>
 				<en>Edwin Mullhouse: The Life and Death of an American Writer 1943-1954, by Jeffrey Cartwright</en>
 			</title_original>
 			<description>
-				<de>Der kleine ${.self:"role":0:"firstname"} ist ein „exzentrischer junger Angeber, der sich für sowas wie ein literarisches Wunder hält“, der mit 10 Jahren einen Roman schreibt, aber mit 11 auf mysteriöse Weise stirbt. Also erstellt sein bester Freund ${.self:"role":1:"firstname"} seine Biografie.</de>
-				<en>The little ${.self:"role":0:"firstname"} is an "eccentric young show-off who fancies himself something of a literary wonder", writes a novel at age 10, but dies mysteriously at age 11. And so his best friend ${.self:"role":1:"firstname"} compiles his biography.</en>
+				<de>Der kleine ${.self:"role":1:"firstname"} ist ein „exzentrischer junger Angeber, der sich für sowas wie ein literarisches Wunder hält“, der mit 10 Jahren einen Roman schreibt, aber mit 11 auf mysteriöse Weise stirbt. Also erstellt sein bester Freund ${.self:"role":2:"firstname"} seine Biografie.</de>
+				<en>The little ${.self:"role":1:"firstname"} is an "eccentric young show-off who fancies himself something of a literary wonder", writes a novel at age 10, but dies mysteriously at age 11. And so his best friend ${.self:"role":2:"firstname"} compiles his biography.</en>
 			</description>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="613bbbf0-0124-4f5a-97cd-f0e2466ae6b8">
@@ -2636,8 +2636,8 @@
 						<en>The Early Years: Aug. 1, 1943 - Aug. 1, 1949</en>
 					</title_original>
 					<description>
-						<de>Die „vorliterarischen Jahre“, in denen ${.self:"role":1:"firstname"} von ${.self:"role":0:"firstname"}s Geburt und Kindheit in Newfield, Connecticut, einschließlich der Zeit im Kindergarten erzählt.</de>
-						<en>The "pre-literate years" in which ${.self:"role":1:"firstname"} tells of ${.self:"role":0:"firstname"}'s birth and childhood in Newfield, Connecticut including time spent in Kindergarten.</en>
+						<de>Die „vorliterarischen Jahre“, in denen ${.self:"role":2:"firstname"} von ${.self:"role":1:"firstname"}s Geburt und Kindheit in Newfield, Connecticut, einschließlich der Zeit im Kindergarten erzählt.</de>
+						<en>The "pre-literate years" in which ${.self:"role":2:"firstname"} tells of ${.self:"role":1:"firstname"}'s birth and childhood in Newfield, Connecticut including time spent in Kindergarten.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="a2b04b81-327a-4c1b-aeba-aa3b0110b7bb">
@@ -2650,8 +2650,8 @@
 						<en>The Middle Years: Aug. 2, 1949 - Aug. 1, 1952</en>
 					</title_original>
 					<description>
-						<de>Die „belesenen Jahre“, in denen ${.self:"role":0:"firstname"} die Schule besucht; seine tragische Obsession mit ${.self:"role":2:"fullname"} steht dabei besonders im Mittelpunkt.</de>
-						<en>The "literate years" when ${.self:"role":0:"firstname"} attends school; his tragic obsession with ${.self:"role":2:"fullname"} featuring prominently.</en>
+						<de>Die „belesenen Jahre“, in denen ${.self:"role":1:"firstname"} die Schule besucht; seine tragische Obsession mit ${.self:"role":3:"fullname"} steht dabei besonders im Mittelpunkt.</de>
+						<en>The "literate years" when ${.self:"role":1:"firstname"} attends school; his tragic obsession with ${.self:"role":3:"fullname"} featuring prominently.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="674b9ff2-3d9b-43c7-9544-c9eb34cb0cb6">
@@ -2664,8 +2664,8 @@
 						<en>The Late Years: Aug. 2, 1952 - Aug. 1, 1954</en>
 					</title_original>
 					<description>
-						<de>Die „literarischen Jahre“ beinhalten ${.self:"role":0:"firstname"}s Verfassen des Romans „Cartoons“ und seinen vorzeitigen Tod.</de>
-						<en>The "literary years" cover the writing of ${.self:"role":0:"firstname"}'s novel "Cartoons" and his untimely death.</en>
+						<de>Die „literarischen Jahre“ beinhalten ${.self:"role":1:"firstname"}s Verfassen des Romans „Cartoons“ und seinen vorzeitigen Tod.</de>
+						<en>The "literary years" cover the writing of ${.self:"role":1:"firstname"}'s novel "Cartoons" and his untimely death.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -2701,8 +2701,8 @@
 				<en>Bones of the Moon</en>
 			</title_original>
 			<description>
-				<de>Die New Yorkerin ${.self:"role":0:"firstname"} findet endlich das Familienglück, doch in ihren Träumen in fantastischen Welten wird sie auch von ihrer dunklen Vergangenheit heimgesucht, und bald greifen die Traumereignisse auf die reale Welt in erschreckender Weise über.</de>
-				<en>New Yorker ${.self:"role":0:"firstname"} finally finds family happiness, but in her dreams in fantastic worlds she is also haunted by her dark past, and soon the dream events spill over into the real world in terrifying ways.</en>
+				<de>Die New Yorkerin ${.self:"role":1:"firstname"} findet endlich das Familienglück, doch in ihren Träumen in fantastischen Welten wird sie auch von ihrer dunklen Vergangenheit heimgesucht, und bald greifen die Traumereignisse auf die reale Welt in erschreckender Weise über.</de>
+				<en>New Yorker ${.self:"role":1:"firstname"} finally finds family happiness, but in her dreams in fantastic worlds she is also haunted by her dark past, and soon the dream events spill over into the real world in terrifying ways.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -2736,8 +2736,8 @@
 				<en>Hooligan</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"firstname"}s Match beginnt, wenn der Schiedsrichter abpfeift. Bei „seinem“ norddeutschen Profifußballclub steht er in der „3. Hälfte“ im Startaufgebot. Seine Jungs, die besten Jahre, ihr Vermächtnis sind ihm heilig. Frau und Kinder haben meist das Nachsehen.</de>
-				<en>${.self:"role":0:"firstname"}'s match starts when the referee blows the final whistle. For "his" northern German professional soccer club, he is in the starting lineup of the "3rd half". His buddies, their best years, their legacy are sacred to him. Wife and children are often neglected.</en>
+				<de>${.self:"role":1:"firstname"}s Match beginnt, wenn der Schiedsrichter abpfeift. Bei „seinem“ norddeutschen Profifußballclub steht er in der „3. Hälfte“ im Startaufgebot. Seine Jungs, die besten Jahre, ihr Vermächtnis sind ihm heilig. Frau und Kinder haben meist das Nachsehen.</de>
+				<en>${.self:"role":1:"firstname"}'s match starts when the referee blows the final whistle. For "his" northern German professional soccer club, he is in the starting lineup of the "3rd half". His buddies, their best years, their legacy are sacred to him. Wife and children are often neglected.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -2762,16 +2762,16 @@
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="e8a3bf50-ab02-43d8-b980-c0fb7234a3b4" creator="9551" comment="https://en.wikipedia.org/wiki/Bruno_Brazil">
 			<title>
-				<de>${.self:"role":0:"fullname"}</de>
-				<en>${.self:"role":0:"fullname"}</en>
+				<de>${.self:"role":1:"fullname"}</de>
+				<en>${.self:"role":1:"fullname"}</en>
 			</title>
 			<title_original>
 				<de>Bruno Brazil</de>
 				<en>Bruno Brazil</en>
 			</title_original>
 			<description>
-				<de>Realverfilmung des Comics. ${.self:"role":0:"firstname"} ist Anführer einer kleinen Elite-Kampfeinheit des US-Geheimdienstes, dem „Cayman Command“. Jedes Mitglied verfügt über besondere Fähigkeiten. Gemeinsam bekämpfen sie Verbrechen und exotische Bedrohungen.</de>
-				<en>Live-action adaptation of the comic book. ${.self:"role":0:"firstname"} is the leader of a small, elite combat unit of the US secret service, the "Cayman Command". Each member has some special skills. Together they fight crime and exotic threats.</en>
+				<de>Realverfilmung des Comics. ${.self:"role":1:"firstname"} ist Anführer einer kleinen Elite-Kampfeinheit des US-Geheimdienstes, dem „Cayman Command“. Jedes Mitglied verfügt über besondere Fähigkeiten. Gemeinsam bekämpfen sie Verbrechen und exotische Bedrohungen.</de>
+				<en>Live-action adaptation of the comic book. ${.self:"role":1:"firstname"} is the leader of a small, elite combat unit of the US secret service, the "Cayman Command". Each member has some special skills. Together they fight crime and exotic threats.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -2800,16 +2800,16 @@
 		</scripttemplate>
 		<scripttemplate product="2" licence_type="3" guid="d545bf8a-b0f4-4888-978e-2a6561027be0" creator="9551" comment="https://de.wikipedia.org/wiki/Kai_Meyer | https://de.wikipedia.org/wiki/Merle-Zyklus">
 			<title>
-				<de>${.self:"role":0:"firstname"}</de>
-				<en>${.self:"role":0:"firstname"}</en>
+				<de>${.self:"role":1:"firstname"}</de>
+				<en>${.self:"role":1:"firstname"}</en>
 			</title>
 			<title_original>
 				<de>Merle</de>
 				<en>Merle</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"firstname"} ist in einem Waisenhaus aufgewachsen und kommt mit 14 Jahren zusammen mit ${.self:"role":1:"firstname"} als Lehrling in die Werkstatt ${.self:"role":3:"firstname"}s. Die einzige Beziehung zu ihren Eltern ist der Zauberspiegel ihrer Mutter, der aus Wasser statt Glas besteht.</de>
-				<en>${.self:"role":0:"firstname"} grew up in an orphanage and comes to ${.self:"role":3:"firstname"}'s workshop as an apprentice at the age of 14, together with ${.self:"role":1:"firstname"}. The only relationship she has with her parents is her mother's magic mirror, which is made of water instead of glass.</en>
+				<de>${.self:"role":1:"firstname"} ist in einem Waisenhaus aufgewachsen und kommt mit 14 Jahren zusammen mit ${.self:"role":2:"firstname"} als Lehrling in die Werkstatt ${.self:"role":4:"firstname"}s. Die einzige Beziehung zu ihren Eltern ist der Zauberspiegel ihrer Mutter, der aus Wasser statt Glas besteht.</de>
+				<en>${.self:"role":1:"firstname"} grew up in an orphanage and comes to ${.self:"role":4:"firstname"}'s workshop as an apprentice at the age of 14, together with ${.self:"role":2:"firstname"}. The only relationship she has with her parents is her mother's magic mirror, which is made of water instead of glass.</en>
 			</description>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="d62fa0cb-c97f-462e-a749-2d2b824fc660">
@@ -2822,8 +2822,8 @@
 						<en>The Flowing Queen</en>
 					</title_original>
 					<description>
-						<de>Der ägyptische Pharao ist von seinen Hohepriestern wiederauferweckt worden und erobert die ganze Welt. Nur Venedig, wo ${.self:"role":0:"firstname"} und ihre Freunde leben, ist noch übrig. Und auch die Fließende Königin muss gerettet werden.</de>
-						<en>The Egyptian Pharaoh has been resurrected by his high priests and is conquering the whole world. Only Venice, where ${.self:"role":0:"firstname"} and her friends live, is left. And the Flowing Queen must also be rescued.</en>
+						<de>Der ägyptische Pharao ist von seinen Hohepriestern wiederauferweckt worden und erobert die ganze Welt. Nur Venedig, wo ${.self:"role":1:"firstname"} und ihre Freunde leben, ist noch übrig. Und auch die Fließende Königin muss gerettet werden.</de>
+						<en>The Egyptian Pharaoh has been resurrected by his high priests and is conquering the whole world. Only Venice, where ${.self:"role":1:"firstname"} and her friends live, is left. And the Flowing Queen must also be rescued.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="3d01ec35-0c90-4e84-a70c-8ee25ef5fda1">
@@ -2836,8 +2836,8 @@
 						<en>The Stone Light</en>
 					</title_original>
 					<description>
-						<de>In Venedig formt sich der Widerstand. ${.self:"role":0:"firstname"}, die Fließende Königin in ihr und ${.self:"role":4:"firstname"} fliegen zu Lord Licht, dem Herrscher der Hölle, der ihnen das Steinerne Licht zeigt, das durch die steinernen Herzen die Menschen kontrollieren kann.</de>
-						<en>In Venice, the resistance is forming. ${.self:"role":0:"firstname"}, the Flowing Queen within her, and ${.self:"role":4:"firstname"} fly to Lord Light, the ruler of Hell, who shows them the Stone Light, which can control people through the stone hearts.</en>
+						<de>In Venedig formt sich der Widerstand. ${.self:"role":1:"firstname"}, die Fließende Königin in ihr und ${.self:"role":5:"firstname"} fliegen zu Lord Licht, dem Herrscher der Hölle, der ihnen das Steinerne Licht zeigt, das durch die steinernen Herzen die Menschen kontrollieren kann.</de>
+						<en>In Venice, the resistance is forming. ${.self:"role":1:"firstname"}, the Flowing Queen within her, and ${.self:"role":5:"firstname"} fly to Lord Light, the ruler of Hell, who shows them the Stone Light, which can control people through the stone hearts.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="045b53c8-6d37-4c3d-a8a0-926f29688678">
@@ -2850,8 +2850,8 @@
 						<en>The Glass Word</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} und ihre Begleiter finden sich im völlig verschneiten Ägypten wieder. Gemeinsam mit dem ägyptischen Hohepriester Seth begeben sie sich zum Eisernen Auge, der Festung der Sphinxen.</de>
-						<en>${.self:"role":0:"firstname"} and their companions find themselves in Egypt, completely covered in snow. Together with the Egyptian high priest Seth, they go to the Iron Eye, the fortress of the Sphinxes.</en>
+						<de>${.self:"role":1:"firstname"} und ihre Begleiter finden sich im völlig verschneiten Ägypten wieder. Gemeinsam mit dem ägyptischen Hohepriester Seth begeben sie sich zum Eisernen Auge, der Festung der Sphinxen.</de>
+						<en>${.self:"role":1:"firstname"} and their companions find themselves in Egypt, completely covered in snow. Together with the Egyptian high priest Seth, they go to the Iron Eye, the fortress of the Sphinxes.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -2890,8 +2890,8 @@
 				<en>Railsea</en>
 			</title_original>
 			<description>
-				<de>Auf einer mit endlosen Gleisen durchzogenen Steampunk-Erde, die von riesigen fleischfressenden Viechern beherrscht wird, die von den Menschen Walfang-artig auch als Nahrung gejagt werden, machen sich ${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} auf die Suche nach einem Schatz.</de>
-				<en>On a steampunk Earth crisscrossed with endless connected railroad tracks and dominated by giant carnivorous creatures, that also are hunted whaling-like by humans for food, ${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"} set out to find a treasure.</en>
+				<de>Auf einer mit endlosen Gleisen durchzogenen Steampunk-Erde, die von riesigen fleischfressenden Viechern beherrscht wird, die von den Menschen Walfang-artig auch als Nahrung gejagt werden, machen sich ${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} auf die Suche nach einem Schatz.</de>
+				<en>On a steampunk Earth crisscrossed with endless connected railroad tracks and dominated by giant carnivorous creatures, that also are hunted whaling-like by humans for food, ${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"} set out to find a treasure.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -2917,58 +2917,58 @@
 		</scripttemplate>
 		<scripttemplate product="2" licence_type="3" guid="af65875a-62c6-44d2-8e62-844ed3b90a9a" creator="9551" comment="https://dc.fandom.com/wiki/Catwoman:_Selina%27s_Big_Score">
 			<title>
-				<de>Catlady: ${.self:"role":0:"firstname"}s großer Streich</de>
-				<en>Catlady: ${.self:"role":0:"firstname"}'s Big Shot</en>
+				<de>Catlady: ${.self:"role":1:"firstname"}s großer Streich</de>
+				<en>Catlady: ${.self:"role":1:"firstname"}'s Big Shot</en>
 			</title>
 			<title_original>
 				<de>Catwoman: Selinas großer Coup</de>
 				<en>Catwoman: Selina's Big Score</en>
 			</title_original>
 			<description>
-				<de>Spin-off und knallharter Heist-Thriller im Bat-Universum, in dem die Katzendame ${.self:"role":0:"fullname"} ein Team für einen Raubzug zusammenstellt, aber auf unerwartete Hindernisse trifft.</de>
-				<en>Spin-off and badass heist thriller in the Bat universe, in which the cat lady ${.self:"role":0:"fullname"} assembles a team for a heist but faces unexpected obstacles.</en>
+				<de>Spin-off und knallharter Heist-Thriller im Bat-Universum, in dem die Katzendame ${.self:"role":1:"fullname"} ein Team für einen Raubzug zusammenstellt, aber auf unerwartete Hindernisse trifft.</de>
+				<en>Spin-off and badass heist thriller in the Bat universe, in which the cat lady ${.self:"role":1:"fullname"} assembles a team for a heist but faces unexpected obstacles.</en>
 			</description>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="d1a8be89-1ded-49ee-8cb4-47cfd4cc64f9">
 					<title>
-						<de>${.self:"role":0:"fullname"}</de>
-						<en>${.self:"role":0:"fullname"}</en>
+						<de>${.self:"role":1:"fullname"}</de>
+						<en>${.self:"role":1:"fullname"}</en>
 					</title>
 					<title_original>
 						<de>Selina</de>
 						<en>Selina</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"fullname"}s Marokko-Raubzug geht schief, als sie feststellt, dass der „Cup of Hassan“ nicht echt ist. ${.self:"role":1:"firstname"} versorgt sie mit Bargeld und einem sicheren Haus in Gotham. Eine neue Gelegenheit wartet.</de>
-						<en>${.self:"role":0:"fullname"}'s Morocco heist goes awry when she realizes the 'Cup of Hassan' is a fake. ${.self:"role":1:"firstname"} sets her up with cash and a safe house in Gotham. A new opportunity is waiting.</en>
+						<de>${.self:"role":1:"fullname"}s Marokko-Raubzug geht schief, als sie feststellt, dass der „Cup of Hassan“ nicht echt ist. ${.self:"role":2:"firstname"} versorgt sie mit Bargeld und einem sicheren Haus in Gotham. Eine neue Gelegenheit wartet.</de>
+						<en>${.self:"role":1:"fullname"}'s Morocco heist goes awry when she realizes the 'Cup of Hassan' is a fake. ${.self:"role":2:"firstname"} sets her up with cash and a safe house in Gotham. A new opportunity is waiting.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="b54f96e8-2ad4-4714-a9ca-6b45a8d8a55d">
 					<title>
-						<de>${.self:"role":4:"firstname"}</de>
-						<en>${.self:"role":4:"firstname"}</en>
+						<de>${.self:"role":5:"firstname"}</de>
+						<en>${.self:"role":5:"firstname"}</en>
 					</title>
 					<title_original>
 						<de>Stark</de>
 						<en>Stark</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} und ${.self:"role":4:"firstname"} stimmen dem Eisenbahnraub zu, aber ${.self:"role":4:"firstname"} besteht darauf, die Kontrolle zu behalten. Sie planen, sich in fünf Tagen in Las Vegas zu treffen. ${.self:"role":4:"firstname"} warnt ${.self:"role":0:"firstname"} vor einem Privatdetektiv.</de>
-						<en>${.self:"role":0:"firstname"} and ${.self:"role":4:"firstname"} agree to the train heist, but ${.self:"role":4:"firstname"} insists on being in control. They plan to meet in Las Vegas in five days. ${.self:"role":4:"firstname"} warns ${.self:"role":0:"firstname"} of a private investigator.</en>
+						<de>${.self:"role":1:"firstname"} und ${.self:"role":5:"firstname"} stimmen dem Eisenbahnraub zu, aber ${.self:"role":5:"firstname"} besteht darauf, die Kontrolle zu behalten. Sie planen, sich in fünf Tagen in Las Vegas zu treffen. ${.self:"role":5:"firstname"} warnt ${.self:"role":1:"firstname"} vor einem Privatdetektiv.</de>
+						<en>${.self:"role":1:"firstname"} and ${.self:"role":5:"firstname"} agree to the train heist, but ${.self:"role":5:"firstname"} insists on being in control. They plan to meet in Las Vegas in five days. ${.self:"role":5:"firstname"} warns ${.self:"role":1:"firstname"} of a private investigator.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="403a5846-8d8b-4d21-87a6-4817ffbf7c4b">
 					<title>
-						<de>${.self:"role":5:"firstname"}</de>
-						<en>${.self:"role":5:"firstname"}</en>
+						<de>${.self:"role":6:"firstname"}</de>
+						<en>${.self:"role":6:"firstname"}</en>
 					</title>
 					<title_original>
 						<de>Slam</de>
 						<en>Slam</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":5:"fullname"} wartet auf ${.self:"role":0:"firstname"}, trifft aber beim Verlassen von ${.self:"role":1:"firstname"}'s auf ${.self:"role":3:"firstname"}. Er folgt ${.self:"role":0:"firstname"}s und ${.self:"role":3:"firstname"}s Spur, muss aber feststellen, dass ${.self:"role":3:"firstname"} von ${.self:"role":2:"fullname"} schwer verprügelt wurde. ${.self:"role":5:"firstname"} tötet ${.self:"role":2:"firstname"}s Männer.</de>
-						<en>${.self:"role":5:"fullname"} waits for ${.self:"role":0:"firstname"} but encounters ${.self:"role":3:"firstname"} leaving ${.self:"role":1:"firstname"}'s. He follows ${.self:"role":0:"firstname"} and ${.self:"role":3:"firstname"}'s trail, only to discover ${.self:"role":3:"firstname"} badly beaten by ${.self:"role":2:"fullname"}. ${.self:"role":5:"firstname"} kills ${.self:"role":2:"firstname"}'s men.</en>
+						<de>${.self:"role":6:"fullname"} wartet auf ${.self:"role":1:"firstname"}, trifft aber beim Verlassen von ${.self:"role":2:"firstname"}'s auf ${.self:"role":4:"firstname"}. Er folgt ${.self:"role":1:"firstname"}s und ${.self:"role":4:"firstname"}s Spur, muss aber feststellen, dass ${.self:"role":4:"firstname"} von ${.self:"role":3:"fullname"} schwer verprügelt wurde. ${.self:"role":6:"firstname"} tötet ${.self:"role":3:"firstname"}s Männer.</de>
+						<en>${.self:"role":6:"fullname"} waits for ${.self:"role":1:"firstname"} but encounters ${.self:"role":4:"firstname"} leaving ${.self:"role":2:"firstname"}'s. He follows ${.self:"role":1:"firstname"} and ${.self:"role":4:"firstname"}'s trail, only to discover ${.self:"role":4:"firstname"} badly beaten by ${.self:"role":3:"fullname"}. ${.self:"role":6:"firstname"} kills ${.self:"role":3:"firstname"}'s men.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="a093e4f1-27ee-4da0-8690-587c565a5da6">
@@ -2981,8 +2981,8 @@
 						<en>Score</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"}, ${.self:"role":6:"firstname"} und ${.self:"role":4:"firstname"} entern erfolgreich den Geldtransport-Zug und werfen die Taschen in den Fluss. ${.self:"role":1:"firstname"}s Boot wartet unten, aber als das Trio an Bord geht, wird auf sie geschossen.</de>
-						<en>${.self:"role":0:"firstname"}, ${.self:"role":6:"firstname"}, and ${.self:"role":4:"firstname"} successfully board the money train, tossing the bags into the river. ${.self:"role":1:"firstname"}'s boat waits below, but when the trio boards, they are shot at.</en>
+						<de>${.self:"role":1:"firstname"}, ${.self:"role":7:"firstname"} und ${.self:"role":5:"firstname"} entern erfolgreich den Geldtransport-Zug und werfen die Taschen in den Fluss. ${.self:"role":2:"firstname"}s Boot wartet unten, aber als das Trio an Bord geht, wird auf sie geschossen.</de>
+						<en>${.self:"role":1:"firstname"}, ${.self:"role":7:"firstname"}, and ${.self:"role":5:"firstname"} successfully board the money train, tossing the bags into the river. ${.self:"role":2:"firstname"}'s boat waits below, but when the trio boards, they are shot at.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -3049,8 +3049,8 @@
 						<en>The Fall of Hyperion</en>
 					</title_original>
 					<description>
-						<de>Während die Pilger im Tal der Zeitgräber auf das Erscheinen des ${.self:"role":3:"firstname"} warten, führt Präsidentin ${.self:"role":0:"fullname"} am Regierungssitz Tau Ceti Center ihren eigenen Feldzug voller List, Tücke und geheimer Pläne.</de>
-						<en>While the pilgrims in the Valley of the Time Tombs wait for the ${.self:"role":3:"firstname"} to appear, President ${.self:"role":0:"fullname"} is fighting her own battle of cunning, guile and secret plans at the Tau Ceti Center seat of government.</en>
+						<de>Während die Pilger im Tal der Zeitgräber auf das Erscheinen des ${.self:"role":4:"firstname"} warten, führt Präsidentin ${.self:"role":1:"fullname"} am Regierungssitz Tau Ceti Center ihren eigenen Feldzug voller List, Tücke und geheimer Pläne.</de>
+						<en>While the pilgrims in the Valley of the Time Tombs wait for the ${.self:"role":4:"firstname"} to appear, President ${.self:"role":1:"fullname"} is fighting her own battle of cunning, guile and secret plans at the Tau Ceti Center seat of government.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="ab3b4af4-3a10-4ee0-8aca-ff13d1cc613f">
@@ -3063,8 +3063,8 @@
 						<en>Endymion</en>
 					</title_original>
 					<description>
-						<de>Gut 250 Jahre später, nach dem Fall der Regierung, als ${.self:"role":2:"firstname"}, die Tochter von ${.self:"role":5:"fullname"} und ${.self:"role":4:"firstname"}, verschwand, soll sie wieder auftauchen. Der Pax schickt 30.000 Soldaten zu den Gräbern.</de>
-						<en>A good 250 years later, after the fall of the government, when ${.self:"role":2:"firstname"}, the daughter of ${.self:"role":5:"fullname"} and ${.self:"role":4:"firstname"}, disappeared, she is supposed to reappear. The Pax sends 30,000 soldiers to the tombs.</en>
+						<de>Gut 250 Jahre später, nach dem Fall der Regierung, als ${.self:"role":3:"firstname"}, die Tochter von ${.self:"role":6:"fullname"} und ${.self:"role":5:"firstname"}, verschwand, soll sie wieder auftauchen. Der Pax schickt 30.000 Soldaten zu den Gräbern.</de>
+						<en>A good 250 years later, after the fall of the government, when ${.self:"role":3:"firstname"}, the daughter of ${.self:"role":6:"fullname"} and ${.self:"role":5:"firstname"}, disappeared, she is supposed to reappear. The Pax sends 30,000 soldiers to the tombs.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="37a91695-7c4d-493c-b802-35af0495cf77">
@@ -3077,8 +3077,8 @@
 						<en>The Rise of Endymion</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":2:"firstname"} schickt ${.self:"role":1:"firstname"} alleine zurück auf den Thetysfluss, um das inzwischen reparierte Raumschiff des Konsul zu suchen. Sie selbst realisiert auf verschiedenen Welten unterschiedliche Bauaufträge als Architektin.</de>
-						<en>${.self:"role":2:"firstname"} sends ${.self:"role":1:"firstname"} alone back to the Thetys River to search for the Consul's spaceship, which has since been repaired. She herself realizes different building contracts as an architect on different worlds.</en>
+						<de>${.self:"role":3:"firstname"} schickt ${.self:"role":2:"firstname"} alleine zurück auf den Thetysfluss, um das inzwischen reparierte Raumschiff des Konsul zu suchen. Sie selbst realisiert auf verschiedenen Welten unterschiedliche Bauaufträge als Architektin.</de>
+						<en>${.self:"role":3:"firstname"} sends ${.self:"role":2:"firstname"} alone back to the Thetys River to search for the Consul's spaceship, which has since been repaired. She herself realizes different building contracts as an architect on different worlds.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -3124,8 +3124,8 @@
 				<en>Ilium/Olympos</en>
 			</title_original>
 			<description>
-				<de>Raum und Zeit sind manipulierbar. ${.self:"role":0:"fullname"}, ein nach 4200 Jahren von den Göttern (sind es überhaupt die „echten“?) wiederbelebter Historiker aus dem 21. Jahrhundert, studiert Homer und den Trojanischen Krieg und hat selbst Einfluss auf das Geschehen.</de>
-				<en>Space and time can be manipulated. ${.self:"role":0:"fullname"}, a 21st century historian resurrected by the gods (are they even the “real” ones?) after 4200 years, studies Homer and the Trojan War and influences the events himself.</en>
+				<de>Raum und Zeit sind manipulierbar. ${.self:"role":1:"fullname"}, ein nach 4200 Jahren von den Göttern (sind es überhaupt die „echten“?) wiederbelebter Historiker aus dem 21. Jahrhundert, studiert Homer und den Trojanischen Krieg und hat selbst Einfluss auf das Geschehen.</de>
+				<en>Space and time can be manipulated. ${.self:"role":1:"fullname"}, a 21st century historian resurrected by the gods (are they even the “real” ones?) after 4200 years, studies Homer and the Trojan War and influences the events himself.</en>
 			</description>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="031f264a-4cbe-4d5d-9462-76ae0d37a550" comment="https://en.wikipedia.org/wiki/Ilium_(novel)">
@@ -3138,8 +3138,8 @@
 						<en>Ilium</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"}, in der Gestalt von ${.self:"role":6:"firstname"}, erschleicht sich ein Schäferstündchen mit der schönen ${.self:"role":3:"fullname"}, doch die hält ihm dann einen Dolch an die Kehle und entwickelt einen Plan, mit dessen Verwirklichung der Krieg zwischen Griechen und Trojanern endet.</de>
-						<en>${.self:"role":0:"firstname"}, in the guise of ${.self:"role":6:"firstname"}, surreptitiously obtains an amorous tête-à-tête with beautiful ${.self:"role":3:"fullname"}, but she then holds a dagger to his throat and devises a plan which would bring the war between the Greeks and Trojans to an end.</en>
+						<de>${.self:"role":1:"firstname"}, in der Gestalt von ${.self:"role":7:"firstname"}, erschleicht sich ein Schäferstündchen mit der schönen ${.self:"role":4:"fullname"}, doch die hält ihm dann einen Dolch an die Kehle und entwickelt einen Plan, mit dessen Verwirklichung der Krieg zwischen Griechen und Trojanern endet.</de>
+						<en>${.self:"role":1:"firstname"}, in the guise of ${.self:"role":7:"firstname"}, surreptitiously obtains an amorous tête-à-tête with beautiful ${.self:"role":4:"fullname"}, but she then holds a dagger to his throat and devises a plan which would bring the war between the Greeks and Trojans to an end.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="30fee702-4677-45b9-935f-f4dee9c1205a" comment="https://en.wikipedia.org/wiki/Olympos_(novel)">
@@ -3203,8 +3203,8 @@
 				<en>Escapade</en>
 			</title_original>
 			<description>
-				<de>Im Sommer 1921 treffen sich 13 illustre Gäste zu einer Séance in Devon. Der Earl of Axminster wird ermordet in einem verschlossenen Zimmer aufgefunden. Die berühmten ${.self:"role":2:"fullname"} und Der Große ${.self:"role":3:"fullname"} bieten ihre Hilfe an.</de>
-				<en>Summer of 1921, 13 distinguished guests gather together for a séance in Devon. The Earl of Axminster is found murdered in a locked room. The famous ${.self:"role":2:"fullname"} and The Great ${.self:"role":3:"fullname"} offer their help.</en>
+				<de>Im Sommer 1921 treffen sich 13 illustre Gäste zu einer Séance in Devon. Der Earl of Axminster wird ermordet in einem verschlossenen Zimmer aufgefunden. Die berühmten ${.self:"role":3:"fullname"} und Der Große ${.self:"role":4:"fullname"} bieten ihre Hilfe an.</de>
+				<en>Summer of 1921, 13 distinguished guests gather together for a séance in Devon. The Earl of Axminster is found murdered in a locked room. The famous ${.self:"role":3:"fullname"} and The Great ${.self:"role":4:"fullname"} offer their help.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -3243,8 +3243,8 @@
 				<en>Masquerade</en>
 			</title_original>
 			<description>
-				<de>Paris 1923 ist ein Mekka für Maler und Schriftsteller aus aller Welt, und die Lost Generation beginnt gerade erst, sich selbst zu finden. ${.self:"role":0:"fullname"} und ${.self:"role":1:"fullname"} untersuchen den Tod eines reichen Verlegers und treffen berühmte Persönlichkeiten.</de>
-				<en>Paris 1923 is a mecca for painters and writers from all over the world, and the Lost Generation is just now beginning to find itself. ${.self:"role":0:"fullname"} and ${.self:"role":1:"fullname"} investigate the demise of a rich publisher and meet famous personalities.</en>
+				<de>Paris 1923 ist ein Mekka für Maler und Schriftsteller aus aller Welt, und die Lost Generation beginnt gerade erst, sich selbst zu finden. ${.self:"role":1:"fullname"} und ${.self:"role":2:"fullname"} untersuchen den Tod eines reichen Verlegers und treffen berühmte Persönlichkeiten.</de>
+				<en>Paris 1923 is a mecca for painters and writers from all over the world, and the Lost Generation is just now beginning to find itself. ${.self:"role":1:"fullname"} and ${.self:"role":2:"fullname"} investigate the demise of a rich publisher and meet famous personalities.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -3283,8 +3283,8 @@
 				<en>Cavalcade</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} werden 1923 nach Deutschland geschickt, um den Killer zu finden, der fast erfolgreich ${.self:"role":3:"fullname"} ermordet hätte. Ihr Betreuer ist ein großer fröhlicher Kerl, aber die Agenten sehen immer mehr von der schrecklichen Seite dieser neuen Partei.</de>
-				<en>${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"} are sent to Germany in 1923 to find the hitman that almost succeeded in killing ${.self:"role":3:"fullname"}. Their guide is a huge and jovial guy, but the agents begin to see an increasing amount of this new party's dreadful face.</en>
+				<de>${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} werden 1923 nach Deutschland geschickt, um den Killer zu finden, der fast erfolgreich ${.self:"role":4:"fullname"} ermordet hätte. Ihr Betreuer ist ein großer fröhlicher Kerl, aber die Agenten sehen immer mehr von der schrecklichen Seite dieser neuen Partei.</de>
+				<en>${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"} are sent to Germany in 1923 to find the hitman that almost succeeded in killing ${.self:"role":4:"fullname"}. Their guide is a huge and jovial guy, but the agents begin to see an increasing amount of this new party's dreadful face.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -3315,16 +3315,16 @@
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="b3aa52bd-7bf4-4d41-81a8-9e51b6ac0301" creator="9551" comment="https://de.wikipedia.org/wiki/Walter_Satterthwait | https://www.goodreads.com/book/show/1232991.Wilde_West">
 			<title>
-				<de>${.self:"role":0:"fullname"} im Amerikanischen Westen</de>
-				<en>${.self:"role":0:"fullname"}'s West</en>
+				<de>${.self:"role":1:"fullname"} im Amerikanischen Westen</de>
+				<en>${.self:"role":1:"fullname"}'s West</en>
 			</title>
 			<title_original>
 				<de>Oscar Wilde im Wilden Westen</de>
 				<en>Wilde West</en>
 			</title_original>
 			<description>
-				<de>Der berühmte Schriftsteller ${.self:"role":0:"fullname"} ist sich nicht zu fein für eine Vortragsreise durch den Wilden Westen und trifft Persönlichkeiten wie ${.self:"role":1:"fullname"}. Doch es geschehen Morde, die ihm angehängt werden.</de>
-				<en>The famous writer ${.self:"role":0:"fullname"} is not too refined for a lecture tour through the Wild West and meets personalities like ${.self:"role":1:"fullname"}. But murders happen and he is framed for them.</en>
+				<de>Der berühmte Schriftsteller ${.self:"role":1:"fullname"} ist sich nicht zu fein für eine Vortragsreise durch den Wilden Westen und trifft Persönlichkeiten wie ${.self:"role":2:"fullname"}. Doch es geschehen Morde, die ihm angehängt werden.</de>
+				<en>The famous writer ${.self:"role":1:"fullname"} is not too refined for a lecture tour through the Wild West and meets personalities like ${.self:"role":2:"fullname"}. But murders happen and he is framed for them.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -3352,16 +3352,16 @@
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="56617d57-9cb3-40a8-afb0-e4621524c8f9" creator="9551" comment="https://de.wikipedia.org/wiki/Walter_Satterthwait | https://www.goodreads.com/book/show/1802533.Miss_Lizzie | translators: the rhyming verse might also be on some on the other language versions of https://en.wikipedia.org/wiki/Lizzie_Borden">
 			<title>
-				<de>Miss ${.self:"role":0:"firstname"}</de>
-				<en>Miss ${.self:"role":0:"firstname"}</en>
+				<de>Miss ${.self:"role":1:"firstname"}</de>
+				<en>Miss ${.self:"role":1:"firstname"}</en>
 			</title>
 			<title_original>
 				<de>Miss Lizzie</de>
 				<en>Miss Lizzie</en>
 			</title_original>
 			<description>
-				<de>„${.self:"role":0:"fullname"} mit dem Beile, hackt Mama in 40 Teile. Das Ergebnis freut sie sehr, bei Papa wird's ein Teil mehr.“ 1892 freigesprochen (wahre Geschichte) trifft sie 61-jährig 1921 (fiktiv) auf die kleine ${.self:"role":1:"firstname"}. Auch deren verhasste Stiefmutter wird bald erschlagen aufgefunden.</de>
-				<en>"${.self:"role":0:"fullname"} took an axe and gave her mother forty whacks. When she saw what she had done, she gave her father forty-one." Acquitted in 1892 (true story), in 1921 at the age of 61 she (fictionally) encounters little ${.self:"role":1:"firstname"}, whose hated stepmother is also soon found slain.</en>
+				<de>„${.self:"role":1:"fullname"} mit dem Beile, hackt Mama in 40 Teile. Das Ergebnis freut sie sehr, bei Papa wird's ein Teil mehr.“ 1892 freigesprochen (wahre Geschichte) trifft sie 61-jährig 1921 (fiktiv) auf die kleine ${.self:"role":2:"firstname"}. Auch deren verhasste Stiefmutter wird bald erschlagen aufgefunden.</de>
+				<en>"${.self:"role":1:"fullname"} took an axe and gave her mother forty whacks. When she saw what she had done, she gave her father forty-one." Acquitted in 1892 (true story), in 1921 at the age of 61 she (fictionally) encounters little ${.self:"role":2:"firstname"}, whose hated stepmother is also soon found slain.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -3392,16 +3392,16 @@
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="f0dce9e4-e7d5-4e7b-b84b-64247bdd944b" creator="9551" comment="https://de.wikipedia.org/wiki/Walter_Satterthwait | https://www.goodreads.com/book/show/27601309-new-york-nocturne">
 			<title>
-				<de>Miss ${.self:"role":0:"firstname"} ist wieder da</de>
-				<en>Manhattan Nights: Miss ${.self:"role":0:"firstname"} Is Back</en>
+				<de>Miss ${.self:"role":1:"firstname"} ist wieder da</de>
+				<en>Manhattan Nights: Miss ${.self:"role":1:"firstname"} Is Back</en>
 			</title>
 			<title_original>
 				<de>Miss Lizzie kehrt zurück</de>
 				<en>New York Nocturne: The Return of Miss Lizzie</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":1:"firstname"} macht mit ihrem Onkel ${.self:"role":2:"firstname"} in den „Roaring Twenties“ New York unsicher - bis er mit einem Beil erschlagen in der Bibliothek gefunden wird. ${.self:"role":0:"fullname"} kommt erneut zur Hilfe, um ${.self:"role":1:"firstname"}s Unschuld zu beweisen.</de>
-				<en>${.self:"role":1:"firstname"} and her uncle ${.self:"role":2:"firstname"} are on the loose in the New York of the Roaring Twenties - until he is found slain with an axe in the library. ${.self:"role":0:"fullname"} again comes to the rescue to prove ${.self:"role":1:"firstname"}'s innocence.</en>
+				<de>${.self:"role":2:"firstname"} macht mit ihrem Onkel ${.self:"role":3:"firstname"} in den „Roaring Twenties“ New York unsicher - bis er mit einem Beil erschlagen in der Bibliothek gefunden wird. ${.self:"role":1:"fullname"} kommt erneut zur Hilfe, um ${.self:"role":2:"firstname"}s Unschuld zu beweisen.</de>
+				<en>${.self:"role":2:"firstname"} and her uncle ${.self:"role":3:"firstname"} are on the loose in the New York of the Roaring Twenties - until he is found slain with an axe in the library. ${.self:"role":1:"fullname"} again comes to the rescue to prove ${.self:"role":2:"firstname"}'s innocence.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -3437,8 +3437,8 @@
 				<en>Dead Horse</en>
 			</title_original>
 			<description>
-				<de>1933 heiratet die reiche ${.self:"role":1:"firstname"} den erfolgreichen Groschenroman-Autor ${.self:"role":0:"firstname"}. Sie feiern ausschweifende Partys auf ihrer Ranch nahe Las Vegas. 1935 begeht ${.self:"role":1:"firstname"} Selbstmord (wahre Geschichte). Was ist wirklich passiert (fiktiv-spekulativ)?</de>
-				<en>In 1933, the wealthy ${.self:"role":1:"firstname"} marries the successful pulp fiction author ${.self:"role":0:"firstname"}. They celebrate lavish parties on their ranch near Las Vegas. In 1935 ${.self:"role":1:"firstname"} commits suicide (true story). What actually happened (fictional-speculative)?</en>
+				<de>1933 heiratet die reiche ${.self:"role":2:"firstname"} den erfolgreichen Groschenroman-Autor ${.self:"role":1:"firstname"}. Sie feiern ausschweifende Partys auf ihrer Ranch nahe Las Vegas. 1935 begeht ${.self:"role":2:"firstname"} Selbstmord (wahre Geschichte). Was ist wirklich passiert (fiktiv-spekulativ)?</de>
+				<en>In 1933, the wealthy ${.self:"role":2:"firstname"} marries the successful pulp fiction author ${.self:"role":1:"firstname"}. They celebrate lavish parties on their ranch near Las Vegas. In 1935 ${.self:"role":2:"firstname"} commits suicide (true story). What actually happened (fictional-speculative)?</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -3485,8 +3485,8 @@
 						<en>Legends in Exile</en>
 					</title_original>
 					<description>
-						<de>Die Einführung von Fabletown und den wichtigsten Figuren. ${.self:"role":0:"fullname"} untersucht den scheinbaren Mord an ${.self:"role":2:"firstname"}. (Sie wurde ja einst im Bett erwischt mit dem ${.self:"role":3:"firstname"}, dem damaligen Verlobten ihrer Schwester ${.self:"role":1:"firstname"} aka Schneeweißchen.)</de>
-						<en>The introduction to Fabletown. ${.self:"role":0:"fullname"} investigates the apparent murder of ${.self:"role":2:"firstname"}. (She was once caught in bed with ${.self:"role":3:"firstname"}, the then-fiancé of her sister ${.self:"role":1:"firstname"}.)</en>
+						<de>Die Einführung von Fabletown und den wichtigsten Figuren. ${.self:"role":1:"fullname"} untersucht den scheinbaren Mord an ${.self:"role":3:"firstname"}. (Sie wurde ja einst im Bett erwischt mit dem ${.self:"role":4:"firstname"}, dem damaligen Verlobten ihrer Schwester ${.self:"role":2:"firstname"} aka Schneeweißchen.)</de>
+						<en>The introduction to Fabletown. ${.self:"role":1:"fullname"} investigates the apparent murder of ${.self:"role":3:"firstname"}. (She was once caught in bed with ${.self:"role":4:"firstname"}, the then-fiancé of her sister ${.self:"role":2:"firstname"}.)</en>
 					</description>
 					<jobs>
 						<job index="15" function="2" required="1" role_guid="847e75c4-c92a-4539-a606-4adbf3c84e44" />
@@ -3506,8 +3506,8 @@
 						<en>Animal Farm</en>
 					</title_original>
 					<description>
-						<de>Die Einführung der Farm, einem Ort für diejenigen Fables, die keine menschliche Gestalt haben oder keine annehmen können. Langsam kommt es auf der Farm zu einer Revolte, die von ${.self:"role":1:"firstname"} eingedämmt werden muss.</de>
-						<en>The introduction of the farm, a place for those Fables who are not human or cannot take on human form. Gradually, a revolt occurs on the farm, which must be contained by ${.self:"role":1:"firstname"}.</en>
+						<de>Die Einführung der Farm, einem Ort für diejenigen Fables, die keine menschliche Gestalt haben oder keine annehmen können. Langsam kommt es auf der Farm zu einer Revolte, die von ${.self:"role":2:"firstname"} eingedämmt werden muss.</de>
+						<en>The introduction of the farm, a place for those Fables who are not human or cannot take on human form. Gradually, a revolt occurs on the farm, which must be contained by ${.self:"role":2:"firstname"}.</en>
 					</description>
 					<jobs>
 						<job index="15" function="2" required="1" role_guid="847e75c4-c92a-4539-a606-4adbf3c84e44" />
@@ -3558,8 +3558,8 @@
 						<en>Storybook Love</en>
 					</title_original>
 					<description>
-						<de>Blaubart versucht ${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} loszuwerden, indem er sie verzaubert und die mörderische Goldlöckchen auf die beiden hetzt. Der ${.self:"role":3:"firstname"} beschließt währenddessen, als Bürgermeister von Fabletown zu kandidieren.</de>
-						<en>Bluebeard hatches a plot to rid himself of ${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"} by enchanting them, and the homicidal Goldilocks attempts to kill the pair. ${.self:"role":3:"firstname"} decides to run for Fabletown Mayor.</en> <!-- TODO: Make ref Bluebeard, Goldilocks -->
+						<de>Blaubart versucht ${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} loszuwerden, indem er sie verzaubert und die mörderische Goldlöckchen auf die beiden hetzt. Der ${.self:"role":4:"firstname"} beschließt währenddessen, als Bürgermeister von Fabletown zu kandidieren.</de>
+						<en>Bluebeard hatches a plot to rid himself of ${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"} by enchanting them, and the homicidal Goldilocks attempts to kill the pair. ${.self:"role":4:"firstname"} decides to run for Fabletown Mayor.</en> <!-- TODO: Make ref Bluebeard, Goldilocks -->
 					</description>
 					<jobs>
 						<job index="15" function="2" required="1" role_guid="847e75c4-c92a-4539-a606-4adbf3c84e44" />
@@ -3575,8 +3575,8 @@
 						<en>Barleycorn Brides</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} erzählt dem Fliegenfänger (aka Froschkönig) die Geschichte eines alten Smalltown-Brauchs.</de>
-						<en>${.self:"role":0:"firstname"} tells Flycatcher (aka the Frog Prince) the story of a Smalltown tradition.</en> <!-- TODO: make ref Flycatcher -->
+						<de>${.self:"role":1:"firstname"} erzählt dem Fliegenfänger (aka Froschkönig) die Geschichte eines alten Smalltown-Brauchs.</de>
+						<en>${.self:"role":1:"firstname"} tells Flycatcher (aka the Frog Prince) the story of a Smalltown tradition.</en> <!-- TODO: make ref Flycatcher -->
 					</description>
 				</scripttemplate>
 				<scripttemplate index="6" product="2" licence_type="2" guid="7f395aa2-ecef-4f40-b06b-357da0a72d87">
@@ -3589,22 +3589,22 @@
 						<en>March of the Wooden Soldiers</en>
 					</title_original>
 					<description>
-						<de>Der ${.self:"role":3:"fullname"} kandidiert weiter für das Amt des Bürgermeisters von Fabletown, während die Gemeinde sich mit der scheinbaren Flucht von Rotkappe aus der Heimat beschäftigt. Der Feind sendet seine ersten Truppen nach Fabletown, um einen Angriff zu beginnen.</de>
-						<en>${.self:"role":3:"fullname"} runs for Mayor of Fabletown while the community deals with the apparent escape from the Homelands of Red Riding Hood. The Adversary sends his first troops into Fabletown to begin an assault.</en> <!-- TODO: make ref Red Riding Hood -->
+						<de>Der ${.self:"role":4:"fullname"} kandidiert weiter für das Amt des Bürgermeisters von Fabletown, während die Gemeinde sich mit der scheinbaren Flucht von Rotkappe aus der Heimat beschäftigt. Der Feind sendet seine ersten Truppen nach Fabletown, um einen Angriff zu beginnen.</de>
+						<en>${.self:"role":4:"fullname"} runs for Mayor of Fabletown while the community deals with the apparent escape from the Homelands of Red Riding Hood. The Adversary sends his first troops into Fabletown to begin an assault.</en> <!-- TODO: make ref Red Riding Hood -->
 					</description>
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="dae9db61-7427-4053-89ee-e756d8369998">
 					<title>
-						<de>${.self:"role":4:"firstname"} zügellos</de>
-						<en>${.self:"role":4:"firstname"} Libertine</en>
+						<de>${.self:"role":5:"firstname"} zügellos</de>
+						<en>${.self:"role":5:"firstname"} Libertine</en>
 					</title>
 					<title_original>
-						<de>${.self:"role":4:"firstname"} zügellos</de>
-						<en>${.self:"role":4:"firstname"} Libertine</en>
+						<de>${.self:"role":5:"firstname"} zügellos</de>
+						<en>${.self:"role":5:"firstname"} Libertine</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":4:"firstname"}s scheinbar frivole Lebensweise stellt sich als Tarnung für andere Tätigkeiten heraus.</de>
-						<en>${.self:"role":4:"firstname"}'s apparently frivolous lifestyle is revealed to be a front.</en>
+						<de>${.self:"role":5:"firstname"}s scheinbar frivole Lebensweise stellt sich als Tarnung für andere Tätigkeiten heraus.</de>
+						<en>${.self:"role":5:"firstname"}'s apparently frivolous lifestyle is revealed to be a front.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -3663,8 +3663,8 @@
 						<en>War Stories</en>
 					</title_original>
 					<description>
-						<de>Ein Abenteuer von ${.self:"role":0:"firstname"} während des Zweiten Weltkriegs.</de>
-						<en>${.self:"role":0:"firstname"}'s adventures during World War II.</en>
+						<de>Ein Abenteuer von ${.self:"role":1:"firstname"} während des Zweiten Weltkriegs.</de>
+						<en>${.self:"role":1:"firstname"}'s adventures during World War II.</en>
 					</description>
 					<effects>
 						<effect trigger="broadcastFirstTime" type="modifyScriptAvailability" enable="1" guid="e80a40b9-dd11-47a1-be43-6c766ac33365" />
@@ -3680,8 +3680,8 @@
 						<en>The Long Year</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":1:"firstname"}s Kinder werden geboren, und sie erkennt, dass sie auf die Farm umziehen muss. ${.self:"role":0:"firstname"} (der wie ein Werwolf mutieren kann) ist dort nicht willkommen und begibt sich stattdessen ins Exil. ${.self:"role":1:"firstname"} begegnet ${.self:"role":0:"firstname"}s entfremdetem Vater, dem Nordwind.</de>
-						<en>${.self:"role":1:"firstname"} gives birth and realizes she must relocate to the Farm. ${.self:"role":0:"firstname"} (who can mutate like a werewolf) isn't allowed there and instead exiles himself. ${.self:"role":1:"firstname"} encounters ${.self:"role":0:"firstname"}'s estranged father, the North Wind.</en> <!-- TODO: Make ref North Wind -->
+						<de>${.self:"role":2:"firstname"}s Kinder werden geboren, und sie erkennt, dass sie auf die Farm umziehen muss. ${.self:"role":1:"firstname"} (der wie ein Werwolf mutieren kann) ist dort nicht willkommen und begibt sich stattdessen ins Exil. ${.self:"role":2:"firstname"} begegnet ${.self:"role":1:"firstname"}s entfremdetem Vater, dem Nordwind.</de>
+						<en>${.self:"role":2:"firstname"} gives birth and realizes she must relocate to the Farm. ${.self:"role":1:"firstname"} (who can mutate like a werewolf) isn't allowed there and instead exiles himself. ${.self:"role":2:"firstname"} encounters ${.self:"role":1:"firstname"}'s estranged father, the North Wind.</en> <!-- TODO: Make ref North Wind -->
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="5a08d936-69b4-47e7-a4ba-2112f8085735">
@@ -3776,8 +3776,8 @@
 						<en>Wolves</en>
 					</title_original>
 					<description>
-						<de>Mowgli sucht nach dem vermissten ${.self:"role":0:"firstname"} und bringt ihm eine Nachricht aus Fabletown.</de>
-						<en>Mowgli searches for the missing ${.self:"role":0:"firstname"} and brings him a message from Fabletown.</en> <!-- TODO: Make ref Mowgli -->
+						<de>Mowgli sucht nach dem vermissten ${.self:"role":1:"firstname"} und bringt ihm eine Nachricht aus Fabletown.</de>
+						<en>Mowgli searches for the missing ${.self:"role":1:"firstname"} and brings him a message from Fabletown.</en> <!-- TODO: Make ref Mowgli -->
 					</description>
 					<jobs>
 						<job index="16" function="2" required="1" role_guid="12543516-3a0f-40fe-8eab-10ff7d799dab" />
@@ -3839,8 +3839,8 @@
 						<en>Happily Ever After</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} kehrt zurück nach Fabletown, überbringt dem Feind eine Warnung und heiratet ${.self:"role":1:"firstname"}.</de>
-						<en>${.self:"role":0:"firstname"} returns to Fabletown, delivers a warning to the Adversary and marries ${.self:"role":1:"firstname"}.</en>
+						<de>${.self:"role":1:"firstname"} kehrt zurück nach Fabletown, überbringt dem Feind eine Warnung und heiratet ${.self:"role":2:"firstname"}.</de>
+						<en>${.self:"role":1:"firstname"} returns to Fabletown, delivers a warning to the Adversary and marries ${.self:"role":2:"firstname"}.</en>
 					</description>
 					<effects>
 						<effect trigger="broadcastFirstTime" type="modifyScriptAvailability" enable="1" guid="89d9d6e9-7348-4894-86c3-18f64aa25d85" />
@@ -3856,8 +3856,8 @@
 						<en>Big and Small</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":4:"firstname"} setzt ihre Mission im Wolkenkönigreich fort, muss aber in eine Maus verwandelt werden, um die Hilfe von Smalltowns Arzt in Anspruch nehmen und einen kranken Riesenkönig behandeln zu können.</de>
-						<en>${.self:"role":4:"firstname"} continues her mission in the Cloud Kingdom, but must be turned into a mouse and enlist the aid of Smalltown's resident medic in order to treat a sick giant king.</en>
+						<de>${.self:"role":5:"firstname"} setzt ihre Mission im Wolkenkönigreich fort, muss aber in eine Maus verwandelt werden, um die Hilfe von Smalltowns Arzt in Anspruch nehmen und einen kranken Riesenkönig behandeln zu können.</de>
+						<en>${.self:"role":5:"firstname"} continues her mission in the Cloud Kingdom, but must be turned into a mouse and enlist the aid of Smalltown's resident medic in order to treat a sick giant king.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="18cc412b-5745-4101-99a6-895afba325d5">
@@ -3905,8 +3905,8 @@
 						<en>Father and Son</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} entscheidet sich, dass die Zeit gekommen ist, sich mit seinem Vater, dem Nordwind, auszusprechen. Auf einer Jagd begegnen seine Kinder ${.self:"role":0:"firstname"}s Geschwistern, die mehr Tiere als Menschen sind.</de>
-						<en>${.self:"role":0:"firstname"} decides that the time has come to square things with his father, the North Wind. On a hunt, his children encounter ${.self:"role":0:"firstname"}'s siblings, who have become more beasts than men.</en> <!-- TODO: make ref North Wind -->
+						<de>${.self:"role":1:"firstname"} entscheidet sich, dass die Zeit gekommen ist, sich mit seinem Vater, dem Nordwind, auszusprechen. Auf einer Jagd begegnen seine Kinder ${.self:"role":1:"firstname"}s Geschwistern, die mehr Tiere als Menschen sind.</de>
+						<en>${.self:"role":1:"firstname"} decides that the time has come to square things with his father, the North Wind. On a hunt, his children encounter ${.self:"role":1:"firstname"}'s siblings, who have become more beasts than men.</en> <!-- TODO: make ref North Wind -->
 					</description>
 				</scripttemplate>
 				<scripttemplate index="5" product="2" licence_type="2" guid="8c6d0770-cf8b-4401-be65-49d09d270123">
@@ -3947,8 +3947,8 @@
 						<en>The Birthday Secret</en>
 					</title_original>
 					<description>
-						<de>Auf der Farm beginnen die Vorbereitung für den Krieg gegen den Feind. Die Kinder von ${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} feiern ihren Geburtstag.</de>
-						<en>Preparation for war begins at the Farm. The children of ${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"} celebrate their birthday.</en>
+						<de>Auf der Farm beginnen die Vorbereitung für den Krieg gegen den Feind. Die Kinder von ${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} feiern ihren Geburtstag.</de>
+						<en>Preparation for war begins at the Farm. The children of ${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"} celebrate their birthday.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -4008,8 +4008,8 @@
 						<en>Kingdom Come</en>
 					</title_original>
 					<description>
-						<de>Boy Blue und ${.self:"role":2:"firstname"} diskutieren ihre Beziehung. Das Angebot von Fliegenfänger wird der Farm überbracht. Pläne, den Krieg zu beginnen, werden geschmiedet.</de>
-						<en>Boy Blue and ${.self:"role":2:"firstname"} discuss their relationship. Flycatcher's offer is brought to the Farm. Plans are made to begin the war.</en> <!-- TODO: make ref Boy Blue, Flycatcher -->
+						<de>Boy Blue und ${.self:"role":3:"firstname"} diskutieren ihre Beziehung. Das Angebot von Fliegenfänger wird der Farm überbracht. Pläne, den Krieg zu beginnen, werden geschmiedet.</de>
+						<en>Boy Blue and ${.self:"role":3:"firstname"} discuss their relationship. Flycatcher's offer is brought to the Farm. Plans are made to begin the war.</en> <!-- TODO: make ref Boy Blue, Flycatcher -->
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="3e672816-13b3-4d69-967f-6cea90d88032">
@@ -4022,8 +4022,8 @@
 						<en>Skullduggery</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":4:"firstname"} zahlt Frau Totenkinder ihre Schulden zurück, indem sie eine Mission übernimmt, die sie nach Süden führt.</de> <!-- TODO: Make ref Frau Totenkinder -->
-						<en>${.self:"role":4:"firstname"} repays her debt to Frau Totenkinder by going on a mission down South.</en>
+						<de>${.self:"role":5:"firstname"} zahlt Frau Totenkinder ihre Schulden zurück, indem sie eine Mission übernimmt, die sie nach Süden führt.</de> <!-- TODO: Make ref Frau Totenkinder -->
+						<en>${.self:"role":5:"firstname"} repays her debt to Frau Totenkinder by going on a mission down South.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="18aa12b8-9b0f-488c-8d65-267a456787db">
@@ -4109,8 +4109,8 @@
 						<en>New Dark Powers</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} und ${.self:"role":6:"firstname"} geraten in einen heftigen Kampf, der den Einfluss der neuen dunklen Mächte aufzeigt. ${.self:"role":1:"firstname"} versinkt immer tiefer in Depressionen. Jack Horner kehrt zurück und begegnet seinem Sohn, dem neuen Jack Frost.</de>
-						<en>${.self:"role":0:"firstname"} and ${.self:"role":6:"firstname"} get into a violent fight that demonstrates the influence of the dark powers present. ${.self:"role":1:"firstname"} sinks deeper and deeper into depression. Jack Horner returns and encounters his son, the new Jack Frost.</en> <!-- TODO: add ref Jack Horner, Jack Frost -->
+						<de>${.self:"role":1:"firstname"} und ${.self:"role":7:"firstname"} geraten in einen heftigen Kampf, der den Einfluss der neuen dunklen Mächte aufzeigt. ${.self:"role":2:"firstname"} versinkt immer tiefer in Depressionen. Jack Horner kehrt zurück und begegnet seinem Sohn, dem neuen Jack Frost.</de>
+						<en>${.self:"role":1:"firstname"} and ${.self:"role":7:"firstname"} get into a violent fight that demonstrates the influence of the dark powers present. ${.self:"role":2:"firstname"} sinks deeper and deeper into depression. Jack Horner returns and encounters his son, the new Jack Frost.</en> <!-- TODO: add ref Jack Horner, Jack Frost -->
 					</description>
 					<jobs>
 						<job index="17" function="2" required="1" role_guid="2e366ce8-f292-4483-acb0-4a83b7808133" />
@@ -4197,16 +4197,16 @@
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="91ce0ca8-c448-4c4d-b162-078ba29ad1d4">
 					<title>
-						<de>Der Zauberspruch der ${.self:"role":1:"firstname"}</de>
-						<en>${.self:"role":1:"firstname"} Magic</en>
+						<de>Der Zauberspruch der ${.self:"role":2:"firstname"}</de>
+						<en>${.self:"role":2:"firstname"} Magic</en>
 					</title>
 					<title_original>
 						<de>Chamäleon Zauber</de>
 						<en>A Spell for Chameleon</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} wird in das dröge Mundania (unsere Welt) verbannt, weil er versehentlich das Gesetz gebrochen hat, indem er kein magisches Talent hat. Er findet einige talentierte Gefährten, die ihm helfen, besonders das wandlungsfähige Mädchen ${.self:"role":1:"firstname"}.</de>
-						<en>${.self:"role":0:"firstname"} is exiled to the dreary (our) Mundane World because he has inadvertently broken the law by not having a magical talent. He finds some talented companions to help him, especially the chameleonic girl ${.self:"role":1:"firstname"}.</en>
+						<de>${.self:"role":1:"firstname"} wird in das dröge Mundania (unsere Welt) verbannt, weil er versehentlich das Gesetz gebrochen hat, indem er kein magisches Talent hat. Er findet einige talentierte Gefährten, die ihm helfen, besonders das wandlungsfähige Mädchen ${.self:"role":2:"firstname"}.</de>
+						<en>${.self:"role":1:"firstname"} is exiled to the dreary (our) Mundane World because he has inadvertently broken the law by not having a magical talent. He finds some talented companions to help him, especially the chameleonic girl ${.self:"role":2:"firstname"}.</en>
 					</description>
 					<effects>
 						<effect trigger="broadcastFirstTime" type="modifyScriptAvailability" guid="f75c6a8b-d30b-48a2-b6bc-1458c19ca7ce" />
@@ -4222,8 +4222,8 @@
 						<en>The Source of Magic</en>
 					</title_original>
 					<description>
-						<de>König ${.self:"role":2:"firstname"} hat ${.self:"role":0:"firstname"}, der nun verheiratet mit ${.self:"role":1:"firstname"} ist, zum offiziellen Forscher ernannt, der nun die Aufgabe hat, das Geheimnis der Magie des Landes zu ergründen und herauszufinden, woher sie kommt.</de>
-						<en>King ${.self:"role":2:"firstname"} has appointed ${.self:"role":0:"firstname"}, who is now married to ${.self:"role":1:"firstname"}, the Official Researcher, who is now tasked to discover the secret behind the magic of the land and where it comes from.</en>
+						<de>König ${.self:"role":3:"firstname"} hat ${.self:"role":1:"firstname"}, der nun verheiratet mit ${.self:"role":2:"firstname"} ist, zum offiziellen Forscher ernannt, der nun die Aufgabe hat, das Geheimnis der Magie des Landes zu ergründen und herauszufinden, woher sie kommt.</de>
+						<en>King ${.self:"role":3:"firstname"} has appointed ${.self:"role":1:"firstname"}, who is now married to ${.self:"role":2:"firstname"}, the Official Researcher, who is now tasked to discover the secret behind the magic of the land and where it comes from.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="8e98489a-ccb1-4759-9c43-c91cd81acd2d">
@@ -4236,8 +4236,8 @@
 						<en>Castle Roogna</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":3:"firstname"}, der nun 12-jährige Sohn von ${.self:"role":0:"firstname"}, kann den Thron erben. Doch sein Selbstvertrauen ist gering, er wird von seinen Altersgenossen und gar von Prinzessin ${.self:"role":4:"firstname"} drangsaliert, weil seine ihm eigenen magischen Fähigkeiten ein wenig unkonventionell sind.</de>
-						<en>${.self:"role":3:"firstname"}, the now 12 year old son of ${.self:"role":0:"firstname"}, can inherit the throne. However, his confidence is low, he is bullied by his agemates and even Princess ${.self:"role":4:"firstname"} because his particular magical abilities are a bit unconvential.</en>
+						<de>${.self:"role":4:"firstname"}, der nun 12-jährige Sohn von ${.self:"role":1:"firstname"}, kann den Thron erben. Doch sein Selbstvertrauen ist gering, er wird von seinen Altersgenossen und gar von Prinzessin ${.self:"role":5:"firstname"} drangsaliert, weil seine ihm eigenen magischen Fähigkeiten ein wenig unkonventionell sind.</de>
+						<en>${.self:"role":4:"firstname"}, the now 12 year old son of ${.self:"role":1:"firstname"}, can inherit the throne. However, his confidence is low, he is bullied by his agemates and even Princess ${.self:"role":5:"firstname"} because his particular magical abilities are a bit unconvential.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -4287,8 +4287,8 @@
 						<en>Centaur Aisle</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":1:"firstname"} ist vorübergehend König, weil ${.self:"role":0:"firstname"} auf einer Mission in Mundania ist. Als er nicht zurückzukehren scheint, begibt er sich auf eine Reise, um Hilfe zu holen, und trifft dabei auf ${.self:"role":2:"firstname"} den Zentauren.</de>
-						<en>${.self:"role":1:"firstname"} is temporarily king because ${.self:"role":0:"firstname"} is on a mission in the Mundane World. When he won't seem to return, he embarks on a journey to get some help and meets ${.self:"role":2:"firstname"} the Centaur.</en>
+						<de>${.self:"role":2:"firstname"} ist vorübergehend König, weil ${.self:"role":1:"firstname"} auf einer Mission in Mundania ist. Als er nicht zurückzukehren scheint, begibt er sich auf eine Reise, um Hilfe zu holen, und trifft dabei auf ${.self:"role":3:"firstname"} den Zentauren.</de>
+						<en>${.self:"role":2:"firstname"} is temporarily king because ${.self:"role":1:"firstname"} is on a mission in the Mundane World. When he won't seem to return, he embarks on a journey to get some help and meets ${.self:"role":3:"firstname"} the Centaur.</en>
 					</description>
 					<effects>
 						<effect trigger="broadcastFirstTime" type="modifyScriptAvailability" guid="f06a42e2-b666-4353-bc53-a0b262071814" />
@@ -4304,8 +4304,8 @@
 						<en>Ogre, Ogre</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":3:"firstname"}, der Halb-Oger, sucht den Guten Magier ${.self:"role":4:"firstname"} auf, um eine Antwort auf seine Frage zu erhalten, obwohl er nicht weiß, was seine Frage ist. Der Magier rät ihm, zu den Ur-Ogern zu reisen.</de>
-						<en>${.self:"role":3:"firstname"} the half-ogre goes to see the Good Magician ${.self:"role":4:"firstname"} to get his question answered, although he doesn't know what his question is. The magician tells him to ravel to the Ancestral Ogres.</en>
+						<de>${.self:"role":4:"firstname"}, der Halb-Oger, sucht den Guten Magier ${.self:"role":5:"firstname"} auf, um eine Antwort auf seine Frage zu erhalten, obwohl er nicht weiß, was seine Frage ist. Der Magier rät ihm, zu den Ur-Ogern zu reisen.</de>
+						<en>${.self:"role":4:"firstname"} the half-ogre goes to see the Good Magician ${.self:"role":5:"firstname"} to get his question answered, although he doesn't know what his question is. The magician tells him to ravel to the Ancestral Ogres.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="95c68e19-35d4-4955-b1f0-9d0db05ca225">
@@ -4318,8 +4318,8 @@
 						<en>Night Mare</en>
 					</title_original>
 					<description>
-						<de>Mähre ${.self:"role":5:"firstname"} ist eine der Nachtmähren, die beauftragt ist, den Bewohnern Albträume zu bringen. Sie ist nicht gewillt, ihre Seele aufzugeben, doch das damit verbundene Gewissen behindert ihre Fähigkeit, die Träume zu überbringen.</de>
-						<en>Mare ${.self:"role":5:"firstname"} is one of the night mares charged with delivering bad dreams to the inhabitants. She is unwilling to relinquish her soul, though the conscience that comes with it impedes her ability to deliver the dreams.</en>
+						<de>Mähre ${.self:"role":6:"firstname"} ist eine der Nachtmähren, die beauftragt ist, den Bewohnern Albträume zu bringen. Sie ist nicht gewillt, ihre Seele aufzugeben, doch das damit verbundene Gewissen behindert ihre Fähigkeit, die Träume zu überbringen.</de>
+						<en>Mare ${.self:"role":6:"firstname"} is one of the night mares charged with delivering bad dreams to the inhabitants. She is unwilling to relinquish her soul, though the conscience that comes with it impedes her ability to deliver the dreams.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -4370,8 +4370,8 @@
 						<en>Dragon on a Pedestal</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} und sein Sohn ${.self:"role":1:"firstname"} treffen am Jungbrunnen auf den Spaltendrachen. ${.self:"role":0:"firstname"} und der Drache werden versehentlich zu Babys zurückverwandelt. Prinzessin ${.self:"role":2:"firstname"} begegnet ${.self:"role":1:"firstname"} und macht ihn klüger, mutiger und stärker.</de>
-						<en>${.self:"role":0:"firstname"} and his son ${.self:"role":1:"firstname"} run into the Gap dragon at the Fountain of Youth. ${.self:"role":0:"firstname"} and the dragon accidentally regress to babies. Princess ${.self:"role":2:"firstname"} comes across ${.self:"role":1:"firstname"} and makes him smarter, braver, and stronger.</en>
+						<de>${.self:"role":1:"firstname"} und sein Sohn ${.self:"role":2:"firstname"} treffen am Jungbrunnen auf den Spaltendrachen. ${.self:"role":1:"firstname"} und der Drache werden versehentlich zu Babys zurückverwandelt. Prinzessin ${.self:"role":3:"firstname"} begegnet ${.self:"role":2:"firstname"} und macht ihn klüger, mutiger und stärker.</de>
+						<en>${.self:"role":1:"firstname"} and his son ${.self:"role":2:"firstname"} run into the Gap dragon at the Fountain of Youth. ${.self:"role":1:"firstname"} and the dragon accidentally regress to babies. Princess ${.self:"role":3:"firstname"} comes across ${.self:"role":2:"firstname"} and makes him smarter, braver, and stronger.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="d1bf5449-a215-446c-b792-363758d3e42c">
@@ -4384,8 +4384,8 @@
 						<en>Crewel Lye: A Caustic Yarn</en>
 					</title_original>
 					<description>
-						<de>Die fünfjährige Prinzessin ${.self:"role":2:"firstname"} bittet einen der Geister von Schloss Roogna, ihr zu erzählen, wie er ein Geist wurde. Der Geist, der vor 400 Jahren als ${.self:"role":3:"firstname"} der Barbar bekannt war, erzählt seine Geschichte.</de>
-						<en>Five-year-old Princess ${.self:"role":2:"firstname"} asks one of Castle Roogna's ghosts to tell her how he became a ghost. The ghost, known as ${.self:"role":3:"firstname"} the Barbarian 400 years ago, tells his story.</en>
+						<de>Die fünfjährige Prinzessin ${.self:"role":3:"firstname"} bittet einen der Geister von Schloss Roogna, ihr zu erzählen, wie er ein Geist wurde. Der Geist, der vor 400 Jahren als ${.self:"role":4:"firstname"} der Barbar bekannt war, erzählt seine Geschichte.</de>
+						<en>Five-year-old Princess ${.self:"role":3:"firstname"} asks one of Castle Roogna's ghosts to tell her how he became a ghost. The ghost, known as ${.self:"role":4:"firstname"} the Barbarian 400 years ago, tells his story.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="980f1d47-4e4d-460a-91f3-58789f186d70">
@@ -4398,8 +4398,8 @@
 						<en>Golem in the Gears</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":4:"firstname"}, ein nur ein paar Zentimeter großer Golem, will sich unbedingt beweisen und sich Respekt verschaffen. Er meldet sich freiwillig, das „Monster Unter Dem Bett“ zu reiten, um den lange verlorenen Drachen seiner Freundin ${.self:"role":2:"firstname"} zu finden.</de>
-						<en>${.self:"role":4:"firstname"}, a golem only a few inches high, is desperate to prove himself and gain respect. He volunteers to ride the "Monster Under The Bed" to find his friend ${.self:"role":2:"firstname"}'s long lost dragon.</en>
+						<de>${.self:"role":5:"firstname"}, ein nur ein paar Zentimeter großer Golem, will sich unbedingt beweisen und sich Respekt verschaffen. Er meldet sich freiwillig, das „Monster Unter Dem Bett“ zu reiten, um den lange verlorenen Drachen seiner Freundin ${.self:"role":3:"firstname"} zu finden.</de>
+						<en>${.self:"role":5:"firstname"}, a golem only a few inches high, is desperate to prove himself and gain respect. He volunteers to ride the "Monster Under The Bed" to find his friend ${.self:"role":3:"firstname"}'s long lost dragon.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -4452,8 +4452,8 @@
 						<en>I Remember Now</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} liegt in einem Krankenhaus in einem fast katatonischen Zustand, unfähig, sich an irgendetwas anderes als an Bruchstücke seiner Vergangenheit zu erinnern. Plötzlich kommen seine Erinnerungen in Strömen zurück.</de>
-						<en>${.self:"role":0:"firstname"} lies in a hospital in a near catatonic state, unable to remember anything but snippets from his past. Suddenly, his memories come flooding back in a torrent.</en>
+						<de>${.self:"role":1:"firstname"} liegt in einem Krankenhaus in einem fast katatonischen Zustand, unfähig, sich an irgendetwas anderes als an Bruchstücke seiner Vergangenheit zu erinnern. Plötzlich kommen seine Erinnerungen in Strömen zurück.</de>
+						<en>${.self:"role":1:"firstname"} lies in a hospital in a near catatonic state, unable to remember anything but snippets from his past. Suddenly, his memories come flooding back in a torrent.</en>
 					</description>
 					<effects>
 						<effect trigger="broadcastFirstTime" type="modifyScriptAvailability" guid="3e6b74d2-b386-47f8-b876-858db1449467" />
@@ -4469,8 +4469,8 @@
 						<en>Anarchy-X</en>
 					</title_original>
 					<description>
-						<de>Rückblende: Als Heroinabhängiger und Möchtegern-Radikaler, der aufgrund wirtschaftlicher Ungleichheit, Korruption und Heuchelei von der heutigen Gesellschaft frustriert war, wurde ${.self:"role":0:"firstname"} dazu gebracht, sich einer angeblich geheimen Organisation anzuschließen.</de>
-						<en>Flashback: As a heroin addict and would-be political radical frustrated with contemporary society due to the economic inequality, corruption and hypocrisy, ${.self:"role":0:"firstname"} was manipulated into joining a supposed secret organization.</en>
+						<de>Rückblende: Als Heroinabhängiger und Möchtegern-Radikaler, der aufgrund wirtschaftlicher Ungleichheit, Korruption und Heuchelei von der heutigen Gesellschaft frustriert war, wurde ${.self:"role":1:"firstname"} dazu gebracht, sich einer angeblich geheimen Organisation anzuschließen.</de>
+						<en>Flashback: As a heroin addict and would-be political radical frustrated with contemporary society due to the economic inequality, corruption and hypocrisy, ${.self:"role":1:"firstname"} was manipulated into joining a supposed secret organization.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="18833c63-c02a-4dfe-ad3b-1637bf1f6d6e">
@@ -4483,8 +4483,8 @@
 						<en>Revolution Calling</en>
 					</title_original>
 					<description>
-						<de>An der Spitze der Organisation, die sich der Revolution verschrieben hat, steht ein mysteriöser politischer und religiöser Demagoge, der nur als ${.self:"role":2:"fullname"} bekannt ist und ${.self:"role":0:"firstname"} durch eine Kombination aus Heroinabhängigkeit und Gehirnwäsche dazu bringt, ein Attentäter zu werden.</de>
-						<en>At the head of the organization, dedicated to revolution, is a mysterious political and religious demagogue known only as ${.self:"role":2:"fullname"}, who manipulates ${.self:"role":0:"firstname"} through a combination of his heroin addiction and brainwashing techniques to become an assassin.</en>
+						<de>An der Spitze der Organisation, die sich der Revolution verschrieben hat, steht ein mysteriöser politischer und religiöser Demagoge, der nur als ${.self:"role":3:"fullname"} bekannt ist und ${.self:"role":1:"firstname"} durch eine Kombination aus Heroinabhängigkeit und Gehirnwäsche dazu bringt, ein Attentäter zu werden.</de>
+						<en>At the head of the organization, dedicated to revolution, is a mysterious political and religious demagogue known only as ${.self:"role":3:"fullname"}, who manipulates ${.self:"role":1:"firstname"} through a combination of his heroin addiction and brainwashing techniques to become an assassin.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="d84d7798-db19-4ca8-b396-f7807ce5c7d2">
@@ -4497,8 +4497,8 @@
 						<en>Operation: Mindcrime</en>
 					</title_original>
 					<description>
-						<de>Immer wenn ${.self:"role":2:"fullname"} das Wort „Mindcrime“ benutzt, wird ${.self:"role":0:"firstname"} zu seiner gefügigen Marionette, ein Zustand, den ${.self:"role":2:"fullname"} dazu benutzt, ${.self:"role":0:"firstname"} zu befehlen, jeden beliebigen Mord zu begehen.</de>
-						<en>Whenever ${.self:"role":2:"fullname"} uses the word "mindcrime", ${.self:"role":0:"firstname"} becomes his docile puppet, a state which ${.self:"role":2:"fullname"} uses to command ${.self:"role":0:"firstname"} to undertake any murder.</en>
+						<de>Immer wenn ${.self:"role":3:"fullname"} das Wort „Mindcrime“ benutzt, wird ${.self:"role":1:"firstname"} zu seiner gefügigen Marionette, ein Zustand, den ${.self:"role":3:"fullname"} dazu benutzt, ${.self:"role":1:"firstname"} zu befehlen, jeden beliebigen Mord zu begehen.</de>
+						<en>Whenever ${.self:"role":3:"fullname"} uses the word "mindcrime", ${.self:"role":1:"firstname"} becomes his docile puppet, a state which ${.self:"role":3:"fullname"} uses to command ${.self:"role":1:"firstname"} to undertake any murder.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="46daf19b-4c77-425f-9a35-6d79b831b5ba">
@@ -4511,8 +4511,8 @@
 						<en>Speak</en>
 					</title_original>
 					<description>
-						<de>Mit seinem wachsenden Einfluss innerhalb der Organisation von ${.self:"role":2:"fullname"} wächst auch ${.self:"role":0:"firstname"}s Ego und sein Festhalten an der Zukunftsvision seines Meisters.</de>
-						<en>As his position within ${.self:"role":2:"fullname"}'s organization grows, so does ${.self:"role":0:"firstname"}'s ego and adherence to his master's vision of the future.</en>
+						<de>Mit seinem wachsenden Einfluss innerhalb der Organisation von ${.self:"role":3:"fullname"} wächst auch ${.self:"role":1:"firstname"}s Ego und sein Festhalten an der Zukunftsvision seines Meisters.</de>
+						<en>As his position within ${.self:"role":3:"fullname"}'s organization grows, so does ${.self:"role":1:"firstname"}'s ego and adherence to his master's vision of the future.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="5" product="2" licence_type="2" guid="84e4c958-9438-4058-82ed-9fcafa53114e">
@@ -4525,8 +4525,8 @@
 						<en>Spreading the Disease</en>
 					</title_original>
 					<description>
-						<de>Durch einen der Mitarbeiter von ${.self:"role":2:"fullname"}, einen korrupten Priester namens Father ${.self:"role":3:"firstname"}, werden ${.self:"role":0:"firstname"} die Dienste von Sister ${.self:"role":1:"firstname"} angeboten, die sich von einer jugendlichen Prostituierten zu einer Nonne gewandelt hat.</de>
-						<en>Through one of ${.self:"role":2:"fullname"}'s associates, a corrupt priest named Father ${.self:"role":3:"firstname"}, ${.self:"role":0:"firstname"} is offered the services of a teenage prostitute-turned-nun named Sister ${.self:"role":1:"firstname"}.</en>
+						<de>Durch einen der Mitarbeiter von ${.self:"role":3:"fullname"}, einen korrupten Priester namens Father ${.self:"role":4:"firstname"}, werden ${.self:"role":1:"firstname"} die Dienste von Sister ${.self:"role":2:"firstname"} angeboten, die sich von einer jugendlichen Prostituierten zu einer Nonne gewandelt hat.</de>
+						<en>Through one of ${.self:"role":3:"fullname"}'s associates, a corrupt priest named Father ${.self:"role":4:"firstname"}, ${.self:"role":1:"firstname"} is offered the services of a teenage prostitute-turned-nun named Sister ${.self:"role":2:"firstname"}.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="6" product="2" licence_type="2" guid="aa539235-bce8-494e-956c-09c104c9bb14">
@@ -4539,22 +4539,22 @@
 						<en>The Mission</en>
 					</title_original>
 					<description>
-						<de>Durch seine Freundschaft und wachsende Zuneigung zu Sister ${.self:"role":1:"firstname"} beginnt ${.self:"role":0:"firstname"}, die Natur seines Handelns zu hinterfragen und erkennt, dass ${.self:"role":2:"fullname"} seine eigenen ruchlosen Absichten verfolgt.</de>
-						<en>Through his friendship and growing affection toward Sister ${.self:"role":1:"firstname"}, ${.self:"role":0:"firstname"} begins to question the nature of what he is doing, seeing that ${.self:"role":2:"fullname"} has his own nefarious agenda.</en>
+						<de>Durch seine Freundschaft und wachsende Zuneigung zu Sister ${.self:"role":2:"firstname"} beginnt ${.self:"role":1:"firstname"}, die Natur seines Handelns zu hinterfragen und erkennt, dass ${.self:"role":3:"fullname"} seine eigenen ruchlosen Absichten verfolgt.</de>
+						<en>Through his friendship and growing affection toward Sister ${.self:"role":2:"firstname"}, ${.self:"role":1:"firstname"} begins to question the nature of what he is doing, seeing that ${.self:"role":3:"fullname"} has his own nefarious agenda.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="6f362a5a-6730-4772-b964-655d6bb3b6aa">
 					<title>
-						<de>Sound Sister ${.self:"role":1:"firstname"}</de>
-						<en>Sound Sister ${.self:"role":1:"firstname"}</en>
+						<de>Sound Sister ${.self:"role":2:"firstname"}</de>
+						<en>Sound Sister ${.self:"role":2:"firstname"}</en>
 					</title>
 					<title_original>
 						<de>Suite Sister Mary</de>
 						<en>Suite Sister Mary</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":2:"fullname"} wird aufmerksam und sieht in ${.self:"role":1:"firstname"} eine potenzielle Bedrohung für seinen Personenkult und befiehlt ${.self:"role":0:"firstname"}, sowohl sie als auch den Priester zu töten. ${.self:"role":0:"firstname"} geht zu ${.self:"role":1:"firstname"}s Kirche und tötet den Priester, ${.self:"role":1:"firstname"} aber nicht.</de>
-						<en>${.self:"role":2:"fullname"} takes notice and, seeing a potential threat in ${.self:"role":1:"firstname"} to his cult of personality, orders ${.self:"role":0:"firstname"} to kill both her and the priest. ${.self:"role":0:"firstname"} goes to ${.self:"role":1:"firstname"}'s church and kills the priest but not ${.self:"role":1:"firstname"}.</en>
+						<de>${.self:"role":3:"fullname"} wird aufmerksam und sieht in ${.self:"role":2:"firstname"} eine potenzielle Bedrohung für seinen Personenkult und befiehlt ${.self:"role":1:"firstname"}, sowohl sie als auch den Priester zu töten. ${.self:"role":1:"firstname"} geht zu ${.self:"role":2:"firstname"}s Kirche und tötet den Priester, ${.self:"role":2:"firstname"} aber nicht.</de>
+						<en>${.self:"role":3:"fullname"} takes notice and, seeing a potential threat in ${.self:"role":2:"firstname"} to his cult of personality, orders ${.self:"role":1:"firstname"} to kill both her and the priest. ${.self:"role":1:"firstname"} goes to ${.self:"role":2:"firstname"}'s church and kills the priest but not ${.self:"role":2:"firstname"}.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="8" product="2" licence_type="2" guid="465d0502-d06f-4ca0-b266-5fae8390ad1a">
@@ -4567,8 +4567,8 @@
 						<en>The Needle Lies</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} liebt ${.self:"role":1:"firstname"} und beschließt, die Organisation mit ihr zu verlassen. ${.self:"role":2:"fullname"} erinnert ${.self:"role":0:"firstname"} jedoch daran, dass die Alternative darin besteht, in sein trostloses Leben als sich selbstverachtender, hilfloser Süchtiger zurückzukehren.</de>
-						<en>${.self:"role":0:"firstname"} loves ${.self:"role":1:"firstname"} and decides to leave the organization with her. ${.self:"role":2:"fullname"}, however, reminds ${.self:"role":0:"firstname"} that the alternative is to go back to his bleak life as a self-loathing helpless addict.</en>
+						<de>${.self:"role":1:"firstname"} liebt ${.self:"role":2:"firstname"} und beschließt, die Organisation mit ihr zu verlassen. ${.self:"role":3:"fullname"} erinnert ${.self:"role":1:"firstname"} jedoch daran, dass die Alternative darin besteht, in sein trostloses Leben als sich selbstverachtender, hilfloser Süchtiger zurückzukehren.</de>
+						<en>${.self:"role":1:"firstname"} loves ${.self:"role":2:"firstname"} and decides to leave the organization with her. ${.self:"role":3:"fullname"}, however, reminds ${.self:"role":1:"firstname"} that the alternative is to go back to his bleak life as a self-loathing helpless addict.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="9" product="2" licence_type="2" guid="802745ff-c3a1-4722-a4d7-5df2123f7a35">
@@ -4581,8 +4581,8 @@
 						<en>Electric Requiem</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} verlässt das Haus, verwirrt und unschlüssig, und er kehrt zu ${.self:"role":1:"firstname"} zurück, nur um sie tot vorzufinden.</de>
-						<en>${.self:"role":0:"firstname"} leaves, conflicted and uncertain, and he returns to ${.self:"role":1:"firstname"} only to find her dead.</en>
+						<de>${.self:"role":1:"firstname"} verlässt das Haus, verwirrt und unschlüssig, und er kehrt zu ${.self:"role":2:"firstname"} zurück, nur um sie tot vorzufinden.</de>
+						<en>${.self:"role":1:"firstname"} leaves, conflicted and uncertain, and he returns to ${.self:"role":2:"firstname"} only to find her dead.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="10" product="2" licence_type="2" guid="2a2e0f2e-9bec-4d00-896c-da835e5236d9">
@@ -4595,8 +4595,8 @@
 						<en>Breaking the Silence</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} kann den Verlust und die Möglichkeit, ${.self:"role":1:"firstname"} selbst getötet zu haben, ohne es zu wissen, nicht verkraften und beginnt, dem Wahnsinn zu verfallen. Er rennt durch die Straßen und ruft ihren Namen.</de>
-						<en>${.self:"role":0:"firstname"} cannot cope with the loss and the possibility that he himself may have killed ${.self:"role":1:"firstname"} without knowing it and he begins to succumb to insanity. He runs through the streets calling her name.</en>
+						<de>${.self:"role":1:"firstname"} kann den Verlust und die Möglichkeit, ${.self:"role":2:"firstname"} selbst getötet zu haben, ohne es zu wissen, nicht verkraften und beginnt, dem Wahnsinn zu verfallen. Er rennt durch die Straßen und ruft ihren Namen.</de>
+						<en>${.self:"role":1:"firstname"} cannot cope with the loss and the possibility that he himself may have killed ${.self:"role":2:"firstname"} without knowing it and he begins to succumb to insanity. He runs through the streets calling her name.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="11" product="2" licence_type="2" guid="140a4e13-10aa-4dec-8fe5-dc761464e64c">
@@ -4609,8 +4609,8 @@
 						<en>I Don't Believe in Love</en>
 					</title_original>
 					<description>
-						<de>Die Polizei trifft ein und versucht, ${.self:"role":0:"firstname"} zu überwältigen. Sie finden eine Waffe und nehmen ihn unter dem Verdacht des Mordes an ${.self:"role":1:"firstname"} und der Morde, die er für ${.self:"role":2:"fullname"} begangen hat, in Gewahrsam.</de>
-						<en>The police arrive and attempt to subdue ${.self:"role":0:"firstname"}. They find a gun and take him into custody under suspicion of ${.self:"role":1:"firstname"}'s murder and the murders he committed for ${.self:"role":2:"fullname"}.</en>
+						<de>Die Polizei trifft ein und versucht, ${.self:"role":1:"firstname"} zu überwältigen. Sie finden eine Waffe und nehmen ihn unter dem Verdacht des Mordes an ${.self:"role":2:"firstname"} und der Morde, die er für ${.self:"role":3:"fullname"} begangen hat, in Gewahrsam.</de>
+						<en>The police arrive and attempt to subdue ${.self:"role":1:"firstname"}. They find a gun and take him into custody under suspicion of ${.self:"role":2:"firstname"}'s murder and the murders he committed for ${.self:"role":3:"fullname"}.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="12" product="2" licence_type="2" guid="75409ccc-a400-4254-8974-1aef6e1ec770">
@@ -4623,8 +4623,8 @@
 						<en>Waiting for 22</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} leidet unter fast vollständigem Gedächtnisverlust und wird in eine psychiatrische Klinik eingewiesen.</de>
-						<en>Suffering from an almost complete loss of memory, ${.self:"role":0:"firstname"} is put into a mental hospital.</en>
+						<de>${.self:"role":1:"firstname"} leidet unter fast vollständigem Gedächtnisverlust und wird in eine psychiatrische Klinik eingewiesen.</de>
+						<en>Suffering from an almost complete loss of memory, ${.self:"role":1:"firstname"} is put into a mental hospital.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="13" product="2" licence_type="2" guid="face4f34-fe0f-4dec-8de7-cb20ade3940c">
@@ -4637,8 +4637,8 @@
 						<en>My Empty Room</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} durchlebt in Gedanken seine letzten Momente mit ${.self:"role":1:"firstname"} noch einmal.</de>
-						<en>${.self:"role":0:"firstname"} retraces in his mind his last moments with ${.self:"role":1:"firstname"}.</en>
+						<de>${.self:"role":1:"firstname"} durchlebt in Gedanken seine letzten Momente mit ${.self:"role":2:"firstname"} noch einmal.</de>
+						<en>${.self:"role":1:"firstname"} retraces in his mind his last moments with ${.self:"role":2:"firstname"}.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="14" product="2" licence_type="2" guid="7bc80d8f-0b60-4a07-ae7f-25c2afa41900">
@@ -4651,8 +4651,8 @@
 						<en>Eyes of a Stranger</en>
 					</title_original>
 					<description>
-						<de>Zurück in der Gegenwart, im Krankenzimmer zu Beginn der Geschichte, hat ${.self:"role":0:"firstname"} sein Gedächtnis wiedererlangt, aber er starrt nun sein Bild in einem Spiegel an, unfähig zu erkennen, wer er ist und was er geworden ist.</de>
-						<en>Back in the present in the hospital room at the beginning of the story ${.self:"role":0:"firstname"} has regained his memory, but now stares at his image in a mirror, unable to recognize who he is and what he has become.</en>
+						<de>Zurück in der Gegenwart, im Krankenzimmer zu Beginn der Geschichte, hat ${.self:"role":1:"firstname"} sein Gedächtnis wiedererlangt, aber er starrt nun sein Bild in einem Spiegel an, unfähig zu erkennen, wer er ist und was er geworden ist.</de>
+						<en>Back in the present in the hospital room at the beginning of the story ${.self:"role":1:"firstname"} has regained his memory, but now stares at his image in a mirror, unable to recognize who he is and what he has become.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -4700,8 +4700,8 @@
 						<en>Best I Can</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} aus einem zerrütteten Zuhause verliebt sich in ${.self:"role":1:"firstname"} mit einer geheimnisvollen Vergangenheit. ${.self:"role":2:"firstname"} buhlt ebenfalls um ${.self:"role":1:"firstname"}. Der intensive Wettbewerb schürt ${.self:"role":0:"firstname"}' Entschlossenheit, der Beste zu sein und ihr Herz zu gewinnen.</de>
-						<en>${.self:"role":0:"firstname"} from a broken home becomes infatuated with ${.self:"role":1:"firstname"} who has a secret past. ${.self:"role":2:"firstname"} also vies for ${.self:"role":1:"firstname"}. The intense competition fuels ${.self:"role":0:"firstname"}'s determination to be the best and win her heart.</en>
+						<de>${.self:"role":1:"firstname"} aus einem zerrütteten Zuhause verliebt sich in ${.self:"role":2:"firstname"} mit einer geheimnisvollen Vergangenheit. ${.self:"role":3:"firstname"} buhlt ebenfalls um ${.self:"role":2:"firstname"}. Der intensive Wettbewerb schürt ${.self:"role":1:"firstname"}' Entschlossenheit, der Beste zu sein und ihr Herz zu gewinnen.</de>
+						<en>${.self:"role":1:"firstname"} from a broken home becomes infatuated with ${.self:"role":2:"firstname"} who has a secret past. ${.self:"role":3:"firstname"} also vies for ${.self:"role":2:"firstname"}. The intense competition fuels ${.self:"role":1:"firstname"}'s determination to be the best and win her heart.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="3ad6c425-c106-47d4-87ff-fb4571db38a5">
@@ -4714,8 +4714,8 @@
 						<en>The Thin Line</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":3:"firstname"}, ${.self:"role":1:"firstname"}s entfremdete Schwester, kehrt in die Stadt zurück. Ihre bewegte Vergangenheit sowohl mit Johnny als auch ${.self:"role":5:"firstname"}, einer alten Flamme, kann sie nur schwer hinter sich lassen kann. Sie bewegt sich auf einem gefährlichen Grat zwischen Liebe und Verzweiflung.</de>
-						<en>${.self:"role":3:"firstname"}, ${.self:"role":1:"firstname"}'s estranged sister, returns to the city. Her haunting past involves both Johnny and ${.self:"role":5:"firstname"}, an old flame, that she struggles to leave behind, walking a dangerous line between love and despair.</en>
+						<de>${.self:"role":4:"firstname"}, ${.self:"role":2:"firstname"}s entfremdete Schwester, kehrt in die Stadt zurück. Ihre bewegte Vergangenheit sowohl mit Johnny als auch ${.self:"role":6:"firstname"}, einer alten Flamme, kann sie nur schwer hinter sich lassen kann. Sie bewegt sich auf einem gefährlichen Grat zwischen Liebe und Verzweiflung.</de>
+						<en>${.self:"role":4:"firstname"}, ${.self:"role":2:"firstname"}'s estranged sister, returns to the city. Her haunting past involves both Johnny and ${.self:"role":6:"firstname"}, an old flame, that she struggles to leave behind, walking a dangerous line between love and despair.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="ce2630ae-67ef-4958-b1ec-637d55c1a597">
@@ -4728,22 +4728,22 @@
 						<en>Jet City Woman</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":1:"firstname"} ist hin- und hergerissen zwischen der Zuneigung von ${.self:"role":0:"firstname"} und Johnny. Ihre unbewältigten Gefühle für Johnny und die wachsende Bindung zu ${.self:"role":0:"firstname"} führen zu einer Dreiecksbeziehung, die die Band, die sie gegründet haben, zu zerreißen droht.</de>
-						<en>${.self:"role":1:"firstname"} finds herself torn between the affection of ${.self:"role":0:"firstname"} and Johnny. Her unresolved feelings for Johnny and the growing bond with ${.self:"role":0:"firstname"} lead to a love triangle that threatens to tear apart the band they've formed.</en>
+						<de>${.self:"role":2:"firstname"} ist hin- und hergerissen zwischen der Zuneigung von ${.self:"role":1:"firstname"} und Johnny. Ihre unbewältigten Gefühle für Johnny und die wachsende Bindung zu ${.self:"role":1:"firstname"} führen zu einer Dreiecksbeziehung, die die Band, die sie gegründet haben, zu zerreißen droht.</de>
+						<en>${.self:"role":2:"firstname"} finds herself torn between the affection of ${.self:"role":1:"firstname"} and Johnny. Her unresolved feelings for Johnny and the growing bond with ${.self:"role":1:"firstname"} lead to a love triangle that threatens to tear apart the band they've formed.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="be63b350-f1a2-44ad-a139-df3a1145ac12">
 					<title>
-						<de>${.self:"role":3:"fullname"}</de>
-						<en>${.self:"role":3:"fullname"}</en>
+						<de>${.self:"role":4:"fullname"}</de>
+						<en>${.self:"role":4:"fullname"}</en>
 					</title>
 					<title_original>
-						<de>${.self:"role":3:"fullname"}</de>
-						<en>${.self:"role":3:"fullname"}</en>
+						<de>${.self:"role":4:"fullname"}</de>
+						<en>${.self:"role":4:"fullname"}</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":3:"firstname"}s Vergangenheit mit ${.self:"role":5:"firstname"} wird aufgedeckt und die dunklen Geheimnisse, die sie teilen. Als Johnny von ihrer Verbindung erfährt, wird er von Schuldgefühlen und Reue übermannt, was zu Konflikten führt, die den Zusammenhalt der Band gefährden.</de>
-						<en>${.self:"role":3:"firstname"}'s history with ${.self:"role":5:"firstname"} is revealed and the dark secrets they share. As Johnny learns of their connection, guilt and regret consume him, igniting conflicts that challenge the band's unity.</en>
+						<de>${.self:"role":4:"firstname"}s Vergangenheit mit ${.self:"role":6:"firstname"} wird aufgedeckt und die dunklen Geheimnisse, die sie teilen. Als Johnny von ihrer Verbindung erfährt, wird er von Schuldgefühlen und Reue übermannt, was zu Konflikten führt, die den Zusammenhalt der Band gefährden.</de>
+						<en>${.self:"role":4:"firstname"}'s history with ${.self:"role":6:"firstname"} is revealed and the dark secrets they share. As Johnny learns of their connection, guilt and regret consume him, igniting conflicts that challenge the band's unity.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="51f80d80-e488-4e57-9e06-34243494f35e">
@@ -4756,8 +4756,8 @@
 						<en>Another Rainy Night</en>
 					</title_original>
 					<description>
-						<de>Johnny, der von Reue geplagt wird, kanalisiert seine Emotionen und seine Gefühle für ${.self:"role":1:"firstname"} in seine Musik. Seine Eifersucht wächst, als er Zeuge der Nähe zwischen ${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} wird, was zu heftigen Konflikten innerhalb der Band führt.</de>
-						<en>Johnny, haunted by regrets, channels his emotions into his music, including his feelings for ${.self:"role":1:"firstname"}. His jealousy grows as he witnesses the closeness between ${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"}, leading to intense conflicts within the band.</en>
+						<de>Johnny, der von Reue geplagt wird, kanalisiert seine Emotionen und seine Gefühle für ${.self:"role":2:"firstname"} in seine Musik. Seine Eifersucht wächst, als er Zeuge der Nähe zwischen ${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} wird, was zu heftigen Konflikten innerhalb der Band führt.</de>
+						<en>Johnny, haunted by regrets, channels his emotions into his music, including his feelings for ${.self:"role":2:"firstname"}. His jealousy grows as he witnesses the closeness between ${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"}, leading to intense conflicts within the band.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="5" product="2" licence_type="2" guid="e592843a-e492-490c-868d-c7f503c63f12">
@@ -4770,8 +4770,8 @@
 						<en>Empire</en>
 					</title_original>
 					<description>
-						<de>Die Stadt erlebt turbulente Zeiten, als Proteste und Demonstrationen die Straßen füllen. Inmitten des Chaos kehrt ${.self:"role":4:"firstname"}, eine Aktivistin und alte Freundin von ${.self:"role":3:"firstname"}, in die Stadt zurück, was alte Flammen neu entfacht und Emotionen weckt.</de>
-						<en>The town faces turbulent times as protests and demonstrations engulf the streets. Amidst the chaos, ${.self:"role":4:"firstname"}, an activist and old friend of ${.self:"role":3:"firstname"}, returns to town, reigniting old flames and stirring up emotions.</en>
+						<de>Die Stadt erlebt turbulente Zeiten, als Proteste und Demonstrationen die Straßen füllen. Inmitten des Chaos kehrt ${.self:"role":5:"firstname"}, eine Aktivistin und alte Freundin von ${.self:"role":4:"firstname"}, in die Stadt zurück, was alte Flammen neu entfacht und Emotionen weckt.</de>
+						<en>The town faces turbulent times as protests and demonstrations engulf the streets. Amidst the chaos, ${.self:"role":5:"firstname"}, an activist and old friend of ${.self:"role":4:"firstname"}, returns to town, reigniting old flames and stirring up emotions.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="6" product="2" licence_type="2" guid="cf005cce-834c-4c9e-9e5f-2873a9b25507">
@@ -4784,8 +4784,8 @@
 						<en>Resistance</en>
 					</title_original>
 					<description>
-						<de>Die zunehmenden Spannungen zwischen ${.self:"role":0:"firstname"}, Johnny und ${.self:"role":3:"firstname"} gipfeln in einer dramatischen Konfrontation während der Proteste. Die Figuren müssen sich mit ihren Fehlern und Verrat aus der Vergangenheit auseinandersetzen.</de>
-						<en>The mounting tensions between ${.self:"role":0:"firstname"}, Johnny, and ${.self:"role":3:"firstname"} culminate in a dramatic confrontation during the protests. The characters must confront their past mistakes and betrayals.</en>
+						<de>Die zunehmenden Spannungen zwischen ${.self:"role":1:"firstname"}, Johnny und ${.self:"role":4:"firstname"} gipfeln in einer dramatischen Konfrontation während der Proteste. Die Figuren müssen sich mit ihren Fehlern und Verrat aus der Vergangenheit auseinandersetzen.</de>
+						<en>The mounting tensions between ${.self:"role":1:"firstname"}, Johnny, and ${.self:"role":4:"firstname"} culminate in a dramatic confrontation during the protests. The characters must confront their past mistakes and betrayals.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="abf90430-b693-43c7-bcd2-e3bf497667d5">
@@ -4798,8 +4798,8 @@
 						<en>Silent Lucidity</en>
 					</title_original>
 					<description>
-						<de>In einem Moment der Verwundbarkeit bieten Johnnys luzide Träume Klarheit über ${.self:"role":1:"firstname"} und sich selbst und führen ihn zur Selbstvergebung. ${.self:"role":3:"firstname"} findet Trost in ihrer wachsenden Bindung zu ${.self:"role":0:"firstname"}, was zu unerwarteten Enthüllungen führt.</de>
-						<en>In a moment of vulnerability, Johnny's lucid dreams offer clarity about ${.self:"role":1:"firstname"} and himself, guiding him towards self-forgiveness. ${.self:"role":3:"firstname"} finds solace in her growing bond with ${.self:"role":0:"firstname"}, leading to unexpected revelations.</en>
+						<de>In einem Moment der Verwundbarkeit bieten Johnnys luzide Träume Klarheit über ${.self:"role":2:"firstname"} und sich selbst und führen ihn zur Selbstvergebung. ${.self:"role":4:"firstname"} findet Trost in ihrer wachsenden Bindung zu ${.self:"role":1:"firstname"}, was zu unerwarteten Enthüllungen führt.</de>
+						<en>In a moment of vulnerability, Johnny's lucid dreams offer clarity about ${.self:"role":2:"firstname"} and himself, guiding him towards self-forgiveness. ${.self:"role":4:"firstname"} finds solace in her growing bond with ${.self:"role":1:"firstname"}, leading to unexpected revelations.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="8" product="2" licence_type="2" guid="7cb3e5b4-8c54-476d-a42d-8a2d633736df">
@@ -4826,8 +4826,8 @@
 						<en>One And Only</en>
 					</title_original>
 					<description>
-						<de>Die Beziehung von ${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} vertieft sich, aber unbewältigte Gefühle und vergangene Verbindungen bedrohen ihr Glück. Die verworrene Vergangenheit zwischen ${.self:"role":3:"firstname"}, ${.self:"role":4:"firstname"} und ${.self:"role":5:"firstname"} bringt unerwartete Wendungen in die Geschichte.</de>
-						<en>${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"}'s relationship deepens, but unresolved feelings and past connections threaten their happiness. The tangled history between ${.self:"role":3:"firstname"}, ${.self:"role":4:"firstname"}, and ${.self:"role":5:"firstname"} brings unexpected twists and turns to the story.</en>
+						<de>Die Beziehung von ${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} vertieft sich, aber unbewältigte Gefühle und vergangene Verbindungen bedrohen ihr Glück. Die verworrene Vergangenheit zwischen ${.self:"role":4:"firstname"}, ${.self:"role":5:"firstname"} und ${.self:"role":6:"firstname"} bringt unerwartete Wendungen in die Geschichte.</de>
+						<en>${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"}'s relationship deepens, but unresolved feelings and past connections threaten their happiness. The tangled history between ${.self:"role":4:"firstname"}, ${.self:"role":5:"firstname"}, and ${.self:"role":6:"firstname"} brings unexpected twists and turns to the story.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="10" product="2" licence_type="2" guid="748bb6bc-b09d-42ac-be6a-3407f9c2f983">
@@ -4840,8 +4840,8 @@
 						<en>Anybody Listening?</en>
 					</title_original>
 					<description>
-						<de>In einer dramatischen Enthüllung kommt ans Licht, dass ${.self:"role":4:"firstname"} die lange verschollene Schwester von ${.self:"role":0:"firstname"} ist. Die Gruppe erkennt, dass der Schlüssel zum Überleben darin liegt, sich ihren Dämonen zu stellen und sich gegenseitig zu unterstützen.</de>
-						<en>In a climactic revelation, it comes to light that ${.self:"role":4:"firstname"} is the long-lost sister of ${.self:"role":0:"firstname"}. The group realizes that facing their demons and supporting each other is the key to survival.</en>
+						<de>In einer dramatischen Enthüllung kommt ans Licht, dass ${.self:"role":5:"firstname"} die lange verschollene Schwester von ${.self:"role":1:"firstname"} ist. Die Gruppe erkennt, dass der Schlüssel zum Überleben darin liegt, sich ihren Dämonen zu stellen und sich gegenseitig zu unterstützen.</de>
+						<en>In a climactic revelation, it comes to light that ${.self:"role":5:"firstname"} is the long-lost sister of ${.self:"role":1:"firstname"}. The group realizes that facing their demons and supporting each other is the key to survival.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -4879,8 +4879,8 @@
 				<en>Operation: Mindcrime (Season 2)</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"firstname"} war für den Mord an Sister ${.self:"role":1:"firstname"} inhaftiert worden, wobei er seinen Verstand verlor, da er durch die Bewußtseinskontrolle wirklich nicht wusste, wer ${.self:"role":1:"firstname"} getötet hatte, und er ihr vor ihrem Tod sehr nahe stand.</de>
-				<en>${.self:"role":0:"firstname"} had been jailed for the murder of Sister ${.self:"role":1:"firstname"}, with his sanity slipping as through the mind control he genuinely didn't know who had killed ${.self:"role":1:"firstname"} and had grown close to her before her death.</en>
+				<de>${.self:"role":1:"firstname"} war für den Mord an Sister ${.self:"role":2:"firstname"} inhaftiert worden, wobei er seinen Verstand verlor, da er durch die Bewußtseinskontrolle wirklich nicht wusste, wer ${.self:"role":2:"firstname"} getötet hatte, und er ihr vor ihrem Tod sehr nahe stand.</de>
+				<en>${.self:"role":1:"firstname"} had been jailed for the murder of Sister ${.self:"role":2:"firstname"}, with his sanity slipping as through the mind control he genuinely didn't know who had killed ${.self:"role":2:"firstname"} and had grown close to her before her death.</en>
 			</description>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="2d815482-0fd1-44d7-a59b-2bdaa0054839">
@@ -4893,8 +4893,8 @@
 						<en>Freiheit Ouvertüre</en>
 					</title_original>
 					<description>
-						<de>Achtzehn Jahre später wird ${.self:"role":0:"firstname"} aus dem Gefängnis entlassen. Die vergangene Geschichte wird in Rückblenden und aus ${.self:"role":0:"firstname"}s heute vermeintlich reiferem Blickwinkel zusammengefasst.</de>
-						<en>Eighteen years laster, ${.self:"role":0:"firstname"} is released from prison. The past story is summarized in flashbacks and from ${.self:"role":0:"firstname"}'s now supposedly more mature point of view.</en>
+						<de>Achtzehn Jahre später wird ${.self:"role":1:"firstname"} aus dem Gefängnis entlassen. Die vergangene Geschichte wird in Rückblenden und aus ${.self:"role":1:"firstname"}s heute vermeintlich reiferem Blickwinkel zusammengefasst.</de>
+						<en>Eighteen years laster, ${.self:"role":1:"firstname"} is released from prison. The past story is summarized in flashbacks and from ${.self:"role":1:"firstname"}'s now supposedly more mature point of view.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="b80c9500-9de5-405f-a5bf-9b68118f97e5">
@@ -4907,8 +4907,8 @@
 						<en>Convict</en>
 					</title_original>
 					<description>
-						<de>Während seiner Inhaftierung konnte ${.self:"role":0:"firstname"} seinen Hass auf ${.self:"role":2:"fullname"} nicht loslassen, einen Manipulator, der innerhalb der massiv korrupten Gesellschaft um ihn herum reich und mächtig geblieben ist.</de>
-						<en>During his incarceration, ${.self:"role":0:"firstname"} has been unable to let go of his hatred for ${.self:"role":2:"fullname"}, a manipulator who has remained rich and powerful within the massively corrupt society around him.</en>
+						<de>Während seiner Inhaftierung konnte ${.self:"role":1:"firstname"} seinen Hass auf ${.self:"role":3:"fullname"} nicht loslassen, einen Manipulator, der innerhalb der massiv korrupten Gesellschaft um ihn herum reich und mächtig geblieben ist.</de>
+						<en>During his incarceration, ${.self:"role":1:"firstname"} has been unable to let go of his hatred for ${.self:"role":3:"fullname"}, a manipulator who has remained rich and powerful within the massively corrupt society around him.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="24a830b1-734d-462f-b244-3ee0a6921e94">
@@ -4921,8 +4921,8 @@
 						<en>I'm American</en>
 					</title_original>
 					<description>
-						<de>Obwohl ${.self:"role":0:"firstname"} zum ersten Mal seit 18 Jahren wieder frei ist, hegt er immer noch Groll gegen die amerikanische Regierung, die er immer noch als autokratisch und gierig ansieht und die einfach nicht zu retten ist.</de>
-						<en>${.self:"role":0:"firstname"}, although free for the first time in 18 years, still harbors resentment against the American government in particular, which he still views as autocratic and greedy, being simply beyond saving.</en>
+						<de>Obwohl ${.self:"role":1:"firstname"} zum ersten Mal seit 18 Jahren wieder frei ist, hegt er immer noch Groll gegen die amerikanische Regierung, die er immer noch als autokratisch und gierig ansieht und die einfach nicht zu retten ist.</de>
+						<en>${.self:"role":1:"firstname"}, although free for the first time in 18 years, still harbors resentment against the American government in particular, which he still views as autocratic and greedy, being simply beyond saving.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="650447d4-7e0e-4356-81e3-401da5345c80">
@@ -4935,8 +4935,8 @@
 						<en>One Foot in Hell</en>
 					</title_original>
 					<description>
-						<de>Die Ausbildung zum Töten und die starke Gehirnwäsche, die ${.self:"role":0:"firstname"} von ${.self:"role":2:"fullname"} erhalten hat, haben ihn immer noch fest im Griff, und er zweifelt immer noch an seinem Verstand. Aber ${.self:"role":0:"firstname"} fühlt sich dennoch zerrissen.</de>
-						<en>The training to kill and powerful brainwashing that ${.self:"role":0:"firstname"} had received from ${.self:"role":2:"fullname"} still has a strong hold over him, with his sanity still much in doubt, but ${.self:"role":0:"firstname"} feels conflicted nonetheless.</en>
+						<de>Die Ausbildung zum Töten und die starke Gehirnwäsche, die ${.self:"role":1:"firstname"} von ${.self:"role":3:"fullname"} erhalten hat, haben ihn immer noch fest im Griff, und er zweifelt immer noch an seinem Verstand. Aber ${.self:"role":1:"firstname"} fühlt sich dennoch zerrissen.</de>
+						<en>The training to kill and powerful brainwashing that ${.self:"role":1:"firstname"} had received from ${.self:"role":3:"fullname"} still has a strong hold over him, with his sanity still much in doubt, but ${.self:"role":1:"firstname"} feels conflicted nonetheless.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="0ba97b56-2f9a-4df1-8b09-bdb0119fb6a4">
@@ -4949,8 +4949,8 @@
 						<en>Hostage</en>
 					</title_original>
 					<description>
-						<de>Obwohl er sich immer noch sehr nach Rache an ${.self:"role":2:"fullname"} sehnt und eine revolutionäre Veränderung in einer maroden Gesellschaft herbeiführen möchte, schweifen seine Gedanken zu ${.self:"role":1:"firstname"} ab.</de>
-						<en>While he still greatly desires revenge upon ${.self:"role":2:"fullname"} and wants to see a revolutionary change in a decrepit society, his thoughts drift to ${.self:"role":1:"firstname"}.</en>
+						<de>Obwohl er sich immer noch sehr nach Rache an ${.self:"role":3:"fullname"} sehnt und eine revolutionäre Veränderung in einer maroden Gesellschaft herbeiführen möchte, schweifen seine Gedanken zu ${.self:"role":2:"firstname"} ab.</de>
+						<en>While he still greatly desires revenge upon ${.self:"role":3:"fullname"} and wants to see a revolutionary change in a decrepit society, his thoughts drift to ${.self:"role":2:"firstname"}.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="5" product="2" licence_type="2" guid="9016dcce-824a-4060-b7f2-957c04269286">
@@ -4963,8 +4963,8 @@
 						<en>The Hands</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} gerät wieder einmal in Schwierigkeiten mit dem Gesetz. Während seines Prozesses bleiben seine Bitten um Gnade und Nachsicht beim Richter und den Geschworenen erfolglos, die sich noch an seine früheren Verbrechen erinnern.</de>
-						<en>${.self:"role":0:"firstname"} lands himself in trouble with the law once again. During his trial, his pleas for mercy and leniency are lost on a judge and jury still remembering his past crimes.</en>
+						<de>${.self:"role":1:"firstname"} gerät wieder einmal in Schwierigkeiten mit dem Gesetz. Während seines Prozesses bleiben seine Bitten um Gnade und Nachsicht beim Richter und den Geschworenen erfolglos, die sich noch an seine früheren Verbrechen erinnern.</de>
+						<en>${.self:"role":1:"firstname"} lands himself in trouble with the law once again. During his trial, his pleas for mercy and leniency are lost on a judge and jury still remembering his past crimes.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="6" product="2" licence_type="2" guid="3120e0ce-3236-4894-a602-dbd9d3a586f7">
@@ -4977,8 +4977,8 @@
 						<en>Speed of Light</en>
 					</title_original>
 					<description>
-						<de>Durch den Gerichtsprozess wird seine Verachtung für die Welt um ihn herum nur noch größer. ${.self:"role":0:"firstname"} grübelt über die Regierung, das Rechtssystem und ${.self:"role":2:"fullname"} nach und macht alle drei für seine Probleme verantwortlich.</de>
-						<en>The court case only deepens his disdain for the world around him, with ${.self:"role":0:"firstname"} mulling over the government, the legal system, and ${.self:"role":2:"fullname"} as he blames all three for all of his problems.</en>
+						<de>Durch den Gerichtsprozess wird seine Verachtung für die Welt um ihn herum nur noch größer. ${.self:"role":1:"firstname"} grübelt über die Regierung, das Rechtssystem und ${.self:"role":3:"fullname"} nach und macht alle drei für seine Probleme verantwortlich.</de>
+						<en>The court case only deepens his disdain for the world around him, with ${.self:"role":1:"firstname"} mulling over the government, the legal system, and ${.self:"role":3:"fullname"} as he blames all three for all of his problems.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="fc5d1546-def6-4f13-8cc9-fa9cfa9a50c1">
@@ -4991,8 +4991,8 @@
 						<en>Signs Say Go</en>
 					</title_original>
 					<description>
-						<de>Nachdem ${.self:"role":0:"firstname"} entkommt und sich erneut auf der Flucht befindet, fasst er aus seinem eigenen Bedürfnis nach Rache, gepaart mit einer Vision von ${.self:"role":1:"firstname"}s Geist, den Entschluss, ${.self:"role":2:"fullname"} zu töten.</de>
-						<en>After ${.self:"role":0:"firstname"} escapes and finds himself yet again on the run, his own need for revenge coupled by a vision of ${.self:"role":1:"firstname"}'s ghost turns his thoughts toward killing ${.self:"role":2:"fullname"}.</en>
+						<de>Nachdem ${.self:"role":1:"firstname"} entkommt und sich erneut auf der Flucht befindet, fasst er aus seinem eigenen Bedürfnis nach Rache, gepaart mit einer Vision von ${.self:"role":2:"firstname"}s Geist, den Entschluss, ${.self:"role":3:"fullname"} zu töten.</de>
+						<en>After ${.self:"role":1:"firstname"} escapes and finds himself yet again on the run, his own need for revenge coupled by a vision of ${.self:"role":2:"firstname"}'s ghost turns his thoughts toward killing ${.self:"role":3:"fullname"}.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="8" product="2" licence_type="2" guid="6abfb6b2-6d1a-42ab-a2be-4644914633cf">
@@ -5005,8 +5005,8 @@
 						<en>Re-Arrange You</en>
 					</title_original>
 					<description>
-						<de>Als die endgültige Konfrontation näher rückt, beginnt ${.self:"role":0:"firstname"} zu zweifeln. Er stellt sich selbst in Frage und grübelt darüber, ob er sich eingestehen sollte, dass es auch seine Schuld ist, dass sein Leben so schlecht ist, wie es ist.</de>
-						<en>As a final confrontation gets closer, ${.self:"role":0:"firstname"} starts to have more doubts. He questions himself and wonders if he should own up to the fact that it's also his fault that his life is as bad as it is.</en>
+						<de>Als die endgültige Konfrontation näher rückt, beginnt ${.self:"role":1:"firstname"} zu zweifeln. Er stellt sich selbst in Frage und grübelt darüber, ob er sich eingestehen sollte, dass es auch seine Schuld ist, dass sein Leben so schlecht ist, wie es ist.</de>
+						<en>As a final confrontation gets closer, ${.self:"role":1:"firstname"} starts to have more doubts. He questions himself and wonders if he should own up to the fact that it's also his fault that his life is as bad as it is.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="9" product="2" licence_type="2" guid="e57a661a-e9f5-45f2-b8bf-00841e2de48a">
@@ -5019,8 +5019,8 @@
 						<en>The Chase</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} spürt ${.self:"role":2:"fullname"} auf, und es beginnt eine dramatische Verfolgungsjagd. ${.self:"role":0:"firstname"} kann sich schließlich der Bewußtseinskontrolle entziehen und tötet ${.self:"role":2:"fullname"}, als der entscheidende Moment kommt.</de>
-						<en>${.self:"role":0:"firstname"} does track down ${.self:"role":2:"fullname"}, beginning a dramatic chase, and ${.self:"role":0:"firstname"} finally fends off the mind control and kills ${.self:"role":2:"fullname"} as the seminal moment comes.</en>
+						<de>${.self:"role":1:"firstname"} spürt ${.self:"role":3:"fullname"} auf, und es beginnt eine dramatische Verfolgungsjagd. ${.self:"role":1:"firstname"} kann sich schließlich der Bewußtseinskontrolle entziehen und tötet ${.self:"role":3:"fullname"}, als der entscheidende Moment kommt.</de>
+						<en>${.self:"role":1:"firstname"} does track down ${.self:"role":3:"fullname"}, beginning a dramatic chase, and ${.self:"role":1:"firstname"} finally fends off the mind control and kills ${.self:"role":3:"fullname"} as the seminal moment comes.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="10" product="2" licence_type="2" guid="a29424fd-5f23-435c-b9db-7c9319f9f8fe">
@@ -5033,8 +5033,8 @@
 						<en>Murderer?</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} begreift, was er in seinem halbbewussten Zustand getan hat, doch der Mord scheint ihm nicht den Trost zu bringen, den er sich so sehr wünscht.</de>
-						<en>${.self:"role":0:"firstname"} realises what he did in his half-conscious state, yet the murder seems to fail to bring him the solace that he so wants.</en>
+						<de>${.self:"role":1:"firstname"} begreift, was er in seinem halbbewussten Zustand getan hat, doch der Mord scheint ihm nicht den Trost zu bringen, den er sich so sehr wünscht.</de>
+						<en>${.self:"role":1:"firstname"} realises what he did in his half-conscious state, yet the murder seems to fail to bring him the solace that he so wants.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="11" product="2" licence_type="2" guid="a33b55fd-7d09-416f-b122-0abeda16fc7e">
@@ -5047,8 +5047,8 @@
 						<en>Circles</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} fragt sich, ob die Ermordung wirklich etwas verbessert hat, und wird weiter von Zweifeln und Verzweiflung zerfressen.</de>
-						<en>Wondering whether the killing has really made anything better, ${.self:"role":0:"firstname"} is further consumed by doubt and despair.</en>
+						<de>${.self:"role":1:"firstname"} fragt sich, ob die Ermordung wirklich etwas verbessert hat, und wird weiter von Zweifeln und Verzweiflung zerfressen.</de>
+						<en>Wondering whether the killing has really made anything better, ${.self:"role":1:"firstname"} is further consumed by doubt and despair.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="12" product="2" licence_type="2" guid="e3f790d7-c4fc-4cbb-bb8f-a6cee24e4043">
@@ -5061,8 +5061,8 @@
 						<en>If I Could Change It All</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} beginnt zu glauben, dass er die Grenze zum reinen Wahnsinn überschritten hat.</de>
-						<en>${.self:"role":0:"firstname"} starts to think that he has crossed the line into pure insanity.</en>
+						<de>${.self:"role":1:"firstname"} beginnt zu glauben, dass er die Grenze zum reinen Wahnsinn überschritten hat.</de>
+						<en>${.self:"role":1:"firstname"} starts to think that he has crossed the line into pure insanity.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="13" product="2" licence_type="2" guid="59d73313-0836-4c9d-b75b-8db8dfaf42c7">
@@ -5075,8 +5075,8 @@
 						<en>An Intentional Confrontation</en>
 					</title_original>
 					<description>
-						<de>Der Geist von ${.self:"role":1:"firstname"} erscheint erneut und konfrontiert ${.self:"role":0:"firstname"}, aber es scheint eine böse Erscheinung zu sein. Da die Welt keinen Ausweg aus seiner Traurigkeit bietet, drängt der Geist ihn, Selbstmord zu begehen.</de>
-						<en>The ghost of ${.self:"role":1:"firstname"} appears again and confronts ${.self:"role":0:"firstname"}, but it seems to be an evil apparition. With the world holding no escape for his sadness, the ghost urges him to commit suicide.</en>
+						<de>Der Geist von ${.self:"role":2:"firstname"} erscheint erneut und konfrontiert ${.self:"role":1:"firstname"}, aber es scheint eine böse Erscheinung zu sein. Da die Welt keinen Ausweg aus seiner Traurigkeit bietet, drängt der Geist ihn, Selbstmord zu begehen.</de>
+						<en>The ghost of ${.self:"role":2:"firstname"} appears again and confronts ${.self:"role":1:"firstname"}, but it seems to be an evil apparition. With the world holding no escape for his sadness, the ghost urges him to commit suicide.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="14" product="2" licence_type="2" guid="370ff293-6655-40b7-afa9-7cf1e58118b7">
@@ -5089,8 +5089,8 @@
 						<en>A Junkie's Blues</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} denkt über seine Vergangenheit als Junkie und über die Einnahme einer Überdosis nach. Aber vielleicht kann er am Leben bleiben und ein besserer Mensch werden? Doch ${.self:"role":1:"firstname"}s Geist sagt nein.</de>
-						<en>${.self:"role":0:"firstname"} contemplates his past as a junkie and about taking an overdose. But maybe he can stay alive and become a better man? However, ${.self:"role":1:"firstname"}'s ghost says no.</en>
+						<de>${.self:"role":1:"firstname"} denkt über seine Vergangenheit als Junkie und über die Einnahme einer Überdosis nach. Aber vielleicht kann er am Leben bleiben und ein besserer Mensch werden? Doch ${.self:"role":2:"firstname"}s Geist sagt nein.</de>
+						<en>${.self:"role":1:"firstname"} contemplates his past as a junkie and about taking an overdose. But maybe he can stay alive and become a better man? However, ${.self:"role":2:"firstname"}'s ghost says no.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="15" product="2" licence_type="2" guid="2405e9a9-dcfd-43a0-a3d6-2612ce01b995">
@@ -5103,8 +5103,8 @@
 						<en>Fear City Slide</en>
 					</title_original>
 					<description>
-						<de>Stimmen sagen ${.self:"role":0:"firstname"}, er solle sich eine Waffe an den Kopf halten, aber er zögert. Schließlich drückt er den Abzug. Es wird offen gelassen, ob dies alles geschieht, weil ${.self:"role":0:"firstname"} immer noch Opfer der Gehirnwäsche ist.</de>
-						<en>Voices tell ${.self:"role":0:"firstname"} to pull a gun to his head, but he's hesitant. Finally he pulls the trigger. It is left unclear if all this happens because ${.self:"role":0:"firstname"} is still victim of the brainwashing.</en>
+						<de>Stimmen sagen ${.self:"role":1:"firstname"}, er solle sich eine Waffe an den Kopf halten, aber er zögert. Schließlich drückt er den Abzug. Es wird offen gelassen, ob dies alles geschieht, weil ${.self:"role":1:"firstname"} immer noch Opfer der Gehirnwäsche ist.</de>
+						<en>Voices tell ${.self:"role":1:"firstname"} to pull a gun to his head, but he's hesitant. Finally he pulls the trigger. It is left unclear if all this happens because ${.self:"role":1:"firstname"} is still victim of the brainwashing.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="16" product="2" licence_type="2" guid="49717199-26b4-4b83-8f2b-908e12e8c89a">
@@ -5117,8 +5117,8 @@
 						<en>All the Promises</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"}s Geist wird mit ${.self:"role":1:"firstname"}s wiedervereint, und es wird enthüllt, dass sie eine Art Happy End im Jenseits finden. Sie reflektieren darüber, dass sie früher nur in den flüchtigen Momenten, in denen sie zusammen waren, glücklich waren.</de>
-						<en>${.self:"role":0:"firstname"}'s spirit is reunited with ${.self:"role":1:"firstname"}'s, with it being revealed that they achieve some kind of happy end in the afterlife. They reflect that the only times they were happy before were in the fleeting moments that they were together.</en>
+						<de>${.self:"role":1:"firstname"}s Geist wird mit ${.self:"role":2:"firstname"}s wiedervereint, und es wird enthüllt, dass sie eine Art Happy End im Jenseits finden. Sie reflektieren darüber, dass sie früher nur in den flüchtigen Momenten, in denen sie zusammen waren, glücklich waren.</de>
+						<en>${.self:"role":1:"firstname"}'s spirit is reunited with ${.self:"role":2:"firstname"}'s, with it being revealed that they achieve some kind of happy end in the afterlife. They reflect that the only times they were happy before were in the fleeting moments that they were together.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -5166,8 +5166,8 @@
 						<en>Streets</en>
 					</title_original>
 					<description>
-						<de>„${.self:"role":0:"fullname"}“, ${.self:"role":0:"firstname"} kurz für sowohl „de-tox“ als auch „Downtown“, ein Drogenhändler aus New Yorks Straßen, hat enormes Talent und Leidenschaft für Musik, wird Rockstar, verkauft Millionen Alben und spielt ausverkaufte Konzerte.</de>
-						<en>"${.self:"role":0:"fullname"}", ${.self:"role":0:"firstname"} short for both "de-tox" and "downtown", a drug dealer from New York's streets, has enormous talent and passion for music, becomes a rock star, sells millions of albums and plays sold-out shows.</en>
+						<de>„${.self:"role":1:"fullname"}“, ${.self:"role":1:"firstname"} kurz für sowohl „de-tox“ als auch „Downtown“, ein Drogenhändler aus New Yorks Straßen, hat enormes Talent und Leidenschaft für Musik, wird Rockstar, verkauft Millionen Alben und spielt ausverkaufte Konzerte.</de>
+						<en>"${.self:"role":1:"fullname"}", ${.self:"role":1:"firstname"} short for both "de-tox" and "downtown", a drug dealer from New York's streets, has enormous talent and passion for music, becomes a rock star, sells millions of albums and plays sold-out shows.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="6187fb24-1057-43ec-b52a-67a75d4e0910">
@@ -5180,8 +5180,8 @@
 						<en>Jesus Saves</en>
 					</title_original>
 					<description>
-						<de>Trotz seines Ruhmes fühlt sich ${.self:"role":0:"firstname"} verloren und hat zu kämpfen. Er findet nicht ganz seine Erfüllung, erleidet Burn-out, wird wieder drogenabhängig und dealt. Von den Junkies wird er als Erlöser gefeiert, daher sein Spitzname.</de>
-						<en>Despite fame, ${.self:"role":0:"firstname"} feels lost and struggles. He doesn't quite find his fulfillment, suffers burn-out, becomes a drug addict again and deals. He is hailed as a savior by the junkies, hence his nickname.</en>
+						<de>Trotz seines Ruhmes fühlt sich ${.self:"role":1:"firstname"} verloren und hat zu kämpfen. Er findet nicht ganz seine Erfüllung, erleidet Burn-out, wird wieder drogenabhängig und dealt. Von den Junkies wird er als Erlöser gefeiert, daher sein Spitzname.</de>
+						<en>Despite fame, ${.self:"role":1:"firstname"} feels lost and struggles. He doesn't quite find his fulfillment, suffers burn-out, becomes a drug addict again and deals. He is hailed as a savior by the junkies, hence his nickname.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="af00fead-7d59-47e5-ac6e-c5dbcebebf62">
@@ -5194,8 +5194,8 @@
 						<en>Tonight He Grins Again</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} landet wieder auf der Straße. „Und was wie eine Grinsekatze lachte war der altbekannte Teufel der Abhängigkeit auf seinem Rücken.“</de>
-						<en>${.self:"role":0:"firstname"} ends up back on the street. "And grinning like a cheshire cat was that same old monkey on his back."</en>
+						<de>${.self:"role":1:"firstname"} landet wieder auf der Straße. „Und was wie eine Grinsekatze lachte war der altbekannte Teufel der Abhängigkeit auf seinem Rücken.“</de>
+						<en>${.self:"role":1:"firstname"} ends up back on the street. "And grinning like a cheshire cat was that same old monkey on his back."</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="59650a48-7471-42c7-9017-0b6cd1b7c24e">
@@ -5208,8 +5208,8 @@
 						<en>Strange Reality</en>
 					</title_original>
 					<description>
-						<de>Eines Tages stößt ${.self:"role":0:"firstname"} auf ein Idol, einen Bluesgitarristen, der ihn inspirierte und jetzt nur noch ein obdachloser Säufer ist, der sich in seinem eigenen Dreck suhlt. Der Anblick des gefallenen Helden erschüttert ${.self:"role":0:"firstname"} zutiefst, denn er erkennt seine eigene Zukunft.</de>
-						<en>One day ${.self:"role":0:"firstname"} chances upon an idol of his, a blues guitarist that inspired him, now nothing more then a homeless wino wallowing in his own filth. The sight of the fallen hero shooks ${.self:"role":0:"firstname"} to the core as he recognizes his own future.</en>
+						<de>Eines Tages stößt ${.self:"role":1:"firstname"} auf ein Idol, einen Bluesgitarristen, der ihn inspirierte und jetzt nur noch ein obdachloser Säufer ist, der sich in seinem eigenen Dreck suhlt. Der Anblick des gefallenen Helden erschüttert ${.self:"role":1:"firstname"} zutiefst, denn er erkennt seine eigene Zukunft.</de>
+						<en>One day ${.self:"role":1:"firstname"} chances upon an idol of his, a blues guitarist that inspired him, now nothing more then a homeless wino wallowing in his own filth. The sight of the fallen hero shooks ${.self:"role":1:"firstname"} to the core as he recognizes his own future.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="51d6d3ab-23e4-44d2-9882-b0fcff8383e9">
@@ -5222,8 +5222,8 @@
 						<en>A Little Too Far</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} beschließt, sich selbst zu retten und seine Karriere zurückzugewinnen, gibt seine Drogen mittels kaltem Entzug auf und beginnt mit seinem Freund ${.self:"role":1:"firstname"}, Clubauftritte zu buchen.</de>
-						<en>${.self:"role":0:"firstname"} resolves to save himself and reclaim his career, quits his drugs cold-turkey and with his friend ${.self:"role":1:"firstname"} starts booking club performances.</en>
+						<de>${.self:"role":1:"firstname"} beschließt, sich selbst zu retten und seine Karriere zurückzugewinnen, gibt seine Drogen mittels kaltem Entzug auf und beginnt mit seinem Freund ${.self:"role":2:"firstname"}, Clubauftritte zu buchen.</de>
+						<en>${.self:"role":1:"firstname"} resolves to save himself and reclaim his career, quits his drugs cold-turkey and with his friend ${.self:"role":2:"firstname"} starts booking club performances.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="5" product="2" licence_type="2" guid="22b95cc2-f419-46f1-ab25-cd1bcf32880b">
@@ -5236,22 +5236,22 @@
 						<en>You're Alive</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"}s erfolgreiches Comeback. Die Skeptiker werden zum Schweigen gebracht, als seine Shows gute Kritiken erhalten und die Zuschauer wieder in Scharen kommen. Aber unter der Oberfläche lauern immer noch Probleme.</de>
-						<en>${.self:"role":0:"firstname"}'s successful comeback. The skeptics are silenced when his shows get good reviews and the crowds start pouring in again. But troubles still lurk beneath the surface.</en>
+						<de>${.self:"role":1:"firstname"}s erfolgreiches Comeback. Die Skeptiker werden zum Schweigen gebracht, als seine Shows gute Kritiken erhalten und die Zuschauer wieder in Scharen kommen. Aber unter der Oberfläche lauern immer noch Probleme.</de>
+						<en>${.self:"role":1:"firstname"}'s successful comeback. The skeptics are silenced when his shows get good reviews and the crowds start pouring in again. But troubles still lurk beneath the surface.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="6" product="2" licence_type="2" guid="11340101-55d4-42fc-9b50-20139d0a8473">
 					<title>
-						<de>${.self:"role":2:"firstname"} und ${.self:"role":1:"firstname"}</de>
-						<en>${.self:"role":2:"firstname"} and ${.self:"role":1:"firstname"}</en>
+						<de>${.self:"role":3:"firstname"} und ${.self:"role":2:"firstname"}</de>
+						<en>${.self:"role":3:"firstname"} and ${.self:"role":2:"firstname"}</en>
 					</title>
 					<title_original>
-						<de>${.self:"role":2:"firstname"} und ${.self:"role":1:"firstname"}</de>
-						<en>${.self:"role":2:"firstname"} and ${.self:"role":1:"firstname"}</en>
+						<de>${.self:"role":3:"firstname"} und ${.self:"role":2:"firstname"}</de>
+						<en>${.self:"role":3:"firstname"} and ${.self:"role":2:"firstname"}</en>
 					</title_original>
 					<description>
-						<de>Eine Konfrontation mit einer gefahrvollen Vergangenheit: Ein rachsüchtiger Drogendealer namens ${.self:"role":2:"firstname"} sucht ${.self:"role":0:"firstname"} heim und bringt ${.self:"role":0:"firstname"}s Freund ${.self:"role":1:"firstname"} um.</de>
-						<en>A confrontation with a dangerous past: A vengeful drug dealer named ${.self:"role":2:"firstname"} comes back to haunt ${.self:"role":0:"firstname"}, leading to ${.self:"role":0:"firstname"}'s friend ${.self:"role":1:"firstname"} being killed.</en>
+						<de>Eine Konfrontation mit einer gefahrvollen Vergangenheit: Ein rachsüchtiger Drogendealer namens ${.self:"role":3:"firstname"} sucht ${.self:"role":1:"firstname"} heim und bringt ${.self:"role":1:"firstname"}s Freund ${.self:"role":2:"firstname"} um.</de>
+						<en>A confrontation with a dangerous past: A vengeful drug dealer named ${.self:"role":3:"firstname"} comes back to haunt ${.self:"role":1:"firstname"}, leading to ${.self:"role":1:"firstname"}'s friend ${.self:"role":2:"firstname"} being killed.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="36a2e468-19bb-4ab7-a17c-4ad37a1da906">
@@ -5264,8 +5264,8 @@
 						<en>St. Patrick's</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} rennt blind in die Nacht, bis er in die St. Patrick's Cathedral stolpert. Er bittet Gott um eine Erklärung, warum es Schmerz und Leid gibt.</de>
-						<en>${.self:"role":0:"firstname"} runs blindly into the night until he stumbles into St. Patrick's Cathedral. He begs God to explain why pain and suffering exist.</en>
+						<de>${.self:"role":1:"firstname"} rennt blind in die Nacht, bis er in die St. Patrick's Cathedral stolpert. Er bittet Gott um eine Erklärung, warum es Schmerz und Leid gibt.</de>
+						<en>${.self:"role":1:"firstname"} runs blindly into the night until he stumbles into St. Patrick's Cathedral. He begs God to explain why pain and suffering exist.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="8" product="2" licence_type="2" guid="03fc57cd-93c5-4c0a-9f49-a86727379df6">
@@ -5278,8 +5278,8 @@
 						<en>Can You Hear Me Now</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} geht zurück in den Club, betritt die Bühne und spielt einen weiteren Song. Die Leute verstehen seine Songs nie besonders tief, vor allem dann nicht, wenn er für ${.self:"role":1:"firstname"} singt.</de>
-						<en>${.self:"role":0:"firstname"} goes back to the club, goes on stage and plays one more song. People never understand his songs very deeply, especially this time when he is reaching for ${.self:"role":1:"firstname"}.</en>
+						<de>${.self:"role":1:"firstname"} geht zurück in den Club, betritt die Bühne und spielt einen weiteren Song. Die Leute verstehen seine Songs nie besonders tief, vor allem dann nicht, wenn er für ${.self:"role":2:"firstname"} singt.</de>
+						<en>${.self:"role":1:"firstname"} goes back to the club, goes on stage and plays one more song. People never understand his songs very deeply, especially this time when he is reaching for ${.self:"role":2:"firstname"}.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="9" product="2" licence_type="2" guid="0b86f210-7553-47ff-99ab-6f5a0683f16d">
@@ -5292,8 +5292,8 @@
 						<en>New York Don't Mean Nothing</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} kehrt auf die Straße zurück und wendet sich hilfesuchend an die Straßenbewohner; ein Obdachloser, ein Zuhälter, ein Junkie und eine Hure geben ihm Ratschläge, aber nicht die Antwort, die er braucht.</de>
-						<en>${.self:"role":0:"firstname"} returns to the streets and turns to its denizens for help; a homeless man, a pimp, a junkie, and a hooker give him advice but not the answer he needs.</en>
+						<de>${.self:"role":1:"firstname"} kehrt auf die Straße zurück und wendet sich hilfesuchend an die Straßenbewohner; ein Obdachloser, ein Zuhälter, ein Junkie und eine Hure geben ihm Ratschläge, aber nicht die Antwort, die er braucht.</de>
+						<en>${.self:"role":1:"firstname"} returns to the streets and turns to its denizens for help; a homeless man, a pimp, a junkie, and a hooker give him advice but not the answer he needs.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="10" product="2" licence_type="2" guid="7e201fa1-6845-4605-b62e-3904c4799f64">
@@ -5306,8 +5306,8 @@
 						<en>Ghost in the Ruins</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} wird von seiner Vergangenheit, den Erinnerungen an seinen gefallenen Helden und dem Preis des Ruhmes verfolgt. Je intensiver er nach einem Weg sucht, seine Schuldgefühle zu lindern, desto schlimmer fühlt er sich.</de>
-						<en>${.self:"role":0:"firstname"} is haunted by his past, memories of his fallen hero, and the cost of fame. The more he searches for a way to ease his guilt the worse he feels.</en>
+						<de>${.self:"role":1:"firstname"} wird von seiner Vergangenheit, den Erinnerungen an seinen gefallenen Helden und dem Preis des Ruhmes verfolgt. Je intensiver er nach einem Weg sucht, seine Schuldgefühle zu lindern, desto schlimmer fühlt er sich.</de>
+						<en>${.self:"role":1:"firstname"} is haunted by his past, memories of his fallen hero, and the cost of fame. The more he searches for a way to ease his guilt the worse he feels.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="11" product="2" licence_type="2" guid="b5f2e103-b1f2-428c-936d-f9b5bcb7f945">
@@ -5320,8 +5320,8 @@
 						<en>If I Go Away</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} erwägt, für immer zu verschwinden, da die Welt ohne ihn besser dran wäre, bis er sich an eine Freundin erinnert, die ihn seine Sucht gekostet hat.</de>
-						<en>${.self:"role":0:"firstname"} considers disappearing forever, the world better off with out him, until he remembers a girlfriend his addiction had cost him.</en>
+						<de>${.self:"role":1:"firstname"} erwägt, für immer zu verschwinden, da die Welt ohne ihn besser dran wäre, bis er sich an eine Freundin erinnert, die ihn seine Sucht gekostet hat.</de>
+						<en>${.self:"role":1:"firstname"} considers disappearing forever, the world better off with out him, until he remembers a girlfriend his addiction had cost him.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="12" product="2" licence_type="2" guid="cfd9d1c6-8f51-45ae-81df-f0f8b7983b5f">
@@ -5334,8 +5334,8 @@
 						<en>Agony and Ecstasy</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} versucht, das Mädchen anzurufen, und scheitert. Er irrt durch die Stadt. Er hat keine Freunde mehr, an die er sich wenden könnte. Die Verzweiflung überzeugt ihn, dass Drogen seinen Schmerz lindern werden.</de>
-						<en>${.self:"role":0:"firstname"} tries to call the girl and fails, wandering through the city. No more friends to turn to. Desperation convincing him that drugs will ease his pain.</en>
+						<de>${.self:"role":1:"firstname"} versucht, das Mädchen anzurufen, und scheitert. Er irrt durch die Stadt. Er hat keine Freunde mehr, an die er sich wenden könnte. Die Verzweiflung überzeugt ihn, dass Drogen seinen Schmerz lindern werden.</de>
+						<en>${.self:"role":1:"firstname"} tries to call the girl and fails, wandering through the city. No more friends to turn to. Desperation convincing him that drugs will ease his pain.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="13" product="2" licence_type="2" guid="a44480bd-4f14-4777-876e-6d0225f0ba80">
@@ -5348,8 +5348,8 @@
 						<en>Heal My Soul</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} erlebt den Tod eines Obdachlosen und sieht, wie der Geist eines Kindes aus dem Körper des alten Mannes austritt. Er folgt ihm auf das Dach eines Hauses.</de>
-						<en>${.self:"role":0:"firstname"} witnesses the death of a homeless man and sees the spirit of a child departing from the old man's body. He follows it to the rooftop.</en>
+						<de>${.self:"role":1:"firstname"} erlebt den Tod eines Obdachlosen und sieht, wie der Geist eines Kindes aus dem Körper des alten Mannes austritt. Er folgt ihm auf das Dach eines Hauses.</de>
+						<en>${.self:"role":1:"firstname"} witnesses the death of a homeless man and sees the spirit of a child departing from the old man's body. He follows it to the rooftop.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="14" product="2" licence_type="2" guid="90cfd1a0-25d0-4373-a871-c3a906e1ed6d">
@@ -5362,8 +5362,8 @@
 						<en>Somewhere in Time</en>
 					</title_original>
 					<description>
-						<de>Auf dem Dach angekommen, singt das Kind, bittet um Vergebung für ein vergeudetes Leben und vergessene Träume und darum, nach Hause zurückzukehren. Das Kind beendet sein Lied, schenkt ${.self:"role":0:"firstname"} ein herzerwärmendes Lächeln und entschwindet in den Nachthimmel.</de>
-						<en>After reaching the roof, the child sings, pleading forgiveness for a wasted life and forgotten dreams, and asks to return home. The child finishes his song, gives ${.self:"role":0:"firstname"} a heart-warming smile, and disappears into the night sky.</en>
+						<de>Auf dem Dach angekommen, singt das Kind, bittet um Vergebung für ein vergeudetes Leben und vergessene Träume und darum, nach Hause zurückzukehren. Das Kind beendet sein Lied, schenkt ${.self:"role":1:"firstname"} ein herzerwärmendes Lächeln und entschwindet in den Nachthimmel.</de>
+						<en>After reaching the roof, the child sings, pleading forgiveness for a wasted life and forgotten dreams, and asks to return home. The child finishes his song, gives ${.self:"role":1:"firstname"} a heart-warming smile, and disappears into the night sky.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="15" product="2" licence_type="2" guid="157a4f36-3547-4477-8f4f-27339b9bc106">
@@ -5376,8 +5376,8 @@
 						<en>Believe</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} erkennt, dass die Erscheinung ihm ein seltsames Gefühl des Friedens gegeben hat, und er kehrt nach Hause zurück, wo er beruhigt schläft und schöne Träume hat.</de>
-						<en>${.self:"role":0:"firstname"} realizes the apparition has given him a strange feeling of peace, and he returns home to comforting sleep and beautiful dreams.</en>
+						<de>${.self:"role":1:"firstname"} erkennt, dass die Erscheinung ihm ein seltsames Gefühl des Friedens gegeben hat, und er kehrt nach Hause zurück, wo er beruhigt schläft und schöne Träume hat.</de>
+						<en>${.self:"role":1:"firstname"} realizes the apparition has given him a strange feeling of peace, and he returns home to comforting sleep and beautiful dreams.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -5411,8 +5411,8 @@
 				<en>Handful of Rain</en>
 			</title_original>
 			<description>
-				<de>Der junge, aufgeweckte ${.self:"role":0:"firstname"} wächst in einem Schwellenland nahe an der rauen Natur auf, sucht dann ein besseres Leben im Westen und trifft dabei auf verschiedene Charaktere, darunter eine Bardame, einen Kriegsveteranen und eine Tänzerin.</de>
-				<en>Young bright ${.self:"role":0:"firstname"} grows up in an emerging country close to harsh nature, then seeks a better life in the West, and meets various characters, including a barmaid, a war veteran, and a dancer.</en>
+				<de>Der junge, aufgeweckte ${.self:"role":1:"firstname"} wächst in einem Schwellenland nahe an der rauen Natur auf, sucht dann ein besseres Leben im Westen und trifft dabei auf verschiedene Charaktere, darunter eine Bardame, einen Kriegsveteranen und eine Tänzerin.</de>
+				<en>Young bright ${.self:"role":1:"firstname"} grows up in an emerging country close to harsh nature, then seeks a better life in the West, and meets various characters, including a barmaid, a war veteran, and a dancer.</en>
 			</description>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="65da1ddb-1ec4-4ff9-a065-37239b9f8e25">
@@ -5425,8 +5425,8 @@
 						<en>Taunting Cobras</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} kommt im Westen an, fühlt sich verloren und überfordert. Er schlägt sich als Straßenkünstler durch. Eine Bar wird zu seinem Zufluchtsort, und ${.self:"role":1:"firstname"}, eine mitfühlende Bardame, hört sich seine Schwierigkeiten an und wird seine Vertraute.</de>
-						<en>${.self:"role":0:"firstname"} arrives in the West, feeling lost and overwhelmed. He ekes out a living as a street performer. A bar becomes his refuge, and ${.self:"role":1:"firstname"}, a compassionate barmaid, listens to his struggles and becomes his confidante.</en>
+						<de>${.self:"role":1:"firstname"} kommt im Westen an, fühlt sich verloren und überfordert. Er schlägt sich als Straßenkünstler durch. Eine Bar wird zu seinem Zufluchtsort, und ${.self:"role":2:"firstname"}, eine mitfühlende Bardame, hört sich seine Schwierigkeiten an und wird seine Vertraute.</de>
+						<en>${.self:"role":1:"firstname"} arrives in the West, feeling lost and overwhelmed. He ekes out a living as a street performer. A bar becomes his refuge, and ${.self:"role":2:"firstname"}, a compassionate barmaid, listens to his struggles and becomes his confidante.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="34c7caa3-f5ee-4c02-a517-de54c494d7f6">
@@ -5439,8 +5439,8 @@
 						<en>Handful Of Rain</en>
 					</title_original>
 					<description>
-						<de>Die Bindung zwischen ${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} wird stärker. In der Bar lernt er ${.self:"role":2:"firstname"} kennen, einen alten Kriegsveteranen, der ihm Geschichten von Widerstandsfähigkeit und Überleben erzählt, die ${.self:"role":0:"firstname"}s innere Kämpfe widerspiegeln.</de>
-						<en>${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"}'s bond grows stronger. At the bar, he meets ${.self:"role":2:"firstname"}, an old war veteran who shares stories of resilience and survival, mirroring ${.self:"role":0:"firstname"}'s internal struggles.</en>
+						<de>Die Bindung zwischen ${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} wird stärker. In der Bar lernt er ${.self:"role":3:"firstname"} kennen, einen alten Kriegsveteranen, der ihm Geschichten von Widerstandsfähigkeit und Überleben erzählt, die ${.self:"role":1:"firstname"}s innere Kämpfe widerspiegeln.</de>
+						<en>${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"}'s bond grows stronger. At the bar, he meets ${.self:"role":3:"firstname"}, an old war veteran who shares stories of resilience and survival, mirroring ${.self:"role":1:"firstname"}'s internal struggles.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="9ff50dcb-35ff-4f5d-b523-3992aac0151d">
@@ -5453,8 +5453,8 @@
 						<en>Chance</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} trifft auf ${.self:"role":3:"firstname"}, eine verführerische und geheimnisvolle Tänzerin, die ihn in ihren Bann zieht. Sie besuchen ein Museum, und er wird in ihre Welt hineingezogen. Doch ihm wird immer mehr ihre bewegte Vergangenheit bewusst.</de>
-						<en>${.self:"role":0:"firstname"} meets ${.self:"role":3:"firstname"}, an alluring and mysterious dancer who captivates him. They visit a museum, and he is drawn into her world. But more and more he realizes her troubled past.</en>
+						<de>${.self:"role":1:"firstname"} trifft auf ${.self:"role":4:"firstname"}, eine verführerische und geheimnisvolle Tänzerin, die ihn in ihren Bann zieht. Sie besuchen ein Museum, und er wird in ihre Welt hineingezogen. Doch ihm wird immer mehr ihre bewegte Vergangenheit bewusst.</de>
+						<en>${.self:"role":1:"firstname"} meets ${.self:"role":4:"firstname"}, an alluring and mysterious dancer who captivates him. They visit a museum, and he is drawn into her world. But more and more he realizes her troubled past.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="3c05f112-d044-4a52-b0fa-286469866b44">
@@ -5467,8 +5467,8 @@
 						<en>Stare Into The Sun</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} verbringt Zeit mit ${.self:"role":2:"firstname"}, der ihm durch seine stille Nachdenklichkeit wertvolle Lebenslektionen vermittelt. ${.self:"role":0:"firstname"} beginnt zu verstehen, dass wahre Stärke darin liegt, sich den eigenen inneren Dämonen zu stellen.</de>
-						<en>${.self:"role":0:"firstname"} spends time with ${.self:"role":2:"firstname"}, who imparts valuable life lessons through his silent contemplation. ${.self:"role":0:"firstname"} begins to understand that true strength lies in confronting one's inner demons.</en>
+						<de>${.self:"role":1:"firstname"} verbringt Zeit mit ${.self:"role":3:"firstname"}, der ihm durch seine stille Nachdenklichkeit wertvolle Lebenslektionen vermittelt. ${.self:"role":1:"firstname"} beginnt zu verstehen, dass wahre Stärke darin liegt, sich den eigenen inneren Dämonen zu stellen.</de>
+						<en>${.self:"role":1:"firstname"} spends time with ${.self:"role":3:"firstname"}, who imparts valuable life lessons through his silent contemplation. ${.self:"role":1:"firstname"} begins to understand that true strength lies in confronting one's inner demons.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="3cb96fc6-a699-41f9-b12c-04d0df11eaeb">
@@ -5481,8 +5481,8 @@
 						<en>Castles Burning</en>
 					</title_original>
 					<description>
-						<de>Zurück allein im Museum betrachtet ${.self:"role":0:"firstname"} in einem Moment der Reflektion Bilder von brennenden Schlössern, die die Vergänglichkeit der Macht und die Notwendigkeit der Selbstfindung symbolisieren. Diese Erfahrung vertieft seine Suche nach einem Sinn.</de>
-						<en>In a moment of reflection back at the museum alone, ${.self:"role":0:"firstname"} looks at paintings of castles burning, symbolizing the impermanence of power and the need for self-discovery. This experience deepens his quest for purpose.</en>
+						<de>Zurück allein im Museum betrachtet ${.self:"role":1:"firstname"} in einem Moment der Reflektion Bilder von brennenden Schlössern, die die Vergänglichkeit der Macht und die Notwendigkeit der Selbstfindung symbolisieren. Diese Erfahrung vertieft seine Suche nach einem Sinn.</de>
+						<en>In a moment of reflection back at the museum alone, ${.self:"role":1:"firstname"} looks at paintings of castles burning, symbolizing the impermanence of power and the need for self-discovery. This experience deepens his quest for purpose.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="5" product="2" licence_type="2" guid="7f58628f-c8ba-43d6-b739-65593653eac2">
@@ -5495,8 +5495,8 @@
 						<en>Visions</en>
 					</title_original>
 					<description>
-						<de>Die Bilder der Ausstellung mit vielen ihm unbekannten Darstellungen der Geschichte des Westens suchen ${.self:"role":0:"firstname"} weiterhin heim und führen zu fast surrealen meditativen Reflexionen, die ihn auf eine Reise der Selbstfindung führen.</de>
-						<en>The pictures from the exhibition with many representations of the history of the West unfamiliar to him continue to haunt ${.self:"role":0:"firstname"}, leading to almost surreal meditative reflections, providing guidance to a journey of self-discovery.</en>
+						<de>Die Bilder der Ausstellung mit vielen ihm unbekannten Darstellungen der Geschichte des Westens suchen ${.self:"role":1:"firstname"} weiterhin heim und führen zu fast surrealen meditativen Reflexionen, die ihn auf eine Reise der Selbstfindung führen.</de>
+						<en>The pictures from the exhibition with many representations of the history of the West unfamiliar to him continue to haunt ${.self:"role":1:"firstname"}, leading to almost surreal meditative reflections, providing guidance to a journey of self-discovery.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="6" product="2" licence_type="2" guid="9e175430-ebd4-43e8-aa3f-2b962229bc22">
@@ -5509,8 +5509,8 @@
 						<en>Watching You Fall</en>
 					</title_original>
 					<description>
-						<de>Durch einen an der Wand montierten Fernseher in einem Motel, der globale Ungerechtigkeiten und einen heuchlerischen Prediger zeigt, wird ${.self:"role":0:"firstname"} weiterhin Zeuge der Grausamkeiten des Westens. Dies weckt in ihm den Wunsch, die Welt positiv zu beeinflussen.</de>
-						<en>Through a wall-mounted TV in a motel displaying global injustices and a hypocritical preacher, ${.self:"role":0:"firstname"} continues to witness the atrocities of the West. This stirs a desire to make a positive impact on the world.</en>
+						<de>Durch einen an der Wand montierten Fernseher in einem Motel, der globale Ungerechtigkeiten und einen heuchlerischen Prediger zeigt, wird ${.self:"role":1:"firstname"} weiterhin Zeuge der Grausamkeiten des Westens. Dies weckt in ihm den Wunsch, die Welt positiv zu beeinflussen.</de>
+						<en>Through a wall-mounted TV in a motel displaying global injustices and a hypocritical preacher, ${.self:"role":1:"firstname"} continues to witness the atrocities of the West. This stirs a desire to make a positive impact on the world.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="7f0aa015-b1d8-4260-b1b6-3b619eb3207d">
@@ -5523,8 +5523,8 @@
 						<en>Nothing's Going On</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} steht vor einem moralischen Dilemma und stellt den Status quo und die Gleichgültigkeit in der Gesellschaft in Frage. Ihm wird klar, dass er für das, woran er glaubt, eintreten muss.</de>
-						<en>${.self:"role":0:"firstname"} faces moral dilemmas, questioning the status quo and societal indifference. He realizes that he must take a stand for what he believes in.</en>
+						<de>${.self:"role":1:"firstname"} steht vor einem moralischen Dilemma und stellt den Status quo und die Gleichgültigkeit in der Gesellschaft in Frage. Ihm wird klar, dass er für das, woran er glaubt, eintreten muss.</de>
+						<en>${.self:"role":1:"firstname"} faces moral dilemmas, questioning the status quo and societal indifference. He realizes that he must take a stand for what he believes in.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="8" product="2" licence_type="2" guid="cf033757-a807-45fb-bf31-202545ff8f95">
@@ -5537,8 +5537,8 @@
 						<en>Symmetry</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} hat ein großes Interesse an Kunst entwickelt und findet Trost in der Unvergänglichkeit von Kunst. Er begreift, dass seine Reise Teil eines größeren Gewebes ist.</de>
-						<en>${.self:"role":0:"firstname"} has become very interested in art and finds solace in art's eternal nature. He understands that his journey is part of a grander tapestry.</en>
+						<de>${.self:"role":1:"firstname"} hat ein großes Interesse an Kunst entwickelt und findet Trost in der Unvergänglichkeit von Kunst. Er begreift, dass seine Reise Teil eines größeren Gewebes ist.</de>
+						<en>${.self:"role":1:"firstname"} has become very interested in art and finds solace in art's eternal nature. He understands that his journey is part of a grander tapestry.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="9" product="2" licence_type="2" guid="b5e7ce21-20da-46bf-b51f-fc3e1eaa4dc1">
@@ -5551,8 +5551,8 @@
 						<en>Alone You Breathe</en>
 					</title_original>
 					<description>
-						<de>Als ${.self:"role":0:"firstname"} ein letztes Mal in die Bar zurückkehrt, beschließt er, sich zu seinen Wurzeln und seiner Herkunft zu bekennen, und mit neu gewonnener Klarheit in sein Heimatland zurückzukehren und als Katalysator für positive Veränderungen in seiner Gemeinde zu wirken.</de>
-						<en>As ${.self:"role":0:"firstname"} returns to the bar for one last time, he decides to embrace his roots and his heritage and, with newfound clarity, to return to his homeland, as a catalyst for positive change in his community.</en>
+						<de>Als ${.self:"role":1:"firstname"} ein letztes Mal in die Bar zurückkehrt, beschließt er, sich zu seinen Wurzeln und seiner Herkunft zu bekennen, und mit neu gewonnener Klarheit in sein Heimatland zurückzukehren und als Katalysator für positive Veränderungen in seiner Gemeinde zu wirken.</de>
+						<en>As ${.self:"role":1:"firstname"} returns to the bar for one last time, he decides to embrace his roots and his heritage and, with newfound clarity, to return to his homeland, as a catalyst for positive change in his community.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -5587,8 +5587,8 @@
 				<en>${title_original_optional}</en>
 			</title_original>
 			<description>
-				<de>Kriegsdrama über den jungen, enthusiastischen und leicht beeindruckbaren ${.self:"role":0:"firstname"} auf der einen, und die warmherzige, aber resolute ${.self:"role":1:"firstname"} auf der anderen Seite der Front in Jugoslawien, und einen Teufels-${.self:"role":2:"firstname"}en dazwischen.</de>
-				<en>War drama about the young, enthusiastic and impressionable ${.self:"role":0:"firstname"} on one side, and the warm-hearted but resolute ${.self:"role":1:"firstname"} on the other side of the front in Yugoslavia, and a devil's ${.self:"role":2:"firstname"} in between.</en>
+				<de>Kriegsdrama über den jungen, enthusiastischen und leicht beeindruckbaren ${.self:"role":1:"firstname"} auf der einen, und die warmherzige, aber resolute ${.self:"role":2:"firstname"} auf der anderen Seite der Front in Jugoslawien, und einen Teufels-${.self:"role":3:"firstname"}en dazwischen.</de>
+				<en>War drama about the young, enthusiastic and impressionable ${.self:"role":1:"firstname"} on one side, and the warm-hearted but resolute ${.self:"role":2:"firstname"} on the other side of the front in Yugoslavia, and a devil's ${.self:"role":3:"firstname"} in between.</en>
 			</description>
 			<variables>
 				<title_original_optional>
@@ -5647,8 +5647,8 @@
 						<en>I Am</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} kann sein Glück nicht fassen, in einem solchen Moment lebendig und jung zu sein. ${.self:"role":1:"firstname"} führt ein gutes Leben in einer liebevollen Familie und hat viele Pläne für eine Zukunft voller Möglichkeiten. Doch langsam ändert sich die Lage...</de>
-						<en>${.self:"role":0:"firstname"} cannot believe his good fortune to be alive and young at such a moment. ${.self:"role":1:"firstname"} has a good life in a loving family and many plans for a future full of possibilities. But slowly the situation is changing...</en>
+						<de>${.self:"role":1:"firstname"} kann sein Glück nicht fassen, in einem solchen Moment lebendig und jung zu sein. ${.self:"role":2:"firstname"} führt ein gutes Leben in einer liebevollen Familie und hat viele Pläne für eine Zukunft voller Möglichkeiten. Doch langsam ändert sich die Lage...</de>
+						<en>${.self:"role":1:"firstname"} cannot believe his good fortune to be alive and young at such a moment. ${.self:"role":2:"firstname"} has a good life in a loving family and many plans for a future full of possibilities. But slowly the situation is changing...</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="a04d98a6-9c12-4d9a-a3af-96c8602ab882">
@@ -5661,8 +5661,8 @@
 						<en>Starlight</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} schließt sich der serbischen Miliz an und findet sich in den Hügeln von Sarajevo wieder, wo er nachts Mörsergranaten abfeuert. In der Stadt ist ${.self:"role":1:"firstname"} beim Waffenkauf und schießt dann mit Kameraden in den Hügeln rund um die Stadt.</de>
-						<en>${.self:"role":0:"firstname"} joins the Serb militia and finds himself in the hills of Sarajevo firing mortar shells at night. In the city, ${.self:"role":1:"firstname"} is buying weapons and then shooting with comrades in the hills around the city.</en>
+						<de>${.self:"role":1:"firstname"} schließt sich der serbischen Miliz an und findet sich in den Hügeln von Sarajevo wieder, wo er nachts Mörsergranaten abfeuert. In der Stadt ist ${.self:"role":2:"firstname"} beim Waffenkauf und schießt dann mit Kameraden in den Hügeln rund um die Stadt.</de>
+						<en>${.self:"role":1:"firstname"} joins the Serb militia and finds himself in the hills of Sarajevo firing mortar shells at night. In the city, ${.self:"role":2:"firstname"} is buying weapons and then shooting with comrades in the hills around the city.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="2af6aed6-cff6-442c-bc62-cb6081832150">
@@ -5689,8 +5689,8 @@
 						<en>Mozart and Madness</en>
 					</title_original>
 					<description>
-						<de>Sonnenuntergang. Der Artilleriebeschuss beginnt. Der ${.self:"role":2:"firstname"} beendet sein Gebet. Er begibt sich nicht in die Schutzräume. Er klettert auf einen einst prachtvollen, zerstörten Brunnen, holt sein Cello heraus. Spielt Mozart, während um ihn herum die Granaten explodieren.</de>
-						<en>Sunset. The artillery shelling begins. The ${.self:"role":2:"firstname"} finishes his prayer. He does not go to the shelters. He climbs on a once magnificent, destroyed fountain, takes out his cello. Plays Mozart while the shells explode around him.</en>
+						<de>Sonnenuntergang. Der Artilleriebeschuss beginnt. Der ${.self:"role":3:"firstname"} beendet sein Gebet. Er begibt sich nicht in die Schutzräume. Er klettert auf einen einst prachtvollen, zerstörten Brunnen, holt sein Cello heraus. Spielt Mozart, während um ihn herum die Granaten explodieren.</de>
+						<en>Sunset. The artillery shelling begins. The ${.self:"role":3:"firstname"} finishes his prayer. He does not go to the shelters. He climbs on a once magnificent, destroyed fountain, takes out his cello. Plays Mozart while the shells explode around him.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="6" product="2" licence_type="2" guid="6c91098b-5b46-460c-945a-1f3c695396a3">
@@ -5703,8 +5703,8 @@
 						<en>Memory</en>
 					</title_original>
 					<description>
-						<de>Von diesem Abend an sollte der ${.self:"role":2:"firstname"} sein Ritual jeden Abend wiederholen. Und jeden Abend hören ${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} aus der Distanz zu und denken über ihr Leben nach, während sie zwischen den Explosionen durch das Niemandsland streifen.</de>
-						<en>From that night on, the ${.self:"role":2:"firstname"} would repeat his ritual every night. And every night ${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"} listen from a distance, thinking about their lives as they roam the no man's land between explosions.</en>
+						<de>Von diesem Abend an sollte der ${.self:"role":3:"firstname"} sein Ritual jeden Abend wiederholen. Und jeden Abend hören ${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} aus der Distanz zu und denken über ihr Leben nach, während sie zwischen den Explosionen durch das Niemandsland streifen.</de>
+						<en>From that night on, the ${.self:"role":3:"firstname"} would repeat his ritual every night. And every night ${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"} listen from a distance, thinking about their lives as they roam the no man's land between explosions.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="98f1d16e-5a8e-4838-8f3b-a51213062008">
@@ -5717,8 +5717,8 @@
 						<en>${title_original_optional}</en>
 					</title_original>
 					<description>
-						<de>Obwohl der Winter sein Bestes tut, die Landschaft in eine Decke vorübergehender Unschuld zu hüllen, eskaliert der Krieg in Gewalt und Brutalität. ${.self:"role":0:"firstname"} ist auf Patrouille und macht eine grausame Entdeckung...</de>
-						<en>Though the winter does its best to cover the landscape with a blanket of temporary innocence, the war only escalates in violence and brutality. ${.self:"role":0:"firstname"} is on patrol and makes a horrifying discovery...</en>
+						<de>Obwohl der Winter sein Bestes tut, die Landschaft in eine Decke vorübergehender Unschuld zu hüllen, eskaliert der Krieg in Gewalt und Brutalität. ${.self:"role":1:"firstname"} ist auf Patrouille und macht eine grausame Entdeckung...</de>
+						<en>Though the winter does its best to cover the landscape with a blanket of temporary innocence, the war only escalates in violence and brutality. ${.self:"role":1:"firstname"} is on patrol and makes a horrifying discovery...</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="8" product="2" licence_type="2" guid="1bbdafb5-6df5-4939-bf3c-1cb7ce4cee11">
@@ -5731,8 +5731,8 @@
 						<en>One Child</en>
 					</title_original>
 					<description>
-						<de>Es ist eine Sache, Granaten in einen Mörser zu stecken, und eine ganz andere, zu sehen, wo sie landen. ${.self:"role":0:"firstname"} gehen die Gesichter der Kinder nicht aus dem Kopf. Er fasst einen Entschluss...</de>
-						<en>It's one thing to put grenades in a mortar, and quite another to see where they land. ${.self:"role":0:"firstname"} can't get the children's faces out of his head. He makes a decision...</en>
+						<de>Es ist eine Sache, Granaten in einen Mörser zu stecken, und eine ganz andere, zu sehen, wo sie landen. ${.self:"role":1:"firstname"} gehen die Gesichter der Kinder nicht aus dem Kopf. Er fasst einen Entschluss...</de>
+						<en>It's one thing to put grenades in a mortar, and quite another to see where they land. ${.self:"role":1:"firstname"} can't get the children's faces out of his head. He makes a decision...</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="9" product="2" licence_type="2" guid="f56ac8f3-39c3-4f8c-8335-2ccca588973e">
@@ -5745,8 +5745,8 @@
 						<en>Carol of the Bells</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} sitzen in ihren jeweiligen Bunkern und lauschen den Weihnachtsliedern des ${.self:"role":2:"firstname"}en, die sich mit den Geräuschen des Krieges vermischen. Es hat gerade aufgehört zu schneien, als die Musik plötzlich abrupt aufhört...</de>
-						<en>${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"} are sitting in their respective bunkers listening to the ${.self:"role":2:"firstname"}'s Christmas carols mixed with the sounds of war. It has just stopped snowing, when the music suddenly stops abruptly...</en>
+						<de>${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} sitzen in ihren jeweiligen Bunkern und lauschen den Weihnachtsliedern des ${.self:"role":3:"firstname"}en, die sich mit den Geräuschen des Krieges vermischen. Es hat gerade aufgehört zu schneien, als die Musik plötzlich abrupt aufhört...</de>
+						<en>${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"} are sitting in their respective bunkers listening to the ${.self:"role":3:"firstname"}'s Christmas carols mixed with the sounds of war. It has just stopped snowing, when the music suddenly stops abruptly...</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="10" product="2" licence_type="2" guid="4da79f0c-f071-4551-becd-e641cea6be0d">
@@ -5759,8 +5759,8 @@
 						<en>Christmas Eve</en>
 					</title_original>
 					<description>
-						<de>Das Schlimmste befürchtend machen sich ${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} auf den Weg durch das Niemandsland. Als sie dort aufeinandertreffen, erkennen sie instinktiv, dass sie beide aus demselben Grund dort sind, und fangen nicht an zu kämpfen.</de>
-						<en>Fearing the worst, ${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"} make their way through No Man's Land. When they meet there, they instinctively realize that they are both there for the same reason and don't start fighting.</en>
+						<de>Das Schlimmste befürchtend machen sich ${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} auf den Weg durch das Niemandsland. Als sie dort aufeinandertreffen, erkennen sie instinktiv, dass sie beide aus demselben Grund dort sind, und fangen nicht an zu kämpfen.</de>
+						<en>Fearing the worst, ${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"} make their way through No Man's Land. When they meet there, they instinctively realize that they are both there for the same reason and don't start fighting.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="11" product="2" licence_type="2" guid="9a2dfccb-8244-408c-955e-3dc7b80e63d0">
@@ -5773,8 +5773,8 @@
 						<en>Not What You See</en>
 					</title_original>
 					<description>
-						<de>Der ${.self:"role":2:"firstname"} liegt blutüberströmt tot im Schnee. Vom klaren Himmel fällt ein Tropfen auf ${.self:"role":0:"firstname"}s Gesicht, doch da oben ist nur die Steinkreatur der Kirche. ${.self:"role":0:"firstname"} versichert ${.self:"role":1:"firstname"}, er sei nicht was sie glaube. Die beiden verlassen gemeinsam die Nacht.</de>
-						<en>The ${.self:"role":2:"firstname"} lies dead in the snow, covered in blood. From the clear sky a drop falls on ${.self:"role":0:"firstname"}'s face, but up there is only the stone gargoyle of the church. ${.self:"role":0:"firstname"} assures ${.self:"role":1:"firstname"} that he is not what she thinks he is. The two leave the night together.</en>
+						<de>Der ${.self:"role":3:"firstname"} liegt blutüberströmt tot im Schnee. Vom klaren Himmel fällt ein Tropfen auf ${.self:"role":1:"firstname"}s Gesicht, doch da oben ist nur die Steinkreatur der Kirche. ${.self:"role":1:"firstname"} versichert ${.self:"role":2:"firstname"}, er sei nicht was sie glaube. Die beiden verlassen gemeinsam die Nacht.</de>
+						<en>The ${.self:"role":3:"firstname"} lies dead in the snow, covered in blood. From the clear sky a drop falls on ${.self:"role":1:"firstname"}'s face, but up there is only the stone gargoyle of the church. ${.self:"role":1:"firstname"} assures ${.self:"role":2:"firstname"} that he is not what she thinks he is. The two leave the night together.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -5811,8 +5811,8 @@
 				<en>My Arms, Your Hearse</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"firstname"}, ein junger Mann, stirbt auf tragische Weise und wird ein Geist. Unfähig, weiterzugehen, bleibt er an das irdische Reich gebunden, wacht über seine ehemalige Liebe ${.self:"role":1:"firstname"}, und kämpft mit unbewältigten Gefühlen und unvollendeten Angelegenheiten.</de>
-				<en>${.self:"role":0:"firstname"}, a young man, dies tragically and becomes a ghost. Unable to move on, he remains tethered to the earthly realm, watching over his former love ${.self:"role":1:"firstname"}, and grappling with unresolved emotions and unfinished business.</en>
+				<de>${.self:"role":1:"firstname"}, ein junger Mann, stirbt auf tragische Weise und wird ein Geist. Unfähig, weiterzugehen, bleibt er an das irdische Reich gebunden, wacht über seine ehemalige Liebe ${.self:"role":2:"firstname"}, und kämpft mit unbewältigten Gefühlen und unvollendeten Angelegenheiten.</de>
+				<en>${.self:"role":1:"firstname"}, a young man, dies tragically and becomes a ghost. Unable to move on, he remains tethered to the earthly realm, watching over his former love ${.self:"role":2:"firstname"}, and grappling with unresolved emotions and unfinished business.</en>
 			</description>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="84b6f0ba-2727-41ef-898a-88b2309250d2">
@@ -5825,8 +5825,8 @@
 						<en>Prologue</en>
 					</title_original>
 					<description>
-						<de>Winter. ${.self:"role":0:"firstname"} wohnt seiner eigenen Beerdigung als Geist bei und betrachtet ${.self:"role":1:"firstname"}. Rückblenden über ihre frühere liebevolle Beziehung. „Ich wusste, es war die Ankunft des Frühlings, daher war unser April ätherisch.“</de>
-						<en>Winter. ${.self:"role":0:"firstname"} is attending his own funeral as a ghost, looking at ${.self:"role":1:"firstname"}. Flashbacks about their former loving relationship. "I knew it was the coming of spring, thus our April Ethereal."</en> <!-- TODO: Use title references once supported (last line of a song always refers to the title of next track/episode) -->
+						<de>Winter. ${.self:"role":1:"firstname"} wohnt seiner eigenen Beerdigung als Geist bei und betrachtet ${.self:"role":2:"firstname"}. Rückblenden über ihre frühere liebevolle Beziehung. „Ich wusste, es war die Ankunft des Frühlings, daher war unser April ätherisch.“</de>
+						<en>Winter. ${.self:"role":1:"firstname"} is attending his own funeral as a ghost, looking at ${.self:"role":2:"firstname"}. Flashbacks about their former loving relationship. "I knew it was the coming of spring, thus our April Ethereal."</en> <!-- TODO: Use title references once supported (last line of a song always refers to the title of next track/episode) -->
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="65e64ed7-32dc-4604-b1fb-3f47ea887856">
@@ -5839,8 +5839,8 @@
 						<en>April Ethereal</en>
 					</title_original>
 					<description>
-						<de>Frühjahr. Rückblenden über Familie und Freunde und seinen seinen besten Freund ${.self:"role":2:"firstname"}, die nun trauern. ${.self:"role":0:"firstname"} begreift langsam seinen Zustand. Er kann sich ${.self:"role":1:"firstname"} nicht bemerkbar machen. „Ich weiß nicht, wie oder warum, ich werde nie wissen, Wann.“</de>
-						<en>Spring. Flashbacks about family and friends and his best friend ${.self:"role":2:"firstname"}, who are now in mourning. ${.self:"role":0:"firstname"} slowly realizes his condition. He cannot make himself noticeable for ${.self:"role":1:"firstname"}. "I don't know how or why, I'll never know When."</en>
+						<de>Frühjahr. Rückblenden über Familie und Freunde und seinen seinen besten Freund ${.self:"role":3:"firstname"}, die nun trauern. ${.self:"role":1:"firstname"} begreift langsam seinen Zustand. Er kann sich ${.self:"role":2:"firstname"} nicht bemerkbar machen. „Ich weiß nicht, wie oder warum, ich werde nie wissen, Wann.“</de>
+						<en>Spring. Flashbacks about family and friends and his best friend ${.self:"role":3:"firstname"}, who are now in mourning. ${.self:"role":1:"firstname"} slowly realizes his condition. He cannot make himself noticeable for ${.self:"role":2:"firstname"}. "I don't know how or why, I'll never know When."</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="a47a42c0-ae97-4fd3-9383-a3b7379455a0">
@@ -5853,8 +5853,8 @@
 						<en>When</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} fühlt sich verloren in der Zeit. Eine höhere Entität ${.self:"role":3:"firstname"} führt ihn. Er hört männliche Stimmen bei ${.self:"role":1:"firstname"}. Sie scheint ihn langsam hinter sich zu lassen. „Das Ende dieses traurigen Madrigal.“</de>
-						<en>${.self:"role":0:"firstname"} feels lost in time. A higher entity ${.self:"role":3:"firstname"} guides him. He hears male voices around ${.self:"role":1:"firstname"}. She seems to be slowly leaving him behind. "The end of this sad Madrigal."</en>
+						<de>${.self:"role":1:"firstname"} fühlt sich verloren in der Zeit. Eine höhere Entität ${.self:"role":4:"firstname"} führt ihn. Er hört männliche Stimmen bei ${.self:"role":2:"firstname"}. Sie scheint ihn langsam hinter sich zu lassen. „Das Ende dieses traurigen Madrigal.“</de>
+						<en>${.self:"role":1:"firstname"} feels lost in time. A higher entity ${.self:"role":4:"firstname"} guides him. He hears male voices around ${.self:"role":2:"firstname"}. She seems to be slowly leaving him behind. "The end of this sad Madrigal."</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="132714c6-553f-4eef-a14e-bdb089c84a40">
@@ -5867,8 +5867,8 @@
 						<en>Madrigal</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":2:"firstname"} scheint etwas über ${.self:"role":0:"firstname"}' Todesursache zu wissen. Währenddessen wird dieser immer frustrierter. Wenn er nicht zu ${.self:"role":1:"firstname"} kommen kann, dann sie vielleicht zu ihm. „Du verlierst dich selbst. Du versteckst dich in der Ecke des Amens.“</de>
-						<en>${.self:"role":2:"firstname"} seems to know something about ${.self:"role":0:"firstname"}' cause of death. Meanwhile, the latter becomes increasingly frustrated. If he can't come to ${.self:"role":1:"firstname"}, maybe she can come to him. "You are losing yourself. Hiding within The Amen Corner."</en>
+						<de>${.self:"role":3:"firstname"} scheint etwas über ${.self:"role":1:"firstname"}' Todesursache zu wissen. Währenddessen wird dieser immer frustrierter. Wenn er nicht zu ${.self:"role":2:"firstname"} kommen kann, dann sie vielleicht zu ihm. „Du verlierst dich selbst. Du versteckst dich in der Ecke des Amens.“</de>
+						<en>${.self:"role":3:"firstname"} seems to know something about ${.self:"role":1:"firstname"}' cause of death. Meanwhile, the latter becomes increasingly frustrated. If he can't come to ${.self:"role":2:"firstname"}, maybe she can come to him. "You are losing yourself. Hiding within The Amen Corner."</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="3804a3c8-e391-4fa4-aa17-55d1d4ffea8a">
@@ -5881,8 +5881,8 @@
 						<en>The Amen Corner</en>
 					</title_original>
 					<description>
-						<de>Sommer. ${.self:"role":2:"firstname"} merkt, dass etwas Übernatürliches vor sich geht: ${.self:"role":0:"firstname"}' steigende Wut zeigt zeigt langsam Wirkung. Er will nun ${.self:"role":1:"firstname"} mit Gewalt zu sich holen. „Der letzte Funke, der mir Leben einhauchte, der Dämon der fallenden Blätter.“</de>
-						<en>Summer. ${.self:"role":2:"firstname"} realizes that something supernatural is going on: ${.self:"role":0:"firstname"}' rising anger is beginning to have an effect. He now wants to get ${.self:"role":1:"firstname"} to him by force. "The final spark that blew life into me, the Demon of the Fall."</en>
+						<de>Sommer. ${.self:"role":3:"firstname"} merkt, dass etwas Übernatürliches vor sich geht: ${.self:"role":1:"firstname"}' steigende Wut zeigt zeigt langsam Wirkung. Er will nun ${.self:"role":2:"firstname"} mit Gewalt zu sich holen. „Der letzte Funke, der mir Leben einhauchte, der Dämon der fallenden Blätter.“</de>
+						<en>Summer. ${.self:"role":3:"firstname"} realizes that something supernatural is going on: ${.self:"role":1:"firstname"}' rising anger is beginning to have an effect. He now wants to get ${.self:"role":2:"firstname"} to him by force. "The final spark that blew life into me, the Demon of the Fall."</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="5" product="2" licence_type="2" guid="34fc79a3-2e26-4599-ae9f-2518748c1ca4">
@@ -5895,8 +5895,8 @@
 						<en>Demon of the Fall</en>
 					</title_original>
 					<description>
-						<de>Herbst. ${.self:"role":0:"firstname"} schafft es endlich, vor ${.self:"role":1:"firstname"} zu erscheinen. Sie sieht ihn ehrfürchtig an - und läuft davon. „Und verloren hatte sie, in mir, ihren Glauben.“</de>
-						<en>Autumn. ${.self:"role":0:"firstname"} finally manages to appear before ${.self:"role":1:"firstname"}. She faces him in awe - and runs away. "And she had lost in me, her Credence."</en>
+						<de>Herbst. ${.self:"role":1:"firstname"} schafft es endlich, vor ${.self:"role":2:"firstname"} zu erscheinen. Sie sieht ihn ehrfürchtig an - und läuft davon. „Und verloren hatte sie, in mir, ihren Glauben.“</de>
+						<en>Autumn. ${.self:"role":1:"firstname"} finally manages to appear before ${.self:"role":2:"firstname"}. She faces him in awe - and runs away. "And she had lost in me, her Credence."</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="6" product="2" licence_type="2" guid="612d52b8-27f4-4c40-af4e-a0839fad7c62">
@@ -5909,8 +5909,8 @@
 						<en>Credence</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} erkennt die Furcht, die er in ${.self:"role":1:"firstname"} ausgelöst hat, und die Fehler seiner Handlungen. „Die Bestätigung des Nachrufs meiner Seele und das Aufzeigen des einst unbekannten Karma.“</de>
-						<en>${.self:"role":0:"firstname"} recognizes the fear he has caused in ${.self:"role":1:"firstname"} and the error of his ways. "Confirming the epitaph of my soul and displaying the once unknown Karma."</en>
+						<de>${.self:"role":1:"firstname"} erkennt die Furcht, die er in ${.self:"role":2:"firstname"} ausgelöst hat, und die Fehler seiner Handlungen. „Die Bestätigung des Nachrufs meiner Seele und das Aufzeigen des einst unbekannten Karma.“</de>
+						<en>${.self:"role":1:"firstname"} recognizes the fear he has caused in ${.self:"role":2:"firstname"} and the error of his ways. "Confirming the epitaph of my soul and displaying the once unknown Karma."</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="1649de50-4a66-494a-8502-63946ca0b538">
@@ -5923,8 +5923,8 @@
 						<en>Karma</en>
 					</title_original>
 					<description>
-						<de>Winter. ${.self:"role":1:"firstname"} versucht, das Erlebte zu verarbeiten. ${.self:"role":0:"firstname"} beginnt, mit Hilfe von ${.self:"role":3:"firstname"} seinen Tod zu akzeptieren. „Gehüllt in ein Schicksal, das ich nicht ändern konnte, und immer bereit für des Winters Epilog.“</de>
-						<en>Winter. ${.self:"role":1:"firstname"} tries to come to terms with what she has experienced. ${.self:"role":0:"firstname"} begins to accept his death with the help of ${.self:"role":3:"firstname"}. "Draped within a fate I could not change, and always welcoming Winter's Epilogue."</en>
+						<de>Winter. ${.self:"role":2:"firstname"} versucht, das Erlebte zu verarbeiten. ${.self:"role":1:"firstname"} beginnt, mit Hilfe von ${.self:"role":4:"firstname"} seinen Tod zu akzeptieren. „Gehüllt in ein Schicksal, das ich nicht ändern konnte, und immer bereit für des Winters Epilog.“</de>
+						<en>Winter. ${.self:"role":2:"firstname"} tries to come to terms with what she has experienced. ${.self:"role":1:"firstname"} begins to accept his death with the help of ${.self:"role":4:"firstname"}. "Draped within a fate I could not change, and always welcoming Winter's Epilogue."</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="8" product="2" licence_type="2" guid="e0e5726b-7253-4807-8212-6ea330968198">
@@ -5937,8 +5937,8 @@
 						<en>Epilogue</en>
 					</title_original>
 					<description>
-						<de>Die letzten Geheimnisse werden gelüftet, und die noch unvollendeten Angelegenheiten werden aufgelöst, so dass ${.self:"role":0:"firstname"} an einen neuen Ort gehen kann. „Aufsteigen und allen erzählen von der Schönheit und dem Prolog.“</de>
-						<en>The last secrets are revealed and the remaining unfinished business is resolved so that ${.self:"role":0:"firstname"} can go to a new place. "Rising and telling everyone about the beauty of its Prologue."</en>
+						<de>Die letzten Geheimnisse werden gelüftet, und die noch unvollendeten Angelegenheiten werden aufgelöst, so dass ${.self:"role":1:"firstname"} an einen neuen Ort gehen kann. „Aufsteigen und allen erzählen von der Schönheit und dem Prolog.“</de>
+						<en>The last secrets are revealed and the remaining unfinished business is resolved so that ${.self:"role":1:"firstname"} can go to a new place. "Rising and telling everyone about the beauty of its Prologue."</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -5975,8 +5975,8 @@
 				<en>Still Life</en>
 			</title_original>
 			<description>
-				<de>Mittelalterliches England: ${.self:"role":0:"firstname"} wurde von einem mächtigen religiösen Rat aus der Stadt verbannt, weil er nicht der Kirche folgte. Er riskiert sein Leben, als er in die Stadt zurückkehrt, um ${.self:"role":1:"firstname"}, die Liebe seines Lebens, zu finden.</de>
-				<en>Medieval England: ${.self:"role":0:"firstname"} was banished from town by a powerful religious council for not following the Church. He risks his life by returning to the town to find ${.self:"role":1:"firstname"}, the love of his life.</en>
+				<de>Mittelalterliches England: ${.self:"role":1:"firstname"} wurde von einem mächtigen religiösen Rat aus der Stadt verbannt, weil er nicht der Kirche folgte. Er riskiert sein Leben, als er in die Stadt zurückkehrt, um ${.self:"role":2:"firstname"}, die Liebe seines Lebens, zu finden.</de>
+				<en>Medieval England: ${.self:"role":1:"firstname"} was banished from town by a powerful religious council for not following the Church. He risks his life by returning to the town to find ${.self:"role":2:"firstname"}, the love of his life.</en>
 			</description>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="c2415199-fd59-47d6-8dd3-ea5d8a734e44">
@@ -5989,8 +5989,8 @@
 						<en>The Moor</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"}s Verbannung ist bereits 15 Jahre her. Rückblenden. Er schlug sich gut. Durch den Wald und das Moor laufend kommt er unerkannt wieder in der Stadt an. Die Atmosphäre dort ist immer noch beklemmend.</de>
-						<en>${.self:"role":0:"firstname"}'s banishment was already 15 years ago. Flashbacks. He survived well. Running through the forest and the moor, he arrives back in the town, unrecognized. The atmosphere there is still oppressive.</en>
+						<de>${.self:"role":1:"firstname"}s Verbannung ist bereits 15 Jahre her. Rückblenden. Er schlug sich gut. Durch den Wald und das Moor laufend kommt er unerkannt wieder in der Stadt an. Die Atmosphäre dort ist immer noch beklemmend.</de>
+						<en>${.self:"role":1:"firstname"}'s banishment was already 15 years ago. Flashbacks. He survived well. Running through the forest and the moor, he arrives back in the town, unrecognized. The atmosphere there is still oppressive.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="448987e1-00a5-4641-a0c2-5f3dced02643">
@@ -6003,8 +6003,8 @@
 						<en>Godhead's Lament</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} muss vorsichtig sein und darf nicht erwischt werden, sonst droht die Hinrichtung. Sein alter Freund ${.self:"role":2:"firstname"} ist, widerstrebend, nun Mitglied des Rates des Kreuzes. ${.self:"role":1:"firstname"} ist nun eine Nonne. Ihre Blicke treffen sich. Es ist immer noch Liebe.</de>
-						<en>${.self:"role":0:"firstname"} has to be careful and must not be caught, otherwise he would be executed. His old friend ${.self:"role":2:"firstname"} is now a reluctant member of the Council of the Cross. ${.self:"role":1:"firstname"} is now a nun. Their eyes meet. It is still love.</en>
+						<de>${.self:"role":1:"firstname"} muss vorsichtig sein und darf nicht erwischt werden, sonst droht die Hinrichtung. Sein alter Freund ${.self:"role":3:"firstname"} ist, widerstrebend, nun Mitglied des Rates des Kreuzes. ${.self:"role":2:"firstname"} ist nun eine Nonne. Ihre Blicke treffen sich. Es ist immer noch Liebe.</de>
+						<en>${.self:"role":1:"firstname"} has to be careful and must not be caught, otherwise he would be executed. His old friend ${.self:"role":3:"firstname"} is now a reluctant member of the Council of the Cross. ${.self:"role":2:"firstname"} is now a nun. Their eyes meet. It is still love.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="403a4b2d-65ef-4a47-b062-ff54b67f86fd">
@@ -6017,8 +6017,8 @@
 						<en>Benighted</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} gelingt es, ${.self:"role":1:"firstname"} heimlich zu treffen. Sie teilen ihre Erlebnisse und lassen ihre Bindung wieder aufflammen. Die Leidenschaft lässt die Gefahr vergessen. ${.self:"role":1:"firstname"} offenbart ihm ihre Nöte, doch sie wagt es noch nicht, mit ihm zu fliehen.</de>
-						<en>${.self:"role":0:"firstname"} manages to meet ${.self:"role":1:"firstname"} in secret. They share their stories and rekindle their bond. The passion makes them forget the danger. ${.self:"role":1:"firstname"} reveals her woes to him, but she does not dare to flee with him just yet.</en>
+						<de>${.self:"role":1:"firstname"} gelingt es, ${.self:"role":2:"firstname"} heimlich zu treffen. Sie teilen ihre Erlebnisse und lassen ihre Bindung wieder aufflammen. Die Leidenschaft lässt die Gefahr vergessen. ${.self:"role":2:"firstname"} offenbart ihm ihre Nöte, doch sie wagt es noch nicht, mit ihm zu fliehen.</de>
+						<en>${.self:"role":1:"firstname"} manages to meet ${.self:"role":2:"firstname"} in secret. They share their stories and rekindle their bond. The passion makes them forget the danger. ${.self:"role":2:"firstname"} reveals her woes to him, but she does not dare to flee with him just yet.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="4d59c3c4-11eb-47f1-80aa-09e524e1643d">
@@ -6031,22 +6031,22 @@
 						<en>Moonlapse Vertigo</en>
 					</title_original>
 					<description>
-						<de>Dem Rat wird ${.self:"role":1:"firstname"}s Verhalten verdächtig. ${.self:"role":0:"firstname"} wird erkannt und muss fliehen, das aufgestachelte Volk hinter ihm her. ${.self:"role":2:"firstname"} und ein weiteres sympathisierendes Ratsmitglied, ${.self:"role":3:"firstname"}, helfen ihm, in den Wald zu entkommen.</de>
-						<en>The council becomes suspicious of ${.self:"role":1:"firstname"}'s behavior. ${.self:"role":0:"firstname"} is identified and has to flee, the incited crowd after him. ${.self:"role":2:"firstname"} and another sympathetic member of the Council, ${.self:"role":3:"firstname"}, help him escape into the forest.</en>
+						<de>Dem Rat wird ${.self:"role":2:"firstname"}s Verhalten verdächtig. ${.self:"role":1:"firstname"} wird erkannt und muss fliehen, das aufgestachelte Volk hinter ihm her. ${.self:"role":3:"firstname"} und ein weiteres sympathisierendes Ratsmitglied, ${.self:"role":4:"firstname"}, helfen ihm, in den Wald zu entkommen.</de>
+						<en>The council becomes suspicious of ${.self:"role":2:"firstname"}'s behavior. ${.self:"role":1:"firstname"} is identified and has to flee, the incited crowd after him. ${.self:"role":3:"firstname"} and another sympathetic member of the Council, ${.self:"role":4:"firstname"}, help him escape into the forest.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="284a4cdd-8c7d-460a-999e-13f5a95a3e97">
 					<title>
-						<de>${.self:"role":1:"firstname"}s Antlitz</de>
-						<en>${.self:"role":1:"firstname"}'s Countenance</en>
+						<de>${.self:"role":2:"firstname"}s Antlitz</de>
+						<en>${.self:"role":2:"firstname"}'s Countenance</en>
 					</title>
 					<title_original>
 						<de>Melindas Gesicht</de>
 						<en>Face of Melinda</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":2:"firstname"} darf sich nicht verdächtig machen. ${.self:"role":0:"firstname"} erkennt, dass ${.self:"role":1:"firstname"} in großer Gefahr ist, wenn sie nicht mit ihm kommt. Er schleicht sich erneut zu ihr. Sie lieben sich, und gemeinsam schlafen sie ein.</de>
-						<en>${.self:"role":2:"firstname"} must not make himself suspicious. ${.self:"role":0:"firstname"} realizes that ${.self:"role":1:"firstname"} is in great danger if she doesn't come with him. He sneaks up to her again. They make love and fall asleep together.</en>
+						<de>${.self:"role":3:"firstname"} darf sich nicht verdächtig machen. ${.self:"role":1:"firstname"} erkennt, dass ${.self:"role":2:"firstname"} in großer Gefahr ist, wenn sie nicht mit ihm kommt. Er schleicht sich erneut zu ihr. Sie lieben sich, und gemeinsam schlafen sie ein.</de>
+						<en>${.self:"role":3:"firstname"} must not make himself suspicious. ${.self:"role":1:"firstname"} realizes that ${.self:"role":2:"firstname"} is in great danger if she doesn't come with him. He sneaks up to her again. They make love and fall asleep together.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="5" product="2" licence_type="2" guid="3d0bc54e-a4d0-469d-bb6c-631d7499e99b">
@@ -6059,8 +6059,8 @@
 						<en>Serenity Painted Death</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} wacht alleine auf. Jemand hatte ihn und ${.self:"role":1:"firstname"} beobachtet. Sie wird zum Tode durch den roten Strang verurteilt. ${.self:"role":0:"firstname"} beobachtet die Hinrichtung, dreht durch, wird zum Berserker, dann gefasst und ins Verließ geworfen.</de>
-						<en>${.self:"role":0:"firstname"} wakes up alone. Someone had been watching him and ${.self:"role":1:"firstname"}. She is sentenced to death by the red rope. ${.self:"role":0:"firstname"} watches the execution, goes mad, becomes a berserker, then is caught and thrown into a dungeon.</en>
+						<de>${.self:"role":1:"firstname"} wacht alleine auf. Jemand hatte ihn und ${.self:"role":2:"firstname"} beobachtet. Sie wird zum Tode durch den roten Strang verurteilt. ${.self:"role":1:"firstname"} beobachtet die Hinrichtung, dreht durch, wird zum Berserker, dann gefasst und ins Verließ geworfen.</de>
+						<en>${.self:"role":1:"firstname"} wakes up alone. Someone had been watching him and ${.self:"role":2:"firstname"}. She is sentenced to death by the red rope. ${.self:"role":1:"firstname"} watches the execution, goes mad, becomes a berserker, then is caught and thrown into a dungeon.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="6" product="2" licence_type="2" guid="4ded0675-0fb9-408f-ae05-d7e8628f4c85">
@@ -6073,8 +6073,8 @@
 						<en>White Cluster</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} wird gefoltert und soll seine Sünden bekennen. Er wird schließlich am Galgen hingerichtet. Er hat eine Vision von ${.self:"role":1:"firstname"} und ihrer Wiedervereinigung im Licht des Todes.</de>
-						<en>${.self:"role":0:"firstname"} is tortured and told to confess his sins. He is finally executed on the gallows. He has a vision of ${.self:"role":1:"firstname"} and their reunion in death's light.</en>
+						<de>${.self:"role":1:"firstname"} wird gefoltert und soll seine Sünden bekennen. Er wird schließlich am Galgen hingerichtet. Er hat eine Vision von ${.self:"role":2:"firstname"} und ihrer Wiedervereinigung im Licht des Todes.</de>
+						<en>${.self:"role":1:"firstname"} is tortured and told to confess his sins. He is finally executed on the gallows. He has a vision of ${.self:"role":2:"firstname"} and their reunion in death's light.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -6112,8 +6112,8 @@
 				<en>Blackwater Park</en>
 			</title_original>
 			<description>
-				<de>Geschichten über das titelgebende kleine, verwunschene Städtchen, das von einem Fluch heimgesucht zu werden scheint, lose verbunden durch die Rahmenhandlung der Ankunft von ${.self:"role":0:"firstname"}, einer aufgewühlten jungen Frau mit einer bewegten Vergangenheit.</de>
-				<en>Stories about the small, enchanted titular village, which seems to be plagued by a curse, loosely linked by the frame story about the arrival of ${.self:"role":0:"firstname"}, a troubled young woman with a haunted past.</en>
+				<de>Geschichten über das titelgebende kleine, verwunschene Städtchen, das von einem Fluch heimgesucht zu werden scheint, lose verbunden durch die Rahmenhandlung der Ankunft von ${.self:"role":1:"firstname"}, einer aufgewühlten jungen Frau mit einer bewegten Vergangenheit.</de>
+				<en>Stories about the small, enchanted titular village, which seems to be plagued by a curse, loosely linked by the frame story about the arrival of ${.self:"role":1:"firstname"}, a troubled young woman with a haunted past.</en>
 			</description>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="61f04514-0170-48c3-9b34-4cc6a5ea8b98">
@@ -6126,8 +6126,8 @@
 						<en>The Leper Affinity</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} kommt in die Stadt, einer traumatischen Vergangenheit entfliehend. Sie lernt ${.self:"role":1:"firstname"} kennen, einen zurückgezogen lebenden Künstler, der von Visionen seiner toten Frau gequält wird.</de>
-						<en>${.self:"role":0:"firstname"} arrives in the town, seeking refuge from a traumatic past. She meets ${.self:"role":1:"firstname"}, a reclusive artist tormented by visions of his dead wife.</en>
+						<de>${.self:"role":1:"firstname"} kommt in die Stadt, einer traumatischen Vergangenheit entfliehend. Sie lernt ${.self:"role":2:"firstname"} kennen, einen zurückgezogen lebenden Künstler, der von Visionen seiner toten Frau gequält wird.</de>
+						<en>${.self:"role":1:"firstname"} arrives in the town, seeking refuge from a traumatic past. She meets ${.self:"role":2:"firstname"}, a reclusive artist tormented by visions of his dead wife.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="6f29e7e8-dd75-439b-9dff-805dfc3c3c1c">
@@ -6140,8 +6140,8 @@
 						<en>Bleak</en>
 					</title_original>
 					<description>
-						<de>Detective ${.self:"role":2:"firstname"} untersucht eine Reihe mysteriöser Todesfälle, die den Ort schon eine Weile lang heimsuchen. Seine eigene Vergangenheit ist durchzogen von Verlust und Reue. Er lernt ${.self:"role":0:"firstname"} kennen und fühlt sich von ihrer rätselhaften Präsenz angezogen.</de>
-						<en>Detective ${.self:"role":2:"firstname"} is investigating a series of mysterious deaths that have been haunting the town for a while. His own past is riddled with loss and regret. He meets ${.self:"role":0:"firstname"} and is drawn to her enigmatic presence.</en>
+						<de>Detective ${.self:"role":3:"firstname"} untersucht eine Reihe mysteriöser Todesfälle, die den Ort schon eine Weile lang heimsuchen. Seine eigene Vergangenheit ist durchzogen von Verlust und Reue. Er lernt ${.self:"role":1:"firstname"} kennen und fühlt sich von ihrer rätselhaften Präsenz angezogen.</de>
+						<en>Detective ${.self:"role":3:"firstname"} is investigating a series of mysterious deaths that have been haunting the town for a while. His own past is riddled with loss and regret. He meets ${.self:"role":1:"firstname"} and is drawn to her enigmatic presence.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="7d552a8f-e9a3-45d9-ab07-6b9a0d87d23c">
@@ -6154,8 +6154,8 @@
 						<en>Harvest</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} beginnt auf der örtlichen Obstplantage zu arbeiten, die dem trauernden Witwer ${.self:"role":3:"fullname"} gehört. Seine Frau fiel einem Mörder zum Opfer, der eine Nachricht über die Sünden der Menschheit hinterließ.</de>
-						<en>${.self:"role":0:"firstname"} begins working at the local orchard, owned by the grieving widower ${.self:"role":3:"fullname"}. His wife fell victim to a murderer who left a message about the sins of mankind.</en>
+						<de>${.self:"role":1:"firstname"} beginnt auf der örtlichen Obstplantage zu arbeiten, die dem trauernden Witwer ${.self:"role":4:"fullname"} gehört. Seine Frau fiel einem Mörder zum Opfer, der eine Nachricht über die Sünden der Menschheit hinterließ.</de>
+						<en>${.self:"role":1:"firstname"} begins working at the local orchard, owned by the grieving widower ${.self:"role":4:"fullname"}. His wife fell victim to a murderer who left a message about the sins of mankind.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="2eee1e6d-471f-44a4-82fd-e7fa16b1baa1">
@@ -6168,8 +6168,8 @@
 						<en>The Drapery Falls</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":2:"firstname"} besucht ${.self:"role":4:"firstname"}, eine geheimnisvolle Frau, die behauptet, mit den Toten kommunizieren zu können. Sie channelt eine Entität, die vom Städtchen Besitz ergriffen haben will und möchte, dass die Menschheit für ihre Sünden büßt.</de>
-						<en>${.self:"role":2:"firstname"} visits ${.self:"role":4:"firstname"}, a mysterious woman who claims to be able to communicate with the dead. She channels an entity that claims to have taken possession of the village and wants humanity to atone for its sins.</en>
+						<de>${.self:"role":3:"firstname"} besucht ${.self:"role":5:"firstname"}, eine geheimnisvolle Frau, die behauptet, mit den Toten kommunizieren zu können. Sie channelt eine Entität, die vom Städtchen Besitz ergriffen haben will und möchte, dass die Menschheit für ihre Sünden büßt.</de>
+						<en>${.self:"role":3:"firstname"} visits ${.self:"role":5:"firstname"}, a mysterious woman who claims to be able to communicate with the dead. She channels an entity that claims to have taken possession of the village and wants humanity to atone for its sins.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="4f9840a1-db25-41c4-9ee1-7cb5f0a2975d">
@@ -6210,8 +6210,8 @@
 						<en>Patterns in the Ivy</en>
 					</title_original>
 					<description>
-						<de>Der Grund für ${.self:"role":0:"firstname"}s Umzug in den Ort wird gezeigt. Ihre Liebesaffäre mit ${.self:"role":1:"firstname"} verschlechtert sich, als seine dunkle, obsessive Natur an die Oberfläche kommt. Die Entität scheint mehr Menschen direkt beeinflussen zu können.</de>
-						<en>The reason for ${.self:"role":0:"firstname"}'s move to the town is revealed. Her love affair with ${.self:"role":1:"firstname"} deteriorates as his dark, obsessive nature comes to the surface. The entity seems to be able to directly affect several more people.</en>
+						<de>Der Grund für ${.self:"role":1:"firstname"}s Umzug in den Ort wird gezeigt. Ihre Liebesaffäre mit ${.self:"role":2:"firstname"} verschlechtert sich, als seine dunkle, obsessive Natur an die Oberfläche kommt. Die Entität scheint mehr Menschen direkt beeinflussen zu können.</de>
+						<en>The reason for ${.self:"role":1:"firstname"}'s move to the town is revealed. Her love affair with ${.self:"role":2:"firstname"} deteriorates as his dark, obsessive nature comes to the surface. The entity seems to be able to directly affect several more people.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="e031baaa-f00e-45a7-a552-d169e3bc8107">
@@ -6224,8 +6224,8 @@
 						<en>Blackwater Park</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":1:"firstname"} ist nicht der Einzige. Im ganzen Ort nimmt das Chaos zu, denn immer mehr Menschen scheinen besessen und verrückt zu werden. Sie versuchen zu verstehen, was passiert, wo sie sind und warum sie die Kontrolle über sich selbst zu verlieren scheinen.</de>
-						<en>${.self:"role":1:"firstname"} is not the only one. Chaos is growing throughout the town as more and more people seem to become possessed and mad. They are trying to understand what is happening, where they are, and why they seem to be losing control of themselves.</en>
+						<de>${.self:"role":2:"firstname"} ist nicht der Einzige. Im ganzen Ort nimmt das Chaos zu, denn immer mehr Menschen scheinen besessen und verrückt zu werden. Sie versuchen zu verstehen, was passiert, wo sie sind und warum sie die Kontrolle über sich selbst zu verlieren scheinen.</de>
+						<en>${.self:"role":2:"firstname"} is not the only one. Chaos is growing throughout the town as more and more people seem to become possessed and mad. They are trying to understand what is happening, where they are, and why they seem to be losing control of themselves.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="8" product="2" licence_type="2" guid="67984644-6511-406d-b6eb-e5576cb56744">
@@ -6238,8 +6238,8 @@
 						<en>Still Day Beneath the Sun</en>
 					</title_original>
 					<description>
-						<de>Das Chaos hat sich in einigen Tötungen entladen, die nicht mehr nur mehr vom bisherigen Serientäter alleine durchgeführt wurden. ${.self:"role":2:"firstname"} ist hoffnungslos überfordert. Zum Glück ist vorerst wieder etwas Ruhe eingekehrt.</de>
-						<en>The chaos has erupted in a number of killings that were no longer carried out by the previous serial killer alone. ${.self:"role":2:"firstname"} is hopelessly overwhelmed. Fortunately, calm has returned for the time being.</en>
+						<de>Das Chaos hat sich in einigen Tötungen entladen, die nicht mehr nur mehr vom bisherigen Serientäter alleine durchgeführt wurden. ${.self:"role":3:"firstname"} ist hoffnungslos überfordert. Zum Glück ist vorerst wieder etwas Ruhe eingekehrt.</de>
+						<en>The chaos has erupted in a number of killings that were no longer carried out by the previous serial killer alone. ${.self:"role":3:"firstname"} is hopelessly overwhelmed. Fortunately, calm has returned for the time being.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="9" product="2" licence_type="2" guid="d2861985-32d2-4d08-ab12-615e15d64a70">
@@ -6252,8 +6252,8 @@
 						<en>Patterns in the Ivy 2</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} sucht ${.self:"role":4:"firstname"} auf. Und tatsächlich scheint ${.self:"role":0:"firstname"} am besten in der Lage zu sein, die richtigen Schlüsse zu ziehen, indem sie sich ihrer eigenen Vergangenheit stellt, und ist nun in der Lage, der Entität entgegenzutreten.</de>
-						<en>${.self:"role":0:"firstname"} seeks out ${.self:"role":4:"firstname"}. And indeed, ${.self:"role":0:"firstname"} seems best able to draw the right conclusions by facing up to her own past and is now in a position to be able to confront the entity.</en>
+						<de>${.self:"role":1:"firstname"} sucht ${.self:"role":5:"firstname"} auf. Und tatsächlich scheint ${.self:"role":1:"firstname"} am besten in der Lage zu sein, die richtigen Schlüsse zu ziehen, indem sie sich ihrer eigenen Vergangenheit stellt, und ist nun in der Lage, der Entität entgegenzutreten.</de>
+						<en>${.self:"role":1:"firstname"} seeks out ${.self:"role":5:"firstname"}. And indeed, ${.self:"role":1:"firstname"} seems best able to draw the right conclusions by facing up to her own past and is now in a position to be able to confront the entity.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -6292,8 +6292,8 @@
 				<en>Ghost Reveries</en>
 			</title_original>
 			<description>
-				<de>Eine nicht-linear erzählte Geschichte über ${.self:"role":0:"firstname"}, der, besessen von dunklen Mächten, seine Mutter tötet. Was hat ihn dazu gebracht, und was ist sein wahrer Hintergrund?</de>
-				<en>A story told non-linearly about ${.self:"role":0:"firstname"} who, possessed by dark forces, kills his mother. What made him do it and what is his true background?</en>
+				<de>Eine nicht-linear erzählte Geschichte über ${.self:"role":1:"firstname"}, der, besessen von dunklen Mächten, seine Mutter tötet. Was hat ihn dazu gebracht, und was ist sein wahrer Hintergrund?</de>
+				<en>A story told non-linearly about ${.self:"role":1:"firstname"} who, possessed by dark forces, kills his mother. What made him do it and what is his true background?</en>
 			</description>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="98cce555-60d5-4f8b-8e21-25c933abcb8d">
@@ -6306,8 +6306,8 @@
 						<en>Ghost of Perdition</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"}, scheinbar von dunklen Mächten besessen und von Visionen und Albträumen heimgesucht, insbesondere über ${.self:"role":1:"firstname"}, eine ehemalige Geliebte, tötet seine Mutter.</de>
-						<en>${.self:"role":0:"firstname"}, seemingly possessed by dark forces and haunted by visions and nightmares, especially about ${.self:"role":1:"firstname"}, a former lover, is killing his mother.</en>
+						<de>${.self:"role":1:"firstname"}, scheinbar von dunklen Mächten besessen und von Visionen und Albträumen heimgesucht, insbesondere über ${.self:"role":2:"firstname"}, eine ehemalige Geliebte, tötet seine Mutter.</de>
+						<en>${.self:"role":1:"firstname"}, seemingly possessed by dark forces and haunted by visions and nightmares, especially about ${.self:"role":2:"firstname"}, a former lover, is killing his mother.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="4b6b2edc-242c-4e87-80e6-51d31f7c7275">
@@ -6320,8 +6320,8 @@
 						<en>The Baying of the Hounds</en>
 					</title_original>
 					<description>
-						<de>Rückblende: ${.self:"role":0:"firstname"} flieht vom Schauplatz eines Rituals, und die Höllenhunde des Teufels jagen ihn. Er wird überwältigt und unterwirft sich.</de>
-						<en>Flashback: ${.self:"role":0:"firstname"} is running from the scene of a ritual, and the devil's hell hounds are chasing him. He is overcome and submits.</en>
+						<de>Rückblende: ${.self:"role":1:"firstname"} flieht vom Schauplatz eines Rituals, und die Höllenhunde des Teufels jagen ihn. Er wird überwältigt und unterwirft sich.</de>
+						<en>Flashback: ${.self:"role":1:"firstname"} is running from the scene of a ritual, and the devil's hell hounds are chasing him. He is overcome and submits.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="cf33cf3f-9674-40c3-a616-e14aa47b9b5c">
@@ -6334,8 +6334,8 @@
 						<en>Beneath the Mire</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} spürt, dass der Teufel ihn beherrscht. Er fühlt sich von der Präsenz in seinem Inneren bedrängt und unterdrückt. Doch er spürt auch die Macht. Seine entfremdete Schwester ${.self:"role":2:"firstname"} versucht unterdessen, wieder mit ihm in Kontakt zu treten.</de>
-						<en>${.self:"role":0:"firstname"} senses the devil possessing him. He feels choked and oppressed by the presence inside him. Yet he also feels the power. Meanwhile, his estranged sister ${.self:"role":2:"firstname"} tries to reconnect with him.</en>
+						<de>${.self:"role":1:"firstname"} spürt, dass der Teufel ihn beherrscht. Er fühlt sich von der Präsenz in seinem Inneren bedrängt und unterdrückt. Doch er spürt auch die Macht. Seine entfremdete Schwester ${.self:"role":3:"firstname"} versucht unterdessen, wieder mit ihm in Kontakt zu treten.</de>
+						<en>${.self:"role":1:"firstname"} senses the devil possessing him. He feels choked and oppressed by the presence inside him. Yet he also feels the power. Meanwhile, his estranged sister ${.self:"role":3:"firstname"} tries to reconnect with him.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="558defc5-5133-48af-a5ca-6fa6e8cd181c">
@@ -6348,8 +6348,8 @@
 						<en>Atonement</en>
 					</title_original>
 					<description>
-						<de>Vorschau oder Halluzination über eine mögliche Zukunft, in der ${.self:"role":0:"firstname"} endlich frei ist und versucht, für seine Sünden und sein Leben, voller Reue, zu büßen. ${.self:"role":3:"fullname"} und eine Frau namens ${.self:"role":4:"firstname"} beraten und helfen ihm.</de>
-						<en>Flash-forward or hallucination about a possible future when ${.self:"role":0:"firstname"} is finally free and attempts to atone for his sins and life with regret. ${.self:"role":3:"fullname"} and a woman named ${.self:"role":4:"firstname"} counsel and help him.</en>
+						<de>Vorschau oder Halluzination über eine mögliche Zukunft, in der ${.self:"role":1:"firstname"} endlich frei ist und versucht, für seine Sünden und sein Leben, voller Reue, zu büßen. ${.self:"role":4:"fullname"} und eine Frau namens ${.self:"role":5:"firstname"} beraten und helfen ihm.</de>
+						<en>Flash-forward or hallucination about a possible future when ${.self:"role":1:"firstname"} is finally free and attempts to atone for his sins and life with regret. ${.self:"role":4:"fullname"} and a woman named ${.self:"role":5:"firstname"} counsel and help him.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="a3947834-1883-4a09-985f-c13bb877af98">
@@ -6362,8 +6362,8 @@
 						<en>Harlequin Forest</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} wird sich der Tragweite seines Handelns bewusst und rennt in den nahe gelegenen Wald. Verzehrt von Trauer und Wahnsinn zündet er ihn in seiner Verwirrung schließlich an, als er versucht, den Teufel auszutreiben.</de>
-						<en>${.self:"role":0:"firstname"} realizes the weight of his actions and runs into the nearby forest. Consumed by sorrow, madness, he ends up setting it on fire in his confusion as he tries to force the devil out.</en>
+						<de>${.self:"role":1:"firstname"} wird sich der Tragweite seines Handelns bewusst und rennt in den nahe gelegenen Wald. Verzehrt von Trauer und Wahnsinn zündet er ihn in seiner Verwirrung schließlich an, als er versucht, den Teufel auszutreiben.</de>
+						<en>${.self:"role":1:"firstname"} realizes the weight of his actions and runs into the nearby forest. Consumed by sorrow, madness, he ends up setting it on fire in his confusion as he tries to force the devil out.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="5" product="2" licence_type="2" guid="356331b1-2a4e-49ca-a78c-f4a303de053e">
@@ -6376,8 +6376,8 @@
 						<en>Hours of Wealth</en>
 					</title_original>
 					<description>
-						<de>Rückblende auf die gute Zeit der Macht, als ${.self:"role":0:"firstname"} vom Teufel alles bekommt, was er sich wünscht. Er wartet außerdem auf seine Befehle. Schließlich wird ihm der Preis genannt: Die Ermordung seiner Mutter.</de>
-						<en>Flashback to the good times of power when ${.self:"role":0:"firstname"} is given by the devil everything he desires. He also lies in wait of his bidding. Finally, he is told the price: Murder his mother.</en>
+						<de>Rückblende auf die gute Zeit der Macht, als ${.self:"role":1:"firstname"} vom Teufel alles bekommt, was er sich wünscht. Er wartet außerdem auf seine Befehle. Schließlich wird ihm der Preis genannt: Die Ermordung seiner Mutter.</de>
+						<en>Flashback to the good times of power when ${.self:"role":1:"firstname"} is given by the devil everything he desires. He also lies in wait of his bidding. Finally, he is told the price: Murder his mother.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="6" product="2" licence_type="2" guid="31f0c8dc-df74-46af-a517-041fd0c69253">
@@ -6390,8 +6390,8 @@
 						<en>The Grand Conjuration</en>
 					</title_original>
 					<description>
-						<de>Rückblende zu dem Ritual, bei dem ${.self:"role":0:"firstname"} zum ersten Mal den Teufel beschwört. Gegen Ende des Rituals bemerkt er seinen Fehler und rennt davon.</de>
-						<en>Flashback to the ritual when ${.self:"role":0:"firstname"} summoned the devil for the first time. Towards the end of the ritual he realizes his mistake and runs.</en>
+						<de>Rückblende zu dem Ritual, bei dem ${.self:"role":1:"firstname"} zum ersten Mal den Teufel beschwört. Gegen Ende des Rituals bemerkt er seinen Fehler und rennt davon.</de>
+						<en>Flashback to the ritual when ${.self:"role":1:"firstname"} summoned the devil for the first time. Towards the end of the ritual he realizes his mistake and runs.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="949c0e00-5ad5-4641-9002-9c7265d12cc0">
@@ -6404,8 +6404,8 @@
 						<en>Isolation Years</en>
 					</title_original>
 					<description>
-						<de>Rück- und Vorblenden zu ${.self:"role":0:"firstname"}' Jahren der Einsamkeit vor und dann nach den Ereignissen, was dann zu einer überraschenden Auflösung zusammen geführt wird.</de>
-						<en>Flashes back and forward to ${.self:"role":0:"firstname"}' years of loneliness before and then after the events, which are then brought together in a surprising resolution.</en>
+						<de>Rück- und Vorblenden zu ${.self:"role":1:"firstname"}' Jahren der Einsamkeit vor und dann nach den Ereignissen, was dann zu einer überraschenden Auflösung zusammen geführt wird.</de>
+						<en>Flashes back and forward to ${.self:"role":1:"firstname"}' years of loneliness before and then after the events, which are then brought together in a surprising resolution.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -6447,8 +6447,8 @@
 				<en>${title_original_optional}</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"firstname"}s Freundin ${.self:"role":1:"firstname"} wurde entführt vom verrückten Professor Dr. ${.self:"role":4:"firstname"}! Er und seine Freunde wollen sie aus dessen Villa befreien. Dort gehen noch viel mehr merkwürdige Dinge vor sich! Und wo ist Benzin für die Kettensäge, wenn man's mal braucht.</de>
-				<en>${.self:"role":0:"firstname"}'s girlfriend ${.self:"role":1:"firstname"} has been kidnapped by the mad professor Dr. ${.self:"role":4:"firstname"}! He and his friends want to free her from his mansion. There are a lot more strange things going on there! And where is gasoline for the chainsaw when you need it.</en>
+				<de>${.self:"role":1:"firstname"}s Freundin ${.self:"role":2:"firstname"} wurde entführt vom verrückten Professor Dr. ${.self:"role":5:"firstname"}! Er und seine Freunde wollen sie aus dessen Villa befreien. Dort gehen noch viel mehr merkwürdige Dinge vor sich! Und wo ist Benzin für die Kettensäge, wenn man's mal braucht.</de>
+				<en>${.self:"role":1:"firstname"}'s girlfriend ${.self:"role":2:"firstname"} has been kidnapped by the mad professor Dr. ${.self:"role":5:"firstname"}! He and his friends want to free her from his mansion. There are a lot more strange things going on there! And where is gasoline for the chainsaw when you need it.</en>
 			</description>
 			<variables>
 				<title_spoofed>
@@ -6531,8 +6531,8 @@
 				<en>${title_original_optional}</en>
 			</title_original>
 			<description>
-				<de>Zurück zur abgedrehten Villa! Dr. ${.self:"role":3:"firstname"} ist diesmal auf unserer Seite. Naja fast. Er will verhindern, dass ${.self:"role":4:"fullname"} die Menschheit versklavt, aber hat was mit der Zeitmaschine gründlich vermasselt. Die Protagonisten müssen's richten.</de>
-				<en>Back to the wacky mansion! Dr. ${.self:"role":3:"firstname"} is on our side this time. Well, almost. He wants to prevent ${.self:"role":4:"fullname"} from enslaving humanity, but has massively screwed up something with the time machine. The protagonists now have to fix things.</en>
+				<de>Zurück zur abgedrehten Villa! Dr. ${.self:"role":4:"firstname"} ist diesmal auf unserer Seite. Naja fast. Er will verhindern, dass ${.self:"role":5:"fullname"} die Menschheit versklavt, aber hat was mit der Zeitmaschine gründlich vermasselt. Die Protagonisten müssen's richten.</de>
+				<en>Back to the wacky mansion! Dr. ${.self:"role":4:"firstname"} is on our side this time. Well, almost. He wants to prevent ${.self:"role":5:"fullname"} from enslaving humanity, but has massively screwed up something with the time machine. The protagonists now have to fix things.</en>
 			</description>
 			<variables>
 				<revenge>
@@ -6576,8 +6576,8 @@
 		<!-- TODO: Add a series with episodes from https://maniac-mansion-mania.com/ to make more use of all the defined roles. -->
 		<scripttemplate product="1" licence_type="1" guid="61d6403e-6ee6-4849-81af-6b08dbc4aaa8" creator="9551" comment="inspired from https://en.wikipedia.org/wiki/Zak_McKracken_and_the_Alien_Mindbenders">
 			<title>
-				<de>${myname}${.self:"role":0:"fullname"}, ${roving} Reporter</de>
-				<en>Hi, ${.self:"role":0:"fullname"}${myname}, ${roving} Reporter</en>
+				<de>${myname}${.self:"role":1:"fullname"}, ${roving} Reporter</de>
+				<en>Hi, ${.self:"role":1:"fullname"}${myname}, ${roving} Reporter</en>
 			</title>
 			<title_original>
 				<de>${title_original_optional}</de>
@@ -6589,8 +6589,8 @@
 			</description>
 			<variables>
 				<title_original_optional>
-					<de>${.self:"role":0:"fullname"} and the Alien Mindbenders|${.self:"role":0:"fullname"} und die außerirdischen Gedankenverdreher|${myname}${.self:"role":0:"fullname"}, ${roving} Reporter</de>
-					<en>${.self:"role":0:"fullname"} and the Alien Mindbenders|${.self:"role":0:"fullname"} and the Alien Mindbenders|Hi, ${.self:"role":0:"fullname"}${myname}, ${roving} Reporter</en>
+					<de>${.self:"role":1:"fullname"} and the Alien Mindbenders|${.self:"role":1:"fullname"} und die außerirdischen Gedankenverdreher|${myname}${.self:"role":1:"fullname"}, ${roving} Reporter</de>
+					<en>${.self:"role":1:"fullname"} and the Alien Mindbenders|${.self:"role":1:"fullname"} and the Alien Mindbenders|Hi, ${.self:"role":1:"fullname"}${myname}, ${roving} Reporter</en>
 				</title_original_optional>
 				<myname>
 					<de>Hi, |Gestatten, |</de>
@@ -6634,8 +6634,8 @@
 				<en>${askmeabout}Loom - The Age of the Great Guilds</en>
 			</title_original>
 			<description>
-				<de>Die Weber perfektionierten ihr Handwerk so, dass sie das Gewebe der Wirklichkeit selbst flechten können, wurden auf eine Insel verbannt und mit der Zeit unfruchtbar. ${.self:"role":1:"fullname"} webt ein Kind, erzürnt die Ältesten und wird in einen Schwan verwandelt.</de>
-				<en>The weavers perfected their craft so that they can weave the fabric of reality itself, were banished to an island, and over time became barren. ${.self:"role":1:"fullname"} weaves a child, enrages the Elders and is transformed into a swan.</en>
+				<de>Die Weber perfektionierten ihr Handwerk so, dass sie das Gewebe der Wirklichkeit selbst flechten können, wurden auf eine Insel verbannt und mit der Zeit unfruchtbar. ${.self:"role":2:"fullname"} webt ein Kind, erzürnt die Ältesten und wird in einen Schwan verwandelt.</de>
+				<en>The weavers perfected their craft so that they can weave the fabric of reality itself, were banished to an island, and over time became barren. ${.self:"role":2:"fullname"} weaves a child, enrages the Elders and is transformed into a swan.</en>
 			</description>
 			<variables>
 				<askmeabout>
@@ -6654,8 +6654,8 @@
 						<en>The Weavers</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":2:"fullname"} zieht ${.self:"role":0:"firstname"} groß. Als über sein Schicksal entschieden werden soll, kracht ein Schwan herein, und die Ältesten werden ebenfalls in Schwäne verwandelt. ${.self:"role":0:"firstname"} versucht, die Insel zu verlassen und die anderen Gilden zu finden.</de>
-						<en>${.self:"role":2:"fullname"} raises ${.self:"role":0:"firstname"}. When his fate is to be decided, a swan is crashing in, and the elders are also turned into swans. ${.self:"role":0:"firstname"} tries to leave the island and find the other guilds.</en>
+						<de>${.self:"role":3:"fullname"} zieht ${.self:"role":1:"firstname"} groß. Als über sein Schicksal entschieden werden soll, kracht ein Schwan herein, und die Ältesten werden ebenfalls in Schwäne verwandelt. ${.self:"role":1:"firstname"} versucht, die Insel zu verlassen und die anderen Gilden zu finden.</de>
+						<en>${.self:"role":3:"fullname"} raises ${.self:"role":1:"firstname"}. When his fate is to be decided, a swan is crashing in, and the elders are also turned into swans. ${.self:"role":1:"firstname"} tries to leave the island and find the other guilds.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="1449f153-8177-4820-97f9-f45313b2e94e">
@@ -6668,8 +6668,8 @@
 						<en>The Glassmakers</en>
 					</title_original>
 					<description>
-						<de>Mit seinem musikalischen Zauber-Rocken machte sich ${.self:"role":0:"firstname"} auf seine Reise und findet Crystalgard, die Stadt der Gilde der Glasmacher, die scharf und in die nahe Zukunft sehen können, und freundet sich mit ${.self:"role":3:"fullname"} an.</de>
-						<en>With his magical musical distaff, ${.self:"role":0:"firstname"} set out on his journey and finds Crystalgard, the city of the Guild of the Glassmakers who can see sharply and into the near future, and befriends ${.self:"role":3:"fullname"}.</en>
+						<de>Mit seinem musikalischen Zauber-Rocken machte sich ${.self:"role":1:"firstname"} auf seine Reise und findet Crystalgard, die Stadt der Gilde der Glasmacher, die scharf und in die nahe Zukunft sehen können, und freundet sich mit ${.self:"role":4:"fullname"} an.</de>
+						<en>With his magical musical distaff, ${.self:"role":1:"firstname"} set out on his journey and finds Crystalgard, the city of the Guild of the Glassmakers who can see sharply and into the near future, and befriends ${.self:"role":4:"fullname"}.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="aa648447-0d49-45a9-aa6f-e9b6a46ec16f">
@@ -6682,8 +6682,8 @@
 						<en>The Shepherds</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} findet die Gilde der Schäfer, die Geistlichen, die sich unsichtbar machen können, und trifft Bishop ${.self:"role":4:"firstname"}, der einen Plan hat, wie die Welt wieder in Einklang zu bringen ist.</de>
-						<en>${.self:"role":0:"firstname"} finds the Guild of the Shepherds, who are the clergy that can turn invisible, and meets Bishop ${.self:"role":4:"firstname"}, who has a plan to bring the world back into harmony.</en>
+						<de>${.self:"role":1:"firstname"} findet die Gilde der Schäfer, die Geistlichen, die sich unsichtbar machen können, und trifft Bishop ${.self:"role":5:"firstname"}, der einen Plan hat, wie die Welt wieder in Einklang zu bringen ist.</de>
+						<en>${.self:"role":1:"firstname"} finds the Guild of the Shepherds, who are the clergy that can turn invisible, and meets Bishop ${.self:"role":5:"firstname"}, who has a plan to bring the world back into harmony.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="ef47e87c-c437-4675-b116-63801a3d6899">
@@ -6696,8 +6696,8 @@
 						<en>The Blacksmiths</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} findet die Gilde der Schmiede, die Meister über Eisen und Feuer, und trifft den Jungen ${.self:"role":5:"fullname"} nahe einer großen Schmiede.</de>
-						<en>${.self:"role":0:"firstname"} finds the Guild of Blacksmiths, masters of iron and fire, and meets young boy ${.self:"role":5:"fullname"} near a large forge.</en>
+						<de>${.self:"role":1:"firstname"} findet die Gilde der Schmiede, die Meister über Eisen und Feuer, und trifft den Jungen ${.self:"role":6:"fullname"} nahe einer großen Schmiede.</de>
+						<en>${.self:"role":1:"firstname"} finds the Guild of Blacksmiths, masters of iron and fire, and meets young boy ${.self:"role":6:"fullname"} near a large forge.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="2e68ab79-4be5-457d-b230-400e7e15b9e7">
@@ -6710,8 +6710,8 @@
 						<en>The Cathedral</en>
 					</title_original>
 					<description>
-						<de>An einem transzendenten Ort, der Kathedrale, kommt es zum Showdown gegen ${.self:"role":6:"fullname"}. Können die in Schwäne verwandelten Weber wieder befreit, und kann das Gewebe der Wirklichkeit geheilt werden?</de>
-						<en>In a transcendent place, the Cathedral, the showdown against ${.self:"role":6:"fullname"} takes place. Can the Weavers-turned-swans be freed again and the fabric of reality be healed?</en>
+						<de>An einem transzendenten Ort, der Kathedrale, kommt es zum Showdown gegen ${.self:"role":7:"fullname"}. Können die in Schwäne verwandelten Weber wieder befreit, und kann das Gewebe der Wirklichkeit geheilt werden?</de>
+						<en>In a transcendent place, the Cathedral, the showdown against ${.self:"role":7:"fullname"} takes place. Can the Weavers-turned-swans be freed again and the fabric of reality be healed?</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -6751,8 +6751,8 @@
 				<en>The ${mystery_object_reference} of ${donkeybay_object_reference}</en>
 			</title_original>
 			<description>
-				<de>Tief in der Karibik vor ein paar hundert Jährchen. Jungspund ${.self:"role":0:"fullname"} strandet auf einer Pirateninsel. Trifft sich aber gut, er wollte eh immer Pirat werden. Doch die Gegend wird heimgesucht von Geisterpirat ${.self:"role":2:"fullname"}. Und dann ist da noch die Liebe.</de> <!-- TODO: ROLELASTx? -->
-				<en>Deep in the Caribbean few 'undred yearsies ago. Youngster ${.self:"role":0:"fullname"} gets stranded on a pirate island. But that be jus' fine, always wanted t' be a pirate anyway. Howe'er, area be 'aunted by ghost pirate ${.self:"role":2:"fullname"}. An' then thar also be love.</en>
+				<de>Tief in der Karibik vor ein paar hundert Jährchen. Jungspund ${.self:"role":1:"fullname"} strandet auf einer Pirateninsel. Trifft sich aber gut, er wollte eh immer Pirat werden. Doch die Gegend wird heimgesucht von Geisterpirat ${.self:"role":3:"fullname"}. Und dann ist da noch die Liebe.</de> <!-- TODO: ROLELASTx? -->
+				<en>Deep in the Caribbean few 'undred yearsies ago. Youngster ${.self:"role":1:"fullname"} gets stranded on a pirate island. But that be jus' fine, always wanted t' be a pirate anyway. Howe'er, area be 'aunted by ghost pirate ${.self:"role":3:"fullname"}. An' then thar also be love.</en>
 			</description>
 			<variables>
 				<hurlyeisland_object_reference> <!-- introducing 'xyz_object_reference' and 'xyz_object_reference_original' as a convention to enable search-and-replace if one wants to play with original names of places, objects etc -->
@@ -6815,8 +6815,8 @@
 						<en>${hurlyeisland_object_reference}</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} ist erstmal auf ${hurlyeisland_object_reference} gestrandet und macht sich mit der eigentlich recht lauschigen Umgebung vertraut. Er trifft auf wegen ${.self:"role":2:"fullname"} vollkommen verängstigte Piraten, eigentlich gestandene Mannsbilder, und andere skurrile Gestalten.</de>
-						<en>${.self:"role":0:"firstname"} is stranded on ${hurlyeisland_object_reference} for now and familiarizes himself with the actually quite lush scenery. He meets pirates who are completely frightened because of ${.self:"role":2:"fullname"}, actually seasoned men, and other bizarre characters.</en>
+						<de>${.self:"role":1:"firstname"} ist erstmal auf ${hurlyeisland_object_reference} gestrandet und macht sich mit der eigentlich recht lauschigen Umgebung vertraut. Er trifft auf wegen ${.self:"role":3:"fullname"} vollkommen verängstigte Piraten, eigentlich gestandene Mannsbilder, und andere skurrile Gestalten.</de>
+						<en>${.self:"role":1:"firstname"} is stranded on ${hurlyeisland_object_reference} for now and familiarizes himself with the actually quite lush scenery. He meets pirates who are completely frightened because of ${.self:"role":3:"fullname"}, actually seasoned men, and other bizarre characters.</en>
 					</description>
 					<effects>
 						<effect trigger="broadcastFirstTime" type="modifyScriptAvailability" guid="c48d5851-d9f8-4fc1-8d34-264dfa3f6384" />
@@ -6832,8 +6832,8 @@
 						<en>The Three Trials</en>
 					</title_original>
 					<description>
-						<de>Die lokale Gouverneurin ${.self:"role":1:"firstname"} scheint schon eine gute Partie zu sein, wie ${.self:"role":0:"firstname"} von Plakaten und Gerede entnehmen kann. Schließlich erfährt ${.self:"role":0:"firstname"}, wie das mit der Piratenaufnahmeprüfung so läuft.</de>
-						<en>The local governor ${.self:"role":1:"firstname"} appears to be quite a catch, as ${.self:"role":0:"firstname"} can tell from posters and gossip. Finally, ${.self:"role":0:"firstname"} learns how this pirate admission thing goes about.</en>
+						<de>Die lokale Gouverneurin ${.self:"role":2:"firstname"} scheint schon eine gute Partie zu sein, wie ${.self:"role":1:"firstname"} von Plakaten und Gerede entnehmen kann. Schließlich erfährt ${.self:"role":1:"firstname"}, wie das mit der Piratenaufnahmeprüfung so läuft.</de>
+						<en>The local governor ${.self:"role":2:"firstname"} appears to be quite a catch, as ${.self:"role":1:"firstname"} can tell from posters and gossip. Finally, ${.self:"role":1:"firstname"} learns how this pirate admission thing goes about.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="ef230bd2-7d96-43ec-bb0d-01e84787243c">
@@ -6846,8 +6846,8 @@
 						<en>You fight like a Cow</en>
 					</title_original>
 					<description>
-						<de>Als erste Prüfung muss ${.self:"role":0:"firstname"} gegen den Schwertmeister der Insel antreten. Dazu gibt es viele Hindernisse zu überwinden, vor allem sind erstmal erbitterte Wortgefechte zu überstehen.</de>
-						<en>As a first test ${.self:"role":0:"firstname"} has to compete against the sword master of the island. There are many obstacles to overcome, especially fierce battles of words.</en>
+						<de>Als erste Prüfung muss ${.self:"role":1:"firstname"} gegen den Schwertmeister der Insel antreten. Dazu gibt es viele Hindernisse zu überwinden, vor allem sind erstmal erbitterte Wortgefechte zu überstehen.</de>
+						<en>As a first test ${.self:"role":1:"firstname"} has to compete against the sword master of the island. There are many obstacles to overcome, especially fierce battles of words.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="1e345224-e090-4a83-9303-55150550d76d">
@@ -6860,8 +6860,8 @@
 						<en>Theft of Hearts</en>
 					</title_original>
 					<description>
-						<de>Der Schwertmeisterin hat ${.self:"role":0:"firstname"} Paroli geboten, jetzt muss er als zweite Prüfung ein wertvolles Artefakt aus dem Haus der Gouverneurin stehlen. Dort wird er freilich von ${.self:"role":1:"firstname"} ertappt. Amors Pfeile treffen ihn. ${.self:"role":1:"firstname"} ist gar nicht mal abgeneigt...</de>
-						<en>The sword master? ${.self:"role":0:"firstname"} stood up to her. Now a valuable artifact must be stolen from the governor's house as the second trial. There, of course, he is caught by ${.self:"role":1:"firstname"}. Cupid's arrows hit him. ${.self:"role":1:"firstname"} isn't even averse...</en>
+						<de>Der Schwertmeisterin hat ${.self:"role":1:"firstname"} Paroli geboten, jetzt muss er als zweite Prüfung ein wertvolles Artefakt aus dem Haus der Gouverneurin stehlen. Dort wird er freilich von ${.self:"role":2:"firstname"} ertappt. Amors Pfeile treffen ihn. ${.self:"role":2:"firstname"} ist gar nicht mal abgeneigt...</de>
+						<en>The sword master? ${.self:"role":1:"firstname"} stood up to her. Now a valuable artifact must be stolen from the governor's house as the second trial. There, of course, he is caught by ${.self:"role":2:"firstname"}. Cupid's arrows hit him. ${.self:"role":2:"firstname"} isn't even averse...</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="6ee0bbaf-6dd4-4360-857e-6d4b492c3463">
@@ -6874,8 +6874,8 @@
 						<en>Treasure Hunt</en>
 					</title_original>
 					<description>
-						<de>Nachdem auf Umwegen das Artefakt erlangt wurde, geht es nun auf Schatzsuche. Nebenbei erfährt ${.self:"role":0:"firstname"}, dass ${.self:"role":2:"fullname"} ${.self:"role":1:"firstname"} auch immer liebte und für sie das ${donkeybay_object_reference}-${mystery_object_reference} lüften wollte, aber dort stattdessen zum Geisterpirat wurde.</de>
-						<en>After the artifact has been obtained in a roundabout way, it's time to go treasure hunting. Casually, ${.self:"role":0:"firstname"} learns that ${.self:"role":2:"fullname"} always loved ${.self:"role":1:"firstname"}, too, and wanted to uncover the ${mystery_object_reference} of ${donkeybay_object_reference} for her, but became a ghost pirate there instead.</en>
+						<de>Nachdem auf Umwegen das Artefakt erlangt wurde, geht es nun auf Schatzsuche. Nebenbei erfährt ${.self:"role":1:"firstname"}, dass ${.self:"role":3:"fullname"} ${.self:"role":2:"firstname"} auch immer liebte und für sie das ${donkeybay_object_reference}-${mystery_object_reference} lüften wollte, aber dort stattdessen zum Geisterpirat wurde.</de>
+						<en>After the artifact has been obtained in a roundabout way, it's time to go treasure hunting. Casually, ${.self:"role":1:"firstname"} learns that ${.self:"role":3:"fullname"} always loved ${.self:"role":2:"firstname"}, too, and wanted to uncover the ${mystery_object_reference} of ${donkeybay_object_reference} for her, but became a ghost pirate there instead.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="5" product="2" licence_type="2" guid="ce069d69-7735-4270-814a-eb5f20c895dd">
@@ -6888,8 +6888,8 @@
 						<en>Behind you, a three-headed monkey!</en>
 					</title_original>
 					<description>
-						<de>Jetzt kann sich ${.self:"role":0:"firstname"} ein Pirat schimpfen, aber oh Schreck! ${.self:"role":2:"fullname"} hat mit seinem Geisterschiff ${.self:"role":1:"firstname"} entführt! ${donkeybay_object_reference}, nicht nur eine Sage! ${.self:"role":0:"firstname"} muss eine Crew zusammentrommeln und zu dieser Insel segeln.</de>
-						<en>Now ${.self:"role":0:"firstname"} can call himself a pirate, but oh horrors! ${.self:"role":2:"fullname"} has kidnapped ${.self:"role":1:"firstname"} with his ghost ship! ${donkeybay_object_reference}, not just a legend! ${.self:"role":0:"firstname"} must round up a crew and sail to this island.</en>
+						<de>Jetzt kann sich ${.self:"role":1:"firstname"} ein Pirat schimpfen, aber oh Schreck! ${.self:"role":3:"fullname"} hat mit seinem Geisterschiff ${.self:"role":2:"firstname"} entführt! ${donkeybay_object_reference}, nicht nur eine Sage! ${.self:"role":1:"firstname"} muss eine Crew zusammentrommeln und zu dieser Insel segeln.</de>
+						<en>Now ${.self:"role":1:"firstname"} can call himself a pirate, but oh horrors! ${.self:"role":3:"fullname"} has kidnapped ${.self:"role":2:"firstname"} with his ghost ship! ${donkeybay_object_reference}, not just a legend! ${.self:"role":1:"firstname"} must round up a crew and sail to this island.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="6" product="2" licence_type="2" guid="0f626bb5-c7fb-4c51-aea7-4fe00f012cad">
@@ -6902,8 +6902,8 @@
 						<en>The Journey</en>
 					</title_original>
 					<description>
-						<de>Der Gebrauchtschiffhändler ${.self:"role":3:"firstname"} war... schwierig, eine Crew zu finden ebenso, und die erweist sich nun auch als nicht besonders... motiviert.</de>
-						<en>The previously-owned-ships dealer ${.self:"role":3:"firstname"} was... tough. And so was finding a crew. And they're now proving to be... not very motivated.</en>
+						<de>Der Gebrauchtschiffhändler ${.self:"role":4:"firstname"} war... schwierig, eine Crew zu finden ebenso, und die erweist sich nun auch als nicht besonders... motiviert.</de>
+						<en>The previously-owned-ships dealer ${.self:"role":4:"firstname"} was... tough. And so was finding a crew. And they're now proving to be... not very motivated.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="50d96da4-78ea-497c-8802-bb586d01682b">
@@ -6916,8 +6916,8 @@
 						<en>${donkeybay_object_reference}</en>
 					</title_original>
 					<description>
-						<de>Dort hinzukommen war schon aufreibend genug, der Legende nach kehrte auch nie jemand lebend zurück. Aber ${.self:"role":0:"firstname"} trifft am Strand zumindest schon mal einen Menschen. Der schiffbrüchige und etwas durchgeknallte Hendrik ist schon seit Jahren gestrandet dort.</de>
-						<en>Getting there was grueling enough, and legend has it that no one ever returned alive. But ${.self:"role":0:"firstname"} encounters another human being on the beach after all. The shipwrecked and slightly crazed Hendrik has been stranded there for years.</en>
+						<de>Dort hinzukommen war schon aufreibend genug, der Legende nach kehrte auch nie jemand lebend zurück. Aber ${.self:"role":1:"firstname"} trifft am Strand zumindest schon mal einen Menschen. Der schiffbrüchige und etwas durchgeknallte Hendrik ist schon seit Jahren gestrandet dort.</de>
+						<en>Getting there was grueling enough, and legend has it that no one ever returned alive. But ${.self:"role":1:"firstname"} encounters another human being on the beach after all. The shipwrecked and slightly crazed Hendrik has been stranded there for years.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="8" product="2" licence_type="2" guid="e7988271-a81f-4dc1-8eed-46fd7d88089d">
@@ -6936,16 +6936,16 @@
 				</scripttemplate>
 				<scripttemplate index="9" product="2" licence_type="2" guid="b93968b6-f863-44a5-b7c4-42a6f434f0a5">
 					<title>
-						<de>${.self:"role":2:"fullname"}'s Schiff</de>
-						<en>${.self:"role":2:"fullname"}'s ship</en>
+						<de>${.self:"role":3:"fullname"}'s Schiff</de>
+						<en>${.self:"role":3:"fullname"}'s ship</en>
 					</title>
 					<title_original>
-						<de>${.self:"role":2:"fullname"}'s Schiff</de>
-						<en>${.self:"role":2:"fullname"}'s ship</en>
+						<de>${.self:"role":3:"fullname"}'s Schiff</de>
+						<en>${.self:"role":3:"fullname"}'s ship</en>
 					</title_original>
 					<description>
-						<de>Schließlich gelangt ${.self:"role":0:"firstname"} in die Höhlen unter der Insel, wo ${.self:"role":2:"fullname"}s Geisterschiff auf Anker liegt. Er klaut Voodoo-Zutaten von dort, und die Kannibalen brauen für ihn dann ein Geistervernichtungs-Elixier.</de>
-						<en>Finally, ${.self:"role":0:"firstname"} gets to the caves under the island, where ${.self:"role":2:"fullname"}'s ghost ship is at anchor. He steals voodoo ingredients from there, and the cannibals then brew a ghost-destroying elixir for him.</en>
+						<de>Schließlich gelangt ${.self:"role":1:"firstname"} in die Höhlen unter der Insel, wo ${.self:"role":3:"fullname"}s Geisterschiff auf Anker liegt. Er klaut Voodoo-Zutaten von dort, und die Kannibalen brauen für ihn dann ein Geistervernichtungs-Elixier.</de>
+						<en>Finally, ${.self:"role":1:"firstname"} gets to the caves under the island, where ${.self:"role":3:"fullname"}'s ghost ship is at anchor. He steals voodoo ingredients from there, and the cannibals then brew a ghost-destroying elixir for him.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="10" product="2" licence_type="2" guid="c5c297fc-ecbb-4595-a342-40fc8f1d3b27">
@@ -6958,8 +6958,8 @@
 						<en>Back to ${hurlyeisland_object_reference}</en>
 					</title_original>
 					<description>
-						<de>Doch ${.self:"role":2:"fullname"} ist inzwischen wieder zurückgesegelt, um ${.self:"role":1:"firstname"} zu heiraten. ${.self:"role":0:"firstname"} muss die Kirche auf ${hurlyeisland_object_reference} stürmen, um das zu verhindern!</de>
-						<en>But ${.self:"role":2:"fullname"} has since sailed back to marry ${.self:"role":1:"firstname"}. ${.self:"role":0:"firstname"} must gatecrash the church on ${hurlyeisland_object_reference} to prevent this!</en>
+						<de>Doch ${.self:"role":3:"fullname"} ist inzwischen wieder zurückgesegelt, um ${.self:"role":2:"firstname"} zu heiraten. ${.self:"role":1:"firstname"} muss die Kirche auf ${hurlyeisland_object_reference} stürmen, um das zu verhindern!</de>
+						<en>But ${.self:"role":3:"fullname"} has since sailed back to marry ${.self:"role":2:"firstname"}. ${.self:"role":1:"firstname"} must gatecrash the church on ${hurlyeisland_object_reference} to prevent this!</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="11" product="2" licence_type="2" guid="a38b5c1a-ee98-49f8-83d0-06a3d27a5eaf">
@@ -6972,8 +6972,8 @@
 						<en>The Elixir</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":1:"firstname"} kann sich schon ganz gut selbst helfen. Und ${.self:"role":0:"firstname"} verliert auch noch das Elixier bei seiner tollpatschigen Rettungsaktion. Wie kann er nun im großen Showdown ${.self:"role":2:"fullname"} doch noch besiegen?</de>
-						<en>${.self:"role":1:"firstname"} can already help herself quite well. And ${.self:"role":0:"firstname"} also loses the elixir during his clumsy rescue attempt. How can he still defeat ${.self:"role":2:"fullname"} in the big showdown?</en>
+						<de>${.self:"role":2:"firstname"} kann sich schon ganz gut selbst helfen. Und ${.self:"role":1:"firstname"} verliert auch noch das Elixier bei seiner tollpatschigen Rettungsaktion. Wie kann er nun im großen Showdown ${.self:"role":3:"fullname"} doch noch besiegen?</de>
+						<en>${.self:"role":2:"firstname"} can already help herself quite well. And ${.self:"role":1:"firstname"} also loses the elixir during his clumsy rescue attempt. How can he still defeat ${.self:"role":3:"fullname"} in the big showdown?</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -7002,30 +7002,30 @@
 		</scripttemplate>
 		<scripttemplate product="2" licence_type="3" guid="c48d5851-d9f8-4fc1-8d34-264dfa3f6384" creator="9551" comment="https://de.wikipedia.org/wiki/Monkey_Island_2:_LeChuck%E2%80%99s_Revenge">
 			<title>
-				<de>${.self:"role":2:"fullname"} schlägt zurück</de>
-				<en>${.self:"role":2:"fullname"} Strikes Back</en>
+				<de>${.self:"role":3:"fullname"} schlägt zurück</de>
+				<en>${.self:"role":3:"fullname"} Strikes Back</en>
 			</title>
 			<title_original>
-				<de>${.self:"role":2:"fullname"}s Rache</de>
-				<en>${.self:"role":2:"fullname"}s's Revenge</en>
+				<de>${.self:"role":3:"fullname"}s Rache</de>
+				<en>${.self:"role":3:"fullname"}s's Revenge</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"firstname"} hat sich einen Bart wachsen lassen, ist aber immer noch nicht so überzeugend als Pirat. Also möchte er es endgültig allen beweisen und den legendären Schatz „Big Whoop“ finden. Doch der untote ${.self:"role":2:"fullname"} kehrt in noch untoterer Form zurück.</de>
-				<en>${.self:"role":0:"firstname"}, who has grown a beard but still is not so convincing as a pirate, wants to finally prove it to everyone and find the legendary treasure "Big Whoop". But the undead ${.self:"role":2:"fullname"} returns in an even more undead form.</en>
+				<de>${.self:"role":1:"firstname"} hat sich einen Bart wachsen lassen, ist aber immer noch nicht so überzeugend als Pirat. Also möchte er es endgültig allen beweisen und den legendären Schatz „Big Whoop“ finden. Doch der untote ${.self:"role":3:"fullname"} kehrt in noch untoterer Form zurück.</de>
+				<en>${.self:"role":1:"firstname"}, who has grown a beard but still is not so convincing as a pirate, wants to finally prove it to everyone and find the legendary treasure "Big Whoop". But the undead ${.self:"role":3:"fullname"} returns in an even more undead form.</en>
 			</description>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="a89e4f67-3f62-4f43-b36a-0066466a9910">
 					<title>
-						<de>Das ${.self:"role":5:"firstname"}-Embargo</de>
-						<en>The ${.self:"role":5:"firstname"} Embargo</en>
+						<de>Das ${.self:"role":6:"firstname"}-Embargo</de>
+						<en>The ${.self:"role":6:"firstname"} Embargo</en>
 					</title>
 					<title_original>
-						<de>Das ${.self:"role":5:"firstname"}-Embargo</de>
-						<en>The ${.self:"role":5:"firstname"} Embargo</en>
+						<de>Das ${.self:"role":6:"firstname"}-Embargo</de>
+						<en>The ${.self:"role":6:"firstname"} Embargo</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} ist auf der Suche nach dem legendären Schatz „Big Whoop“ auf Scabb Island, als er mit ${.self:"role":5:"firstname"}s völlig legitimen Raubüberfall und einem Insel-Embargo konfrontiert wird. Er freundet sich in Woodtick mit Kartenmacher ${.self:"role":4:"firstname"} an.</de>
-						<en>${.self:"role":0:"firstname"} searches for the legendary treasure of "Big Whoop" on Scabb Island while facing ${.self:"role":5:"firstname"}'s totally legit robbery and an island embargo. He becomes friends with mapmaker ${.self:"role":4:"firstname"} in Woodtick.</en>
+						<de>${.self:"role":1:"firstname"} ist auf der Suche nach dem legendären Schatz „Big Whoop“ auf Scabb Island, als er mit ${.self:"role":6:"firstname"}s völlig legitimen Raubüberfall und einem Insel-Embargo konfrontiert wird. Er freundet sich in Woodtick mit Kartenmacher ${.self:"role":5:"firstname"} an.</de>
+						<en>${.self:"role":1:"firstname"} searches for the legendary treasure of "Big Whoop" on Scabb Island while facing ${.self:"role":6:"firstname"}'s totally legit robbery and an island embargo. He becomes friends with mapmaker ${.self:"role":5:"firstname"} in Woodtick.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="d64d81fc-1fc0-4780-b885-f45cf0bfe93c">
@@ -7038,8 +7038,8 @@
 						<en>Guidance from the Voodoo Lady</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} holt sich Rat bei der Voodoo-Lady im International House of Mojo und plant, ${.self:"role":5:"firstname"} mit einer Voodoo-Puppe zu erledigen.</de>
-						<en>${.self:"role":0:"firstname"} seeks advice from the Voodoo Lady at the International House of Mojo and plans to take down ${.self:"role":5:"firstname"} with a voodoo doll.</en>
+						<de>${.self:"role":1:"firstname"} holt sich Rat bei der Voodoo-Lady im International House of Mojo und plant, ${.self:"role":6:"firstname"} mit einer Voodoo-Puppe zu erledigen.</de>
+						<en>${.self:"role":1:"firstname"} seeks advice from the Voodoo Lady at the International House of Mojo and plans to take down ${.self:"role":6:"firstname"} with a voodoo doll.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="b598a116-fdda-47eb-ac3a-90de50cb0cf4">
@@ -7052,8 +7052,8 @@
 						<en>A Voodoo Confrontation</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} setzt eine Voodoo-Puppe gegen ${.self:"role":5:"firstname"} ein, aber ein schwerer Fehler bringt den rachsüchtigen ${.self:"role":2:"fullname"} zurück.</de>
-						<en>${.self:"role":0:"firstname"} uses a voodoo doll against ${.self:"role":5:"firstname"}, but a grave mistake brings back the vengeful ${.self:"role":2:"fullname"}.</en>
+						<de>${.self:"role":1:"firstname"} setzt eine Voodoo-Puppe gegen ${.self:"role":6:"firstname"} ein, aber ein schwerer Fehler bringt den rachsüchtigen ${.self:"role":3:"fullname"} zurück.</de>
+						<en>${.self:"role":1:"firstname"} uses a voodoo doll against ${.self:"role":6:"firstname"}, but a grave mistake brings back the vengeful ${.self:"role":3:"fullname"}.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="1a28e944-a682-4320-b898-901c2b345615">
@@ -7066,8 +7066,8 @@
 						<en>Revenge from Beyond the Grave</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":2:"fullname"} kehrt als Zombie zurück, um sich an ${.self:"role":0:"firstname"} zu rächen. Um ihm zu entkommen, verrät die Voodoo-Lady das Geheimnis von Big Whoop.</de>
-						<en>${.self:"role":2:"fullname"} returns as a zombie, seeking revenge on ${.self:"role":0:"firstname"}. The Voodoo Lady reveals the secret of Big Whoop to escape him.</en>
+						<de>${.self:"role":3:"fullname"} kehrt als Zombie zurück, um sich an ${.self:"role":1:"firstname"} zu rächen. Um ihm zu entkommen, verrät die Voodoo-Lady das Geheimnis von Big Whoop.</de>
+						<en>${.self:"role":3:"fullname"} returns as a zombie, seeking revenge on ${.self:"role":1:"firstname"}. The Voodoo Lady reveals the secret of Big Whoop to escape him.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="83d14cdc-230d-46af-8d8b-1282c251d440">
@@ -7080,8 +7080,8 @@
 						<en>Four Map Pieces</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} chartert ein Schiff und macht sich auf den Weg, die in vier Teile geteilte Karte von Big Whoop zu finden.</de>
-						<en>${.self:"role":0:"firstname"} charters a ship and sets out to find the map of Big Whoop, which is divided into four parts.</en>
+						<de>${.self:"role":1:"firstname"} chartert ein Schiff und macht sich auf den Weg, die in vier Teile geteilte Karte von Big Whoop zu finden.</de>
+						<en>${.self:"role":1:"firstname"} charters a ship and sets out to find the map of Big Whoop, which is divided into four parts.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="5" product="2" licence_type="2" guid="46c64856-cf98-4cf9-a5b0-e7f8df8bd28b">
@@ -7094,22 +7094,22 @@
 						<en>Prison Break on Phatt Island</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} wird auf Phatt Island gefangen gehalten und muss einen Weg finden, zu entkommen und seine Suche fortzusetzen.</de>
-						<en>Imprisoned on Phatt Island, ${.self:"role":0:"firstname"} must find a way to escape and continue his quest.</en>
+						<de>${.self:"role":1:"firstname"} wird auf Phatt Island gefangen gehalten und muss einen Weg finden, zu entkommen und seine Suche fortzusetzen.</de>
+						<en>Imprisoned on Phatt Island, ${.self:"role":1:"firstname"} must find a way to escape and continue his quest.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="6" product="2" licence_type="2" guid="2c3c8ea3-e4d3-43a3-92d9-9241f496a446">
 					<title>
-						<de>${.self:"role":3:"firstname"}, Särge und Wiedersehen</de>
-						<en>${.self:"role":3:"firstname"}, Coffins, and Reunions</en>
+						<de>${.self:"role":4:"firstname"}, Särge und Wiedersehen</de>
+						<en>${.self:"role":4:"firstname"}, Coffins, and Reunions</en>
 					</title>
 					<title_original>
-						<de>${.self:"role":3:"firstname"}, Särge und Wiedersehen</de>
-						<en>${.self:"role":3:"firstname"}, Coffins, and Reunions</en>
+						<de>${.self:"role":4:"firstname"}, Särge und Wiedersehen</de>
+						<en>${.self:"role":4:"firstname"}, Coffins, and Reunions</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} begegnet ${.self:"role":3:"firstname"}, der nun gebrauchte Särge verkauft, und trifft ${.self:"role":1:"firstname"} auf Booty Island im Laufe verschiedener Abenteuer wie einem Spuckwettbewerb.</de>
-						<en>${.self:"role":0:"firstname"} encounters ${.self:"role":3:"firstname"}, who now sells previously owned coffins, and reunites with ${.self:"role":1:"firstname"} on Booty Island amidst various adventures such as a spitting contest.</en>
+						<de>${.self:"role":1:"firstname"} begegnet ${.self:"role":4:"firstname"}, der nun gebrauchte Särge verkauft, und trifft ${.self:"role":2:"firstname"} auf Booty Island im Laufe verschiedener Abenteuer wie einem Spuckwettbewerb.</de>
+						<en>${.self:"role":1:"firstname"} encounters ${.self:"role":4:"firstname"}, who now sells previously owned coffins, and reunites with ${.self:"role":2:"firstname"} on Booty Island amidst various adventures such as a spitting contest.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="a1285eaa-009f-4572-a91f-cda78b091569">
@@ -7122,22 +7122,22 @@
 						<en>Quests and Revelations</en>
 					</title_original>
 					<description>
-						<de>Im Laufe verschiedener Aufgaben und Herausforderungen wie etwa eine Karnevalsfeier sammelt ${.self:"role":0:"firstname"} mit der Hilfe von Freunden und Verbündeten alle Kartenteile ein.</de>
-						<en>Amidst quests and challenges, such as a Mardi Gras party, ${.self:"role":0:"firstname"} gathers all the map pieces with the help of friends and allies.</en>
+						<de>Im Laufe verschiedener Aufgaben und Herausforderungen wie etwa eine Karnevalsfeier sammelt ${.self:"role":1:"firstname"} mit der Hilfe von Freunden und Verbündeten alle Kartenteile ein.</de>
+						<en>Amidst quests and challenges, such as a Mardi Gras party, ${.self:"role":1:"firstname"} gathers all the map pieces with the help of friends and allies.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="8" product="2" licence_type="2" guid="33239572-ffe7-4b68-81e2-86e88a6d7705">
 					<title>
-						<de>${.self:"role":2:"fullname"}s Festung</de>
-						<en>${.self:"role":2:"fullname"}'s Fortress</en>
+						<de>${.self:"role":3:"fullname"}s Festung</de>
+						<en>${.self:"role":3:"fullname"}'s Fortress</en>
 					</title>
 					<title_original>
-						<de>${.self:"role":2:"fullname"}s Festung</de>
-						<en>${.self:"role":2:"fullname"}'s Fortress</en>
+						<de>${.self:"role":3:"fullname"}s Festung</de>
+						<en>${.self:"role":3:"fullname"}'s Fortress</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":2:"fullname"} entführt ${.self:"role":4:"firstname"} und die Karte, was ${.self:"role":0:"firstname"} dazu zwingt, dessen Festung zu infiltrieren und sich großer Gefahr zu stellen.</de>
-						<en>${.self:"role":2:"fullname"} kidnaps ${.self:"role":4:"firstname"} and the map, leading ${.self:"role":0:"firstname"} to infiltrate his fortress and face great danger.</en>
+						<de>${.self:"role":3:"fullname"} entführt ${.self:"role":5:"firstname"} und die Karte, was ${.self:"role":1:"firstname"} dazu zwingt, dessen Festung zu infiltrieren und sich großer Gefahr zu stellen.</de>
+						<en>${.self:"role":3:"fullname"} kidnaps ${.self:"role":5:"firstname"} and the map, leading ${.self:"role":1:"firstname"} to infiltrate his fortress and face great danger.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="9" product="2" licence_type="2" guid="6d1ad74b-6fd7-49f2-82e7-bc27b7fac6f0">
@@ -7150,8 +7150,8 @@
 						<en>Dinky Island</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} kommt auf Dinky Island an, entdeckt das Versteck von Big Whoop und sieht sich unter der Erde unheimlichen Offenbarungen gegenüber.</de>
-						<en>${.self:"role":0:"firstname"} arrives on Dinky Island, discovers Big Whoop's location, and faces eerie revelations underground.</en>
+						<de>${.self:"role":1:"firstname"} kommt auf Dinky Island an, entdeckt das Versteck von Big Whoop und sieht sich unter der Erde unheimlichen Offenbarungen gegenüber.</de>
+						<en>${.self:"role":1:"firstname"} arrives on Dinky Island, discovers Big Whoop's location, and faces eerie revelations underground.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="10" product="2" licence_type="2" guid="5df3fb31-499e-45cf-969d-e2ddbaac5548">
@@ -7164,8 +7164,8 @@
 						<en>The Voodoo Showdown</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} und ${.self:"role":2:"fullname"} liefern sich ein Voodoo-Duell, und schockierende Familiengeheimnisse werden enthüllt.</de>
-						<en>${.self:"role":0:"firstname"} and ${.self:"role":2:"fullname"} engage in a voodoo duel, and shocking family secrets are revealed.</en>
+						<de>${.self:"role":1:"firstname"} und ${.self:"role":3:"fullname"} liefern sich ein Voodoo-Duell, und schockierende Familiengeheimnisse werden enthüllt.</de>
+						<en>${.self:"role":1:"firstname"} and ${.self:"role":3:"fullname"} engage in a voodoo duel, and shocking family secrets are revealed.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="11" product="2" licence_type="2" guid="ae371367-645b-4f6b-83b8-c0c0614de2a7">
@@ -7178,8 +7178,8 @@
 						<en>The Final Confrontation</en>
 					</title_original>
 					<description>
-						<de>Big Whoop entpuppt sich als etwas anderes als erwartet. Als die Wahrheit ans Licht kommt, macht sich ${.self:"role":1:"firstname"} auf Dinky Island Sorgen um ${.self:"role":0:"firstname"}s Schicksal.</de>
-						<en>Big Whoop turns out to be something different than expected. As the truth unravels, ${.self:"role":1:"firstname"} on Dinky Island worries about ${.self:"role":0:"firstname"}'s fate.</en>
+						<de>Big Whoop entpuppt sich als etwas anderes als erwartet. Als die Wahrheit ans Licht kommt, macht sich ${.self:"role":2:"firstname"} auf Dinky Island Sorgen um ${.self:"role":1:"firstname"}s Schicksal.</de>
+						<en>Big Whoop turns out to be something different than expected. As the truth unravels, ${.self:"role":2:"firstname"} on Dinky Island worries about ${.self:"role":1:"firstname"}'s fate.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -7265,8 +7265,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>Secrets of Cocytus</en>
 					</title_original>
 					<description>
-						<de>In uralten Untergrund-Strukturen stößt das Team auf mysteriöse grüne Kristalle mit außergewöhnlichen Kräften. Konflikte entstehen, der deutsche Geologe und Unsympath ${.self:"role":1:"fullname"} dreht durch.</de>
-						<en>In ancient underground structures, the team uncovers mysterious green crystals with extraordinary powers. Conflicts arise, unlikeable German geologist ${.self:"role":1:"fullname"} goes crazy.</en>
+						<de>In uralten Untergrund-Strukturen stößt das Team auf mysteriöse grüne Kristalle mit außergewöhnlichen Kräften. Konflikte entstehen, der deutsche Geologe und Unsympath ${.self:"role":2:"fullname"} dreht durch.</de>
+						<en>In ancient underground structures, the team uncovers mysterious green crystals with extraordinary powers. Conflicts arise, unlikeable German geologist ${.self:"role":2:"fullname"} goes crazy.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="a06e11c0-8c57-4e0f-896d-aae8ccbd1ba9">
@@ -7279,8 +7279,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>Journey to Spacetime Six</en>
 					</title_original>
 					<description>
-						<de>Die Gruppe trifft auf ein konserviertes Wesen mit lebenswichtigem Wissen. ${.self:"role":2:"firstname"} übersetzt. ${.self:"role":0:"firstname"} begibt sich auf eine gefährliche Mission in die sechste Raumzeit, um den Außerirdischen den Weg zurück in „unsere“ Realität zu zeigen.</de>
-						<en>The group encounters a preserved creature with vital knowledge. ${.self:"role":2:"firstname"} translates. ${.self:"role":0:"firstname"} embarks on a perilous mission into Spacetime Six, to show the Aliens the way back to "our" reality.</en>
+						<de>Die Gruppe trifft auf ein konserviertes Wesen mit lebenswichtigem Wissen. ${.self:"role":3:"firstname"} übersetzt. ${.self:"role":1:"firstname"} begibt sich auf eine gefährliche Mission in die sechste Raumzeit, um den Außerirdischen den Weg zurück in „unsere“ Realität zu zeigen.</de>
+						<en>The group encounters a preserved creature with vital knowledge. ${.self:"role":3:"firstname"} translates. ${.self:"role":1:"firstname"} embarks on a perilous mission into Spacetime Six, to show the Aliens the way back to "our" reality.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -7315,8 +7315,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 				<en>${title_original_optional}</en>
 			</title_original>
 			<description>
-				<de>Cartoon-Reihe über den 8-jährigen Wunderknaben ${.self:"role":0:"fullname"}. Er baut aus einem Staubsauger ein Raumfahrzeug, schnappt sich seinen Pogo-Stick, setzt den Footballhelm seines älteren Bruders auf, wird zu ${captain} ${ween_object_reference} und macht sich auf...</de>
-				<en>Cartoon series about the 8-year-old boy genius ${.self:"role":0:"fullname"}. He builds a spacecraft out of a vacuum cleaner, grabs his pogo stick, puts on his older brother's football helmet, becomes ${captain} ${ween_object_reference} and sets out...</en>
+				<de>Cartoon-Reihe über den 8-jährigen Wunderknaben ${.self:"role":1:"fullname"}. Er baut aus einem Staubsauger ein Raumfahrzeug, schnappt sich seinen Pogo-Stick, setzt den Footballhelm seines älteren Bruders auf, wird zu ${captain} ${ween_object_reference} und macht sich auf...</de>
+				<en>Cartoon series about the 8-year-old boy genius ${.self:"role":1:"fullname"}. He builds a spacecraft out of a vacuum cleaner, grabs his pogo stick, puts on his older brother's football helmet, becomes ${captain} ${ween_object_reference} and sets out...</en>
 			</description>
 			<variables>
 				<title_spoofed>
@@ -7383,22 +7383,22 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>Marooned on Mars</en>
 					</title_original>
 					<description>
-						<de>Eines Abends sind ${.self:"role":0:"firstname"}s Eltern außer Haus. Das ist die Gelegenheit. Er steuert sein erstes Ziel an: den Mars. Während er den Planeten erkundet, stehlen die ${.self:"role":2:"firstname"}s wichtige Komponenten seines Gefährts...</de>
-						<en>One night ${.self:"role":0:"firstname"}'s parents are out of the house. This is the opportunity. He heads for his first destination: Mars. While he explores the planet, the ${.self:"role":2:"firstname"}s steal important components of his spacecraft...</en>
+						<de>Eines Abends sind ${.self:"role":1:"firstname"}s Eltern außer Haus. Das ist die Gelegenheit. Er steuert sein erstes Ziel an: den Mars. Während er den Planeten erkundet, stehlen die ${.self:"role":3:"firstname"}s wichtige Komponenten seines Gefährts...</de>
+						<en>One night ${.self:"role":1:"firstname"}'s parents are out of the house. This is the opportunity. He heads for his first destination: Mars. While he explores the planet, the ${.self:"role":3:"firstname"}s steal important components of his spacecraft...</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="5b733f65-8a43-46b9-b009-ebb300c9ef2d">
 					<title>
-						<de>Invasion der ${.self:"role":2:"firstname"}s</de>
-						<en>Invasion of the ${.self:"role":2:"firstname"}s</en>
+						<de>Invasion der ${.self:"role":3:"firstname"}s</de>
+						<en>Invasion of the ${.self:"role":3:"firstname"}s</en>
 					</title>
 					<title_original>
-						<de>Invasion der ${.self:"role":2:"firstname"}s</de>
-						<en>Invasion of the ${.self:"role":2:"firstname"}s</en>
+						<de>Invasion der ${.self:"role":3:"firstname"}s</de>
+						<en>Invasion of the ${.self:"role":3:"firstname"}s</en>
 					</title_original>
 					<description>
-						<de>${ween_object_reference} schafft es rechtzeitig zurück zur Erde, bevor seine Eltern nach Hause kommen. Seinen neuen Gefährten, den kleinen grünen einäugigen ${.self:"role":1:"firstname"}, kann er jedoch nicht verstecken. Die ${.self:"role":2:"firstname"}s haben inzwischen ein Mutterschiff im Erdorbit...</de>
-						<en>${ween_object_reference} makes it back to Earth in time before his parents come home. However, he can't hide his new companion, the little green one-eyed ${.self:"role":1:"firstname"}. The ${.self:"role":2:"firstname"}s, meanwhile, have a mothership in Earth orbit...</en>
+						<de>${ween_object_reference} schafft es rechtzeitig zurück zur Erde, bevor seine Eltern nach Hause kommen. Seinen neuen Gefährten, den kleinen grünen einäugigen ${.self:"role":2:"firstname"}, kann er jedoch nicht verstecken. Die ${.self:"role":3:"firstname"}s haben inzwischen ein Mutterschiff im Erdorbit...</de>
+						<en>${ween_object_reference} makes it back to Earth in time before his parents come home. However, he can't hide his new companion, the little green one-eyed ${.self:"role":2:"firstname"}. The ${.self:"role":3:"firstname"}s, meanwhile, have a mothership in Earth orbit...</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="e1360097-a12f-4cbf-81a8-a7299d9ee789">
@@ -7411,8 +7411,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Earth Explodes</en>
 					</title_original>
 					<description>
-						<de>Das ${.self:"role":2:"firstname"}-Mutterschiff hat seine Strahlenkanonen auf mehrere Wahrzeichen auf der Erde gerichtet. Kann ${ween_object_reference} in das Schiff eindringen, die Kanonen finden und vernichten?</de>
-						<en>The ${.self:"role":2:"firstname"} mothership has aimed its ray guns at several landmarks on Earth. Can ${ween_object_reference} penetrate the ship, find the cannons and destroy them?</en>
+						<de>Das ${.self:"role":3:"firstname"}-Mutterschiff hat seine Strahlenkanonen auf mehrere Wahrzeichen auf der Erde gerichtet. Kann ${ween_object_reference} in das Schiff eindringen, die Kanonen finden und vernichten?</de>
+						<en>The ${.self:"role":3:"firstname"} mothership has aimed its ray guns at several landmarks on Earth. Can ${ween_object_reference} penetrate the ship, find the cannons and destroy them?</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="c028f88d-bae8-474f-9654-5e3ff79b05a8">
@@ -7425,8 +7425,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>${ween_object_reference} Must Die!</en>
 					</title_original>
 					<description>
-						<de>Es stellt sich heraus, die ${.self:"role":2:"firstname"}s werden von einem Großen Gehirn ferngesteuert und kontrolliert. ${ween_object_reference} macht sich auf auf dessen Heimatplaneten...</de>
-						<en>It turns out the ${.self:"role":2:"firstname"}s are remotely controlled by a Great Brain. ${ween_object_reference} sets out for its home planet...</en>
+						<de>Es stellt sich heraus, die ${.self:"role":3:"firstname"}s werden von einem Großen Gehirn ferngesteuert und kontrolliert. ${ween_object_reference} macht sich auf auf dessen Heimatplaneten...</de>
+						<en>It turns out the ${.self:"role":3:"firstname"}s are remotely controlled by a Great Brain. ${ween_object_reference} sets out for its home planet...</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="daba5e8b-11ec-4ae0-aae8-10a110bb4784">
@@ -7439,8 +7439,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>Secret of the Oracle</en>
 					</title_original>
 					<description>
-						<de>Das Große Gehirn ist besiegt, doch, wie ${ween_object_reference} mittels seinem selbstgebauten überlichtschnellen Radiogerät feststellt: die ${.self:"role":3:"firstname"} wollen die ganze Galaxie zerstören. Vielleicht kann das geheimnisvolle Orakel auf dem Planeten ${gnostika_object_reference} helfen...</de>
-						<en>The Great Brain is defeated, but, as ${ween_object_reference} discovers by means of his self-built faster-than-light radio: the ${.self:"role":3:"firstname"} want to destroy the whole galaxy. Maybe the mysterious oracle on the planet ${gnostika_object_reference} can help...</en>
+						<de>Das Große Gehirn ist besiegt, doch, wie ${ween_object_reference} mittels seinem selbstgebauten überlichtschnellen Radiogerät feststellt: die ${.self:"role":4:"firstname"} wollen die ganze Galaxie zerstören. Vielleicht kann das geheimnisvolle Orakel auf dem Planeten ${gnostika_object_reference} helfen...</de>
+						<en>The Great Brain is defeated, but, as ${ween_object_reference} discovers by means of his self-built faster-than-light radio: the ${.self:"role":4:"firstname"} want to destroy the whole galaxy. Maybe the mysterious oracle on the planet ${gnostika_object_reference} can help...</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="5" product="2" licence_type="2" guid="be85e20a-3dbc-421a-93d6-5bdfad070ede">
@@ -7453,8 +7453,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Armageddon Machine</en>
 					</title_original>
 					<description>
-						<de>Auf ${gnostika_object_reference} muss ${ween_object_reference} feststellen, dass dessen Rat der Unsterblichen Weisen bereits von den ${.self:"role":3:"firstname"} entführt wurde. ${ween_object_reference} muss die Weisen befreien, um das Orakel aktivieren zu können...</de>
-						<en>On ${gnostika_object_reference}, ${ween_object_reference} finds that its Council of Immortal Sages has already been kidnapped by the ${.self:"role":3:"firstname"}. ${ween_object_reference} must free the sages in order to be able to activate the oracle...</en>
+						<de>Auf ${gnostika_object_reference} muss ${ween_object_reference} feststellen, dass dessen Rat der Unsterblichen Weisen bereits von den ${.self:"role":4:"firstname"} entführt wurde. ${ween_object_reference} muss die Weisen befreien, um das Orakel aktivieren zu können...</de>
+						<en>On ${gnostika_object_reference}, ${ween_object_reference} finds that its Council of Immortal Sages has already been kidnapped by the ${.self:"role":4:"firstname"}. ${ween_object_reference} must free the sages in order to be able to activate the oracle...</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="6" product="2" licence_type="2" guid="45e0e001-645a-449e-a861-abb17b3192b7">
@@ -7467,8 +7467,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>Goodbye, Galaxy</en>
 					</title_original>
 					<description>
-						<de>Vom Orakel erfuhr ${ween_object_reference}, die ${.self:"role":3:"firstname"} sind Schattenwesen von der dunklen Seite der Galaxie und haben auf ${codrakiv_object_reference} eine Vernichtungsmaschine. Sie wollen die Galaxie zerstören und nach ihren Vorstellungen wieder aufbauen. ${ween_object_reference} muss sie stoppen...</de>
-						<en>${ween_object_reference} learned from the oracle that the ${.self:"role":3:"firstname"} are shadow beings from the dark side of the galaxy and have an extermination machine on ${codrakiv_object_reference}. They want to destroy the galaxy and rebuild it according to their ideas. ${ween_object_reference} must stop them...</en>
+						<de>Vom Orakel erfuhr ${ween_object_reference}, die ${.self:"role":4:"firstname"} sind Schattenwesen von der dunklen Seite der Galaxie und haben auf ${codrakiv_object_reference} eine Vernichtungsmaschine. Sie wollen die Galaxie zerstören und nach ihren Vorstellungen wieder aufbauen. ${ween_object_reference} muss sie stoppen...</de>
+						<en>${ween_object_reference} learned from the oracle that the ${.self:"role":4:"firstname"} are shadow beings from the dark side of the galaxy and have an extermination machine on ${codrakiv_object_reference}. They want to destroy the galaxy and rebuild it according to their ideas. ${ween_object_reference} must stop them...</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="754c2dec-f377-4b4b-a24a-4b4b3a93b35b">
@@ -7481,8 +7481,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>Aliens Ate My Babysitter</en>
 					</title_original>
 					<description>
-						<de>Wieder steckte ${.self:"role":0:"firstname"}s böswilliger Erzfeind aus der Schule, der einen IQ-Punkt mehr hat, hinter allem und kontrollierte all die Alien-Rassen. Und dieser macht auch einfach nicht halt und will diesmal gleich das ganze Universum zerstören. Der große Showdown beginnt...</de>
-						<en>Again, ${.self:"role":0:"firstname"}'s malicious nemesis from school, who has one IQ point more, was behind everything and controlled all the alien races. And he just doesn't stop and wants to destroy the whole universe this time. The big showdown begins...</en>
+						<de>Wieder steckte ${.self:"role":1:"firstname"}s böswilliger Erzfeind aus der Schule, der einen IQ-Punkt mehr hat, hinter allem und kontrollierte all die Alien-Rassen. Und dieser macht auch einfach nicht halt und will diesmal gleich das ganze Universum zerstören. Der große Showdown beginnt...</de>
+						<en>Again, ${.self:"role":1:"firstname"}'s malicious nemesis from school, who has one IQ point more, was behind everything and controlled all the alien races. And he just doesn't stop and wants to destroy the whole universe this time. The big showdown begins...</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -7510,21 +7510,21 @@ The project, which was cancelled by a major producer, is now free to be realized
 		</scripttemplate>
 		<scripttemplate product="2" licence_type="3" guid="c0d67fc9-1388-4715-b708-713df17c681a" creator="9551" comment="https://en.wikipedia.org/wiki/Leisure_Suit_Larry | TODO: ref nicknames once feature available">
 			<title>
-				<de>Leather Jacket ${.self:"role":0:"firstname"}, ${ladykiller}</de>
-				<en>Leather Jacket ${.self:"role":0:"firstname"}, ${ladykiller}</en>
+				<de>Leather Jacket ${.self:"role":1:"firstname"}, ${ladykiller}</de>
+				<en>Leather Jacket ${.self:"role":1:"firstname"}, ${ladykiller}</en>
 			</title>
 			<title_original>
 				<de>${title_original_optional}</de>
 				<en>${title_original_optional}</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"firstname"} ist bis Mitte 30 unberührt und unschuldig. Nun will er's aber wissen und sucht eine Absteige auf. Nach einigen Schwierigkeiten... Endlich! Langsam kriegt er den Dreh raus, und beginnt dann nach der Frau seines Lebens zu suchen.</de>
-				<en>${.self:"role":0:"firstname"} is untouched and innocent until his mid-30s. But now he wants to get it done and seeks out a flophouse. After some difficulties... Finally! Slowly he gets the hang of it, and then starts looking for the woman of his life.</en>
+				<de>${.self:"role":1:"firstname"} ist bis Mitte 30 unberührt und unschuldig. Nun will er's aber wissen und sucht eine Absteige auf. Nach einigen Schwierigkeiten... Endlich! Langsam kriegt er den Dreh raus, und beginnt dann nach der Frau seines Lebens zu suchen.</de>
+				<en>${.self:"role":1:"firstname"} is untouched and innocent until his mid-30s. But now he wants to get it done and seeks out a flophouse. After some difficulties... Finally! Slowly he gets the hang of it, and then starts looking for the woman of his life.</en>
 			</description>
 			<variables>
 				<title_original_optional>
-					<de>Leisure Suit ${.self:"role":0:"firstname"}|Leisure Suit ${.self:"role":0:"firstname"}, ${ladykiller}</de>
-					<en>Leisure Suit ${.self:"role":0:"firstname"}|Leisure Suit ${.self:"role":0:"firstname"}, ${ladykiller}</en>
+					<de>Leisure Suit ${.self:"role":1:"firstname"}|Leisure Suit ${.self:"role":1:"firstname"}, ${ladykiller}</de>
+					<en>Leisure Suit ${.self:"role":1:"firstname"}|Leisure Suit ${.self:"role":1:"firstname"}, ${ladykiller}</en>
 				</title_original_optional>
 				<ladykiller>
 					<de>Ladykiller|Schwerenöter vom Dienst|Reizender Charmeur|Bezaubernder Schmeichler</de>
@@ -7534,12 +7534,12 @@ The project, which was cancelled by a major producer, is now free to be realized
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="8f5a2c84-89b4-41fe-9e27-3898382f612b">
 					<title>
-						<de>Leather Jacket ${.self:"role":0:"firstname"} aus dem Land der alleinigen Leidhammel</de>
-						<en>Leather jacket ${.self:"role":0:"firstname"} from the Land of the Lone Lobsters</en>
+						<de>Leather Jacket ${.self:"role":1:"firstname"} aus dem Land der alleinigen Leidhammel</de>
+						<en>Leather jacket ${.self:"role":1:"firstname"} from the Land of the Lone Lobsters</en>
 					</title>
 					<title_original>
-						<de>Leisure Suit ${.self:"role":0:"firstname"} im Lande der Lounge-Echsen</de>
-						<en>Leisure Suit ${.self:"role":0:"firstname"} in the Land of the Lounge Lizards</en>
+						<de>Leisure Suit ${.self:"role":1:"firstname"} im Lande der Lounge-Echsen</de>
+						<en>Leisure Suit ${.self:"role":1:"firstname"} in the Land of the Lounge Lizards</en>
 					</title_original>
 					<description>
 						<de>Es hagelt nur so an Abfuhren. Schließlich in einem schmutzigen Etablissement ... ein nicht so berauschendes Erlebnis, und er fängt sich auch noch was ein. Eine Dame am Pool scheint ihn endlich wirklich ein bisschen zu mögen...</de>
@@ -7556,22 +7556,22 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>Looking for Love (in Several Wrong Places)</en>
 					</title_original>
 					<description>
-						<de>Nach der nur kurzweiligen Affäre gewinnt ${.self:"role":0:"firstname"} immerhin in der Lotterie und macht sich auf in die Südsee, und gerät nicht nur in erotische Abenteuer, sondern macht auch Bekanntschaft mit den Geheimdiensten...</de>
-						<en>After the only short-lived affair, ${.self:"role":0:"firstname"} wins the lottery at least, and sets off to the South Seas. He not only gets into erotic adventures, but also gets involved with the secret services...</en>
+						<de>Nach der nur kurzweiligen Affäre gewinnt ${.self:"role":1:"firstname"} immerhin in der Lotterie und macht sich auf in die Südsee, und gerät nicht nur in erotische Abenteuer, sondern macht auch Bekanntschaft mit den Geheimdiensten...</de>
+						<en>After the only short-lived affair, ${.self:"role":1:"firstname"} wins the lottery at least, and sets off to the South Seas. He not only gets into erotic adventures, but also gets involved with the secret services...</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="4985f4d8-734b-4991-a7af-eee33546e38f">
 					<title>
-						<de>Fervent ${.self:"role":1:"firstname"} beim Fördern vibrierender Vernakularität</de>
-						<en>Fervent ${.self:"role":1:"firstname"} Fostering Vibrating Vernacular</en>
+						<de>Fervent ${.self:"role":2:"firstname"} beim Fördern vibrierender Vernakularität</de>
+						<en>Fervent ${.self:"role":2:"firstname"} Fostering Vibrating Vernacular</en>
 					</title>
 					<title_original>
-						<de>Passionate ${.self:"role":1:"firstname"} auf der Suche nach vibrierenden Muskeln</de>
-						<en>Passionate ${.self:"role":1:"firstname"} in Pursuit of the Pulsating Pectorals</en>
+						<de>Passionate ${.self:"role":2:"firstname"} auf der Suche nach vibrierenden Muskeln</de>
+						<en>Passionate ${.self:"role":2:"firstname"} in Pursuit of the Pulsating Pectorals</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} hat 5 Jahre lang ein tolles Leben auf Hawaii und eine glückliche Ehe, doch plötzlich wird er verlassen, als sich seine Frau in eine andere Frau verliebt. Nach einigen Abenteuern findet er eine neue für's Leben, aber dann geht was schief...</de>
-						<en>${.self:"role":0:"firstname"} has a great life in Hawaii for 5 years and a happy marriage, but suddenly he is abandoned when his wife falls in love with another woman. After some adventures he finds someone new for life, but then something goes wrong...</en>
+						<de>${.self:"role":1:"firstname"} hat 5 Jahre lang ein tolles Leben auf Hawaii und eine glückliche Ehe, doch plötzlich wird er verlassen, als sich seine Frau in eine andere Frau verliebt. Nach einigen Abenteuern findet er eine neue für's Leben, aber dann geht was schief...</de>
+						<en>${.self:"role":1:"firstname"} has a great life in Hawaii for 5 years and a happy marriage, but suddenly he is abandoned when his wife falls in love with another woman. After some adventures he finds someone new for life, but then something goes wrong...</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="a7bbc175-7b5d-45c6-ad1a-9482ab041222" comment="https://en.wikipedia.org/wiki/Leisure_Suit_Larry#Leisure_Suit_Larry_4:_The_Missing_Floppies | spoof title reference to https://floppapedia-revamped.fandom.com/wiki/Big_Floppa">
@@ -7584,22 +7584,22 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Missing Floppies</en>
 					</title_original>
 					<description>
-						<de>Dies ist eine etwas abgespacete Episode. ${.self:"role":0:"firstname"} findet sich in einem Schwarzen Loch wieder. Nanu, was ist denn hier passiert? Obwohl... schwarzes Loch... höhö. Und was machen die herumfliegenden Disketten und Wildkatzen hier.</de>
-						<en>This is a somewhat spaced out episode. ${.self:"role":0:"firstname"} finds himself in a black hole. Well, what happened here? Although... black hole... heh. And what are the floppy disks and wildcats flying around doing here.</en>
+						<de>Dies ist eine etwas abgespacete Episode. ${.self:"role":1:"firstname"} findet sich in einem Schwarzen Loch wieder. Nanu, was ist denn hier passiert? Obwohl... schwarzes Loch... höhö. Und was machen die herumfliegenden Disketten und Wildkatzen hier.</de>
+						<en>This is a somewhat spaced out episode. ${.self:"role":1:"firstname"} finds himself in a black hole. Well, what happened here? Although... black hole... heh. And what are the floppy disks and wildcats flying around doing here.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="d7c7c96a-1bc3-4e1b-8875-d20ff1ddf632">
 					<title>
-						<de>Fervent ${.self:"role":1:"firstname"} als wenig verdeckte Ermittlerin</de>
-						<en>Fervent ${.self:"role":1:"firstname"} as an Undercover Agent</en>
+						<de>Fervent ${.self:"role":2:"firstname"} als wenig verdeckte Ermittlerin</de>
+						<en>Fervent ${.self:"role":2:"firstname"} as an Undercover Agent</en>
 					</title>
 					<title_original>
-						<de>Passionate ${.self:"role":1:"firstname"} macht beim Geheimdienst mit</de>
-						<en>Passionate ${.self:"role":1:"firstname"} Does a Little Undercover Work</en>
+						<de>Passionate ${.self:"role":2:"firstname"} macht beim Geheimdienst mit</de>
+						<en>Passionate ${.self:"role":2:"firstname"} Does a Little Undercover Work</en>
 					</title_original>
 					<description>
-						<de>Nach dieser seltsamen Amnesie findet sich ${.self:"role":0:"firstname"} in der Erwachsenenfilmindustrie wieder, für die er weltweit auf der Suche nach Models ist. ${.self:"role":1:"firstname"} ist inzwischen für's FBI unterwegs.</de>
-						<en>After this strange amnesia, ${.self:"role":0:"firstname"} finds himself in the adult film industry, for which he is searching for models worldwide. ${.self:"role":1:"firstname"}, meanwhile, is on the road for the FBI.</en>
+						<de>Nach dieser seltsamen Amnesie findet sich ${.self:"role":1:"firstname"} in der Erwachsenenfilmindustrie wieder, für die er weltweit auf der Suche nach Models ist. ${.self:"role":2:"firstname"} ist inzwischen für's FBI unterwegs.</de>
+						<en>After this strange amnesia, ${.self:"role":1:"firstname"} finds himself in the adult film industry, for which he is searching for models worldwide. ${.self:"role":2:"firstname"}, meanwhile, is on the road for the FBI.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="5" product="2" licence_type="2" guid="6ff0a3a1-6c6c-45e4-bfd3-f2729b6210d7">
@@ -7612,8 +7612,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>Shape Up or Slip Out!</en>	
 					</title_original>
 					<description>
-						<de>Wieder schweren Herzens getrennt von ${.self:"role":1:"firstname"}, gewinnt ${.self:"role":0:"firstname"} einen Aufenthalt in einem Resort, wo er aber als nichtzahlender Gast schäbig behandelt wird. Aber er versucht dennoch wieder auf allerlei Art und Weise, bei den Frauen zu landen. Vor allem geht's um Fitness...</de>
-						<en>Separated from ${.self:"role":1:"firstname"} again with a heavy heart, ${.self:"role":0:"firstname"} wins a stay at a resort, where, however, he is treated shabbily as a non-paying guest. But he still tries again in all sorts of ways to land with the women. Most of all, it's about fitness...</en>
+						<de>Wieder schweren Herzens getrennt von ${.self:"role":2:"firstname"}, gewinnt ${.self:"role":1:"firstname"} einen Aufenthalt in einem Resort, wo er aber als nichtzahlender Gast schäbig behandelt wird. Aber er versucht dennoch wieder auf allerlei Art und Weise, bei den Frauen zu landen. Vor allem geht's um Fitness...</de>
+						<en>Separated from ${.self:"role":2:"firstname"} again with a heavy heart, ${.self:"role":1:"firstname"} wins a stay at a resort, where, however, he is treated shabbily as a non-paying guest. But he still tries again in all sorts of ways to land with the women. Most of all, it's about fitness...</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="6" product="2" licence_type="2" guid="4065b465-ca94-4d7f-b49a-ec020bcb4630">
@@ -7626,8 +7626,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>Love for Sail!</en>
 					</title_original>
 					<description>
-						<de>Diesmal auf einem Kreuzfahrtschiff mit prominenten Stars und Sternchen besetzt (oder deren Doppelgängern?) werden viele Wettbewerbe und Spielchen veranstaltet, die ${.self:"role":0:"firstname"} gewinnen will.</de>
-						<en>This time on a cruise ship filled with prominent stars and starlets (or their doppelgängers?) there are many contests and games that ${.self:"role":0:"firstname"} wants to win.</en>
+						<de>Diesmal auf einem Kreuzfahrtschiff mit prominenten Stars und Sternchen besetzt (oder deren Doppelgängern?) werden viele Wettbewerbe und Spielchen veranstaltet, die ${.self:"role":1:"firstname"} gewinnen will.</de>
+						<en>This time on a cruise ship filled with prominent stars and starlets (or their doppelgängers?) there are many contests and games that ${.self:"role":1:"firstname"} wants to win.</en>
 					</description>	
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="503f7801-dc8d-4f55-a0e9-c017592eba62">
@@ -7640,8 +7640,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>Magna Cum Laude</en>
 					</title_original>
 					<description>
-						<de>Ein Spinoff? Es geht diesmal um ${.self:"role":0:"firstname"}s Neffen, der auch ${.self:"role":0:"firstname"} heißt, im College ist und bei einer Dating Show mitmacht. Onkel ${.self:"role":0:"firstname"} gibt immerhin noch wertvolle Tips. Was ist mit ${.self:"role":1:"firstname"}? Ist noch offen, vielleicht in der nächsten Staffel...</de>
-						<en>A spinoff? This time it's about ${.self:"role":0:"firstname"}'s nephew, who is also named ${.self:"role":0:"firstname"}, and who's in college, and participating in a dating show. Uncle ${.self:"role":0:"firstname"} still gives valuable tips, at least. What about ${.self:"role":1:"firstname"}? It's still open, maybe next season...</en>
+						<de>Ein Spinoff? Es geht diesmal um ${.self:"role":1:"firstname"}s Neffen, der auch ${.self:"role":1:"firstname"} heißt, im College ist und bei einer Dating Show mitmacht. Onkel ${.self:"role":1:"firstname"} gibt immerhin noch wertvolle Tips. Was ist mit ${.self:"role":2:"firstname"}? Ist noch offen, vielleicht in der nächsten Staffel...</de>
+						<en>A spinoff? This time it's about ${.self:"role":1:"firstname"}'s nephew, who is also named ${.self:"role":1:"firstname"}, and who's in college, and participating in a dating show. Uncle ${.self:"role":1:"firstname"} still gives valuable tips, at least. What about ${.self:"role":2:"firstname"}? It's still open, maybe next season...</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -7901,8 +7901,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 				<en>Full Throttle</en>
 			</title_original>
 			<description>
-				<de>In einer nahen Zukunft der Hovercraft-Fahrzeuge wird Biker-Gang-Anführer ${.self:"role":0:"firstname"} unschuldig des Mordes an ${.self:"role":1:"fullname"}, Vorstand der letzten Motorradfabrik, bezichtigt, und kommt auf der Flucht einer Veschwörung auf die Spur.</de>
-				<en>In a near future of hovercraft vehicles, biker gang leader ${.self:"role":0:"firstname"} is innocently accused of murdering ${.self:"role":1:"fullname"}, executive of the last motorcycle factory, and comes across a conspiracy while on the run.</en>
+				<de>In einer nahen Zukunft der Hovercraft-Fahrzeuge wird Biker-Gang-Anführer ${.self:"role":1:"firstname"} unschuldig des Mordes an ${.self:"role":2:"fullname"}, Vorstand der letzten Motorradfabrik, bezichtigt, und kommt auf der Flucht einer Veschwörung auf die Spur.</de>
+				<en>In a near future of hovercraft vehicles, biker gang leader ${.self:"role":1:"firstname"} is innocently accused of murdering ${.self:"role":2:"fullname"}, executive of the last motorcycle factory, and comes across a conspiracy while on the run.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -7935,8 +7935,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 				<en>Turrican</en>
 			</title_original>
 			<description>
-				<de>„Shoot! Or! Die! Hahahaha!“ Flotte Anime-SciFi-Action über Soldat ${.self:"role":0:"fullname"} in seinem biomechanischen Anzug, der die Weltraumkolonie Alterra von der außer Kontrolle geratenen künstlichen Intelligenz M.O.R.G.U.L. befreien muss.</de>
-				<en>"Shoot! Or! Die! Hahahaha!" Fast-paced anime sci-fi action about soldier ${.self:"role":0:"fullname"} in his biomechanical suit who must liberate the space colony Alterra from the artificial intelligence M.O.R.G.U.L. that has gone out of control.</en>
+				<de>„Shoot! Or! Die! Hahahaha!“ Flotte Anime-SciFi-Action über Soldat ${.self:"role":1:"fullname"} in seinem biomechanischen Anzug, der die Weltraumkolonie Alterra von der außer Kontrolle geratenen künstlichen Intelligenz M.O.R.G.U.L. befreien muss.</de>
+				<en>"Shoot! Or! Die! Hahahaha!" Fast-paced anime sci-fi action about soldier ${.self:"role":1:"fullname"} in his biomechanical suit who must liberate the space colony Alterra from the artificial intelligence M.O.R.G.U.L. that has gone out of control.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -7970,8 +7970,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 				<en>Turrican 2: The Final Fight</en>
 			</title_original>
 			<description>
-				<de>Das United-Planets-Raumschiff Avalon 1 wird von Mutanten angegriffen, angeführt von ${.self:"role":2:"fullname"}. ${.self:"role":0:"fullname"} muss den Tag retten. Erneut inklusive tollem Soundtrack von Claus Bruellhaecks, der sich mal wieder selbst übertroffen hat.</de>
-				<en>The United Planets spaceship Avalon 1 is under attack by mutants, led by ${.self:"role":2:"fullname"}. ${.self:"role":0:"fullname"} must save the day. Once more including a great soundtrack by Claus Bruellhaecks, who has again outdone himself.</en>
+				<de>Das United-Planets-Raumschiff Avalon 1 wird von Mutanten angegriffen, angeführt von ${.self:"role":3:"fullname"}. ${.self:"role":1:"fullname"} muss den Tag retten. Erneut inklusive tollem Soundtrack von Claus Bruellhaecks, der sich mal wieder selbst übertroffen hat.</de>
+				<en>The United Planets spaceship Avalon 1 is under attack by mutants, led by ${.self:"role":3:"fullname"}. ${.self:"role":1:"fullname"} must save the day. Once more including a great soundtrack by Claus Bruellhaecks, who has again outdone himself.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -8005,8 +8005,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 				<en>Turrican 3: Payment Day</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":0:"firstname"}, jetzt ein Anführer in den United Planets Freedom Forces, sieht sich einer neuen Bedrohung gegenüber, als unerwartet ${.self:"role":2:"fullname"} zurückkehrt, Schrecken verbreitet und unschuldiges Leben versklavt.</de>
-				<en>${.self:"role":0:"firstname"}, now leader in the United Planets Freedom Forces, faces a new threat as, unexpectedly, ${.self:"role":2:"fullname"} returns, spreading terror and enslaving innocent lives.</en>
+				<de>${.self:"role":1:"firstname"}, jetzt ein Anführer in den United Planets Freedom Forces, sieht sich einer neuen Bedrohung gegenüber, als unerwartet ${.self:"role":3:"fullname"} zurückkehrt, Schrecken verbreitet und unschuldiges Leben versklavt.</de>
+				<en>${.self:"role":1:"firstname"}, now leader in the United Planets Freedom Forces, faces a new threat as, unexpectedly, ${.self:"role":3:"fullname"} returns, spreading terror and enslaving innocent lives.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -8071,8 +8071,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 				<en>Pyjamarama</en>
 			</title_original>
 			<description>
-				<de>Oh nein, ${.self:"role":0:"firstname"} hat vergessen, den Wecker zu stellen. So kommt er zu spät zur Arbeit. Jetzt muss er ihn im Traum stellen, wobei er allerlei im Haus herumspukenden Gestalten begegnet. Nur wo ist der verflixte Aufziehschlüssel? Vielleicht auf dem Mond?</de>
-				<en>Oh no, ${.self:"role":0:"firstname"} forgot to set the alarm clock. So he'll be too late for work. Now he has to set it in his dreams, encountering all sorts of creatures haunting the house. Only where is the darned wind-up key? Maybe on the moon?</en>
+				<de>Oh nein, ${.self:"role":1:"firstname"} hat vergessen, den Wecker zu stellen. So kommt er zu spät zur Arbeit. Jetzt muss er ihn im Traum stellen, wobei er allerlei im Haus herumspukenden Gestalten begegnet. Nur wo ist der verflixte Aufziehschlüssel? Vielleicht auf dem Mond?</de>
+				<en>Oh no, ${.self:"role":1:"firstname"} forgot to set the alarm clock. So he'll be too late for work. Now he has to set it in his dreams, encountering all sorts of creatures haunting the house. Only where is the darned wind-up key? Maybe on the moon?</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -8108,8 +8108,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 				<en>Automania</en>
 			</title_original>
 			<description>
-				<de>Zweiter Teil der Reihe um den britischen Arbeiter ${.self:"role":0:"fullname"} und seine Familie. Er hatte es geschafft und war rechtzeitig aufgewacht, doch in der Autofabrik geht's genauso verrückt zu wie in seinen Träumen.</de>
-				<en>Second part of the series about the British worker ${.self:"role":0:"fullname"} and his family. He had made it and woke up in time, but things in the car factory are just as crazy as in his dreams.</en>
+				<de>Zweiter Teil der Reihe um den britischen Arbeiter ${.self:"role":1:"fullname"} und seine Familie. Er hatte es geschafft und war rechtzeitig aufgewacht, doch in der Autofabrik geht's genauso verrückt zu wie in seinen Träumen.</de>
+				<en>Second part of the series about the British worker ${.self:"role":1:"fullname"} and his family. He had made it and woke up in time, but things in the car factory are just as crazy as in his dreams.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -8137,16 +8137,16 @@ The project, which was cancelled by a major producer, is now free to be realized
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="cc74462f-0e7f-4acc-b95f-fd61e1756037" creator="9551" comment="https://en.wikipedia.org/wiki/Everyone%27s_a_Wally">
 			<title>
-				<de>Wir alle sind ${.self:"role":0:"firstname"}</de>
-				<en>We all are ${.self:"role":0:"firstname"}</en>
+				<de>Wir alle sind ${.self:"role":1:"firstname"}</de>
+				<en>We all are ${.self:"role":1:"firstname"}</en>
 			</title>
 			<title_original>
-				<de>Wir alle sind ${.self:"role":0:"firstname"}</de>
-				<en>Everyone's a ${.self:"role":0:"firstname"}</en>
+				<de>Wir alle sind ${.self:"role":1:"firstname"}</de>
+				<en>Everyone's a ${.self:"role":1:"firstname"}</en>
 			</title_original>
 			<description>
-				<de>Nicht nur ${.self:"role":0:"firstname"}, sondern auch seine Kumpels, seine Frau ${.self:"role":1:"firstname"} und selbst sein kleines krabbelndes Baby ${.self:"role":2:"firstname"} haben ihre verrückten Jobs, denen sie den ganzen lieben langen Tag nachkommen müssen.</de>
-				<en>Not only ${.self:"role":0:"firstname"}, but also his buddies, his wife ${.self:"role":1:"firstname"} and even his little crawling baby ${.self:"role":2:"firstname"} have their crazy jobs that they have to keep up with all day long.</en>
+				<de>Nicht nur ${.self:"role":1:"firstname"}, sondern auch seine Kumpels, seine Frau ${.self:"role":2:"firstname"} und selbst sein kleines krabbelndes Baby ${.self:"role":3:"firstname"} haben ihre verrückten Jobs, denen sie den ganzen lieben langen Tag nachkommen müssen.</de>
+				<en>Not only ${.self:"role":1:"firstname"}, but also his buddies, his wife ${.self:"role":2:"firstname"} and even his little crawling baby ${.self:"role":3:"firstname"} have their crazy jobs that they have to keep up with all day long.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -8174,16 +8174,16 @@ The project, which was cancelled by a major producer, is now free to be realized
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="d621350a-5e57-4519-814a-5ea9f78d6553" creator="9551" comment="https://www.mobygames.com/game/63125/herberts-dummy-run/">
 			<title>
-				<de>${.self:"role":2:"firstname"} lernt laufen</de>
-				<en>${.self:"role":2:"firstname"}'s Trial Run</en>
+				<de>${.self:"role":3:"firstname"} lernt laufen</de>
+				<en>${.self:"role":3:"firstname"}'s Trial Run</en>
 			</title>
 			<title_original>
-				<de>${.self:"role":2:"firstname"} lernt laufen</de>
-				<en>${.self:"role":2:"firstname"}'s Dummy Run</en>
+				<de>${.self:"role":3:"firstname"} lernt laufen</de>
+				<en>${.self:"role":3:"firstname"}'s Dummy Run</en>
 			</title_original>
 			<description>
-				<de>Och, wie schnell sie groß werden. Aber natürlich läuft bei ${.self:"role":0:"fullname"} und seiner Familie alles ein bisschen anders. Wenn der kleine ${.self:"role":2:"fullname"} laufen lernt, dann ist das daher mit ganz besonderen Hindernissen verbunden.</de>
-				<en>Oh my, how quickly they grow up. But of course everything runs a little differently with ${.self:"role":0:"fullname"} and his family. So when little ${.self:"role":2:"fullname"} learns to run, it's fraught with very special obstacles.</en>
+				<de>Och, wie schnell sie groß werden. Aber natürlich läuft bei ${.self:"role":1:"fullname"} und seiner Familie alles ein bisschen anders. Wenn der kleine ${.self:"role":3:"fullname"} laufen lernt, dann ist das daher mit ganz besonderen Hindernissen verbunden.</de>
+				<en>Oh my, how quickly they grow up. But of course everything runs a little differently with ${.self:"role":1:"fullname"} and his family. So when little ${.self:"role":3:"fullname"} learns to run, it's fraught with very special obstacles.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -8219,8 +8219,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 				<en>Three Weeks in Paradise</en>
 			</title_original>
 			<description>
-				<de>${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} werden im Urlaub prompt von Kannibalen gefangen genommen. Wieder treiben allerlei skurrile Fantasiegestalten ihr Unwesen. Was haben die Hauptfiguren (oder die Drehbuchautoren) nur wieder konsumiert?</de>
-				<en>${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"} are promptly captured by cannibals while on vacation. Again, all sorts of bizarre fantasy creatures are up to mischief. Just what have the main characters (or the scriptwriters) consumed?</en>
+				<de>${.self:"role":2:"firstname"} und ${.self:"role":3:"firstname"} werden im Urlaub prompt von Kannibalen gefangen genommen. Wieder treiben allerlei skurrile Fantasiegestalten ihr Unwesen. Was haben die Hauptfiguren (oder die Drehbuchautoren) nur wieder konsumiert?</de>
+				<en>${.self:"role":2:"firstname"} and ${.self:"role":3:"firstname"} are promptly captured by cannibals while on vacation. Again, all sorts of bizarre fantasy creatures are up to mischief. Just what have the main characters (or the scriptwriters) consumed?</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -8292,8 +8292,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 				<en>The King of Chicago</en>
 			</title_original>
 			<description>
-				<de>1931: Southside-Mafia-Boss ${.self:"role":1:"fullname"} wird nach Alcatraz gebracht und hinterlässt ein Machtvakuum in der kriminellen Unterwelt Chicagos. ${.self:"role":0:"firstname"}, ein ehrgeiziger Emporkömmling der rivalisierenden Northside-Gang, will den Thron für sich.</de>
-				<en>1931: Southside mafia boss ${.self:"role":1:"fullname"} is sent to Alcatraz, leaving a power vacuum within Chicago's criminal underworld. ${.self:"role":0:"firstname"}, an ambitious up-and-comer in the rival Northside gang, wants the throne for himself.</en>
+				<de>1931: Southside-Mafia-Boss ${.self:"role":2:"fullname"} wird nach Alcatraz gebracht und hinterlässt ein Machtvakuum in der kriminellen Unterwelt Chicagos. ${.self:"role":1:"firstname"}, ein ehrgeiziger Emporkömmling der rivalisierenden Northside-Gang, will den Thron für sich.</de>
+				<en>1931: Southside mafia boss ${.self:"role":2:"fullname"} is sent to Alcatraz, leaving a power vacuum within Chicago's criminal underworld. ${.self:"role":1:"firstname"}, an ambitious up-and-comer in the rival Northside gang, wants the throne for himself.</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -8330,8 +8330,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 				<en>It Came from the Desert</en>
 			</title_original>
 			<description>
-				<de>Hommage an die SciFi-/Horror-B-Movies der 1950er Jahre. Der Geologe ${.self:"role":0:"fullname"} untersucht die Absturzstelle eines Meteors in Kalifornien. Dessen Strahlung lässt Ameisen auf eine enorme Größe anwachsen...</de>
-				<en>Homage to the sci-fi/horror B-movies of the 1950s. The geologist ${.self:"role":0:"fullname"} investigates the crash site of a meteor in California. Its radiation causes ants to grow to an enormous size...</en>
+				<de>Hommage an die SciFi-/Horror-B-Movies der 1950er Jahre. Der Geologe ${.self:"role":1:"fullname"} untersucht die Absturzstelle eines Meteors in Kalifornien. Dessen Strahlung lässt Ameisen auf eine enorme Größe anwachsen...</de>
+				<en>Homage to the sci-fi/horror B-movies of the 1950s. The geologist ${.self:"role":1:"fullname"} investigates the crash site of a meteor in California. Its radiation causes ants to grow to an enormous size...</en>
 			</description>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -8397,16 +8397,16 @@ The project, which was cancelled by a major producer, is now free to be realized
 
 		<scripttemplate product="2" licence_type="3" guid="71f4752c-2c8f-41f0-82c6-3461e02e8160" creator="9551" comment="TODO: To test a future 'franchise script' feature. Episode titles and contents by ChatGPT. A bit formulaic perhaps.">
 			<title>
-				<de>${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} - Die ${new} ${adventures}</de>
-				<en>${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"} - The ${new} ${adventures}</en>
+				<de>${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} - Die ${new} ${adventures}</de>
+				<en>${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"} - The ${new} ${adventures}</en>
 			</title>
 			<title_original>
-				<de>${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} - Die ${new} ${adventures}</de>
-				<en>${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"} - The ${new} ${adventures}</en>
+				<de>${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} - Die ${new} ${adventures}</de>
+				<en>${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"} - The ${new} ${adventures}</en>
 			</title_original>
 			<description>
-				<de>Eine Neuauflage der beliebten tschechischen Marionettenserie über Vater ${.self:"role":0:"firstname"}, den kleinen Sohn ${.self:"role":1:"firstname"}, Schulfreundin ${.self:"role":3:"firstname"}, Großmutter Frau ${.self:"role":2:"firstname"} und Hund ${.self:"role":4:"firstname"}. Behutsam modernisiert, so dass der Charme erhalten bleibt.</de>
-				<en>A new edition of the popular Czech puppet series about father ${.self:"role":0:"firstname"}, little son ${.self:"role":1:"firstname"}, school girl friend ${.self:"role":3:"firstname"}, grandmother Ms. ${.self:"role":2:"firstname"} and dog ${.self:"role":4:"firstname"}. Cautiously modernized, so that the charm is preserved.</en>
+				<de>Eine Neuauflage der beliebten tschechischen Marionettenserie über Vater ${.self:"role":1:"firstname"}, den kleinen Sohn ${.self:"role":2:"firstname"}, Schulfreundin ${.self:"role":4:"firstname"}, Großmutter Frau ${.self:"role":3:"firstname"} und Hund ${.self:"role":5:"firstname"}. Behutsam modernisiert, so dass der Charme erhalten bleibt.</de>
+				<en>A new edition of the popular Czech puppet series about father ${.self:"role":1:"firstname"}, little son ${.self:"role":2:"firstname"}, school girl friend ${.self:"role":4:"firstname"}, grandmother Ms. ${.self:"role":3:"firstname"} and dog ${.self:"role":5:"firstname"}. Cautiously modernized, so that the charm is preserved.</en>
 			</description>
 			<variables>
 				<new>
@@ -8429,8 +8429,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Mischievous Pet</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":1:"firstname"} bringt einen streunenden Hund mit nach Hause und sorgt damit für Chaos im Haushalt. ${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} versuchen, den Hund vor Frau ${.self:"role":2:"firstname"} zu verstecken, was zu witzigen Begegnungen und einer herzerwärmenden Auflösung führt.</de>
-						<en>${.self:"role":1:"firstname"} brings home a stray dog, causing chaos in the household. ${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"} try to hide the dog from Ms. ${.self:"role":2:"firstname"}, leading to hilarious encounters and a heartwarming resolution.</en>
+						<de>${.self:"role":2:"firstname"} bringt einen streunenden Hund mit nach Hause und sorgt damit für Chaos im Haushalt. ${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} versuchen, den Hund vor Frau ${.self:"role":3:"firstname"} zu verstecken, was zu witzigen Begegnungen und einer herzerwärmenden Auflösung führt.</de>
+						<en>${.self:"role":2:"firstname"} brings home a stray dog, causing chaos in the household. ${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"} try to hide the dog from Ms. ${.self:"role":3:"firstname"}, leading to hilarious encounters and a heartwarming resolution.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="84a75131-37e9-4ffe-821f-0c3deb7ce740">
@@ -8443,8 +8443,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Magical Adventure</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} entdeckt ein geheimnisvolles altes Buch, und mit ${.self:"role":1:"firstname"}s Hilfe begeben sie sich versehentlich in eine magische Welt. Dort müssen sie sich mit skurrilen Wesen herumschlagen und einen Weg zurück nach Hause finden.</de>
-						<en>${.self:"role":0:"firstname"} discovers a mysterious old book, and with ${.self:"role":1:"firstname"}'s help, they accidentally transport themselves into a magical world. They must navigate whimsical creatures and find a way back home.</en>
+						<de>${.self:"role":1:"firstname"} entdeckt ein geheimnisvolles altes Buch, und mit ${.self:"role":2:"firstname"}s Hilfe begeben sie sich versehentlich in eine magische Welt. Dort müssen sie sich mit skurrilen Wesen herumschlagen und einen Weg zurück nach Hause finden.</de>
+						<en>${.self:"role":1:"firstname"} discovers a mysterious old book, and with ${.self:"role":2:"firstname"}'s help, they accidentally transport themselves into a magical world. They must navigate whimsical creatures and find a way back home.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="8823f7b7-3748-4683-94b4-f4fc35be6f56">
@@ -8457,8 +8457,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Talent Show</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":1:"firstname"} und ${.self:"role":3:"firstname"} beschließen, an einer lokalen Talentshow teilzunehmen, aber sie brauchen ${.self:"role":0:"firstname"}s Hilfe, um ihren Auftritt vorzubereiten. ${.self:"role":0:"firstname"}s mangelnde Talentmanagementfähigkeiten führen jedoch zu skurrilen Missgeschicken.</de>
-						<en>${.self:"role":1:"firstname"} and ${.self:"role":3:"firstname"} decide to participate in a local talent show, but they need ${.self:"role":0:"firstname"}'s help to prepare their act. However, ${.self:"role":0:"firstname"}'s lack of talent management skills leads to comical mishaps.</en>
+						<de>${.self:"role":2:"firstname"} und ${.self:"role":4:"firstname"} beschließen, an einer lokalen Talentshow teilzunehmen, aber sie brauchen ${.self:"role":1:"firstname"}s Hilfe, um ihren Auftritt vorzubereiten. ${.self:"role":1:"firstname"}s mangelnde Talentmanagementfähigkeiten führen jedoch zu skurrilen Missgeschicken.</de>
+						<en>${.self:"role":2:"firstname"} and ${.self:"role":4:"firstname"} decide to participate in a local talent show, but they need ${.self:"role":1:"firstname"}'s help to prepare their act. However, ${.self:"role":1:"firstname"}'s lack of talent management skills leads to comical mishaps.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="9db22b70-29f8-4b67-b4a2-ac512e6022d5">
@@ -8471,8 +8471,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Great Camping Disaster</en>
 					</title_original>
 					<description>
-						<de>Die Familie beschließt, einen Campingausflug zu machen, aber ${.self:"role":0:"firstname"}s mangelnde Outdoor-Kenntnisse führen zu einer Reihe von lustigen Camping-Desastern. ${.self:"role":1:"firstname"} und ${.self:"role":4:"firstname"} lassen sich clevere Lösungen einfallen, um den Tag zu retten.</de>
-						<en>The family decides to go on a camping trip, but ${.self:"role":0:"firstname"}'s lack of outdoor skills creates a series of hilarious camping disasters. ${.self:"role":1:"firstname"} and the ${.self:"role":4:"firstname"} come up with clever solutions to save the day.</en>
+						<de>Die Familie beschließt, einen Campingausflug zu machen, aber ${.self:"role":1:"firstname"}s mangelnde Outdoor-Kenntnisse führen zu einer Reihe von lustigen Camping-Desastern. ${.self:"role":2:"firstname"} und ${.self:"role":5:"firstname"} lassen sich clevere Lösungen einfallen, um den Tag zu retten.</de>
+						<en>The family decides to go on a camping trip, but ${.self:"role":1:"firstname"}'s lack of outdoor skills creates a series of hilarious camping disasters. ${.self:"role":2:"firstname"} and the ${.self:"role":5:"firstname"} come up with clever solutions to save the day.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="bff2275b-56d2-4581-a88b-9632a1510e38">
@@ -8485,8 +8485,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Mystery of the Missing Cake</en>
 					</title_original>
 					<description>
-						<de>Frau ${.self:"role":2:"firstname"} backt einen leckeren Kuchen für einen besonderen Anlass, aber er verschwindet auf mysteriöse Weise. ${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} werden zu Amateurdetektiven, um das Rätsel zu lösen, und kommen dabei unerwarteten Schuldigen auf die Spur.</de>
-						<en>Ms. ${.self:"role":2:"firstname"} bakes a delicious cake for a special occasion, but it mysteriously disappears. ${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"} turn into amateur detectives to solve the mystery, uncovering unexpected culprits.</en>
+						<de>Frau ${.self:"role":3:"firstname"} backt einen leckeren Kuchen für einen besonderen Anlass, aber er verschwindet auf mysteriöse Weise. ${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} werden zu Amateurdetektiven, um das Rätsel zu lösen, und kommen dabei unerwarteten Schuldigen auf die Spur.</de>
+						<en>Ms. ${.self:"role":3:"firstname"} bakes a delicious cake for a special occasion, but it mysteriously disappears. ${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"} turn into amateur detectives to solve the mystery, uncovering unexpected culprits.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="5" product="2" licence_type="2" guid="75a226c4-26cc-4a3d-b39c-e0c154f5841b">
@@ -8499,8 +8499,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Robot Invasion</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} bestellt versehentlich einen schlecht funktionierenden Roboter, der im Haus für Chaos sorgt. Mit ${.self:"role":1:"firstname"}s spitzbübischen Ideen versuchen sie, den Roboter zu überlisten, bevor er ihr Leben übernimmt.</de>
-						<en>${.self:"role":0:"firstname"} accidentally orders a malfunctioning robot, causing chaos in the house. With ${.self:"role":0:"firstname"}'s mischievous ideas, they attempt to outsmart the robot before it takes over their lives.</en>
+						<de>${.self:"role":1:"firstname"} bestellt versehentlich einen schlecht funktionierenden Roboter, der im Haus für Chaos sorgt. Mit ${.self:"role":2:"firstname"}s spitzbübischen Ideen versuchen sie, den Roboter zu überlisten, bevor er ihr Leben übernimmt.</de>
+						<en>${.self:"role":1:"firstname"} accidentally orders a malfunctioning robot, causing chaos in the house. With ${.self:"role":1:"firstname"}'s mischievous ideas, they attempt to outsmart the robot before it takes over their lives.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="6" product="2" licence_type="2" guid="59b6fb38-f8be-43e7-9273-7e93ca321199">
@@ -8513,8 +8513,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Birthday Surprise</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} planen eine Überraschungsgeburtstagsfeier für Frau ${.self:"role":2:"firstname"}, aber alles geht schief. Ihre Versuche, die Überraschung geheim zu halten, führen zu witzigen Missverständnissen und unerwarteten Wendungen.</de>
-						<en>${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"} plan a surprise birthday party for Ms. ${.self:"role":2:"firstname"}, but everything goes awry. Their attempts to keep the surprise under wraps result in hilarious misunderstandings and unexpected twists.</en>
+						<de>${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} planen eine Überraschungsgeburtstagsfeier für Frau ${.self:"role":3:"firstname"}, aber alles geht schief. Ihre Versuche, die Überraschung geheim zu halten, führen zu witzigen Missverständnissen und unerwarteten Wendungen.</de>
+						<en>${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"} plan a surprise birthday party for Ms. ${.self:"role":3:"firstname"}, but everything goes awry. Their attempts to keep the surprise under wraps result in hilarious misunderstandings and unexpected twists.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="7bfa386a-d0c6-4d89-9f86-52e5ab9e0e7c">
@@ -8527,8 +8527,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Magical Time Travel</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":1:"firstname"} entdeckt auf dem Dachboden eine Zeitreisemaschine und überredet ${.self:"role":0:"firstname"}, sich auf ein Abenteuer in die Vergangenheit zu begeben. Ihre Reise führt sie in verschiedene historische Epochen, was zu lustigen Begegnungen und wertvollen Lektionen führt.</de>
-						<en>${.self:"role":1:"firstname"} discovers a time-traveling machine in the attic and convinces ${.self:"role":0:"firstname"} to go on an adventure to the past. Their journey takes them to various historical eras, leading to humorous encounters and valuable lessons.</en>
+						<de>${.self:"role":2:"firstname"} entdeckt auf dem Dachboden eine Zeitreisemaschine und überredet ${.self:"role":1:"firstname"}, sich auf ein Abenteuer in die Vergangenheit zu begeben. Ihre Reise führt sie in verschiedene historische Epochen, was zu lustigen Begegnungen und wertvollen Lektionen führt.</de>
+						<en>${.self:"role":2:"firstname"} discovers a time-traveling machine in the attic and convinces ${.self:"role":1:"firstname"} to go on an adventure to the past. Their journey takes them to various historical eras, leading to humorous encounters and valuable lessons.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="8" product="2" licence_type="2" guid="c42695d0-c3cc-4d97-bcca-9cf521793fd3">
@@ -8541,8 +8541,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Case of the Missing Treasure</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":3:"firstname"} findet eine alte Schatzkarte, und mit ${.self:"role":4:"firstname"}s Hilfe überredet sie ${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"}, sich auf eine Schatzsuche zu begeben. Ihre Reise ist gespickt mit lustigen Hindernissen und unerwarteten Entdeckungen, die zu einer überraschenden Wendung führen.</de>
-						<en>${.self:"role":3:"firstname"} finds an old treasure map, and with ${.self:"role":4:"firstname"}'s help, she convinces ${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"} to embark on a treasure hunt. Their journey is filled with funny obstacles and unexpected discoveries, leading to a surprising twist.</en>
+						<de>${.self:"role":4:"firstname"} findet eine alte Schatzkarte, und mit ${.self:"role":5:"firstname"}s Hilfe überredet sie ${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"}, sich auf eine Schatzsuche zu begeben. Ihre Reise ist gespickt mit lustigen Hindernissen und unerwarteten Entdeckungen, die zu einer überraschenden Wendung führen.</de>
+						<en>${.self:"role":4:"firstname"} finds an old treasure map, and with ${.self:"role":5:"firstname"}'s help, she convinces ${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"} to embark on a treasure hunt. Their journey is filled with funny obstacles and unexpected discoveries, leading to a surprising twist.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="9" product="2" licence_type="2" guid="752a897a-c895-411c-a864-f95e6e1dd6fb">
@@ -8555,8 +8555,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Music Band Fiasco</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":3:"firstname"}, inspiriert von einer berühmten Musikband, überredet ${.self:"role":1:"firstname"} und ${.self:"role":4:"firstname"}, ihre eigene Band zu gründen. ${.self:"role":0:"firstname"} schließt sich widerwillig an, was zu urkomischen Versuchen führt, Instrumente zu spielen und chaotische, aber amüsante Auftritte zu gestalten.</de>
-						<en>${.self:"role":3:"firstname"}, inspired by a famous music band, convinces ${.self:"role":1:"firstname"} and ${.self:"role":4:"firstname"} to form their own band. ${.self:"role":0:"firstname"} reluctantly joins in, leading to hilarious attempts at playing instruments and creating chaotic but amusing performances.</en>
+						<de>${.self:"role":4:"firstname"}, inspiriert von einer berühmten Musikband, überredet ${.self:"role":2:"firstname"} und ${.self:"role":5:"firstname"}, ihre eigene Band zu gründen. ${.self:"role":1:"firstname"} schließt sich widerwillig an, was zu urkomischen Versuchen führt, Instrumente zu spielen und chaotische, aber amüsante Auftritte zu gestalten.</de>
+						<en>${.self:"role":4:"firstname"}, inspired by a famous music band, convinces ${.self:"role":2:"firstname"} and ${.self:"role":5:"firstname"} to form their own band. ${.self:"role":1:"firstname"} reluctantly joins in, leading to hilarious attempts at playing instruments and creating chaotic but amusing performances.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -8590,22 +8590,22 @@ The project, which was cancelled by a major producer, is now free to be realized
 				<en>The Jerrodettes</en>
 			</title_original>
 			<description>
-				<de>„Lass sie das nicht tun, Daddy. Lass die Sterne nicht verlöschen.“ Die allwissende ${.self:"role":0:"firstname"}-AI kann die kleine ${.self:"role":3:"firstname"} gerade vielleicht nicht beruhigen, aber die Familie erlebt auf ihrem Raumschiff auch allerlei andere Abenteuer und Herausforderungen.</de>
-				<en>"Don't let them, daddy. Don't let the stars run down." The all-knowing ${.self:"role":0:"firstname"} AI may not be able to calm little ${.self:"role":3:"firstname"} right now, but the family also experience all sorts of other adventures and challenges on their spaceship.</en>
+				<de>„Lass sie das nicht tun, Daddy. Lass die Sterne nicht verlöschen.“ Die allwissende ${.self:"role":1:"firstname"}-AI kann die kleine ${.self:"role":4:"firstname"} gerade vielleicht nicht beruhigen, aber die Familie erlebt auf ihrem Raumschiff auch allerlei andere Abenteuer und Herausforderungen.</de>
+				<en>"Don't let them, daddy. Don't let the stars run down." The all-knowing ${.self:"role":1:"firstname"} AI may not be able to calm little ${.self:"role":4:"firstname"} right now, but the family also experience all sorts of other adventures and challenges on their spaceship.</en>
 			</description>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="5b4ac580-4921-4fb6-855f-6bf1dda5a046">
 					<title>
-						<de>${.self:"role":0:"firstname"}s Missgeschick</de>
-						<en>${.self:"role":0:"firstname"}'s Mishap</en>
+						<de>${.self:"role":1:"firstname"}s Missgeschick</de>
+						<en>${.self:"role":1:"firstname"}'s Mishap</en>
 					</title>
 					<title_original>
-						<de>${.self:"role":0:"firstname"}s Missgeschick</de>
-						<en>${.self:"role":0:"firstname"}'s Mishap</en>
+						<de>${.self:"role":1:"firstname"}s Missgeschick</de>
+						<en>${.self:"role":1:"firstname"}'s Mishap</en>
 					</title_original>
 					<description>
-						<de>Eine Panne bei den ${.self:"role":0:"firstname"}-Berechnungen führt die ${.self:"role":1:"firstname"}-Familie auf unerwartete Umwege und zur Begegnung mit einem schelmischen Alien-Tierchen names Quirkle vom Planeten Zintar und all seinen verspielten Kapriolen.</de>
-						<en>A glitch in ${.self:"role":0:"firstname"}'s calculations leads the ${.self:"role":1:"firstname"} family on unexpected detours and to an encounter with a mischievous alien pet named Quirkle from the planet Zintar and all its playful antics.</en>
+						<de>Eine Panne bei den ${.self:"role":1:"firstname"}-Berechnungen führt die ${.self:"role":2:"firstname"}-Familie auf unerwartete Umwege und zur Begegnung mit einem schelmischen Alien-Tierchen names Quirkle vom Planeten Zintar und all seinen verspielten Kapriolen.</de>
+						<en>A glitch in ${.self:"role":1:"firstname"}'s calculations leads the ${.self:"role":2:"firstname"} family on unexpected detours and to an encounter with a mischievous alien pet named Quirkle from the planet Zintar and all its playful antics.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="4c92538e-e3e6-44ba-a433-2938f7b8fcb7">
@@ -8618,8 +8618,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>Cosmic Cuisine Catastrophe</en>
 					</title_original>
 					<description>
-						<de>Die Familie entdeckt ein einzigartiges interstellares Food-Festival. ${.self:"role":0:"firstname"} gibt kulinarische Ratschläge, aber der Versuch, ein regionales Gericht zuzubereiten, geht schief. Währenddessen entwickelt Quirkle eine Vorliebe für exotische Weltraumfrüchte.</de>
-						<en>The family discovers a unique interstellar food festival. ${.self:"role":0:"firstname"} provides culinary advice, but the attempt to cook a local dish goes awry. Meanwhile, Quirkle develops a taste for exotic space fruits.</en>
+						<de>Die Familie entdeckt ein einzigartiges interstellares Food-Festival. ${.self:"role":1:"firstname"} gibt kulinarische Ratschläge, aber der Versuch, ein regionales Gericht zuzubereiten, geht schief. Währenddessen entwickelt Quirkle eine Vorliebe für exotische Weltraumfrüchte.</de>
+						<en>The family discovers a unique interstellar food festival. ${.self:"role":1:"firstname"} provides culinary advice, but the attempt to cook a local dish goes awry. Meanwhile, Quirkle develops a taste for exotic space fruits.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="3ac4cf90-d8ac-4376-8f8c-49b806069af0">
@@ -8632,8 +8632,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>Star School Shenanigans</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":3:"firstname"} und II kommen in eine futuristische Weltraumschule. ${.self:"role":0:"firstname"} leistet akademische Unterstützung, aber der schelmische Quirkle stiftet Chaos unter den Schülern, was zu einem Besuch des Schulleiters führt - einer intelligenten Gaswolke.</de>
-						<en>${.self:"role":3:"firstname"} and II enroll in a futuristic space school. ${.self:"role":0:"firstname"} offers academic support, but the mischievous Quirkle creates mayhem among the students, prompting a visit from the school principal - an intelligent gas cloud.</en>
+						<de>${.self:"role":4:"firstname"} und II kommen in eine futuristische Weltraumschule. ${.self:"role":1:"firstname"} leistet akademische Unterstützung, aber der schelmische Quirkle stiftet Chaos unter den Schülern, was zu einem Besuch des Schulleiters führt - einer intelligenten Gaswolke.</de>
+						<en>${.self:"role":4:"firstname"} and II enroll in a futuristic space school. ${.self:"role":1:"firstname"} offers academic support, but the mischievous Quirkle creates mayhem among the students, prompting a visit from the school principal - an intelligent gas cloud.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="2a62df01-b00e-4335-907e-64a6ea6034f7">
@@ -8646,8 +8646,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>Galactic Gardening</en>
 					</title_original>
 					<description>
-						<de>Die ${.self:"role":1:"firstname"}s versuchen, auf ihrem Raumschiff einen kosmischen Garten anzupflanzen. ${.self:"role":0:"firstname"} berät sie in Sachen extraterrestrische Flora, doch Quirkles unberechenbarer Appetit verwandelt den Garten - in ein skurriles Wunderland.</de>
-						<en>The ${.self:"role":1:"firstname"}s attempt to grow a cosmic garden on their spaceship. ${.self:"role":0:"firstname"} advises on extraterrestrial flora, but Quirkle's unpredictable appetite transforms the garden - into a whimsical wonderland.</en>
+						<de>Die ${.self:"role":2:"firstname"}s versuchen, auf ihrem Raumschiff einen kosmischen Garten anzupflanzen. ${.self:"role":1:"firstname"} berät sie in Sachen extraterrestrische Flora, doch Quirkles unberechenbarer Appetit verwandelt den Garten - in ein skurriles Wunderland.</de>
+						<en>The ${.self:"role":2:"firstname"}s attempt to grow a cosmic garden on their spaceship. ${.self:"role":1:"firstname"} advises on extraterrestrial flora, but Quirkle's unpredictable appetite transforms the garden - into a whimsical wonderland.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="8dd92ed2-3274-44e1-9389-dadf2eb53528">
@@ -8660,8 +8660,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>Universal Harmony</en>
 					</title_original>
 					<description>
-						<de>Die ${.self:"role":1:"firstname"}s organisieren zusammen mit neuen Freunden verschiedener Planeten eine intergalaktische Talentshow, um kosmische Diversität zu feiern. ${.self:"role":0:"firstname"} hilft bei der Koordinierung, doch natürlich passieren unvorhergesehene Dinge.</de>
-						<en>The ${.self:"role":1:"firstname"}s, joined by new friends from different planets, organize an intergalactic talent show to celebrate cosmic diversity. ${.self:"role":0:"firstname"} assists in coordinating, but of course unforeseen things happen.</en>
+						<de>Die ${.self:"role":2:"firstname"}s organisieren zusammen mit neuen Freunden verschiedener Planeten eine intergalaktische Talentshow, um kosmische Diversität zu feiern. ${.self:"role":1:"firstname"} hilft bei der Koordinierung, doch natürlich passieren unvorhergesehene Dinge.</de>
+						<en>The ${.self:"role":2:"firstname"}s, joined by new friends from different planets, organize an intergalactic talent show to celebrate cosmic diversity. ${.self:"role":1:"firstname"} assists in coordinating, but of course unforeseen things happen.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -8714,8 +8714,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>Pilot</en>
 					</title_original>
 					<description>
-						<de>Die Ankunft der Außerirdischen und der Integrationsprozess wird in Rückblenden erzählt, während Detective ${.self:"role":0:"firstname"} und sein neuer Partner, der Tenctonese ${.self:"role":1:"firstname"}, ihren ersten Mordfall lösen.</de>
-						<en>The arrival of the aliens and the integration process is told in flashbacks as Detective ${.self:"role":0:"firstname"} and his new partner, Tenctonese ${.self:"role":1:"firstname"}, solve their first murder case.</en>
+						<de>Die Ankunft der Außerirdischen und der Integrationsprozess wird in Rückblenden erzählt, während Detective ${.self:"role":1:"firstname"} und sein neuer Partner, der Tenctonese ${.self:"role":2:"firstname"}, ihren ersten Mordfall lösen.</de>
+						<en>The arrival of the aliens and the integration process is told in flashbacks as Detective ${.self:"role":1:"firstname"} and his new partner, Tenctonese ${.self:"role":2:"firstname"}, solve their first murder case.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="16d5ae99-b475-4990-81f6-597c25e3d961">
@@ -8728,8 +8728,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Psycho Trip</en>
 					</title_original>
 					<description>
-						<de>Als eine mysteriöse Droge die Tenctonese-Gemeinschaft infiziert, müssen ${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} den Dealer finden, der sie verkauft. Doch während ihrer Ermittlungen geraten sie in einen Strudel aus Gewalt und Verzweiflung.</de>
-						<en>When a mysterious drug infects the Tenctonese community, ${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"} must find the dealer who is selling it. But during their investigation, they get caught up in a maelstrom of violence and despair.</en>
+						<de>Als eine mysteriöse Droge die Tenctonese-Gemeinschaft infiziert, müssen ${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} den Dealer finden, der sie verkauft. Doch während ihrer Ermittlungen geraten sie in einen Strudel aus Gewalt und Verzweiflung.</de>
+						<en>When a mysterious drug infects the Tenctonese community, ${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"} must find the dealer who is selling it. But during their investigation, they get caught up in a maelstrom of violence and despair.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="b6c478a1-5503-402a-b534-668325494dbe">
@@ -8742,8 +8742,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Exploiter</en>
 					</title_original>
 					<description>
-						<de>Eine skrupelloser Unternehmer nutzt Tenctonese-Arbeiter aus, was zu einer Serie von Protesten führt. ${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} müssen sich zwischen ihrer Pflicht als Gesetzeshüter und ihrem Gewissen entscheiden und diejenigen zu schützen, die am meisten gefährdet sind.</de>
-						<en>An unscrupulous entrepreneur exploits Tenctonese workers, leading to a series of protests. ${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"} must choose between their duty as law enforcement officers and their conscience to protect those who are most at risk.</en>
+						<de>Eine skrupelloser Unternehmer nutzt Tenctonese-Arbeiter aus, was zu einer Serie von Protesten führt. ${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} müssen sich zwischen ihrer Pflicht als Gesetzeshüter und ihrem Gewissen entscheiden und diejenigen zu schützen, die am meisten gefährdet sind.</de>
+						<en>An unscrupulous entrepreneur exploits Tenctonese workers, leading to a series of protests. ${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"} must choose between their duty as law enforcement officers and their conscience to protect those who are most at risk.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="f699a9d5-ed6e-4024-97b3-0f4e40a03bb5">
@@ -8756,8 +8756,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Racist</en>
 					</title_original>
 					<description>
-						<de>Ein brutaler Mord führt zu Spannungen zwischen den menschlichen und Tenctonese-Gemeinschaften. Während ${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} den Täter jagen, werden sie mit latentem Rassismus konfrontiert.</de>
-						<en>A brutal murder leads to tensions between the human and Tenctonese communities. While ${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"} hunt down the perpetrator, they are confronted with latent racism.</en>
+						<de>Ein brutaler Mord führt zu Spannungen zwischen den menschlichen und Tenctonese-Gemeinschaften. Während ${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} den Täter jagen, werden sie mit latentem Rassismus konfrontiert.</de>
+						<en>A brutal murder leads to tensions between the human and Tenctonese communities. While ${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"} hunt down the perpetrator, they are confronted with latent racism.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="a9ed05a6-21db-4a40-a7f8-669fadc66e6e">
@@ -8770,8 +8770,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Party</en>
 					</title_original>
 					<description>
-						<de>Während eines traditionellen Tenctonese-Festes kommt es zu einem Angriff, der die Feierlichkeiten in ein Chaos stürzt. ${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} müssen das Motiv aufdecken und gleichzeitig die fragile Harmonie zwischen den beiden Gemeinschaften bewahren.</de>
-						<en>During a traditional Tenctonese festival, an attack occurs that throws the festivities into chaos. ${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"} must uncover the motive while preserving the fragile harmony between the two communities.</en>
+						<de>Während eines traditionellen Tenctonese-Festes kommt es zu einem Angriff, der die Feierlichkeiten in ein Chaos stürzt. ${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} müssen das Motiv aufdecken und gleichzeitig die fragile Harmonie zwischen den beiden Gemeinschaften bewahren.</de>
+						<en>During a traditional Tenctonese festival, an attack occurs that throws the festivities into chaos. ${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"} must uncover the motive while preserving the fragile harmony between the two communities.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="5" product="2" licence_type="2" guid="17579c8c-7b10-41b4-9bd4-4a96794afedc">
@@ -8784,8 +8784,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Conspiracy</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} und ${.self:"role":1:"firstname"} entdecken eine Verschwörung, die sowohl die menschliche als auch die Tenctonese-Gemeinschaft bedroht. Bei ihren Ermittlungen geraten sie ins Visier gefährlicher Gegner, die nicht zögern, über Leichen zu gehen.</de>
-						<en>${.self:"role":0:"firstname"} and ${.self:"role":1:"firstname"} discover a conspiracy that threatens both the human and Tenctonese communities. During their investigations, they are targeted by dangerous enemies who will not hesitate to walk over dead bodies.</en>
+						<de>${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} entdecken eine Verschwörung, die sowohl die menschliche als auch die Tenctonese-Gemeinschaft bedroht. Bei ihren Ermittlungen geraten sie ins Visier gefährlicher Gegner, die nicht zögern, über Leichen zu gehen.</de>
+						<en>${.self:"role":1:"firstname"} and ${.self:"role":2:"firstname"} discover a conspiracy that threatens both the human and Tenctonese communities. During their investigations, they are targeted by dangerous enemies who will not hesitate to walk over dead bodies.</en>
 					</description>
 				</scripttemplate>
 			</children>
@@ -8823,22 +8823,22 @@ The project, which was cancelled by a major producer, is now free to be realized
 				<en>Dallas Tales</en>
 			</title_original>
 			<description>
-				<de>Die Originalserie für Kinder zu langweilig? Dem kann Abhilfe geschaffen werden. Die eh schon überzeichneten Charaktere des Clans um ${.self:"role":0:"fullname"} erleben neu inszenierte Abenteuer in diesem lustigen Cartoon! Bietet auch Humorebenen für Erwachsene.</de>
-				<en>The original series too boring for children? This can be remedied. The characters of the clan around ${.self:"role":0:"fullname"}, already overdrawn anyway, experience reimagined adventures in this funny cartoon! Also offers levels of humor for adults.</en>
+				<de>Die Originalserie für Kinder zu langweilig? Dem kann Abhilfe geschaffen werden. Die eh schon überzeichneten Charaktere des Clans um ${.self:"role":1:"fullname"} erleben neu inszenierte Abenteuer in diesem lustigen Cartoon! Bietet auch Humorebenen für Erwachsene.</de>
+				<en>The original series too boring for children? This can be remedied. The characters of the clan around ${.self:"role":1:"fullname"}, already overdrawn anyway, experience reimagined adventures in this funny cartoon! Also offers levels of humor for adults.</en>
 			</description>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="fa486dbb-ca59-41fb-85fb-4f48a6607417">
 					<title>
-						<de>${.self:"role":1:"firstname"} in Gefahr</de>
-						<en>${.self:"role":1:"firstname"} in Danger</en>
+						<de>${.self:"role":2:"firstname"} in Gefahr</de>
+						<en>${.self:"role":2:"firstname"} in Danger</en>
 					</title>
 					<title_original>
-						<de>${.self:"role":1:"firstname"} in Gefahr</de>
-						<en>${.self:"role":1:"firstname"} in Danger</en>
+						<de>${.self:"role":2:"firstname"} in Gefahr</de>
+						<en>${.self:"role":2:"firstname"} in Danger</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":1:"firstname"} jagt seinen Hut in einem Tornado, als er von fiesen als Präriehunde getarnten Roboter-Aliens nahe der Area 51 gefangen genommen wird. Der Clan startet eine Rettungsaktion und erhält unerwartete Hilfe von einem UFO-Forscher.</de>
-						<en>${.self:"role":1:"firstname"}'s chasing his hat in a tornado when he's captured by mischievous nasty robot aliens disguised as prairie dogs near Area 51. The clan mounts a rescue mission with unexpected help from a UFO researcher.</en>
+						<de>${.self:"role":2:"firstname"} jagt seinen Hut in einem Tornado, als er von fiesen als Präriehunde getarnten Roboter-Aliens nahe der Area 51 gefangen genommen wird. Der Clan startet eine Rettungsaktion und erhält unerwartete Hilfe von einem UFO-Forscher.</de>
+						<en>${.self:"role":2:"firstname"}'s chasing his hat in a tornado when he's captured by mischievous nasty robot aliens disguised as prairie dogs near Area 51. The clan mounts a rescue mission with unexpected help from a UFO researcher.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="f77f2a57-13af-42b9-92d7-ebdc7cc6f9bc">
@@ -8857,16 +8857,16 @@ The project, which was cancelled by a major producer, is now free to be realized
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="a2e54e7e-7844-4628-b12d-1a9559cacbfb">
 					<title>
-						<de>Miss ${.self:"role":2:"firstname"}s letztes Programm</de>
-						<en>Miss ${.self:"role":2:"firstname"}'s Last Show</en>
+						<de>Miss ${.self:"role":3:"firstname"}s letztes Programm</de>
+						<en>Miss ${.self:"role":3:"firstname"}'s Last Show</en>
 					</title>
 					<title_original>
-						<de>Miss ${.self:"role":2:"firstname"}s letztes Programm</de>
-						<en>Miss ${.self:"role":2:"firstname"}'s Last Show</en>
+						<de>Miss ${.self:"role":3:"firstname"}s letztes Programm</de>
+						<en>Miss ${.self:"role":3:"firstname"}'s Last Show</en>
 					</title_original>
 					<description>
-						<de>Miss ${.self:"role":2:"firstname"} spielt für ein Gemeindetheaterstück vor. Doch als sich herausstellt, dass ihr Co-Star ein entflohener Papagei ist, bricht das Chaos aus, und ${.self:"role":0:"firstname"} versucht, die Situation zu seinem Vorteil zu nutzen.</de>
-						<en>Miss ${.self:"role":2:"firstname"} auditions for a community theater play. But when her co-star is revealed to be an escaped parrot, chaos ensues, and ${.self:"role":0:"firstname"} tries to use the situation to his advantage.</en>
+						<de>Miss ${.self:"role":3:"firstname"} spielt für ein Gemeindetheaterstück vor. Doch als sich herausstellt, dass ihr Co-Star ein entflohener Papagei ist, bricht das Chaos aus, und ${.self:"role":1:"firstname"} versucht, die Situation zu seinem Vorteil zu nutzen.</de>
+						<en>Miss ${.self:"role":3:"firstname"} auditions for a community theater play. But when her co-star is revealed to be an escaped parrot, chaos ensues, and ${.self:"role":1:"firstname"} tries to use the situation to his advantage.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="55bb50b8-a8e3-41a2-853a-cd4d5f222d6d">
@@ -8879,8 +8879,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Voyeur</en>
 					</title_original>
 					<description>
-						<de>Das Fluggerät eines schelmischen Nachbarn fängt peinliche Familienmomente ein. ${.self:"role":0:"firstname"} und der Clan schmieden einen Plan, es außer Gefecht zu setzen, was zu einer urkomischen Verfolgungsjagd durch die Ranch führt.</de>
-						<en>A mischievous neighbor's flying vehicle captures embarrassing family moments. ${.self:"role":0:"firstname"} and the clan plot to take it down, leading to a hilarious chase through the ranch.</en>
+						<de>Das Fluggerät eines schelmischen Nachbarn fängt peinliche Familienmomente ein. ${.self:"role":1:"firstname"} und der Clan schmieden einen Plan, es außer Gefecht zu setzen, was zu einer urkomischen Verfolgungsjagd durch die Ranch führt.</de>
+						<en>A mischievous neighbor's flying vehicle captures embarrassing family moments. ${.self:"role":1:"firstname"} and the clan plot to take it down, leading to a hilarious chase through the ranch.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="c95e7859-2b68-4236-b0f6-f88ea3f59952">
@@ -8893,8 +8893,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Contract that Disappeared</en>
 					</title_original>
 					<description>
-						<de>Der Geheimfundus der Verträge von ${.self:"role":0:"firstname"} wird mit der Comicsammlung seiner Nichte vertauscht. Bei der verzweifelten Suche nach den verlorenen Dokumenten kommt es zu Missverständnissen.</de>
-						<en>${.self:"role":0:"firstname"}'s secret stash of contracts is swapped with his niece's comic book collection. The desperate search for the lost documents leads to misunderstandings.</en>
+						<de>Der Geheimfundus der Verträge von ${.self:"role":1:"firstname"} wird mit der Comicsammlung seiner Nichte vertauscht. Bei der verzweifelten Suche nach den verlorenen Dokumenten kommt es zu Missverständnissen.</de>
+						<en>${.self:"role":1:"firstname"}'s secret stash of contracts is swapped with his niece's comic book collection. The desperate search for the lost documents leads to misunderstandings.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="5" product="2" licence_type="2" guid="6276c74f-5fb6-4c32-8201-0711c0866c5c">
@@ -8907,8 +8907,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Struggle for the Well</en>
 					</title_original>
 					<description>
-						<de>Ein Streit um Kühe löst einen Ölgeysir aus, und ${.self:"role":0:"firstname"} und Familie errichten einen Vergnügungspark drum herum. Rivalisierende Ölmagnaten versuchen eine Sabotage, aber ${.self:"role":3:"firstname"}s Rodeo-Fähigkeiten retten den Tag.</de>
-						<en>A cow dispute leads to an oil geyser, and ${.self:"role":0:"firstname"} and family build an amusement park around it. Rival oil tycoons attempt sabotage, but ${.self:"role":3:"firstname"}'s rodeo skills save the day.</en>
+						<de>Ein Streit um Kühe löst einen Ölgeysir aus, und ${.self:"role":1:"firstname"} und Familie errichten einen Vergnügungspark drum herum. Rivalisierende Ölmagnaten versuchen eine Sabotage, aber ${.self:"role":4:"firstname"}s Rodeo-Fähigkeiten retten den Tag.</de>
+						<en>A cow dispute leads to an oil geyser, and ${.self:"role":1:"firstname"} and family build an amusement park around it. Rival oil tycoons attempt sabotage, but ${.self:"role":4:"firstname"}'s rodeo skills save the day.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="6" product="2" licence_type="2" guid="09757f9f-1c49-47e8-8774-398d7968ee12">
@@ -8921,8 +8921,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Assassination</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} engagiert einen ungeschickten „Attentäter“, um einen Anschlag vorzutäuschen für Publicity. Die Heiterkeit nimmt ihren Lauf, als der so genannte Auftragskiller sich als ehrgeiziger Schauspieler entpuppt.</de>
-						<en>${.self:"role":0:"firstname"} hires an inept "assassin" to fake an attack for publicity. Hilarity ensues when the so-called hitman turns out to be an ambitious actor.</en>
+						<de>${.self:"role":1:"firstname"} engagiert einen ungeschickten „Attentäter“, um einen Anschlag vorzutäuschen für Publicity. Die Heiterkeit nimmt ihren Lauf, als der so genannte Auftragskiller sich als ehrgeiziger Schauspieler entpuppt.</de>
+						<en>${.self:"role":1:"firstname"} hires an inept "assassin" to fake an attack for publicity. Hilarity ensues when the so-called hitman turns out to be an ambitious actor.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="54fb4ff0-b21d-4e7c-9f6b-0e17429c6f09">
@@ -8935,8 +8935,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>The Heart Attack</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":4:"firstname"}s Jalapeño-Esswettbewerb gerät aus den Fugen, und die Familie glaubt, er hat einen Herzinfarkt erlitten. Als die Wahrheit ans Licht kommt, kommt es zum heiteren Krankenhauschaos.</de>
-						<en>${.self:"role":4:"firstname"}'s jalapeño-eating contest goes awry, and the family believes he's had a heart attack. A comedic hospital chaos ensues as the truth is revealed.</en>
+						<de>${.self:"role":5:"firstname"}s Jalapeño-Esswettbewerb gerät aus den Fugen, und die Familie glaubt, er hat einen Herzinfarkt erlitten. Als die Wahrheit ans Licht kommt, kommt es zum heiteren Krankenhauschaos.</de>
+						<en>${.self:"role":5:"firstname"}'s jalapeño-eating contest goes awry, and the family believes he's had a heart attack. A comedic hospital chaos ensues as the truth is revealed.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="8" product="2" licence_type="2" guid="ad7d7efd-f29f-41d3-a635-af0c053b1edc">
@@ -8955,16 +8955,16 @@ The project, which was cancelled by a major producer, is now free to be realized
 				</scripttemplate>
 				<scripttemplate index="9" product="2" licence_type="2" guid="414a4fed-dba4-4762-9741-8eca28e8ad55">
 					<title>
-						<de>${.self:"role":0:"firstname"} und der Spieler</de>
-						<en>${.self:"role":0:"firstname"} and the Player</en>
+						<de>${.self:"role":1:"firstname"} und der Spieler</de>
+						<en>${.self:"role":1:"firstname"} and the Player</en>
 					</title>
 					<title_original>
-						<de>${.self:"role":0:"firstname"} und der Spieler</de>
-						<en>${.self:"role":0:"firstname"} and the Player</en>
+						<de>${.self:"role":1:"firstname"} und der Spieler</de>
+						<en>${.self:"role":1:"firstname"} and the Player</en>
 					</title_original>
 					<description>
-						<de>${.self:"role":0:"firstname"} will einen Schachcomputer besiegen, doch der blamiert ihn und zwingt ihn bei jedem Zug, seine Machenschaften zu überdenken. Dabei wird in schlauen Rückblenden von ${.self:"role":0:"firstname"}'s Aufstieg erzählt und wie er einen Gegenspieler bekämpfte.</de>
-						<en>${.self:"role":0:"firstname"} wants to defeat a chess computer, but it puts him to shame and forces him to rethink his machinations with every move. In the process, the story of ${.self:"role":0:"firstname"}'s rise and how he fought an opponent is told in clever flashbacks.</en>
+						<de>${.self:"role":1:"firstname"} will einen Schachcomputer besiegen, doch der blamiert ihn und zwingt ihn bei jedem Zug, seine Machenschaften zu überdenken. Dabei wird in schlauen Rückblenden von ${.self:"role":1:"firstname"}'s Aufstieg erzählt und wie er einen Gegenspieler bekämpfte.</de>
+						<en>${.self:"role":1:"firstname"} wants to defeat a chess computer, but it puts him to shame and forces him to rethink his machinations with every move. In the process, the story of ${.self:"role":1:"firstname"}'s rise and how he fought an opponent is told in clever flashbacks.</en>
 					</description>
 				</scripttemplate>
 			</children>

--- a/res/database/Default/user/stukov_scripts_adaptations.xml
+++ b/res/database/Default/user/stukov_scripts_adaptations.xml
@@ -14,9 +14,9 @@
 				<pl>Pamięć, smutek i cierń</pl>
 			</title_original>
 			<description>
-				<de>Verfilmung der epischen Fantasy-Serie über die Welt von Osten Ard. Die Geschichte von ${.self:"role":0:"firstname"} Mondkalb (wegen seiner Zerstreung so genannt) und ${.self:"role":1:"firstname"} Sturmkönig - und ihrer tödlichen Feindschaft.</de>
-				<en>Film adaptation of the epic fantasy series about the world of Osten Ard. The story of ${.self:"role":0:"firstname"} Mooncalf (named so because of his absent-mindedness) and ${.self:"role":1:"firstname"} Storm King - and their deadly enmity.</en>
-				<pl>Filmowa adaptacja epickiej serii fantasy o świecie Osten Ard. Historia ${.self:"role":0:"firstname"} Mooncalfa (nazwanego tak z powodu roztargnienia) i ${.self:"role":1:"firstname"} Storm Kinga - oraz ich śmiertelnej wrogości.</pl>
+				<de>Verfilmung der epischen Fantasy-Serie über die Welt von Osten Ard. Die Geschichte von ${.self:"role":1:"firstname"} Mondkalb (wegen seiner Zerstreung so genannt) und ${.self:"role":2:"firstname"} Sturmkönig - und ihrer tödlichen Feindschaft.</de>
+				<en>Film adaptation of the epic fantasy series about the world of Osten Ard. The story of ${.self:"role":1:"firstname"} Mooncalf (named so because of his absent-mindedness) and ${.self:"role":2:"firstname"} Storm King - and their deadly enmity.</en>
+				<pl>Filmowa adaptacja epickiej serii fantasy o świecie Osten Ard. Historia ${.self:"role":1:"firstname"} Mooncalfa (nazwanego tak z powodu roztargnienia) i ${.self:"role":2:"firstname"} Storm Kinga - oraz ich śmiertelnej wrogości.</pl>
 			</description>
 			<children>
 				<scripttemplate licence_type="2" product="2" index="0" guid="Stukov_Das-Geheimnis_der_großen_Schwerter_1">
@@ -31,9 +31,9 @@
 						<pl>Krzesło Smocza Kość I</pl>
 					</title_original>
 					<description>
-						<de>Der betagte König Johan liegt im Sterben, und um die Thronfolge entbrennt ein hinterhältiger Kampf unter seinen Söhnen ${.self:"role":4:"firstname"} und ${.self:"role":3:"firstname"}. Der Küchenjunge ${.self:"role":0:"firstname"} gerät mitten in die Auseinandersetzungen.</de>
-						<en>The aged King John is dying, and a treacherous battle breaks out among his sons ${.self:"role":4:"firstname"} and ${.self:"role":3:"firstname"} over the succession to the throne. The kitchen boy ${.self:"role":0:"firstname"} gets caught in the middle of the confrontations.</en>
-						<pl>Starzejący się król Jan umiera, a między jego synami ${.self:"role":4:"firstname"} i ${.self:"role":3:"firstname"} wybucha zdradziecka walka o sukcesję tronu. Chłopiec kuchenny ${.self:"role":0:"firstname"} zostaje wciągnięty w sam środek konfrontacji.</pl>
+						<de>Der betagte König Johan liegt im Sterben, und um die Thronfolge entbrennt ein hinterhältiger Kampf unter seinen Söhnen ${.self:"role":5:"firstname"} und ${.self:"role":4:"firstname"}. Der Küchenjunge ${.self:"role":1:"firstname"} gerät mitten in die Auseinandersetzungen.</de>
+						<en>The aged King John is dying, and a treacherous battle breaks out among his sons ${.self:"role":5:"firstname"} and ${.self:"role":4:"firstname"} over the succession to the throne. The kitchen boy ${.self:"role":1:"firstname"} gets caught in the middle of the confrontations.</en>
+						<pl>Starzejący się król Jan umiera, a między jego synami ${.self:"role":5:"firstname"} i ${.self:"role":4:"firstname"} wybucha zdradziecka walka o sukcesję tronu. Chłopiec kuchenny ${.self:"role":1:"firstname"} zostaje wciągnięty w sam środek konfrontacji.</pl>
 					</description>
 				</scripttemplate>
 				<scripttemplate licence_type="2" product="2" index="1" guid="Stukov_Das-Geheimnis_der_großen_Schwerter_2">
@@ -48,9 +48,9 @@
 						<pl>Krzesło Smocza Kość II</pl>
 					</title_original>
 					<description>
-						<de>Welche Ziele aber verfolgen die geheimnisvollen Elbenvölker der Nornen und Sithi, denen das Land einst gehörte? Aus Misstrauen gegenüber seinem Bruder ${.self:"role":3:"firstname"} schliesst Koenig ${.self:"role":4:"firstname"} einen Bund mit den Nornen und erhält das große Schwert Leid.</de>
-						<en>But what are the goals of the mysterious elven nations of the Norns and Sithi, to whom the land once belonged? Out of mistrust towards his brother ${.self:"role":3:"firstname"}, King ${.self:"role":4:"firstname"} enters into a covenant with the Norns and receives the great sword Sorrow.</en>
-						<pl>Ale jakie są cele tajemniczych elfich narodów Nornów i Sithi, do których niegdyś należały te ziemie? Z braku zaufania do swojego brata ${.self:"role":3:"firstname"}, król ${.self:"role":4:"firstname"} zawiera przymierze z Nornami i otrzymuje wielki miecz Smutek.</pl>
+						<de>Welche Ziele aber verfolgen die geheimnisvollen Elbenvölker der Nornen und Sithi, denen das Land einst gehörte? Aus Misstrauen gegenüber seinem Bruder ${.self:"role":4:"firstname"} schliesst Koenig ${.self:"role":5:"firstname"} einen Bund mit den Nornen und erhält das große Schwert Leid.</de>
+						<en>But what are the goals of the mysterious elven nations of the Norns and Sithi, to whom the land once belonged? Out of mistrust towards his brother ${.self:"role":4:"firstname"}, King ${.self:"role":5:"firstname"} enters into a covenant with the Norns and receives the great sword Sorrow.</en>
+						<pl>Ale jakie są cele tajemniczych elfich narodów Nornów i Sithi, do których niegdyś należały te ziemie? Z braku zaufania do swojego brata ${.self:"role":4:"firstname"}, król ${.self:"role":5:"firstname"} zawiera przymierze z Nornami i otrzymuje wielki miecz Smutek.</pl>
 					</description>
 				</scripttemplate>
 				<scripttemplate licence_type="2" product="2" index="2" guid="Stukov_Das-Geheimnis_der_großen_Schwerter_3">
@@ -65,9 +65,9 @@
 						<pl>Kamień pożegnalny I</pl>
 					</title_original>
 					<description>
-						<de>Auf dem Hochhorst herrschen Sturmkönig ${.self:"role":1:"firstname"}s Kreaturen. Aber noch regt sich Widerstand.</de>
-						<en>Storm King ${.self:"role":1:"firstname"}'s creatures rule on the high eyrie. But resistance is still stirring.</en>
-						<pl>Stworzenia Króla Burzy ${.self:"role":1:"firstname"} rządzą na wysokim oku. Ale opór wciąż trwa.</pl>
+						<de>Auf dem Hochhorst herrschen Sturmkönig ${.self:"role":2:"firstname"}s Kreaturen. Aber noch regt sich Widerstand.</de>
+						<en>Storm King ${.self:"role":2:"firstname"}'s creatures rule on the high eyrie. But resistance is still stirring.</en>
+						<pl>Stworzenia Króla Burzy ${.self:"role":2:"firstname"} rządzą na wysokim oku. Ale opór wciąż trwa.</pl>
 					</description>
 				</scripttemplate>
 				<scripttemplate licence_type="2" product="2" index="3" guid="Stukov_Das-Geheimnis_der_großen_Schwerter_4">
@@ -82,9 +82,9 @@
 						<pl>Kamień pożegnalny II</pl>
 					</title_original>
 					<description>
-						<de>Die Gruppe um Prinz ${.self:"role":3:"firstname"} erreicht die alte Festung der Sitthi auf dem Abschiedsstein. Von dort aus beginnt der letzte Kampf um Osten Ard.</de>
-						<en>The group around Prince ${.self:"role":3:"firstname"} reaches the old fortress of the Sitthi on the Farewell Stone. From there, the final battle for Osten Ard begins.</en>
-						<pl>Grupa wokół księcia ${.self:"role":3:"firstname"} dociera do starej fortecy Sitthi na Kamieniu Pożegnalnym. Stamtąd rozpoczyna się ostateczna bitwa o Osten Ard.</pl>
+						<de>Die Gruppe um Prinz ${.self:"role":4:"firstname"} erreicht die alte Festung der Sitthi auf dem Abschiedsstein. Von dort aus beginnt der letzte Kampf um Osten Ard.</de>
+						<en>The group around Prince ${.self:"role":4:"firstname"} reaches the old fortress of the Sitthi on the Farewell Stone. From there, the final battle for Osten Ard begins.</en>
+						<pl>Grupa wokół księcia ${.self:"role":4:"firstname"} dociera do starej fortecy Sitthi na Kamieniu Pożegnalnym. Stamtąd rozpoczyna się ostateczna bitwa o Osten Ard.</pl>
 					</description>
 				</scripttemplate>
 				<scripttemplate licence_type="2" product="2" index="4" guid="Stukov_Das-Geheimnis_der_großen_Schwerter_5">
@@ -116,9 +116,9 @@
 						<pl>Do Wieży Zielonego Anioła</pl>
 					</title_original>
 					<description>
-						<de>Während vor den Toren des Hochhorstes ${.self:"role":3:"firstname"}s Armee warted, findet im Engelsturm die entscheidende Auseinandersetzung zwischen ${.self:"role":4:"firstname"}, ${.self:"role":5:"firstname"}, ${.self:"role":0:"firstname"} und ${.self:"role":2:"firstname"} statt.</de>
-						<en>While ${.self:"role":3:"firstname"}'s army waits outside the gates of the High Eyrie, the decisive confrontation between ${.self:"role":4:"firstname"}, ${.self:"role":5:"firstname"}, ${.self:"role":0:"firstname"} and ${.self:"role":2:"firstname"} takes place in the Angel Tower.</en>
-						<pl>Podczas gdy armia ${.self:"role":3:"firstname"} czeka przed bramami High Eyrie, decydująca konfrontacja pomiędzy ${.self:"role":4:"firstname"}, ${.self:"role":5:"firstname"}, ${.self:"role":0:"firstname"} i ${.self:"role":2:"firstname"} ma miejsce w Angel Tower.</pl>
+						<de>Während vor den Toren des Hochhorstes ${.self:"role":4:"firstname"}s Armee warted, findet im Engelsturm die entscheidende Auseinandersetzung zwischen ${.self:"role":5:"firstname"}, ${.self:"role":6:"firstname"}, ${.self:"role":1:"firstname"} und ${.self:"role":3:"firstname"} statt.</de>
+						<en>While ${.self:"role":4:"firstname"}'s army waits outside the gates of the High Eyrie, the decisive confrontation between ${.self:"role":5:"firstname"}, ${.self:"role":6:"firstname"}, ${.self:"role":1:"firstname"} and ${.self:"role":3:"firstname"} takes place in the Angel Tower.</en>
+						<pl>Podczas gdy armia ${.self:"role":4:"firstname"} czeka przed bramami High Eyrie, decydująca konfrontacja pomiędzy ${.self:"role":5:"firstname"}, ${.self:"role":6:"firstname"}, ${.self:"role":1:"firstname"} i ${.self:"role":3:"firstname"} ma miejsce w Angel Tower.</pl>
 					</description>
 				</scripttemplate>
 			</children>

--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -475,12 +475,12 @@ Type TDatabaseLoader
 				expression = expression.Replace("["+i+"|Nick]", "${.self:~qcast~q:"+i+":~qnickname~q}")
 			EndIf
 
-			'attention: role(name) NUMBER to INDEX! (i-1)
+			'role(name) assumption is that NUMBER corrensponds to job INDEX (0=director, 1..x=actors)
 			if expression.Find("%ROLENAME"+i) >= 0
-				expression = expression.Replace("%ROLENAME"+i+"%", "${.self:~qrole~q:"+(i-1)+":~qfirstname~q}")
+				expression = expression.Replace("%ROLENAME"+i+"%", "${.self:~qrole~q:"+(i)+":~qfirstname~q}")
 			EndIf
 			if expression.Find("%ROLE"+i) >= 0
-				expression = expression.Replace("%ROLE"+i+"%", "${.self:~qrole~q:"+(i-1)+":~qfullname~q}")
+				expression = expression.Replace("%ROLE"+i+"%", "${.self:~qrole~q:"+(i)+":~qfullname~q}")
 			EndIf
 		Next
 

--- a/source/game.gamescriptexpression.bmx
+++ b/source/game.gamescriptexpression.bmx
@@ -566,7 +566,7 @@ Function SEFN_script:SToken(params:STokenGroup Var, context:SScriptExpressionCon
 			Local roleIndex:Int = Int(params.GetToken(2 + tokenOffset).GetValueText())
  			If roleIndex < 0 Then Return New SToken( TK_ERROR, "role index must be positive.", params.GetToken(0) )
 
-			Local actors:TPersonProductionJob[] = script.GetSpecificJob(TVTPersonJob.ACTOR | TVTPersonJob.SUPPORTINGACTOR)
+			Local actors:TPersonProductionJob[] = script.GetJobs()
 			If roleIndex >= actors.length Then Return New SToken( TK_ERROR, "(not enough actors for role #" + roleIndex+".)", params.GetToken(0) )
 
 			Local role:TProgrammeRole = TScript._EnsureRole(actors[roleIndex])


### PR DESCRIPTION
closes #1203

Anpassung der Datenbank, des Reparaturcodes und des Zugriffs via Index.
Nicht repariert wären die Spielstände, die mit der Discord-Snapshot erstellt wurden, da dort ja der falsche Index gesetzt wurde. Das ließe sich nur beheben, wenn man jetzt nochmal die Datenbankversion hochsetzt und eine Indexersetzung in der neuen Rollensyntax macht.