### PR TITLE
Umbenennung roles in lang-Dateien

### DIFF
--- a/res/database/Default/lang/de.xml
+++ b/res/database/Default/lang/de.xml
@@ -22,7 +22,7 @@
 
 		<person guid="SpeedMinister-celebritypeople-KarlHeinzDorfmichel" first_name="Karlheinz" last_name="Dorfmichel" />
 	</persons>
-	<roles>
+	<programmeroles>
 		<!--
 			<role guid="script-roles-ron-001" first_name="Vincent" last_name="Graf" title="" />
 		-->
@@ -127,5 +127,5 @@
 
 		<role guid="6e48da2f-d468-4542-9510-c3412e8841f7" first_name="" last_name="Wirsch" title="Kommissar" />
 		<role guid="3b128a1f-c2e5-4f76-aa97-0d23d44568d2" first_name="Darlene" last_name="" title="Assistentin" />
-	</roles>
+	</programmeroles>
 </tvtdb>

--- a/res/database/Default/lang/en.xml
+++ b/res/database/Default/lang/en.xml
@@ -41,7 +41,7 @@
 
 		<person guid="SpeedMinister-celebritypeople-KarlHeinzDorfmichel" first_name="John D." last_name="Silly Billy" />
 	</persons>
-	<roles>
+	<programmeroles>
 		<!--
 			<role guid="script-roles-ron-001" first_name="Vincent" last_name="Count" title="" />
 		-->
@@ -146,5 +146,5 @@
 
 		<role guid="6e48da2f-d468-4542-9510-c3412e8841f7" first_name="" last_name="Gruff" title="Inspector" />
 		<role guid="3b128a1f-c2e5-4f76-aa97-0d23d44568d2" first_name="Darlene" last_name="" title="Assistant" />
-	</roles>
+	</programmeroles>
 </tvtdb>

--- a/res/database/Default/lang/pl.xml
+++ b/res/database/Default/lang/pl.xml
@@ -41,7 +41,7 @@
 
 		<person guid="SpeedMinister-celebritypeople-KarlHeinzDorfmichel" first_name="Jasio" last_name="Głupkowaty" />
 	</persons>
-	<roles>
+	<programmeroles>
 		<!--
 			<role guid="script-roles-ron-001" first_name="Vincent" last_name="Count" title="" />
 		-->
@@ -146,5 +146,5 @@
 
 		<role guid="6e48da2f-d468-4542-9510-c3412e8841f7" first_name="" last_name="Gruff" title="Inspektor" />
 		<role guid="3b128a1f-c2e5-4f76-aa97-0d23d44568d2" first_name="Darlene" last_name="" title="Asystentka" />
-	</roles>
+	</programmeroles>
 </tvtdb>

--- a/res/database/Default/lang_original/de.xml
+++ b/res/database/Default/lang_original/de.xml
@@ -22,7 +22,7 @@
 
 		<person guid="SpeedMinister-celebritypeople-KarlHeinzDorfmichel" first_name="Karlheinz" last_name="Dorfmichel" />
 	</persons>
-	<roles>
+	<programmeroles>
 		<!--
 			<role guid="script-roles-ron-001" first_name="Vincent" last_name="Graf" title="" />
 		-->
@@ -127,5 +127,5 @@
 
 		<role guid="6e48da2f-d468-4542-9510-c3412e8841f7" first_name="" last_name="Wirsch" title="Kommissar" />
 		<role guid="3b128a1f-c2e5-4f76-aa97-0d23d44568d2" first_name="Marlene" last_name="" title="Assistentin" />
-	</roles>
+	</programmeroles>
 </tvtdb>

--- a/res/database/Default/lang_original/en.xml
+++ b/res/database/Default/lang_original/en.xml
@@ -41,7 +41,7 @@
 
 		<person guid="SpeedMinister-celebritypeople-KarlHeinzDorfmichel" first_name="John D." last_name="Silly Billy" />
 	</persons>
-	<roles>
+	<programmeroles>
 		<!--
 			<role guid="script-roles-ron-001" first_name="Vincent" last_name="Count" title="" />
 		-->
@@ -146,5 +146,5 @@
 
 		<role guid="6e48da2f-d468-4542-9510-c3412e8841f7" first_name="" last_name="Gruff" title="Inspector" />
 		<role guid="3b128a1f-c2e5-4f76-aa97-0d23d44568d2" first_name="Marlene" last_name="" title="Assistant" />
-	</roles>
+	</programmeroles>
 </tvtdb>

--- a/res/database/Default/lang_original/pl.xml
+++ b/res/database/Default/lang_original/pl.xml
@@ -41,7 +41,7 @@
 
 		<person guid="SpeedMinister-celebritypeople-KarlHeinzDorfmichel" first_name="Jasio" last_name="Głupkowaty" />
 	</persons>
-	<roles>
+	<programmeroles>
 		<!--
 			<role guid="script-roles-ron-001" first_name="Vincent" last_name="Count" title="" />
 		-->
@@ -146,5 +146,5 @@
 
 		<role guid="6e48da2f-d468-4542-9510-c3412e8841f7" first_name="" last_name="Gruff" title="Inspektor" />
 		<role guid="3b128a1f-c2e5-4f76-aa97-0d23d44568d2" first_name="Marlene" last_name="" title="Asystentka" />
-	</roles>
+	</programmeroles>
 </tvtdb>

--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -2853,7 +2853,8 @@ Type TDatabaseLoader
 		Next
 
 		Local nodeAllRoles:TxmlNode
-		nodeAllRoles = xml.FindRootChildLC("roles")
+		nodeAllRoles = xml.FindRootChildLC("programmeroles")
+		If Not nodeAllRoles Then nodeAllRoles = xml.FindRootChildLC("roles")
 		For Local nodeRole:TxmlNode = EachIn xml.GetNodeChildElements(nodeAllRoles)
 			If nodeRole.getName() <> "role" Then Continue
 			Local data:TData = New TData


### PR DESCRIPTION
Umsetzung der vorgeschlagenen Umbenennung von roles nach programmeroles. Fallback im Datenbankeinlesecode ist ergänzt.