### PR TITLE
Erweiterung der Vergleichsoperatoren

### DIFF
--- a/source/Dig/base.util.scriptexpression_ng.bmx
+++ b/source/Dig/base.util.scriptexpression_ng.bmx
@@ -1608,11 +1608,16 @@ Function SEFN_If:SToken(params:STokenGroup Var, context:SScriptExpressionContext
 	
 End Function
 
+'distinguish between eq (regular compare with 3 or 5 parameters
+'and all_eq with arbitrary parameter number
+
+'rename to all_eq
 Function SEFN_Eq:SToken(params:STokenGroup Var, context:SScriptExpressionContext var)
 	Local first:SToken = params.GetToken(0)
 	Return New SToken( TK_BOOLEAN, Long(TScriptExpression._CountEqualValues(params, 1) = params.added - 1), first.linenum, first.linepos )
 End Function
 
+'rename to n_all_eq
 Function SEFN_NEq:SToken(params:STokenGroup Var, context:SScriptExpressionContext var)
 	Local first:SToken = params.GetToken(0)
 	Return New SToken( TK_BOOLEAN, Long(TScriptExpression._CountEqualValues(params, 1) <> params.added - 1), first.linenum, first.linepos )
@@ -1620,7 +1625,18 @@ End Function
 
 Function SEFN_Gt:SToken(params:STokenGroup Var, context:SScriptExpressionContext var)
 	Local first:SToken = params.GetToken(0)
+	'proposed semantics for all comparisons
+	'1,2,4, >5 parameters error
+	'3 like before
+	'5 if 2 compare 3 then 4 else 5
 	If params.added < 3 Then Return New SToken( TK_BOOLEAN, False, first.linenum, first.linepos )
+	If params.added = 5
+		If Long(params.GetToken(1).CompareWith(params.GetToken(2)) > 0)
+			Return params.GetToken(3)
+		Else
+			Return params.GetToken(4)
+		EndIf
+	EndIf
 	Return New SToken( TK_BOOLEAN, Long(params.GetToken(1).CompareWith(params.GetToken(2)) > 0), first.linenum, first.linepos )
 End Function
 
@@ -1704,7 +1720,9 @@ TScriptExpression.RegisterFunctionHandler( "not", SEFN_Not, 1, -1)
 TScriptExpression.RegisterFunctionHandler( "and", SEFN_And, 1, -1)
 TScriptExpression.RegisterFunctionHandler( "or",  SEFN_Or,  1, -1)
 TScriptExpression.RegisterFunctionHandler( "if",  SEFN_If,  1,  3)
+'neq vs nalleq
 TScriptExpression.RegisterFunctionHandler( "neq",  SEFN_NEq,  1, -1)
+'eq vs alleq
 TScriptExpression.RegisterFunctionHandler( "eq",  SEFN_Eq,  1, -1)
 TScriptExpression.RegisterFunctionHandler( "gt",  SEFN_Gt,  2,  2)
 TScriptExpression.RegisterFunctionHandler( "gte", SEFN_Gte, 2,  2)

--- a/source/Dig/base.util.scriptexpression_ng.bmx
+++ b/source/Dig/base.util.scriptexpression_ng.bmx
@@ -188,6 +188,7 @@ Struct STokenGroup
 	End Method
 
 	Method SetToken(index:Int, s:SToken)
+		If index < 0 Then Return
 		If index < token.Length
 			token[index] = s
 		Else

--- a/source/Dig/base.util.scriptexpression_ng.bmx
+++ b/source/Dig/base.util.scriptexpression_ng.bmx
@@ -260,6 +260,14 @@ Struct SToken
 		Self.linepos = linepos
 	End Method
 
+	Method New( id:Int, valueInt:Int, linenum:Int, linepos:Int = 0 )
+		Self.id = id
+		Self.valueLong = valueInt
+		Self.valueType = ETokenValueType.Integer
+		Self.linenum = linenum
+		Self.linepos = linepos
+	End Method
+
 	Method New( id:Int, valueLong:Long, linenum:Int, linepos:Int = 0 )
 		Self.id = id
 		Self.valueLong = valueLong
@@ -292,7 +300,14 @@ Struct SToken
 		Self.linepos = linepos
 	End Method
 
-	
+	Method New( id:Int, valueInt:Int, token:SToken )
+		Self.id = id
+		Self.valueLong = valueInt
+		Self.valueType = ETokenValueType.Integer
+		Self.linenum = token.linenum
+		Self.linepos = token.linepos
+	End Method
+
 	Method New( id:Int, valueLong:Long, token:SToken )
 		Self.id = id
 		Self.valueLong = valueLong
@@ -1576,17 +1591,17 @@ End Type
 ' Register default functions
 Function SEFN_Or:SToken(params:STokenGroup Var, context:SScriptExpressionContext var)
 	Local first:SToken = params.GetToken(0)
-	Return New SToken( TK_BOOLEAN, Long(TScriptExpression._CountTrueValues(params, 1) > 0), first.linenum, first.linepos )
+	Return New SToken( TK_BOOLEAN, TScriptExpression._CountTrueValues(params, 1) > 0, first.linenum, first.linepos )
 End Function
 
 Function SEFN_And:SToken(params:STokenGroup Var, context:SScriptExpressionContext var)
 	Local first:SToken = params.GetToken(0)
-	Return New SToken( TK_BOOLEAN, Long(TScriptExpression._CountTrueValues(params, 1) = params.added - 1), first.linenum, first.linepos )
+	Return New SToken( TK_BOOLEAN, TScriptExpression._CountTrueValues(params, 1) = params.added - 1, first.linenum, first.linepos )
 End Function
 
 Function SEFN_Not:SToken(params:STokenGroup Var, context:SScriptExpressionContext var)
 	Local first:SToken = params.GetToken(0)
-	Return New SToken( TK_BOOLEAN, Long(TScriptExpression._CountTrueValues(params, 1) = 0), first.linenum, first.linepos )
+	Return New SToken( TK_BOOLEAN, TScriptExpression._CountTrueValues(params, 1) = 0, first.linenum, first.linepos )
 End Function
 
 Function SEFN_If:SToken(params:STokenGroup Var, context:SScriptExpressionContext var)
@@ -1622,7 +1637,7 @@ Function SEFN_Select:SToken(params:STokenGroup Var, context:SScriptExpressionCon
 	Local key:SToken = params.GetToken(1)
 	Local i:Int = 2
 	Repeat
-		If Long(key.CompareWith(params.GetToken(i)) = 0) Then Return params.GetToken(i+1)
+		If key.CompareWith(params.GetToken(i)) = 0 Then Return params.GetToken(i+1)
 		i:+2
 	Until  i >= params.added - 1
 	Return params.GetToken(i)
@@ -1630,9 +1645,9 @@ End Function
 
 Function SEFN_Eq:SToken(params:STokenGroup Var, context:SScriptExpressionContext var)
 	Local first:SToken = params.GetToken(0)
-	If params.added = 3 Then Return New SToken( TK_BOOLEAN, Long(params.GetToken(1).CompareWith(params.GetToken(2)) = 0), first.linenum, first.linepos )
+	If params.added = 3 Then Return New SToken( TK_BOOLEAN, params.GetToken(1).CompareWith(params.GetToken(2)) = 0, first.linenum, first.linepos )
 	If params.added = 5
-		If Long(params.GetToken(1).CompareWith(params.GetToken(2)) = 0)
+		If params.GetToken(1).CompareWith(params.GetToken(2)) = 0
 			Return params.GetToken(3)
 		Else
 			Return params.GetToken(4)
@@ -1643,9 +1658,9 @@ End Function
 
 Function SEFN_NEq:SToken(params:STokenGroup Var, context:SScriptExpressionContext var)
 	Local first:SToken = params.GetToken(0)
-	If params.added = 3 Then Return New SToken( TK_BOOLEAN, Long(params.GetToken(1).CompareWith(params.GetToken(2)) <> 0), first.linenum, first.linepos )
+	If params.added = 3 Then Return New SToken( TK_BOOLEAN, params.GetToken(1).CompareWith(params.GetToken(2)) <> 0, first.linenum, first.linepos )
 	If params.added = 5
-		If Long(params.GetToken(1).CompareWith(params.GetToken(2)) <> 0)
+		If params.GetToken(1).CompareWith(params.GetToken(2)) <> 0
 			Return params.GetToken(3)
 		Else
 			Return params.GetToken(4)
@@ -1656,9 +1671,9 @@ End Function
 
 Function SEFN_Gt:SToken(params:STokenGroup Var, context:SScriptExpressionContext var)
 	Local first:SToken = params.GetToken(0)
-	If params.added = 3 Then Return New SToken( TK_BOOLEAN, Long(params.GetToken(1).CompareWith(params.GetToken(2)) > 0), first.linenum, first.linepos )
+	If params.added = 3 Then Return New SToken( TK_BOOLEAN, params.GetToken(1).CompareWith(params.GetToken(2)) > 0, first.linenum, first.linepos )
 	If params.added = 5
-		If Long(params.GetToken(1).CompareWith(params.GetToken(2)) > 0)
+		If params.GetToken(1).CompareWith(params.GetToken(2)) > 0
 			Return params.GetToken(3)
 		Else
 			Return params.GetToken(4)
@@ -1669,9 +1684,9 @@ End Function
 
 Function SEFN_Gte:SToken(params:STokenGroup Var, context:SScriptExpressionContext var)
 	Local first:SToken = params.GetToken(0)
-	If params.added = 3 Then Return New SToken( TK_BOOLEAN, Long(params.GetToken(1).CompareWith(params.GetToken(2)) => 0), first.linenum, first.linepos )
+	If params.added = 3 Then Return New SToken( TK_BOOLEAN, params.GetToken(1).CompareWith(params.GetToken(2)) => 0, first.linenum, first.linepos )
 	If params.added = 5
-		If Long(params.GetToken(1).CompareWith(params.GetToken(2)) => 0)
+		If params.GetToken(1).CompareWith(params.GetToken(2)) => 0
 			Return params.GetToken(3)
 		Else
 			Return params.GetToken(4)
@@ -1682,9 +1697,9 @@ End Function
 
 Function SEFN_Lt:SToken(params:STokenGroup Var, context:SScriptExpressionContext var)
 	Local first:SToken = params.GetToken(0)
-	If params.added = 3 Then Return New SToken( TK_BOOLEAN, Long(params.GetToken(1).CompareWith(params.GetToken(2)) < 0), first.linenum, first.linepos )
+	If params.added = 3 Then Return New SToken( TK_BOOLEAN, params.GetToken(1).CompareWith(params.GetToken(2)) < 0, first.linenum, first.linepos )
 	If params.added = 5
-		If Long(params.GetToken(1).CompareWith(params.GetToken(2)) < 0)
+		If params.GetToken(1).CompareWith(params.GetToken(2)) < 0
 			Return params.GetToken(3)
 		Else
 			Return params.GetToken(4)
@@ -1695,9 +1710,9 @@ End Function
 
 Function SEFN_Lte:SToken(params:STokenGroup Var, context:SScriptExpressionContext var)
 	Local first:SToken = params.GetToken(0)
-	If params.added = 3 Then Return New SToken( TK_BOOLEAN, Long(params.GetToken(1).CompareWith(params.GetToken(2)) <= 0), first.linenum, first.linepos )
+	If params.added = 3 Then Return New SToken( TK_BOOLEAN, params.GetToken(1).CompareWith(params.GetToken(2)) <= 0, first.linenum, first.linepos )
 	If params.added = 5
-		If Long(params.GetToken(1).CompareWith(params.GetToken(2)) <= 0)
+		If params.GetToken(1).CompareWith(params.GetToken(2)) <= 0
 			Return params.GetToken(3)
 		Else
 			Return params.GetToken(4)

--- a/source/Dig/base.util.scriptexpression_ng.bmx
+++ b/source/Dig/base.util.scriptexpression_ng.bmx
@@ -178,8 +178,11 @@ Struct STokenGroup
 		If added < token.Length
 			token[added] = s
 		Else
-			If added >= dynamicToken.Length + token.Length - 5 Then dynamicToken = dynamicToken[..added]
-			dynamicToken[added - token.Length] = s
+			Local dynamicArrayIndex:Int = added - token.Length
+			'resize dynamic array if needed
+			If dynamicArrayIndex >= dynamicToken.Length Then dynamicToken = dynamicToken[..dynamicArrayIndex + 5]
+
+			dynamicToken[dynamicArrayIndex] = s
 		EndIf
 		added :+ 1
 	End Method
@@ -187,8 +190,10 @@ Struct STokenGroup
 	Method SetToken(index:Int, s:SToken)
 		If index < token.Length
 			token[index] = s
-		ElseIf index < dynamicToken.Length + token.Length
-			dynamicToken[index - token.Length] = s
+		Else
+			Local dynamicArrayIndex:Int = added - token.Length
+			If dynamicArrayIndex >= dynamicToken.Length Then dynamicToken = dynamicToken[..dynamicArrayIndex + 5]
+			dynamicToken[dynamicArrayIndex] = s
 		EndIf
 	End Method
 	
@@ -1635,8 +1640,6 @@ Function SEFN_Eq:SToken(params:STokenGroup Var, context:SScriptExpressionContext
 	EndIf
 	Return New SToken( TK_ERROR, "2 or 4 parameters expected", first )
 End Function
-'.alleq could check if an arbitrary number of parameters are equal
-'Return New SToken( TK_BOOLEAN, Long(TScriptExpression._CountEqualValues(params, 1) = params.added - 1), first.linenum, first.linepos )
 
 Function SEFN_NEq:SToken(params:STokenGroup Var, context:SScriptExpressionContext var)
 	Local first:SToken = params.GetToken(0)

--- a/source/Dig/base.util.scriptexpression_ng.bmx
+++ b/source/Dig/base.util.scriptexpression_ng.bmx
@@ -1608,28 +1608,37 @@ Function SEFN_If:SToken(params:STokenGroup Var, context:SScriptExpressionContext
 	
 End Function
 
-'distinguish between eq (regular compare with 3 or 5 parameters
-'and all_eq with arbitrary parameter number
-
-'rename to all_eq
 Function SEFN_Eq:SToken(params:STokenGroup Var, context:SScriptExpressionContext var)
 	Local first:SToken = params.GetToken(0)
-	Return New SToken( TK_BOOLEAN, Long(TScriptExpression._CountEqualValues(params, 1) = params.added - 1), first.linenum, first.linepos )
+	If params.added = 3 Then Return New SToken( TK_BOOLEAN, Long(params.GetToken(1).CompareWith(params.GetToken(2)) = 0), first.linenum, first.linepos )
+	If params.added = 5
+		If Long(params.GetToken(1).CompareWith(params.GetToken(2)) = 0)
+			Return params.GetToken(3)
+		Else
+			Return params.GetToken(4)
+		EndIf
+	EndIf
+	Return New SToken( TK_ERROR, "2 or 4 parameters expected", params.GetToken(0) )
 End Function
+'.alleq could check if an arbitrary number of parameters are equal
+'Return New SToken( TK_BOOLEAN, Long(TScriptExpression._CountEqualValues(params, 1) = params.added - 1), first.linenum, first.linepos )
 
-'rename to n_all_eq
 Function SEFN_NEq:SToken(params:STokenGroup Var, context:SScriptExpressionContext var)
 	Local first:SToken = params.GetToken(0)
-	Return New SToken( TK_BOOLEAN, Long(TScriptExpression._CountEqualValues(params, 1) <> params.added - 1), first.linenum, first.linepos )
+	If params.added = 3 Then Return New SToken( TK_BOOLEAN, Long(params.GetToken(1).CompareWith(params.GetToken(2)) <> 0), first.linenum, first.linepos )
+	If params.added = 5
+		If Long(params.GetToken(1).CompareWith(params.GetToken(2)) <> 0)
+			Return params.GetToken(3)
+		Else
+			Return params.GetToken(4)
+		EndIf
+	EndIf
+	Return New SToken( TK_ERROR, "2 or 4 parameters expected", params.GetToken(0) )
 End Function
 
 Function SEFN_Gt:SToken(params:STokenGroup Var, context:SScriptExpressionContext var)
 	Local first:SToken = params.GetToken(0)
-	'proposed semantics for all comparisons
-	'1,2,4, >5 parameters error
-	'3 like before
-	'5 if 2 compare 3 then 4 else 5
-	If params.added < 3 Then Return New SToken( TK_BOOLEAN, False, first.linenum, first.linepos )
+	If params.added = 3 Then Return New SToken( TK_BOOLEAN, Long(params.GetToken(1).CompareWith(params.GetToken(2)) > 0), first.linenum, first.linepos )
 	If params.added = 5
 		If Long(params.GetToken(1).CompareWith(params.GetToken(2)) > 0)
 			Return params.GetToken(3)
@@ -1637,25 +1646,46 @@ Function SEFN_Gt:SToken(params:STokenGroup Var, context:SScriptExpressionContext
 			Return params.GetToken(4)
 		EndIf
 	EndIf
-	Return New SToken( TK_BOOLEAN, Long(params.GetToken(1).CompareWith(params.GetToken(2)) > 0), first.linenum, first.linepos )
+	Return New SToken( TK_ERROR, "2 or 4 parameters expected", params.GetToken(0) )
 End Function
 
 Function SEFN_Gte:SToken(params:STokenGroup Var, context:SScriptExpressionContext var)
 	Local first:SToken = params.GetToken(0)
-	If params.added < 3 Then Return New SToken( TK_BOOLEAN, False, first.linenum, first.linepos )
-	Return New SToken( TK_BOOLEAN, Long(params.GetToken(1).CompareWith(params.GetToken(2)) >= 0), first.linenum, first.linepos )
+	If params.added = 3 Then Return New SToken( TK_BOOLEAN, Long(params.GetToken(1).CompareWith(params.GetToken(2)) => 0), first.linenum, first.linepos )
+	If params.added = 5
+		If Long(params.GetToken(1).CompareWith(params.GetToken(2)) => 0)
+			Return params.GetToken(3)
+		Else
+			Return params.GetToken(4)
+		EndIf
+	EndIf
+	Return New SToken( TK_ERROR, "2 or 4 parameters expected", params.GetToken(0) )
 End Function
 
 Function SEFN_Lt:SToken(params:STokenGroup Var, context:SScriptExpressionContext var)
 	Local first:SToken = params.GetToken(0)
-	If params.added < 3 Then Return New SToken( TK_BOOLEAN, False, first.linenum, first.linepos )
-	Return New SToken( TK_BOOLEAN, Long(params.GetToken(1).CompareWith(params.GetToken(2)) < 0), first.linenum, first.linepos )
+	If params.added = 3 Then Return New SToken( TK_BOOLEAN, Long(params.GetToken(1).CompareWith(params.GetToken(2)) < 0), first.linenum, first.linepos )
+	If params.added = 5
+		If Long(params.GetToken(1).CompareWith(params.GetToken(2)) < 0)
+			Return params.GetToken(3)
+		Else
+			Return params.GetToken(4)
+		EndIf
+	EndIf
+	Return New SToken( TK_ERROR, "2 or 4 parameters expected", params.GetToken(0) )
 End Function
 
 Function SEFN_Lte:SToken(params:STokenGroup Var, context:SScriptExpressionContext var)
 	Local first:SToken = params.GetToken(0)
-	If params.added < 3 Then Return New SToken( TK_BOOLEAN, False, first.linenum, first.linepos )
-	Return New SToken( TK_BOOLEAN, Long(params.GetToken(1).CompareWith(params.GetToken(2)) <= 0), first.linenum, first.linepos )
+	If params.added = 3 Then Return New SToken( TK_BOOLEAN, Long(params.GetToken(1).CompareWith(params.GetToken(2)) <= 0), first.linenum, first.linepos )
+	If params.added = 5
+		If Long(params.GetToken(1).CompareWith(params.GetToken(2)) <= 0)
+			Return params.GetToken(3)
+		Else
+			Return params.GetToken(4)
+		EndIf
+	EndIf
+	Return New SToken( TK_ERROR, "2 or 4 parameters expected", params.GetToken(0) )
 End Function
 
 Function SEFN_Concat:SToken(params:STokenGroup Var, context:SScriptExpressionContext var)
@@ -1715,19 +1745,22 @@ End Function
 
 
 ' Register the functions
-' The two numbers are MInimum and Maximum number of allowed parameters
+' The two numbers are minimum and maximum number of allowed parameters
 TScriptExpression.RegisterFunctionHandler( "not", SEFN_Not, 1, -1)
 TScriptExpression.RegisterFunctionHandler( "and", SEFN_And, 1, -1)
 TScriptExpression.RegisterFunctionHandler( "or",  SEFN_Or,  1, -1)
 TScriptExpression.RegisterFunctionHandler( "if",  SEFN_If,  1,  3)
-'neq vs nalleq
-TScriptExpression.RegisterFunctionHandler( "neq",  SEFN_NEq,  1, -1)
-'eq vs alleq
-TScriptExpression.RegisterFunctionHandler( "eq",  SEFN_Eq,  1, -1)
-TScriptExpression.RegisterFunctionHandler( "gt",  SEFN_Gt,  2,  2)
-TScriptExpression.RegisterFunctionHandler( "gte", SEFN_Gte, 2,  2)
-TScriptExpression.RegisterFunctionHandler( "lt",  SEFN_Lt,  2,  2)
-TScriptExpression.RegisterFunctionHandler( "lte", SEFN_Lte, 2,  2)
+
+'2 or 4 parameters
+'.cmp:x:y -> result of comparison
+'.cmp:x:y:a:b is short for .if:${.cmp:x:y}:a:b
+TScriptExpression.RegisterFunctionHandler( "neq", SEFN_NEq, 2, 4)
+TScriptExpression.RegisterFunctionHandler( "eq",  SEFN_Eq,  2, 4)
+TScriptExpression.RegisterFunctionHandler( "gt",  SEFN_Gt,  2, 4)
+TScriptExpression.RegisterFunctionHandler( "gte", SEFN_Gte, 2, 4)
+TScriptExpression.RegisterFunctionHandler( "lt",  SEFN_Lt,  2, 4)
+TScriptExpression.RegisterFunctionHandler( "lte", SEFN_Lte, 2, 4)
+
 TScriptExpression.RegisterFunctionHandler( "concat", SEFN_Concat, 2,  2)
 TScriptExpression.RegisterFunctionHandler( "ucfirst", SEFN_UCFirst, 1,  1)
 TScriptExpression.RegisterFunctionHandler( "csv", SEFN_Csv, 2,  3)


### PR DESCRIPTION
see #1212

Bevor ich richtig anfange, möchte ich sicherstellen, dass die Richtung stimmt.
Als ersten Punkt würde ich gern für alle Vergleichsfunktionen die Kurzschreibweisen einführen:
* .cmp:param1:param2 liefert boolen wie bisher
* .comp:param1:param2:resultTrue:resultFalse liefert je nach Vergleich das erste oder zweite Ergebnis
Eine andere Parameterzahl führt zu einem Fehler. Damit könnten einfache Verzeigungen weniger aufwändig geschrieben werden. Und das Verhalten ist "offensichtlich" (keine impliziten Defaults).

Um das einheitlich zu gestalten würde ich gern .eq und .neq semantisch ändern, da ich die akutelle Implementierung auch eher für einen seltenen Sonderfall halte. Aktuell kann .eq beliebig viele Parameter bekommen und ist "true" genau dann wenn alle gleich sind - es ist also ein .alleq -  .neq hingegen ist wahr genau dann wenn nicht alle gleich sind, ist also ein .nalleq.
Das würde ich tatsächlich auch auftrennen (oder die alleq-Varianten wegen unwahrscheinlicher Verwendung mit vielen Parametern weglassen).

(Zusätzlich könnte mittelfristig die Implementierung für alleq optimiert werden, denn man muss nicht erst alle auswerten, um das Ergebnis zu wissen. Sobalt zwei Werte unterschiedlich sind, kann false zurückgegeben werden.)