### PR TITLE
Referenz auf dynamische Rollen bei Serien

### DIFF
--- a/source/game.person.base.bmx
+++ b/source/game.person.base.bmx
@@ -1954,6 +1954,10 @@ Type TPersonProductionJob
 
 	'only valid for actors
 	Field roleID:Int = 0
+	'marker if a random role should be created
+	'1=job from parent, only reset role on parent reset
+	'2=job overridden in child, reset role also on child reset
+	Field randomRole:Int = 0
 	
 	
 	Method Init:TPersonProductionJob(personID:Int, job:Int, gender:Int=0, country:String="", roleID:Int=0)

--- a/source/game.production.scripttemplate.bmx
+++ b/source/game.production.scripttemplate.bmx
@@ -177,6 +177,10 @@ Type TScriptTemplate Extends TScriptBase
 	'stored there so that children could reuse it)
 	Method Reset:int()
 		ResetVariables()
+		'reset random roles - always for overridden jobs (2) or if reset is done on parent
+		For Local j:TPersonProductionJob = EachIn jobs
+			If j.randomRole = 2 Or (j.randomRole And Not parentScriptID) Then j.roleID = 0
+		Next
 	End Method
 
 
@@ -371,6 +375,10 @@ Type TScriptTemplate Extends TScriptBase
 		'convert instances to new copies (to avoid modification of the
 		'template jobs)
 		For local i:int = 0 until result.length
+			If result[i].randomRole And result[i].roleId = 0
+				Local role:TProgrammeRole = GetProgrammeRoleCollection().CreateRandomRole(result[i].country, result[i].gender)
+				result[i].roleID = role.id
+			EndIf
 			result[i] = result[i].Copy()
 			Local finalJob:TPersonProductionJob = result[i]
 			If finalJob.gender = 0 And finalJob.roleID <> 0


### PR DESCRIPTION
see #1220

Proof of concept:
* Wie bisher werden die Jobs aus der Vorlage ins Drehbuch geklont
* Bei Filmen gibt es kein Problem.
* Bei Mehrfachproduktioonen ist das Problem offen (sollte bei einer Rollenreferenz immer derselbe Name erscheinen oder bei jeder Episode ein anderer - Host vs Gast, aber da passt das Konzept von Rollen vielleicht ohnehin nicht)
* Bei Serien markiert man einen Job explizit (randomRole), so dass innerhalb einer Serie der Rollenname gleich bleibt.
* Bei der Drehbucherstellung wird dann eine zufällige Rolle erzeugt und an alle Serien weitergegeben
* Beim Drehbuchreset wird diese Rolle wieder "zurückgesetzt"
* In einer möglichen finalen Version würde man ein neues Attribut einführen und nicht role_guid als Marker missbrauchen