### PR TITLE
Datenbankbereinigung localized string

### DIFF
--- a/res/database/Default/database_news.xml
+++ b/res/database/Default/database_news.xml
@@ -1048,9 +1048,7 @@
 
 		<news guid="93431fa9-d6bd-4258-b3d0-12ba6124cf2f" type="0" creator="8936" created_by="jorgaeff" comment="https://de.wikipedia.org/wiki/Reinhold_Messner#Besteigung_des_Lhotse">
 			<title>
-				<de>Siegwart Messier</de>
-				<en>Siegwart Messier</en>
-				<pl>Siegwart Messier</pl>
+				<all>Siegwart Messier</all>
 			</title>
 			<description>
 				<de>Siegwart Messier hat als erster Mensch alle 14 Achttausender erstiegen. Während sich andere für Gipfelfotos vom Helikopter absetzen lassen kletterte der Bergsteiger aus Südtirol jeden Berg selbst hinauf.</de>
@@ -1201,9 +1199,7 @@
 		<news guid="c1d45e4e-3c3f-4843-ae47-2823cee994df" type="0" creator="7430" created_by="Sjaele" comment="https://en.wikipedia.org/wiki/Documenta">
 			<!-- deutschbezogen -->
 			<title>
-				<de>Aktena 8</de>
-				<en>Aktena 8</en>
-				<pl>Aktena 8</pl>
+				<all>Aktena 8</all>
 			</title>
 			<description>
 				<de>Am 12. Juni öffnet die weltgrößte Kunstausstellung ihre Pforten. Sie widmet sich der künstlerischen Auseinandersetzung mit Krieg und Gewalt, mit Utopien und Utopieverlust.</de>
@@ -1988,9 +1984,7 @@
 				<pl>W ciągu 17 dni listopada nie zabraknie bajek. Sponsorami są firma Lottery i Federalne Centrum Edukacji Politycznej.</pl>
 			</description>
 			<variables>
-				<currentyear>
-					<de>${.worldtime:"year"}</de>
-				</currentyear>
+				<currentyear>${.worldtime:"year"}</currentyear>
 			</variables>
 			<data genre="5" price="0.7" quality="25" fictional="0" />
 			<availability script='${.eq:${.worldtime:"month"}:10}' year_range_from="1990" year_range_to="-1" /> <!-- can appear annually -->
@@ -4075,12 +4069,10 @@ Oczekuje się, że jej normalny rozmiar ciała zostanie osiągnięty w ciągu ty
 		</news>
 		<news guid="094806da-5113-4b57-b09a-c0639ebc20f9" thread_guid="3af0567a-bc40-43f0-94c1-f2e1cefb2238" type="0" creator="">
 			<title>
-				<de>${title}</de>
-				<en>${title}</en>
+				<all>${title}</all>
 			</title>
 			<description>
-				<de>${desc}</de>
-				<en>${desc}</en>
+				<all>${desc}</all>
 			</description>
 			<effects>
 				<effect trigger="happen" type="triggernews" news="18200428-fdff-4e2d-88fa-4902939c7aa3" />
@@ -4096,9 +4088,7 @@ Oczekuje się, że jej normalny rozmiar ciała zostanie osiągnięty w ciągu ty
 					<en>The ${minister} requests in Parliament the obligation of every citizen to keep a${animal_gen_${index}}.</en>
 					<pl>${minister} domaga się w parlamencie zobowiązania każdego obywatela, aby trzymać w domu ${animal_gen_${index}}.</pl>
 				</desc>
-				<index>
-					<de>0|1|2|3|4|5|6|7|8|9|a|b|c|d</de>
-				</index>
+				<index>0|1|2|3|4|5|6|7|8|9|a|b|c|d</index>
 				<minister>
 					<de>Finanzminister|Innenminister|Außenminister|Verteidigungsminister|Regierungschef|DG-Metall-Chef|BV-Energie-Chef|ADCA-Chef|Bahnchef|Verkehrsminister</de>
 					<en>Finance Minister|Interior Minister|Foreign Minister|Defense Minister|Prime Minister|WA-Steel Chief|EI-Energy Chief|AB-Automobile Chief|Railways Secretary|Transport Secretary</en>
@@ -5018,9 +5008,8 @@ Oczekuje się, że jej normalny rozmiar ciała zostanie osiągnięty w ciągu ty
 				<pl>Komputery wariują</pl>
 			</title>
 			<description>
+				<all>3.14159265358979323846264338327950-2884197169399375105820974944592307-8164062862089986280348253421170679-8214808651328230664709384460955058-22317253594081284811174502...</all>
 				<de>3,14159265358979323846264338327950-2884197169399375105820974944592307-8164062862089986280348253421170679-8214808651328230664709384460955058-22317253594081284811174502...</de>
-				<en>3.14159265358979323846264338327950-2884197169399375105820974944592307-8164062862089986280348253421170679-8214808651328230664709384460955058-22317253594081284811174502...</en>
-				<pl>3.14159265358979323846264338327950-2884197169399375105820974944592307-8164062862089986280348253421170679-8214808651328230664709384460955058-22317253594081284811174502...</pl>
 			</description>
 			<effects>
 				<effect trigger="happen" type="triggernews" news="2195e517-be06-4729-8508-824119e5d4aa" />
@@ -6799,9 +6788,7 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 				<en>${therapper_${i}} ${artistname_${i}} has been watching the ${rap_${i}} scene ${withdisdain}. ${theirverdictproper_${i}}${rap_${i}} is dead!</en>
 			</description>
 			<variables>
-				<i>
-					<de>0|1|2|3|4|5|6</de>
-				</i>
+				<i>0|1|2|3|4|5|6</i>
 				<artistname_0>
 					<de>Shoop Doggie Doug|JJ Cold L</de>
 				</artistname_0>
@@ -6921,9 +6908,7 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 				<en>${therapper_${i}} ${artistname_${i}} has been watching the ${rap_${i}} scene ${withdisdain}. ${theirverdictproper_${i}}${rap_${i}} is dead!</en>
 			</description>
 			<variables>
-				<i>
-					<de>0|1|2|3|4|5|6</de>
-				</i>
+				<i>0|1|2|3|4|5|6</i>
 				<artistname_0>
 					<de>The Candyhill Mob|Grandmixer Flesh &amp; the Ferocious 5</de>
 				</artistname_0>
@@ -7044,9 +7029,7 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 				<en>${motherjob_${i}} ${mothername_${i}} wants to adopt scandalous ${childjob_${j}} ${childname_${j}}. "The child must be helped!" ${mothername_${i}} explained.</en>
 			</description>
 			<variables>
-				<i>
-					<de>0|1|2|3|4|5</de>
-				</i>
+				<i>0|1|2|3|4|5</i>
 				<mothername_0>
 					<de>Madonara</de>
 				</mothername_0>
@@ -7089,9 +7072,7 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 					<de>Schauspielerin</de>
 					<en>Actress</en>
 				</motherjob_5>
-				<j>
-					<de>0|1|2|3|4|5</de>
-				</j>
+				<j>0|1|2|3|4|5</j>
 				<childname_0>
 					<de>Whitney Speers</de>
 				</childname_0>
@@ -7177,9 +7158,7 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 				<en>${motherjob_${i}} ${mothername_${i}} wants to adopt scandalous ${childjob_${j}} ${childname_${j}}. "The child must be helped!" ${mothername_${i}} explained.</en>
 			</description>
 			<variables>
-				<i>
-					<de>0|1|2|3|4|5</de>
-				</i>
+				<i>0|1|2|3|4|5</i>
 				<mothername_0>
 					<de>Polly Dalton</de>
 				</mothername_0>
@@ -7222,9 +7201,7 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 					<de>Tänzerin und Schauspielerin</de>
 					<en>Dancer and actress</en>
 				</motherjob_5>
-				<j>
-					<de>0|1|2|3|4|5</de>
-				</j>
+				<j>0|1|2|3|4|5</j>
 				<childname_0>
 					<de>Madonara</de>
 				</childname_0>
@@ -7310,12 +7287,8 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 				<en>In ${town}, ${vigilantcitizen_${g}} named ${johndoe_${g}} is celebrated as a ${hero_${g}}. ${hadwitnessed_${i}}. ${mayorhonors}.</en>
 			</description>
 			<variables>
-				<g>
-					<de>m|f</de>
-				</g>
-				<i>
-					<de>0|1|2|3|4|5|6|7|8|9</de>
-				</i>
+				<g>m|f</g>
+				<i>0|1|2|3|4|5|6|7|8|9</i>
 				<hero_m>
 					<de>Held</de>
 					<en>hero</en>
@@ -7348,9 +7321,7 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 					<de>Sie</de>
 					<en>She</en>
 				</they_f>
-				<town>
-					<de>${.stationmap:"randomcity"}</de>
-				</town>
+				<town>${.stationmap:"randomcity"}</town>
 				<shotathief_0>
 					<de>erschießt Dieb</de>
 					<en>shot a thief</en>
@@ -7457,9 +7428,7 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 					<de>nach Österreich|in die Schweiz|nach Nepal|nach Peru|nach Norwegen|nach Bhutan|nach Kirgisistan|nach Chile</de>
 					<en>to Austria|to Switzerland|to Nepal|to Peru|to Norway|to Bhutan|to Kyrgyzstan|to Chile</en>
 				</toaustria>
-				<missedcount>
-					<de>143|87|210|62|176|125|199|54|231|98|114</de>
-				</missedcount>
+				<missedcount>143|87|210|62|176|125|199|54|231|98|114</missedcount>
 			</variables>
 			<data genre="4" price="1" quality="58" fictional="1" />
 			<effects>
@@ -7516,9 +7485,7 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 				<en>${therenowned_${i}} auctions off ${theirfamous_${i}}. The proceeds go to ${hungry} ${children}.</en>
 			</description>
 			<variables>
-				<i>
-					<de>0|1|2|3|4|5|6</de>
-				</i>
+				<i>0|1|2|3|4|5|6</i>
 				<name_0>
 					<de>Günther Krass</de>
 				</name_0>
@@ -7687,12 +7654,8 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 				<en>Today there was a fire ${inbuilding_${i}} in ${town}. Fortunately, the ${occupants_${i}} got away with minor smoke inhalation and a scare.</en>
 			</description>
 			<variables>
-				<town>
-					<de>${.stationmap:"randomcity"}</de>
-				</town>
-				<i>
-					<de>0|1|2|3|4|5|6|7|8|9|a|b|c</de>
-				</i>
+				<town>${.stationmap:"randomcity"}</town>
+				<i>0|1|2|3|4|5|6|7|8|9|a|b|c</i>
 				<inbuilding_0>
 					<de>in einem Mehrfamilienhaus</de>
 					<en>in an apartment building</en>
@@ -7822,13 +7785,10 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 				<en>${greenland_${i}} is ${icehockey_${k}} World Champion</en>
 			</title>
 			<description>
-				<de>${inathrillingduel_${k}}</de>
-				<en>${inathrillingduel_${k}}</en>
+				<all>${inathrillingduel_${k}}</all>
 			</description>
 			<variables>
-				<i>
-					<de>0|1|2|3|4</de>
-				</i>
+				<i>0|1|2|3|4</i>
 				<greenland_0>
 					<de>Grönland</de>
 					<en>Greenland</en>
@@ -7889,29 +7849,17 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 					<de>lässt</de>
 					<en>leaves</en>
 				</leave_4>
-				<the_0>
-					<de></de> <!-- intentionally blank -->
-					<en></en>
-				</the_0>
+				<!-- intentionally blank -->
+				<the_0></the_0>
 				<the_1>
 					<de>die </de>
 					<en>the </en>
 				</the_1>
-				<the_2>
-					<de></de> <!-- intentionally blank -->
-					<en></en>
-				</the_2>
-				<the_3>
-					<de></de> <!-- intentionally blank -->
-					<en></en>
-				</the_3>
-				<the_4>
-					<de></de> <!-- intentionally blank -->
-					<en></en>
-				</the_4>
-				<j>
-					<de>0|1|2|3|4|5|6|7|8|9|a</de>
-				</j>
+				<!-- intentionally blank -->
+				<the_2></the_2>
+				<the_3></the_3>
+				<the_4></the_4>
+				<j>0|1|2|3|4|5|6|7|8|9|a</j>
 				<kenya_0>
 					<de>Kenia</de>
 					<en>Kenya</en>
@@ -7956,9 +7904,7 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 					<de>Tonga</de>
 					<en>Tonga</en>
 				</kenya_a>
-				<k>
-					<de>0|1|2|3</de>
-				</k>
+				<k>0|1|2|3</k>
 				<icehockey_0>
 					<de>Junioren-Eishockey|Juniorinnen-Eishockey|Amateur-Eishockey</de>
 					<en>Junior Ice Hockey|Junior Women's Ice Hockey|Amateur Ice Hockey</en>
@@ -7975,15 +7921,9 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 					<de>Fässer-Eisspringen|Stab-Eissprung|Eisstockschleudern</de>
 					<en>Barrel Ice Jumping|Ice Pole Vault|Ice Stock Skidding</en> <!-- https://en.wikipedia.org/wiki/Barrel_jumping | last 2 made-up fictional sports -->
 				</icehockey_3>
-				<scorefor>
-					<de>4|4|4|5|5|5|6|6|7|8|9</de>
-				</scorefor>
-				<scoreagainst>
-					<de>0|1|1|2|2|2|3|3|3</de>
-				</scoreagainst>
-				<pointscount>
-					<de>01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|25|27|28|29|30</de>
-				</pointscount>
+				<scorefor>4|4|4|5|5|5|6|6|7|8|9</scorefor>
+				<scoreagainst>0|1|1|2|2|2|3|3|3</scoreagainst>
+				<pointscount>01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|25|27|28|29|30</pointscount>
 				<inathrillingduel_0>
 					<de>In einem spannenden Duell gegen ${kenya_${j}} ${win_${i}} ${the_${i}}${greenland_${i}} das ${icehockey_${k}}-Weltmeisterschafts-Finale mit ${scorefor}:${scoreagainst}.</de>
 					<en>In a thrilling duel against ${kenya_${j}}, ${the_${i}}${greenland_${i}} ${win_${i}} the ${icehockey_${k}} World Championship final ${scorefor}-${scoreagainst}.</en>
@@ -8000,15 +7940,10 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 					<de>In einem spannenden Wettkampf ${leave_${i}} ${the_${i}}${greenland_${i}} den hartnäckigsten Konkurrenten ${kenya_${j}} hinter sich und ${win_${i}} mit 0,${pointscount} Metern Vorsprung.</de>
 					<en>In a thrilling competition, ${the_${i}}${greenland_${i}} ${leave_${i}} behind the fiercest competitor ${kenya_${j}} and ${win_${i}} with a 0.${pointscount} feet lead.</en>
 				</inathrillingduel_3>
-				<artistfirstname> <!-- Scandinavian / Nordic name generator doesn't seem to be implemented yet -->
-					<de>Lars|Erik|Björn|Henrik|Olaf|Magnus|Anders|Sven|Thor|Gustav|Axel|Finn|Oskar|Kristian|Rune|Nils|Jørgen|Viggo|Arvid|Harald</de>
-				</artistfirstname>
-				<artistlastname>
-					<de>Hansen|Johansson|Andersen|Nielsen|Jørgensen|Svensson|Petersen|Olsen|Larsen|Pedersen|Eriksson|Christiansen|Nilsen|Berg|Magnusson|Kristiansen|Sørensen|Sandberg|Lund|Holm</de>
-				</artistlastname>
-				<exhibitiontown>
-					<de>${.stationmap:"randomcity"}</de>
-				</exhibitiontown>
+				<!-- Scandinavian / Nordic name generator doesn't seem to be implemented yet - dk exists -->
+				<artistfirstname>Lars|Erik|Björn|Henrik|Olaf|Magnus|Anders|Sven|Thor|Gustav|Axel|Finn|Oskar|Kristian|Rune|Nils|Jørgen|Viggo|Arvid|Harald</artistfirstname>
+				<artistlastname>Hansen|Johansson|Andersen|Nielsen|Jørgensen|Svensson|Petersen|Olsen|Larsen|Pedersen|Eriksson|Christiansen|Nilsen|Berg|Magnusson|Kristiansen|Sørensen|Sandberg|Lund|Holm</artistlastname>
+				<exhibitiontown>${.stationmap:"randomcity"}</exhibitiontown>
 			</variables>
 			<data genre="2" price="1" quality="15" fictional="1" />
 			<effects>
@@ -8143,13 +8078,10 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 				<en>${kenya_${j}} is ${armwrestling_${k}} World Champion</en>
 			</title>
 			<description>
-				<de>${inathrillingduel_${k}}</de>
-				<en>${inathrillingduel_${k}}</en>
+				<all>${inathrillingduel_${k}}</all>
 			</description>
 			<variables>
-				<i>
-					<de>0|1|2|3|4</de>
-				</i>
+				<i>0|1|2|3|4</i>
 				<greenland_0>
 					<de>Grönland</de>
 					<en>Greenland</en>
@@ -8170,29 +8102,17 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 					<de>Neufundland</de>
 					<en>Newfoundland</en>
 				</greenland_4>
-				<the_0>
-					<de></de> <!-- intentionally blank -->
-					<en></en>
-				</the_0>
+				<!-- intentionally blank -->
+				<the_0></the_0>
 				<the_1>
 					<de>die </de>
 					<en>the </en>
 				</the_1>
-				<the_2>
-					<de></de> <!-- intentionally blank -->
-					<en></en>
-				</the_2>
-				<the_3>
-					<de></de> <!-- intentionally blank -->
-					<en></en>
-				</the_3>
-				<the_4>
-					<de></de> <!-- intentionally blank -->
-					<en></en>
-				</the_4>
-				<j>
-					<de>0|1|2|3|4|5|6|7|8|9|a</de>
-				</j>
+				<!-- intentionally blank -->
+				<the_2></the_2>
+				<the_3></the_3>
+				<the_4></the_4>
+				<j>0|1|2|3|4|5|6|7|8|9|a</j>
 				<kenya_0>
 					<de>Kenia</de>
 					<en>Kenya</en>
@@ -8237,9 +8157,7 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 					<de>Tonga</de>
 					<en>Tonga</en>
 				</kenya_a>
-				<k>
-					<de>0|1|2|3</de>
-				</k>
+				<k>0|1|2|3</k>
 				<armwrestling_0>
 					<de>Armdrücken|Baumstamm-Wasserrollen|Kanupolo|Ultimate-Frisbee</de>
 					<en>Arm Wrestling|Water Log Rolling|Canoe Polo|Ultimate Frisbee</en> <!-- https://en.wikipedia.org/wiki/Arm_wrestling | https://en.wikipedia.org/wiki/Logrolling_(sport) | https://en.wikipedia.org/wiki/Canoe_polo | https://en.wikipedia.org/wiki/Ultimate_(sport) -->
@@ -8256,15 +8174,9 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 					<de>Frisbee-Weitwurf|Schleuderball</de>
 					<en>Frisbee Long Throw|Schleuderball</en> <!-- https://de.wikipedia.org/wiki/Frisbee | https://de.wikipedia.org/wiki/Schleuderball -->
 				</armwrestling_3>
-				<scorefor>
-					<de>4|4|4|5|5|5|6|6|7|8|9</de>
-				</scorefor>
-				<scoreagainst>
-					<de>0|1|1|2|2|2|3|3|3</de>
-				</scoreagainst>
-				<pointscount>
-					<de>01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|25|27|28|29|30</de>
-				</pointscount>
+				<scorefor>4|4|4|5|5|5|6|6|7|8|9</scorefor>
+				<scoreagainst>0|1|1|2|2|2|3|3|3</scoreagainst>
+				<pointscount>01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|25|27|28|29|30</pointscount>
 				<inathrillingduel_0>
 					<de>In einem spannenden Finale schlug ${kenya_${j}} ${the_${i}}${greenland_${i}} mit ${scorefor}:${scoreagainst} und wurde neuer Weltmeister im ${armwrestling_${k}}.</de>
 					<en>In a thrilling final, ${kenya_${j}} beat ${the_${i}}${greenland_${i}} with ${scorefor}:${scoreagainst} to become the new world champion in ${armwrestling_${k}}.</en>
@@ -8281,15 +8193,9 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 					<de>In einem spannenden Wettkampf lässt ${kenya_${j}} den hartnäckigsten Konkurrenten ${the_${i}}${greenland_${i}} hinter sich und gewinnt mit 0,${pointscount} Metern Vorsprung.</de>
 					<en>In a thrilling competition, ${kenya_${j}} leaves behind their fiercest competitor ${the_${i}}${greenland_${i}} and wins with a 0.${pointscount} feet lead.</en>
 				</inathrillingduel_3>
-				<artistfirstname>
-					<de>${.persongenerator:"firstname":"fr":"male"}</de>
-				</artistfirstname>
-				<artistlastname>
-					<de>${.persongenerator:"lastname":"en":"male"}</de>
-				</artistlastname>
-				<exhibitiontown>
-					<de>${.stationmap:"randomcity"}</de>
-				</exhibitiontown>
+				<artistfirstname>${.persongenerator:"firstname":"fr":"male"}</artistfirstname>
+				<artistlastname>${.persongenerator:"lastname":"en":"male"}</artistlastname>
+				<exhibitiontown>${.stationmap:"randomcity"}</exhibitiontown>
 			</variables>
 			<data genre="2" price="1" quality="20" fictional="1" />
 			<effects>
@@ -8428,9 +8334,7 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 				<en>An ${indonesian_fem_${i}} passenger plane has been missing for several hours.</en>
 			</description>
 			<variables>
-				<i>
-					<de>0|1|2|3|4|5|6|7|8|9|a|b|c|d|e</de>
-				</i>
+				<i>0|1|2|3|4|5|6|7|8|9|a|b|c|d|e</i>
 				<indonesian_neu_0>
 					<de>Indonesisches</de>
 					<en>Indonesian</en>
@@ -8611,9 +8515,7 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 					<de>Indien</de>
 					<en>India</en>
 				</indonesia_e>
-				<deathcount>
-					<de>291|224|312|178|267|205|326|156|239|303|327</de>
-				</deathcount>
+				<deathcount>291|224|312|178|267|205|326|156|239|303|327</deathcount>
 				<indianocean>
 					<de>Indischen Ozean|Pazifischen Ozean</de>
 					<en>Indian Ocean|Pacific Ocean</en>
@@ -8773,12 +8675,8 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 				<en>According to a survey from April ${currentyear}, ${percentcount} of Germans want their old currency back.</en>
 			</description>
 			<variables>
-				<percentcount>
-					<de>76|77|78|79|80|81|82|83|84|85|86|87|88|89|90|91|92|93|94</de>
-				</percentcount>
-				<currentyear>
-					<de>${.worldtime:"year"}</de>
-				</currentyear>
+				<percentcount>76|77|78|79|80|81|82|83|84|85|86|87|88|89|90|91|92|93|94</percentcount>
+				<currentyear>${.worldtime:"year"}</currentyear>
 			</variables>
 			<data genre="0" price="1" quality="20" fictional="1" />
 			<availability year_range_from="2002" script='${.eq:${.worldtime:"month"}:5}' />
@@ -8794,12 +8692,8 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 				<en>According to a survey from April ${currentyear}, ${percentcount} of Germans want the Reichsmark back.</en>
 			</description>
 			<variables>
-				<percentcount>
-					<de>17|18|18|18|18|18|18|19</de>
-				</percentcount>
-				<currentyear>
-					<de>${.worldtime:"year"}</de>
-				</currentyear>
+				<percentcount>17|18|18|18|18|18|18|19</percentcount>
+				<currentyear>${.worldtime:"year"}</currentyear>
 			</variables>
 			<data genre="0" price="1" quality="20" fictional="1" />
 			<availability year_range_to="2001" script='${.eq:${.worldtime:"month"}:5}' />
@@ -8815,9 +8709,7 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 				<en>Following historical precedent, ${swedenandnorway_${i}} want to form a union. ${finland_${i}} also would join the new USN (Union of Scandinavian Nations).</en>
 			</description>
 			<variables>
-				<i>
-					<de>0|1|2|3|4|5|6|7|8|9</de>
-				</i>
+				<i>0|1|2|3|4|5|6|7|8|9</i>
 				<swedenandnorway_0>
 					<de>Schweden und Norwegen</de>
 					<en>Sweden and Norway</en>
@@ -8898,9 +8790,7 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 					<de>Norwegen|Schweden|Dänemark</de>
 					<en>Norway|Sweden|Denmark</en>
 				</finland_9>
-				<exhibitiontown>
-					<de>${.stationmap:"randomcity"}</de>
-				</exhibitiontown>
+				<exhibitiontown>${.stationmap:"randomcity"}</exhibitiontown>
 			</variables>
 			<data genre="0" price="1" quality="45" fictional="1" />
 			<effects>
@@ -8947,17 +8837,14 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 
 		<news guid="a218144b-a3b0-4840-b793-134e902d7227" type="0" creator="" created_by="-" comment="some variations created with help of ChatGPT | TODO: more variations">
 			<title>
-				<de>${counterfeitmoneysecured_${i}}</de>
-				<en>${counterfeitmoneysecured_${i}}</en>
+				<all>${counterfeitmoneysecured_${i}}</all>
 			</title>
 			<description>
 				<de>${aschoolboy_${g}} namens ${johndoe_${g}} ${triedto_${i}}.</de>
 				<en>${aschoolboy_${g}} named ${johndoe_${g}} ${triedto_${i}}.</en>
 			</description>
 			<variables>
-				<i>
-					<de>0|1|2|3|4|5</de>
-				</i>
+				<i>0|1|2|3|4|5</i>
 				<counterfeitmoneysecured_0>
 					<de>Falschgeld in ${town} gesichert</de>
 					<en>Counterfeit money in ${town} secured</en>
@@ -8982,9 +8869,7 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 					<de>Mittagessen-Schwarzmarkt in ${town} aufgelöst</de>
 					<en>Lunch black market in ${town} disbanded</en>
 				</counterfeitmoneysecured_5>
-				<age>
-					<de>12|13|14|15|16</de>
-				</age>
+				<age>12|13|14|15|16</age>
 				<g>
 					<de>m|f</de>
 				</g>
@@ -9016,9 +8901,7 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 					<de>Böllern|Comic-Tassen|Glitzerstiften|Einhornmasken|Mega-Kaugummibällen|Riesengummibärchen|Hip-Hop-Schallplatten|Heavy-Metal-Alben|Videospielen</de>
 					<en>firecrackers|cartoon cups|glitter pens|unicorn masks|mega chewing gum balls|giant gummy bears|hip hop records|heavy metal albums|video games</en>
 				</firecrackers>
-				<town>
-					<de>${.stationmap:"randomcity"}</de>
-				</town>
+				<town>${.stationmap:"randomcity"}</town>
 				<johndoe_m>
 					<de>${.persongenerator:"firstname":"de":"male"}</de>
 					<en>${.persongenerator:"firstname":"en":"male"}</en>
@@ -9078,8 +8961,7 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 			</description>
 			<variables>
 				<leipzig>
-					<de>Leipzig|Dresden|Halle|Erfurt|Magdeburg|Potsdam|Rostock|Chemnitz|Cottbus</de>
-					<en>Leipzig|Dresden|Halle|Erfurt|Magdeburg|Potsdam|Rostock|Chemnitz|Cottbus</en>
+					<all>Leipzig|Dresden|Halle|Erfurt|Magdeburg|Potsdam|Rostock|Chemnitz|Cottbus</all>
 				</leipzig>
 			</variables>
 			<data genre="4" price="1" quality="25" fictional="1" />
@@ -9194,8 +9076,7 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 
 		<news guid="e3ccc4f2-2f73-4871-b3be-117ed74f0238" type="0" creator="" created_by="-">
 			<title>
-				<de>${footballteam} ${struck_${i}}</de>
-				<en>${footballteam} ${struck_${i}}</en>
+				<all>${footballteam} ${struck_${i}}</all>
 			</title>
 			<description>
 				<de>Die ${russian_${i}} ${footballteam} wurde beim Training ${struckbylightning_${i}}. ${three} Spieler wurden schwer verletzt ins Krankenhaus gebracht.</de>
@@ -9206,9 +9087,7 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 					<de>Fußballelf|Rugbymannschaft|Feldhockeymannschaft|Polomannschaft|Baseballmannschaft</de> <!-- nur feminin! -->
 					<en>Football Team|Rugby Team|Field Hockey Team|Polo Team|Baseball Team</en>
 				</footballteam>
-				<i>
-					<de>0|1|2|3|4</de>
-				</i>
+				<i>0|1|2|3|4</i>
 				<struck_0>
 					<de>vom Blitz getroffen</de>
 					<en>struck by lightning</en>
@@ -9295,12 +9174,8 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 					<de>München|Schwabing|Starnberg|Grünwald|Ingolstadt|Charlottenburg|Berlin-Mitte|Grunewald|Spandau|Frankfurt-Innenstadt|Sachsenhausen|Blankenese|Hamburg-Winterhude|Monaco|Paris</de>
 					<en>Munich|Schwabing|Starnberg|Grünwald|Ingolstadt|Charlottenburg|Berlin-Mitte|Grunewald|Spandau|Frankfurt-Innenstadt|Sachsenhausen|Blankenese|Hamburg-Winterhude|Monaco|Paris</en>
 				</munich>
-				<amounteuro>
-					<de>4|5|6|7|8</de>
-				</amounteuro>
-				<amountcent>
-					<de>12|24|36|48|60|72|84|96</de>
-				</amountcent>
+				<amounteuro>4|5|6|7|8</amounteuro>
+				<amountcent>12|24|36|48|60|72|84|96</amountcent>
 			</variables>
 			<data genre="4" price="1" quality="10" fictional="1" />
 			<availability year_range_from="2002" />
@@ -9324,12 +9199,8 @@ W tym roku ponownie spodziewane są demonstracje.</pl>
 					<de>München|Schwabing|Starnberg|Grünwald|Ingolstadt|Charlottenburg|Berlin-Mitte|Grunewald|Spandau|Frankfurt-Innenstadt|Sachsenhausen|Blankenese|Hamburg-Winterhude</de>
 					<en>Munich|Schwabing|Starnberg|Grünwald|Ingolstadt|Charlottenburg|Berlin-Mitte|Grunewald|Spandau|Frankfurt-Innenstadt|Sachsenhausen|Blankenese|Hamburg-Winterhude</en>
 				</munich>
-				<amountdm>
-					<de>5|6|7|8|9</de>
-				</amountdm>
-				<amountpf>
-					<de>12|24|36|48|60|72|84|96</de>
-				</amountpf>
+				<amountdm>5|6|7|8|9</amountdm>
+				<amountpf>12|24|36|48|60|72|84|96</amountpf>
 			</variables>
 			<data genre="4" price="1" quality="10" fictional="1" />
 			<availability year_range_to="2001" />

--- a/res/database/Default/database_programmes_fictional.xml
+++ b/res/database/Default/database_programmes_fictional.xml
@@ -1012,11 +1012,7 @@ Ekscytująca rozrywka i łamiące mózg pytania.</pl>
 						<en>Cameroon 2-1 Colombia</en>
 						<pl>Kamerun - Kolumbia</pl>
 					</title>
-					<description>
-						<de></de>
-						<en></en>
-						<pl></pl> 
-					</description>
+					<description></description>
 					<staff>
 						<member index="1" function="2">8dbf9ebe-a0a1-4400-8ed5-82cd8ac0185e</member>
 						<member index="2" function="2">b360f7b8-3d87-4f6a-96c5-cc7a8ab8c488</member>
@@ -1028,11 +1024,7 @@ Ekscytująca rozrywka i łamiące mózg pytania.</pl>
 						<en>CSFR 4-1 Costa Rica</en>
 						<pl>Czechosłowacja - Costa Rica</pl>
 					</title>
-					<description>
-						<de></de>
-						<en></en>
-						<pl></pl>
-					</description>
+					<description></description>
 					<staff>
 						<member index="1" function="2">c0b2d723-bf35-4e05-868c-205815edd356</member>
 						<member index="2" function="2">b11fed5e-9636-4a9d-b13a-f5d490fef1b9</member>
@@ -1044,11 +1036,7 @@ Ekscytująca rozrywka i łamiące mózg pytania.</pl>
 						<en>Brazil 0-1 Argentina</en>
 						<pl>Brazylia - Argentyna</pl>
 					</title>
-					<description>
-						<de></de>
-						<en></en>
-						<pl></pl>
-					</description>
+					<description></description>
 					<staff>
 						<member index="1" function="2">88595c7f-30bf-4600-add4-43098011d419</member>
 						<member index="2" function="2">1d71a663-3fc0-44b5-9887-583eb5ca9959</member>
@@ -1223,9 +1211,7 @@ Ekscytująca rozrywka i łamiące mózg pytania.</pl>
 				</programme>
 				<programme guid="02613833-d54e-4b6b-8de8-2370f4d5bb57" product="4" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
-						<de>Monet</de>
-						<en>Monet</en>
-						<pl>Monet</pl>
+						<all>Monet</all>
 					</title>
 					<description>
 						<de>Diesmal reist ${.self:"cast":1:"lastname"} nach Paris um Nachfahren des bedeutenden Impressionisten Monet zu suchen.</de>
@@ -1236,9 +1222,7 @@ Ekscytująca rozrywka i łamiące mózg pytania.</pl>
 				</programme>
 				<programme guid="9ada2a37-6ff5-4ff0-9766-7d0b2d98cff4" product="4" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
-						<de>Picasso</de>
-						<en>Picasso</en>
-						<pl>Picasso</pl>
+						<all>Picasso</all>
 					</title>
 					<description>
 						<de>In Madrid spürt ${.self:"cast":1:"fullname"} einen Neffen Picassos auf. Interessante Anekdoten würzen diese Episode.</de>
@@ -1249,9 +1233,7 @@ Ekscytująca rozrywka i łamiące mózg pytania.</pl>
 				</programme>
 				<programme guid="494fa370-4744-4616-aa14-910aa692af25" product="4" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
-						<de>Rembrandt</de>
-						<en>Rembrandt</en>
-						<pl>Rembrandt</pl>
+						<all>Rembrandt</all>
 					</title>
 					<description>
 						<de>${.self:"cast":1:"lastname"} sendet diesmal direkt vom Hausboot eines Rembrandt-Nachfahren. Neben Kochrezepten erfährt der Zuschauer vieles aus Rembrandts Leben.</de>
@@ -1262,9 +1244,7 @@ Ekscytująca rozrywka i łamiące mózg pytania.</pl>
 				</programme>
 				<programme guid="6eccf754-bb87-40e5-bb5c-931fd2124a1b" product="4" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
-						<de>Kandinsky</de>
-						<en>Kandinsky</en>
-						<pl>Kandinsky</pl>
+						<all>Kandinsky</all>
 					</title>
 					<description>
 						<de>Bortsch und Kandinsky. Neben einem geselligem Essen begleiten die Zuschauer ${.self:"cast":1:"lastname"} durch die Geschichte mit Zaren und Kandinsky.</de>
@@ -1517,9 +1497,7 @@ Czy ta dwójka oferuje wystarczająco dużo materiału na ekscytujący panel?</p
 				</programme>
 				<programme guid="8ffd3e59-e711-45ca-9810-b22c221bad9b" product="3" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
-						<de>${.self:"cast":2:"fullname"}</de>
-						<en>${.self:"cast":2:"fullname"}</en>
-						<pl>${.self:"cast":2:"fullname"}</pl>
+						<all>${.self:"cast":2:"fullname"}</all>
 					</title>
 					<description>
 						<de>Das letzte Mal zu Gast bei ${.self:"cast":1:"fullname"}: ihr Nachfolger ${.self:"cast":2:"fullname"}. Er redet über seine neue Sendung und macht sich lustig über den Abgang des ehemaligen Stars ${.self:"cast":1:"fullname"}.</de>
@@ -1713,9 +1691,7 @@ Czy ta dwójka oferuje wystarczająco dużo materiału na ekscytujący panel?</p
 		</programme>
 		<programme guid="cf19bea6-f3ae-4ea1-92fb-3bccc8d5c9e3" product="7" licence_type="3" fictional="1" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny" comment="Screenplay continuation added as fb34ed9a-528e-45a9-83b9-16475c2ab67c">
 			<title>
-				<de>Hot Quiz</de>
-				<en>Hot Quiz</en>
-				<pl>Hot Quiz</pl>
+				<all>Hot Quiz</all>
 			</title>
 			<description>
 				<de>Die Moderatorin macht sich nackig und die Anrufer arm. Brüste gegen Geld, wie im echten Leben.</de>
@@ -1734,9 +1710,7 @@ Czy ta dwójka oferuje wystarczająco dużo materiału na ekscytujący panel?</p
 			<children>
 				<programme guid="a710207e-6dff-4583-a015-94292f152ba9" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
-						<de>Daniela</de>
-						<en>Daniela</en>
-						<pl>Daniela</pl>
+						<all>Daniela</all>
 					</title>
 					<description>
 						<de>Heute moderiert Daniela die Sendung. Kniffelige, nahezu unlösbare Aufgaben werden gestellt. Richtige Lösungen sorgen für einen Strip von Daniela.</de>
@@ -1766,9 +1740,7 @@ Czy ta dwójka oferuje wystarczająco dużo materiału na ekscytujący panel?</p
 				</programme>
 				<programme guid="ee67bae0-ba95-4cef-8e0a-4aa03c130264" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="5578" created_by="Ronny">
 					<title>
-						<de>Mandy</de>
-						<en>Mandy</en>
-						<pl>Mandy</pl>
+						<all>Mandy</all>
 					</title>
 					<description>
 						<de>Mandy ist ein echtes Cowgirl, die Quizfragen allerdings zum Mäusemelken.</de>
@@ -1782,9 +1754,7 @@ Czy ta dwójka oferuje wystarczająco dużo materiału na ekscytujący panel?</p
 				</programme>
 				<programme guid="4c067d5a-18a9-4646-ab7e-ef240fe18ab0" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="">
 					<title>
-						<de>Peggy</de>
-						<en>Peggy</en>
-						<pl>Peggy</pl>
+						<all>Peggy</all>
 					</title>
 					<description>
 						<de>Peggy kommt vom Lande, und alle Fragen drehen sich um die dicksten Kartoffeln der Bäuerin.</de>
@@ -2203,9 +2173,7 @@ Pouczające historie przekazują aktualne odkrycia uznanych psychologów dzieci�
 			<children>
 				<programme guid="ronny-programme-komtess-01-ep-01" product="2" licence_type="2" creator="5578" created_by="Ronny">
 					<title>
-						<de>Jaqueline Montegrieux</de>
-						<en>Jaqueline Montegrieux</en>
-						<pl>Jaqueline Montegrieux</pl>
+						<all>Jaqueline Montegrieux</all>
 					</title>
 					<description>
 						<de>Jaqueline, Tochter des Grafen Montegrieux erblüht und entdeckt bisher unerkannte Gefühle für den Stallburschen Henri.</de>
@@ -2217,9 +2185,7 @@ Pouczające historie przekazują aktualne odkrycia uznanych psychologów dzieci�
 				</programme>
 				<programme guid="ronny-programme-komtess-01-ep-02" product="2" licence_type="2" creator="5578" created_by="Ronny">
 					<title>
-						<de>Francine du Pomeranc</de>
-						<en>Francine du Pomeranc</en>
-						<pl>Francine du Pomeranc</pl>
+						<all>Francine du Pomeranc</all>
 					</title>
 					<description>
 						<de>Der umtriebige Graf Pomeranc besucht den Landsitz Montegrieux. Er versucht Jaqueline nachzustellen, während seine Tochter Francine Henri schöne Augen macht...</de>

--- a/res/database/Default/database_scripts.xml
+++ b/res/database/Default/database_scripts.xml
@@ -107,12 +107,8 @@
 					<de>Urwitzige|Liebevolle|Turbulente|Romantische|Traurige|Überraschende</de>
 					<en>Hilarious|Lovely|Turbulent|Romantic|Melancholic|Surprising</en>
 				</funny>
-				<namewoman>
-					<de>${.persongenerator:"firstname":"":"female"}</de>
-				</namewoman>
-				<nameman>
-					<de>${.persongenerator:"firstname":"":"male"}</de>
-				</nameman>
+				<namewoman>${.persongenerator:"firstname":"":"female"}</namewoman>
+				<nameman>${.persongenerator:"firstname":"":"male"}</nameman>
 			</variables>
 
 			<jobs>
@@ -139,8 +135,7 @@
 
 		<scripttemplate product="1" licence_type="1" guid="scripttemplate-random-ron-fightagainst01">
 			<title>
-				<de>${ADJECTIVE} ${OBJECT}</de>
-				<en>${ADJECTIVE} ${OBJECT}</en>
+				<all>${ADJECTIVE} ${OBJECT}</all>
 			</title>
 			<description>
 				<de>${JOB} ${.self:"role":1:"firstname"} ${ACTION} ${ENEMY}. Sie wollen ${VICTIM} ${ACTION2}.</de>
@@ -203,8 +198,7 @@
 
 		<scripttemplate product="1" licence_type="1" guid="scripttemplate-random-ron-subtilehumor01">
 			<title>
-				<de>${NUMBER} ${OBJECT} ${ACTION}</de>
-				<en>${NUMBER} ${OBJECT} ${ACTION}</en>
+				<all>${NUMBER} ${OBJECT} ${ACTION}</all>
 			</title>
 			<description>
 				<de>Subtiles Drama trifft Holzhammerhumor. Alleiniger Star ist Nummer 1 der ${NUMBER} ${OBJECT}.</de>
@@ -212,9 +206,7 @@
 			</description>
 
 			<variables>
-				<number>
-					<de>2|3|4|5</de>
-				</number>
+				<number>2|3|4|5</number>
 				<object>
 					<de>Idioten|Trottel|Deppen|Gangster|Schwerenöter|Polizisten|Feuerwehrmänner|Politiker</de>
 					<en>Idiots|Fools|Dorks|Gangsters|Charmers|Policemen|Firefighters|Politicians</en>
@@ -249,8 +241,7 @@
 
 		<scripttemplate product="1" licence_type="1" guid="scripttemplate-random-ron-eroticmovie1">
 			<title>
-				<de>${WOMAN} ${ACTION} ${MAN}</de>
-				<en>${WOMAN} ${ACTION} ${MAN}</en>
+				<all>${WOMAN} ${ACTION} ${MAN}</all>
 			</title>
 			<description>
 				<de>${WOMAN} ist eine Tagträumerin und verliert sich in ihren erotischen Fantasien.</de>
@@ -258,9 +249,7 @@
 			</description>
 
 			<variables>
-				<woman>
-					<de>${.persongenerator:"firstname":"de":"female"}|${.persongenerator:"firstname":"es":"female"}|${.persongenerator:"firstname":"":"female"}|Julie|Anne|Cecille|Verona|Ludmilla|Barbarelle|Susan|Penelope</de>
-				</woman>
+				<woman>${.persongenerator:"firstname":"de":"female"}|${.persongenerator:"firstname":"es":"female"}|${.persongenerator:"firstname":"":"female"}|Julie|Anne|Cecille|Verona|Ludmilla|Barbarelle|Susan|Penelope</woman>
 				<action>
 					<de>verführt den|umgarnt den|turtelt mit dem|bezirzt den</de>
 					<en>seduces the|enchants the|whispers sweet nothings to the|bewitches the</en>
@@ -292,12 +281,10 @@
 
 		<scripttemplate product="1" licence_type="1" guid="scripttemplate-random-ron-horrormovie1">
 			<title>
-				<de>${TITLE}</de>
-				<en>${TITLE}</en>
+				<all>${TITLE}</all>
 			</title>
 			<description>
-				<de>${DESCRIPTION}</de>
-				<en>${DESCRIPTION}</en>
+				<all>${DESCRIPTION}</all>
 			</description>
 			<variables>
 				<title>
@@ -308,9 +295,7 @@
 					<de>Schloss|Landsitz|Hotel|Gasthaus|Gasthof|Forsthaus|Dorf|Leuchtturm</de>
 					<en>Castle|Country House|Hotel|Guesthouse|Tavern|Forest Lodge|Village|Lighthouse</en> <!-- 'Inn' conflicting with article 'A' (must be 'An') for now -->
 				</building>
-				<count>
-					<de>|||3 |4 |5 |8 |10 |1000 </de>
-				</count>
+				<count>|||3 |4 |5 |8 |10 |1000 </count>
 				<terror>
 					<de>des Horrors|des Terrors|der Angst|der Panik|des Übels</de>
 					<en>of Horror|of Terror|of Fear|of Panic|of Disgust</en>
@@ -360,8 +345,7 @@
 
 		<scripttemplate product="1" licence_type="1" guid="scripttemplate-random-ron-dramamovie1">
 			<title>
-				<de>${TITLE}</de>
-				<en>${TITLE}</en>
+				<all>${TITLE}</all>
 			</title>
 			<description>
 				<de>${NAME} ${DESCRIPTIONACTION}. Seine ${ENVIRONMENT} ${ENVIRONMENTACTION}.${FEELING}</de>
@@ -430,8 +414,7 @@
 
 		<scripttemplate product="3" licence_type="1" guid="scripttemplate-random-ron-show1">
 			<title>
-				<de>${KIND}${DATE}</de>
-				<en>${KIND}${DATE}</en>
+				<all>${KIND}${DATE}</all>
 			</title>
 			<description>
 				<de>Lustige Einspieler und Gäste bekannt aus Funk und Fernsehen. Der Moderator bietet peinliche Tanzeinlagen. Nette Unterhaltung für Unbesorgte.</de>
@@ -444,8 +427,7 @@
 					<en>The ${INNER} Quiz|The ${INNER}-Duel|The ${INNER} Show</en>
 				</kind>
 				<inner>
-					<de>${ATTRIBUTE} ${GROUP}</de>
-					<en>${ATTRIBUTE} ${GROUP}</en>
+					<all>${ATTRIBUTE} ${GROUP}</all>
 				</inner>
 				<attribute>
 					<de>tierische|große|abgefahrene|lustige|skurrile</de>
@@ -455,10 +437,8 @@
 					<de>Promi|Kinder|Politiker|Musik|Film|Rate|Reise</de>
 					<en>Celebrity|Kids|Politicians|Music|Movie|Guessing|Travel</en>
 				</group>
-				<date>
-					<!-- either add the game year (with space!), or nothing -->
-					<de>| ${.worldtime:"year"}</de>
-				</date>
+				<!-- either add the game year (with space!), or nothing -->
+				<date>| ${.worldtime:"year"}</date>
 			</variables>
 
 			<jobs>
@@ -485,12 +465,10 @@
 		<!-- === SERIES === -->
 		<scripttemplate product="2" licence_type="3" guid="scripttemplate-random-ron-averagedayseries01" comment="">
 			<title>
-				<de>${adj}${who_${i}}${titleaddendum}</de>
-				<en>${adj}${who_${i}}${titleaddendum}</en>
+				<all>${adj}${who_${i}}${titleaddendum}</all>
 			</title>
 			<description>
-				<de>${seriesabout} ${how_${i}}. ${adj}${who_${i}}${legacy}. ${jokes}</de>
-				<en>${seriesabout} ${how_${i}}. ${adj}${who_${i}}${legacy}. ${jokes}</en>
+				<all>${seriesabout} ${how_${i}}. ${adj}${who_${i}}${legacy}. ${jokes}</all>
 			</description>
 			<variables>
 				<seriesabout>
@@ -501,9 +479,7 @@
 					<de>Ein Haufen |Die Hinterwäldler-|Verrückte |Wahnsinns-|Bayrische |Tugendhafte |Durchgedrehte |Fromme |Zankende |Schelmische |Verschmitzte |Witzige |Abenteuerlustige |Extravagante |Geheimnisvolle |Exzentrische |Temperamentvolle |Joviale |Hartnäckige |Lebensfrohe |Verwegene |Brillante </de>
 					<en>A Bunch of |The Hillbilly |Crazy |The Frenzied |Bavarian |Virtuous |Nutty |Devout |Quarreling |Mischievous |Impish |Witty |Adventurous |Flamboyant |The Mysterious |Eccentric |Spirited |The Jovial |The Tenacious |The Vivacious |Swashbuckling |The Brilliant </en>
 				</adj>
-				<i>
-					<de>0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f|g|h</de> <!-- must be same as j in episodes -->
-				</i>
+				<i>0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f|g|h</i><!-- must be same as j in episodes -->
 				<who_0>
 					<de>Waschweiber</de>
 					<en>Washer Women</en> <!-- always capitalized for now, even in flow-text. TODO: possibly change as soon as capitalization per expression available. -->
@@ -664,18 +640,11 @@
 					<de>Gags am laufenden Band.|Treffsichere Pointen.|Unterhaltung pur.|Lacher ohne Ende.|Punktgenaue Pointen.|Lacher im Sekundentakt.|Humor der Extraklasse.|Bauchweh vor Lachen.|Humor in Hülle und Fülle.|Höchste Heiterkeit.|Dauerlachen garantiert.|Komik in Perfektion.|Amüsement ohne Ende.|Lachen ohne Unterlass.|Achterbahnfahrt des Lachens.|Meisterwerk des Humors.|Eine urkomische Erfahrung.|Unterhaltsame Heiterkeit.|||||</de>
 					<en>Gags non-stop.|Spot-on punchlines.|Pure entertainment.|Endless laughter.|Comic brilliance.|Laugh-a-minute extravaganza.|Top-notch humor.|Side-splitting comedy.|Jokes galore.|Hilarity at its best.|Unstoppable laughs.|Comic perfection.|Non-stop amusement.|Laughs that keep on coming.|Rollercoaster of humor.|A comedic tour de force.|An uproarious experience.|Entertaining hilarity.|||||</en>
 				</jokes>
-				<town>
-					<de>${.stationmap:"randomcity"}</de>
-				</town>
-				<firstname1> <!-- all these are more or less gender-neutral/-flexible first names, source: internet. TODO: maybe the Bavarians and the nuns need special treatment -->
-					<de>Addison|Alex|Anouk|Anuk|Avery|Benja|Beverly|Billie|Bozan|Cameron|Charlie|Cherry|Celeste|Conny|Daniele|Darian|Devin|Eden|Elliot|Elya|Esra|Felice|Finley|Flo|Gale|Gerritt|Glenn|Günes|Hadir|Harley|Henny|Ihsan|Immi|Indra|Isa|Islay|Jamal|Jayce|Jean|Jody|Jona|Junis|Kaj|Kennedy|Kim|Kourtney|Kyler|Lee|Lindsay|Lou|Luka|Mans|Marley|Meredith|Michele|Mika|Nicola|Nikita|Noah|Oakley|Oyama|Parker|Paulin|Pim|Quincy|Regis|René|Robby|Rory|Rowan|Sasha|Scout|Siro|Shiloh|Taylor|Tiam|Tony|Tyler|Ude|Vada|Valo|Wally|Whitney|Wynne|Zero|Zohar</de>
-				</firstname1>
-				<firstname2>
-					<de>Alexis|Angel|Aria|Ashley|Aydin|Bent|Billy|Blair|Bobby|Camilie|Casey|Chaska|Chris|Dakota|Dany|Deniz|Dylan|Elis|Elia|Enid|Erin|Evin|Feng|Finn|Fiore|Florin|Gates|Gerit|Güven|Hadley|Helge|Hilal|Ilter|Indiana|Ino|Ira|Jade|Jamie|James|Jayden|Jesse|Jorah|June|Kai|Kaya|Kelsey|Kerry|Konni|Kris|Leslie|Loki|Luca|Maria|Marlin|Marlo|Marlon|Maxime|Merle|Milou|Nicki|Nikky|Özbek|Ola|Pahul|Pat|Payden|Pleun|Raleigh|Raven|Reese|Reign|Riley|Robin|Ryan|Sandy|Sean|Shannon|Skyler|Simone|Terry|Tjade|Toni|Umut|Uli|Val|Vanja|Wanja|Yael|Yuki|Zia</de>
-				</firstname2>
-				<firstname3>
-					<de>Amar|Andrea|Ari|Ashton|Bailey|Bene|Bente|Blake|Bo|Bob|Carol|Carter|Charly|Corey|Dani|Darcy|Derya|Dominique|Eike|Elvin|Emerson|Esin|Farina|Fidan|Friedel|Francis|Gin|Gwenaël|Hadar|Haik|Harper|Hemke|Ilya|Indigo|Isa|Jaime|Janne|Jean|Jessi|Jordan|Joyce|Kay|Kendall|Kersten|Kiran|Kristan|Lesley|Lorin|Luan|Malu|Marian|Maxi|Mel|Mian|Nika|Niki|Nino|Nova|Paris|Patrice|Phoenix|Orly|Qian|Quinn|Rayan|Renée|Rey|Robbie|Sam|Sanja|Sascha|Shanti|Sidney|Theodore|Tomke|Tracy|Ulli|Uzay|Valentine|Vesa|Yuri|Wisal|Zisan</de>
-				</firstname3>
+				<town>${.stationmap:"randomcity"}</town>
+				<!-- all these are more or less gender-neutral/-flexible first names, source: internet. TODO: maybe the Bavarians and the nuns need special treatment -->
+				<firstname1>Addison|Alex|Anouk|Anuk|Avery|Benja|Beverly|Billie|Bozan|Cameron|Charlie|Cherry|Celeste|Conny|Daniele|Darian|Devin|Eden|Elliot|Elya|Esra|Felice|Finley|Flo|Gale|Gerritt|Glenn|Günes|Hadir|Harley|Henny|Ihsan|Immi|Indra|Isa|Islay|Jamal|Jayce|Jean|Jody|Jona|Junis|Kaj|Kennedy|Kim|Kourtney|Kyler|Lee|Lindsay|Lou|Luka|Mans|Marley|Meredith|Michele|Mika|Nicola|Nikita|Noah|Oakley|Oyama|Parker|Paulin|Pim|Quincy|Regis|René|Robby|Rory|Rowan|Sasha|Scout|Siro|Shiloh|Taylor|Tiam|Tony|Tyler|Ude|Vada|Valo|Wally|Whitney|Wynne|Zero|Zohar</firstname1>
+				<firstname2>Alexis|Angel|Aria|Ashley|Aydin|Bent|Billy|Blair|Bobby|Camilie|Casey|Chaska|Chris|Dakota|Dany|Deniz|Dylan|Elis|Elia|Enid|Erin|Evin|Feng|Finn|Fiore|Florin|Gates|Gerit|Güven|Hadley|Helge|Hilal|Ilter|Indiana|Ino|Ira|Jade|Jamie|James|Jayden|Jesse|Jorah|June|Kai|Kaya|Kelsey|Kerry|Konni|Kris|Leslie|Loki|Luca|Maria|Marlin|Marlo|Marlon|Maxime|Merle|Milou|Nicki|Nikky|Özbek|Ola|Pahul|Pat|Payden|Pleun|Raleigh|Raven|Reese|Reign|Riley|Robin|Ryan|Sandy|Sean|Shannon|Skyler|Simone|Terry|Tjade|Toni|Umut|Uli|Val|Vanja|Wanja|Yael|Yuki|Zia</firstname2>
+				<firstname3>Amar|Andrea|Ari|Ashton|Bailey|Bene|Bente|Blake|Bo|Bob|Carol|Carter|Charly|Corey|Dani|Darcy|Derya|Dominique|Eike|Elvin|Emerson|Esin|Farina|Fidan|Friedel|Francis|Gin|Gwenaël|Hadar|Haik|Harper|Hemke|Ilya|Indigo|Isa|Jaime|Janne|Jean|Jessi|Jordan|Joyce|Kay|Kendall|Kersten|Kiran|Kristan|Lesley|Lorin|Luan|Malu|Marian|Maxi|Mel|Mian|Nika|Niki|Nino|Nova|Paris|Patrice|Phoenix|Orly|Qian|Quinn|Rayan|Renée|Rey|Robbie|Sam|Sanja|Sascha|Shanti|Sidney|Theodore|Tomke|Tracy|Ulli|Uzay|Valentine|Vesa|Yuri|Wisal|Zisan</firstname3>
 				<location_0>
 					<de>Paradies</de> <!-- alle Orte nur Maskulinum, Neutrum und wo 'im xyz' passt -->
 					<en>paradise</en>
@@ -778,8 +747,7 @@
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="scripttemplate-random-ron-averagedayseries01_02">
 					<title>
-						<de>${overtime} ${atworkplace_${i}}</de>
-						<en>${overtime} ${atworkplace_${i}}</en>
+						<all>${overtime} ${atworkplace_${i}}</all>
 					</title>
 					<description>
 						<de>Die ${who_${i}} ${havetheirhandsfull}. ${who_${j}} aus ${othertown} ${description_${i}}</de>
@@ -866,12 +834,8 @@
 							<de>haben alle Hände voll zu tun|sind schwer beschäftigt|sind voll im Einsatz|sind schwer bei der Arbeit|sind gestresst|sind gestresst, es wird ihnen nichts geschenkt</de>
 							<en>have their hands full|are heavily busy|are in full action|are hard at work|are stressed|are stressed, they get nothing for free</en>
 						</havetheirhandsfull>
-						<j>
-							<de>0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f|g|h</de> <!-- must be same count and elements as i -->
-						</j>
-						<othertown>
-							<de>${.stationmap:"randomcity"}</de>
-						</othertown>
+						<j>0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f|g|h</j><!-- must be same count and elements as i -->
+						<othertown>${.stationmap:"randomcity"}</othertown>
 						<description_0>
 							<de>sind auf Durchreise und wollen ihre Montur gereinigt haben, pronto! Unsere ${who_${i}} müssen Extrazuschlag aushandeln.</de>
 							<en>are passing through and want their gear cleaned, pronto! Our ${who_${i}} have to negotiate an extra surcharge.</en>
@@ -952,12 +916,12 @@
 						<en>${trouble} in ${location_${k}}</en> <!-- TODO: apply capitalization function when available -->
 					</title>
 					<description>
-						<de>${descriptions}</de>
+						<all>${descriptions}</all>
 					</description>
 					<episodes min="1" max="2" />
 					<variables>
 						<descriptions>
-							<de>${description_0}|${description_1}</de>
+							<all>${description_0}|${description_1}</all>
 						</descriptions>
 						<description_0>
 							<de>${gang} ${rioting} ${bikers} ${appears}${whythere_${k}}${causingtrouble}. Die ${who_${i}} ${solvetheconflict} ${intheirownway}.</de>
@@ -971,12 +935,8 @@
 							<de>Ärger|Panik|Pechsträhne|Chaos|Durcheinander|Desaster|Aufruhr|Krise|Aufregung|Verwüstung|Unruhe|Tumult|Eklat|Zoff|Krawall</de>
 							<en>Trouble|Panic|Streak of bad luck|Chaos|Mayhem|Disaster|Turmoil|Crisis|Commotion|Havoc|Unrest|Tumult|Uproar|Down and out|Riot</en>
 						</trouble>
-						<j>
-							<de>0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f|g|h</de> <!-- must be same count and elements as i -->
-						</j>
-						<k>
-							<de>0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f|g|h</de>
-						</k>
+						<j>0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f|g|h</j><!-- must be same count and elements as i -->
+						<k>0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f|g|h</k>
 						<whythere_0>
 							<de>, überrumpelt Petrus an der Himmelspforte und will dem ewigen Frieden ein für alle mal den Garaus zu machen</de>
 							<en>, overpowers St. Peter at the Gates of Heaven, and wants to put an end to eternal peace once and for all</en>
@@ -1077,9 +1037,7 @@
 							<de>auf ihre Weise|auf ihre ureigene Art|ganz auf ihre Weise|so, wie es nur sie können|ziemlich originell|auf überraschende Weise</de>
 							<en>in their own way|in their innate manner|in their very own way|as only they can|quite originally|in a surprising way</en>
 						</intheirownway>
-						<othertown>
-							<de>${.stationmap:"randomcity"}</de>
-						</othertown>
+						<othertown>${.stationmap:"randomcity"}</othertown>
 						<park>
 							<de>Der „${location_${k}}-Park“|Der „${location_${k}}-Vorgarten“|Der „${location_${k}}-Garten“|Der „${location_${k}}-Rosengarten“|Der „${location_${k}}-Blumengarten“|Die „${location_${k}}-Kantine“|Der „${location_${k}}-Platz“|Der „${location_${k}}-Spielplatz“|Der „${location_${k}}-Plaza“|Die „${location_${k}}-Piazza“|Die „${location_${k}}-Passage“|Die „${location_${k}}-Allee“|Der „${location_${k}}-Boulevard“</de>
 							<en>"${location_${k}} park"|"${location_${k}} frontyard"|"${location_${k}} garden"|"${location_${k}} rose garden"|"${location_${k}} flower garden"|"${location_${k}} cantina"|"${location_${k}} square"|"${location_${k}} playground"|"${location_${k}} plaza"|"${location_${k}} piazza"|"${location_${k}} arcade"|"${location_${k}} avenue"|"${location_${k}} boulevard"</en> <!-- TODO: apply capitalization function when available -->
@@ -1108,12 +1066,12 @@
 						<en>${meeting} in ${location_${k}}</en> <!-- TODO: apply capitalization function when available -->
 					</title>
 					<description>
-						<de>${descriptions}</de>
+						<all>${descriptions}</all>
 					</description>
 					<episodes min="1" max="2" />
 					<variables>
 						<descriptions>
-							<de>${description_0}|${description_1}</de>
+							<all>${description_0}|${description_1}</all>
 						</descriptions>
 						<description_0>
 							<de>Im ${location_${k}}${allstillright} ${whythere_${k}}</de>
@@ -1127,12 +1085,8 @@
 							<de>Treffen|Aufruhr|Fette Beute|Klamauk|Überraschungsfeier|Versammlung|Ringelpiez|Trubel|Wiedersehen|Begegnung|Spektakel|Scherz|Ereignis|Belustigung</de>
 							<en>Meeting|Riot|Fuss|Big booty|Surprise party|Gathering|Revelry|Hustle and bustle|Reunion|Encounter|Spectacle|Frolic|Happening|Merrymaking</en>
 						</meeting>
-						<j>
-							<de>0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f|g|h</de> <!-- must be same count and elements as i -->
-						</j>
-						<k>
-							<de>0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f|g|h</de>
-						</k>
+						<j>0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f|g|h</j><!-- must be same count and elements as i -->
+						<k>0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f|g|h</k>
 						<allstillright>
 							<de> ist die Welt noch in Ordnung.| ist alles in Ordnung.|, da lässt sich's aushalten.| ist alles gut.| gibt es nur gute Vibes.| ist's wie im Himmel.| ist die Stimmung stets ausgelassen.| ist die Luft voller Liebe und Freude.| ist jeder Tag ein Fest.| gibt es immer was zu feiern.| ist die Laune stets bestens.| gibt es nur strahlende Gesichter.| herrscht eine wunderbare Atmosphäre.| ist das Glück zu Hause.| scheint die Zeit stillzustehen.| gibt es keine Sorgen oder Probleme.| ist die Welt voller Magie.| fühlt man sich wie im siebten Himmel.</de>
 							<en>, all's right with the world.| everything's alright.|, life is comfortable and enjoyable.|, life is good.|, there are only good vibes.|, it's like heaven.|, the atmosphere is always lively.|, the air is full of love and joy.|, every day is a celebration.|, there is always something to celebrate.|, everyone is in high spirits.|, there are only smiles and joy.|, there is a wonderful atmosphere.|, happiness resides.|, time seems to stand still.|, there are no worries or troubles.|, the world is full of magic.|, it feels like being on cloud nine.</en>
@@ -1213,9 +1167,7 @@
 							<de>Eine improvisierte Volksmusik-Jam-Session findet statt. ${firstname2} hat eine sehr schöne Stimme.|Ein Chili-Kochwettbewerb findet statt gegen ${who_${j}} aus ${othertown}. ${firstname3} wird ganz heiß, es ist dann doch recht scharfes Chili.|Eine Handwerks-Challenge findet statt gegen ${who_${j}} aus ${othertown}. Der Ort gehört mal so richtig aufgemöbelt. ${firstname1} kann gut mit Hammer und Nägeln umgehen.|Eine alte Zeitkapsel wird entdeckt, die nostalgische Erinnerungen und eine Suche nach ihrem Besitzer auslöst. ${firstname1} denkt zurück an Elvis.|Eine Escape-Room-Challenge findet statt gegen ${who_${j}} aus ${othertown}. ${firstname2} und ${firstname3} stecken mal wieder fest. ${firstname1} befreit sie.|Eine Spendenaktion findet statt. ${firstname1} hat wie immer kein Kleingeld dabei.|Eine Hundetrainingsvorführung findet statt. ${firstname1} und ${firstname3} haben selber Hunde und zeigen allen, wie's geht.|Unsere ${who_${i}} sowie ${who_${j}} aus ${othertown} organisieren eine Schnitzeljagd. ${firstname1} und ${firstname3} verlaufen sich mal wieder. ${firstname2} sammelt sie wieder ein.|Ein Kochwettbewerb findet statt gegen gegen ${who_${j}} aus ${othertown}. ${firstname1} überzeugt mit einer italienisch-vietnamesischen Crossover-Cuisine-Kreation.|Plötzlich taucht ein Flashmob mit verrückten Künstlern auf. ${firstname1} packt den Hula-Hoop-Reifen aus und macht mit.|Eine versteckte Schatzkarte wird entdeckt. ${firstname1} und ${firstname2} sind ganz baff: Wo könnte denn nur diese Affeninsel sein?|Ein Talentwettbewerb findet statt. Kein Problem für unsere ${who_${i}}, sind ja offensichtlich die talentiertesten, wenn sie schon ein TVTower-Kamerateam dabei haben.</de>
 							<en>An impromptu country music jam session takes place. ${firstname2} has a very nice voice.|A chili cooking contest takes place against ${who_${j}} from ${othertown}. ${firstname3} gets all hot, it ends up being quite spicy chili.|A craft challenge takes place against ${who_${j}} from ${othertown}. The place really really needs to be spruced up. ${firstname1} is good with hammer and nails.|An old time capsule is discovered, triggering nostalgic memories and a search for its owner. ${firstname1} remembers and reflects on Elvis.|An escape room challenge takes place against ${who_${j}} from ${othertown}. ${firstname2} and ${firstname3} get stuck as always. ${firstname1} sets them free.|A fundraiser takes place. ${firstname1} has no change as usual.|A dog training demonstration takes place. ${firstname1} and ${firstname3} have dogs themselves and show everyone how it's done.|Our ${who_${i}} and ${who_${j}} from ${othertown} organize a scavenger hunt. ${firstname1} and ${firstname3} get lost as usual. ${firstname2} picks them up again.|A cooking competition takes place against ${who_${j}} from ${othertown}. ${firstname1} convinces with an Italian-Vietnamese crossover cuisine creation.|Suddenly a flash mob with crazy artists shows up. ${firstname1} unpacks the hula hoop and joins in.|A hidden treasure map is discovered. ${firstname1} and ${firstname2} are flabbergasted: Where could this ape island be?|A talent contest takes place. No problem for our ${who_${i}}, obviously they are the most talented, since they already have a TVTower camera team with them.</en>
 						</musicsession>
-						<othertown>
-							<de>${.stationmap:"randomcity"}</de>
-						</othertown>
+						<othertown>${.stationmap:"randomcity"}</othertown>
 						<bar>
 							<de>Die ${location_${k}}-Bar|Der ${location_${k}}-Stadl|Der ${location_${k}}-Garten|Der ${location_${k}}-Biergarten|Das ${location_${k}}-Bierzelt|Die ${location_${k}}-Nachtgalerie|Die ${location_${k}}-Nachtkantine|Das ${location_${k}}-Festival</de>
 							<en>${location_${k}} bar|${location_${k}} barn|${location_${k}} garden|${location_${k}} beer garden|${location_${k}} beer tent|${location_${k}} night arcade|${location_${k}} night-cantina|${location_${k}} festival</en> <!-- TODO: apply capitalization function when available -->
@@ -1251,8 +1203,7 @@
 		<!-- === SERIES === -->
 		<scripttemplate product="2" licence_type="3" guid="scripttemplate-random-ron-animalseries01" comment="English title vs text casings">
 			<title>
-				<de>${TITLE}</de>
-				<en>${TITLE}</en>
+				<all>${TITLE}</all>
 			</title>
 			<description>
 				<de>Dokumentation über ${ANIMALS}.
@@ -1264,43 +1215,37 @@ ${EXTRA}</en>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="scripttemplate-random-ron-animalseries01_01">
 					<title>
-						<de>${TITLEEPISODE1}</de>
-						<en>${TITLEEPISODE1}</en>
+						<all>${TITLEEPISODE1}</all>
 					</title>
 					<blocks min="1" max="1" />
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="scripttemplate-random-ron-animalseries01_02">
 					<title>
-						<de>${TITLEEPISODE2}</de>
-						<en>${TITLEEPISODE2}</en>
+						<all>${TITLEEPISODE2}</all>
 					</title>
 					<blocks min="1" max="1" />
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="scripttemplate-random-ron-animalseries01_03">
 					<title>
-						<de>${TITLEEPISODE3}</de>
-						<en>${TITLEEPISODE3}</en>
+						<all>${TITLEEPISODE3}</all>
 					</title>
 					<blocks min="1" max="1" />
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="scripttemplate-random-ron-animalseries01_04">
 					<title>
-						<de>${TITLEEPISODE4}</de>
-						<en>${TITLEEPISODE4}</en>
+						<all>${TITLEEPISODE4}</all>
 					</title>
 					<blocks min="1" max="1" />
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="scripttemplate-random-ron-animalseries01_05">
 					<title>
-						<de>${TITLEEPISODE5}</de>
-						<en>${TITLEEPISODE5}</en>
+						<all>${TITLEEPISODE5}</all>
 					</title>
 					<blocks min="1" max="1" />
 				</scripttemplate>
 				<scripttemplate index="5" product="2" licence_type="2" guid="scripttemplate-random-ron-animalseries01_06">
 					<title>
-						<de>${TITLEEPISODE6}</de>
-						<en>${TITLEEPISODE6}</en>
+						<all>${TITLEEPISODE6}</all>
 					</title>
 					<blocks min="1" max="1" />
 				</scripttemplate>
@@ -1414,9 +1359,7 @@ ${EXTRA}</en>
 				<en>As every evening, a guest is expected, often a star in the realm of literature, and his or her new book is discussed.</en>
 			</description>
 			<variables>
-				<currentyear>
-					<de>${.worldtime:"year"}</de>
-				</currentyear>
+				<currentyear>${.worldtime:"year"}</currentyear>
 			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" /> <!-- TODO: preselection -->
@@ -1449,9 +1392,7 @@ ${EXTRA}</en>
 				<en>Betty Botterblom (or a stand-in) tells exclusively about the latest cultural achievements of the free West.</en>
 			</description>
 			<variables>
-				<currentyear>
-					<de>${.worldtime:"year"}</de>
-				</currentyear>
+				<currentyear>${.worldtime:"year"}</currentyear>
 			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" /> <!-- TODO: preselection -->
@@ -1482,9 +1423,7 @@ ${EXTRA}</en>
 				<en>The politics format. Politicians answer questions about the state of the nation.</en>
 			</description>
 			<variables>
-				<currentyear>
-					<de>${.worldtime:"year"}</de>
-				</currentyear>
+				<currentyear>${.worldtime:"year"}</currentyear>
 			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1519,9 +1458,7 @@ Spannende Unterhaltung und knifflige Fragen.</de>
 Exciting entertainment and brain-teasing trivia questions.</en>
 			</description>
 			<variables>
-				<currentyear>
-					<de>${.worldtime:"year"}</de>
-				</currentyear>
+				<currentyear>${.worldtime:"year"}</currentyear>
 			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" /> <!-- TODO: preselection -->
@@ -1551,9 +1488,7 @@ Exciting entertainment and brain-teasing trivia questions.</en>
 				<en>Only on television and nowhere else are these junk items to be auctioned off to the unsuspecting.</en>
 			</description>
 			<variables>
-				<currentyear>
-					<de>${.worldtime:"year"}</de>
-				</currentyear>
+				<currentyear>${.worldtime:"year"}</currentyear>
 			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" /> <!-- TODO: preselection -->
@@ -1579,9 +1514,7 @@ Exciting entertainment and brain-teasing trivia questions.</en>
 				<en>Here, men compete against women. The gender with the most calls wins.</en>
 			</description>
 			<variables>
-				<currentyear>
-					<de>${.worldtime:"year"}</de>
-				</currentyear>
+				<currentyear>${.worldtime:"year"}</currentyear>
 			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" /> <!-- TODO: preselection -->
@@ -1608,9 +1541,7 @@ Exciting entertainment and brain-teasing trivia questions.</en>
 				<en>The teledialogue surveys viewers to topics of high significance. Opinion-forming and gainful.</en>
 			</description>
 			<variables>
-				<currentyear>
-					<de>${.worldtime:"year"}</de>
-				</currentyear>
+				<currentyear>${.worldtime:"year"}</currentyear>
 			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" /> <!-- TODO: preselection -->
@@ -1636,9 +1567,7 @@ Exciting entertainment and brain-teasing trivia questions.</en>
 				<en>The teledialogue surveys viewers to topics of high significance. Opinion-forming and gainful.</en>
 			</description>
 			<variables>
-				<currentyear>
-					<de>${.worldtime:"year"}</de>
-				</currentyear>
+				<currentyear>${.worldtime:"year"}</currentyear>
 			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" /> <!-- TODO: preselection -->
@@ -1664,9 +1593,7 @@ Exciting entertainment and brain-teasing trivia questions.</en>
 				<en>The teledialogue surveys viewers to topics of high significance. Opinion-forming and gainful.</en>
 			</description>
 			<variables>
-				<currentyear>
-					<de>${.worldtime:"year"}</de>
-				</currentyear>
+				<currentyear>${.worldtime:"year"}</currentyear>
 			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" /> <!-- TODO: preselection -->
@@ -1692,9 +1619,7 @@ Exciting entertainment and brain-teasing trivia questions.</en>
 				<en>The teledialogue surveys viewers to topics of high significance. Opinion-forming and gainful.</en>
 			</description>
 			<variables>
-				<currentyear>
-					<de>${.worldtime:"year"}</de>
-				</currentyear>
+				<currentyear>${.worldtime:"year"}</currentyear>
 			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" /> <!-- TODO: preselection -->
@@ -1720,9 +1645,7 @@ Exciting entertainment and brain-teasing trivia questions.</en>
 				<en>Short quiz sessions for dimwitted callers. The questions asked are about currently published pulp novels.</en>
 			</description>
 			<variables>
-				<currentyear>
-					<de>${.worldtime:"year"}</de>
-				</currentyear>
+				<currentyear>${.worldtime:"year"}</currentyear>
 			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" /> <!-- TODO: preselection -->
@@ -1748,9 +1671,7 @@ Exciting entertainment and brain-teasing trivia questions.</en>
 				<en>Shabby call-in show in which candidates have to recognize celebrities' breasts. At most, it's the broadcaster who's winning here.</en>
 			</description>
 			<variables>
-				<currentyear>
-					<de>${.worldtime:"year"}</de>
-				</currentyear>
+				<currentyear>${.worldtime:"year"}</currentyear>
 			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" /> <!-- TODO: preselection -->
@@ -1778,9 +1699,7 @@ Exciting entertainment and brain-teasing trivia questions.</en>
 				<en>Two clairvoyants confuse with blurred interpretations of their callers' future and past.</en>
 			</description>
 			<variables>
-				<currentyear>
-					<de>${.worldtime:"year"}</de>
-				</currentyear>
+				<currentyear>${.worldtime:"year"}</currentyear>
 			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" /> <!-- TODO: preselection (and mention in the description like in the programme version) -->
@@ -1800,17 +1719,14 @@ Exciting entertainment and brain-teasing trivia questions.</en>
 		</scripttemplate>
 		<scripttemplate product="3" licence_type="1" guid="fb34ed9a-528e-45a9-83b9-16475c2ab67c" creator="" comment="Screenplay version / continuation of cf19bea6-f3ae-4ea1-92fb-3bccc8d5c9e3 | deliberately not a series format in the screenplay version">
 			<title>
-				<de>Hot Quiz ${currentyear}</de>
-				<en>Hot Quiz ${currentyear}</en>
+				<all>Hot Quiz ${currentyear}</all>
 			</title>
 			<description>
 				<de>Die Moderatorin macht sich nackig und die Anrufer arm. Brüste gegen Geld, wie im echten Leben.</de>
 				<en>The presenter gets naked and the callers poor. Breasts for money, like in real life.</en>
 			</description>
 			<variables>
-				<currentyear>
-					<de>${.worldtime:"year"}</de>
-				</currentyear>
+				<currentyear>${.worldtime:"year"}</currentyear>
 			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" /> <!-- TODO: preselection -->
@@ -1837,9 +1753,7 @@ Exciting entertainment and brain-teasing trivia questions.</en>
 				<en>Speed chess against the grandmasters. Call in, manage to get through, and checkmate the grandmaster. Use your brains, study, lose money in the waiting loop. The complete all-inclusive service package.</en>
 			</description>
 			<variables>
-				<currentyear>
-					<de>${.worldtime:"year"}</de>
-				</currentyear>
+				<currentyear>${.worldtime:"year"}</currentyear>
 			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" /> <!-- TODO: preselection -->
@@ -1865,9 +1779,7 @@ Exciting entertainment and brain-teasing trivia questions.</en>
 				<en>The most beautiful breasts in the world. Discreetly packaged. Nothing and yet much to see. The sophisticated erotic show with interludes about the culture of the respective country. Even critics were able to make friends with it.</en>
 			</description>
 			<variables>
-				<currentyear>
-					<de>${.worldtime:"year"}</de>
-				</currentyear>
+				<currentyear>${.worldtime:"year"}</currentyear>
 			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" /> <!-- TODO: preselection -->

--- a/res/database/Default/database_scripts.xml
+++ b/res/database/Default/database_scripts.xml
@@ -146,12 +146,10 @@
 				<!-- international title for all incarnations - so "de" is enough -->
 				<!-- scr0llbaer: that may be true, but probably still not a good idea, because someone might add nested variables later, which then would resolve into German. EDIT: addressed in https://github.com/TVTower/TVTower/pull/906 -->
 				<object>
-					<de>Cannons|Guns|Ropes|Knives|Jaws|Dynamite|Bones</de>
-					<en>Cannons|Guns|Ropes|Knives|Jaws|Dynamite|Bones</en>
+					<all>Cannons|Guns|Ropes|Knives|Jaws|Dynamite|Bones</all>
 				</object>
 				<adjective>
-					<de>Flying|Burning|Bloody|Rusty|Explosive|Violent|Cruel|Cool|Gangster|Red|Guilty</de>
-					<en>Flying|Burning|Bloody|Rusty|Explosive|Violent|Cruel|Cool|Gangster|Red|Guilty</en>
+					<all>Flying|Burning|Bloody|Rusty|Explosive|Violent|Cruel|Cool|Gangster|Red|Guilty</all>
 				</adjective>
 				<job>
 					<de>Ex-Cop|Feuerwehrmann|Chefarzt|Bestatter|Grundschullehrer|Klimaforscher|Paläontologe</de>
@@ -485,8 +483,7 @@
 					<en>Washer Women</en> <!-- always capitalized for now, even in flow-text. TODO: possibly change as soon as capitalization per expression available. -->
 				</who_0>
 				<who_1>
-					<de>Drag-Queens</de>
-					<en>Drag-Queens</en>
+					<all>Drag-Queens</all>
 				</who_1>
 				<who_2>
 					<de>Schwerenöter</de>
@@ -501,8 +498,7 @@
 					<en>Lifeguards</en>
 				</who_4>
 				<who_5>
-					<de>Clowns</de>
-					<en>Clowns</en>
+					<all>Clowns</all>
 				</who_5>
 				<who_6>
 					<de>Krankenpfleger</de>

--- a/res/database/Default/user/ariksan.xml
+++ b/res/database/Default/user/ariksan.xml
@@ -4,8 +4,7 @@
 	<scripttemplates>
 		<scripttemplate product="2" licence_type="3" guid="script-ariksan-mkw" creator="9621" comment="inspired by German realtor docu soaps">
 			<title>
-				<de>${title} (${randomcity})</de>
-				<en>${title} (${randomcity})</en>
+				<all>${title} (${randomcity})</all>
 			</title>
 			<description>
 				<de>Makler versuchen Wohnungen und Häuser an Kunden mit ungewöhnlichen Ansprüchen zu verkaufen oder zu vermieten. Ob Geisterjäger oder Zirkusartisten - die skurrilen Kunden lassen die Makler an ihre Grenzen gehen und sorgen für jede Menge Unterhaltung.</de>
@@ -16,19 +15,15 @@
 					<de>Träumen, Planen, Pleitegehen|Zoff, Zank, Abbruchbude|Himmel, Hölle, Hinterhof|Pech, Pannen, Pfusch|Vermieten, Verkaufen, Verzweifeln|Rausch, Reue, Ratenzahlung|Luxus, Lügen, Leerstand|Wohnen, Wunder, Wahnsinn|Traumhaus, Tränen, Trennungsschmerz|Schimmel, Schäden, Rost|Düster, Trostlos, Öde|Ratenzahlung, Rost, Bankrott|Suchen, Finden, Blechen|Renovieren, Sanieren, Abkassieren</de>
 					<en>Dreaming, Planning, Bankruptcy|Conflict, Quarrel, Breakdown|Cheating, Building, Bankruptcy|Luxury, Lies, Vacancy|Excess, Regret, Installment Plan|Miracle, Madness, Living|Cheap, Big, Dangerous|Rent, Spent, Repent|Bore, Explore, Adore|Sign, Align, Decline|Rent, Buy, Cry|Live, Obtain, Groan|Lease, Purchase, Debt|Place, Embrace, Palatial-Grace</en>
 				</title>
-				<randomcity>
-					<de>${.stationmap:"randomcity"}</de>
-				</randomcity>
+				<randomcity>${.stationmap:"randomcity"}</randomcity>
 			</variables>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="script-ariksan-mkw01">
 					<title>
-						<de>${titleprefix} ${wohnobjekt}</de>
-						<en>${titleprefix} ${wohnobjekt}</en>
+						<all>${titleprefix} ${wohnobjekt}</all>
 					</title>
 					<description>
-						<de>${wohn${wohnselector}}</de>
-						<en>${wohn${wohnselector}}</en>
+						<all>${wohn${wohnselector}}</all>
 					</description>
 					<variables>
 						<suchende_person>
@@ -56,16 +51,14 @@
 							<en>tries to sell ${wohnobjekt} to ${suchende_person2}|tries to rent out a ${wohnobjekt} to ${suchende_person2}|tries to foist ${wohnobjekt} upon ${suchende_person2}</en>
 						</artofthedeal>
 						<wohnsucher>
-							<de>${suchende_person} ${wohnobjekt} ${wohngrund}</de>
-							<en>${suchende_person} ${wohnobjekt} ${wohngrund}</en>
+							<all>${suchende_person} ${wohnobjekt} ${wohngrund}</all>
 						</wohnsucher>
 						<wohnfinder>
 							<de>Der Makler versucht, ${suchende_person2} ${wohnobjekt} ${artofthedeal}.</de>
 							<en>The realtor ${artofthedeal}.</en>
 						</wohnfinder>
 						<wohnselector>
-							<de>finder|sucher</de>
-							<en>finder|sucher</en>
+							<all>finder|sucher</all>
 						</wohnselector>
 					</variables>
 					<episodes value="8" />
@@ -126,8 +119,7 @@
 		</scripttemplate>
 		<scripttemplate product="2" licence_type="3" guid="script-ariksan-flavor" creator="9621" comment="very loosely inspired by kitchen nightmares TODO change job to chef when available">
 			<title>
-				<de>${title} - ${currentyear} Edition</de>
-				<en>${title} - ${currentyear} Edition</en>
+				<all>${title} - ${currentyear} Edition</all>
 			</title>
 			<description>
 				<de>Mutige Köche stürzen sich in kulinarische Missgeschicke. Von schrägen Kombinationen bis zu absurden Geschmacksexperimenten - ein Fest der Gaumenverwirrung und ein Fiasko für den guten Geschmack!</de>
@@ -138,9 +130,7 @@
 					<de>Geschmacksdesaster|Essensrausch|Küchenkatastrophen|Kulinarische Katastrophen|Das Küchenchaos|Die Gourmet-Patzer|Kulinarische Gemetzel|Das Feinschmecker-Experiment|Food Fiasco|Kulinarischer Kataklysmus|Geschmacksversagen|Menü Mayhem|Küchenkataklysmus|Rezeptdesaster</de>
 					<en>Flavor Fiasco|Food Frenzy|Kitchen Catastrophes|Culinary Calamities|Cooking Chaos|Gourmet Gaffes|Culinary Carnage|Chef's Nightmares|Food Fiasco|Cuisine Cataclysm|Flavor Failures|Menu Mayhem|Kitchen Cataclysm|Recipe Reckoning</en>
 				</title>
-				<currentyear>
-					<de>${.worldtime:"year"}</de>
-				</currentyear>
+				<currentyear>${.worldtime:"year"}</currentyear>
 			</variables>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="script-ariksan-flavor01">
@@ -192,8 +182,7 @@
 		</scripttemplate>
 		<scripttemplate product="2" licence_type="3" guid="script-ariksan-storage" creator="9621" comment="inspired by storage wars">
 			<title>
-				<de>${title} ${currentyear} Edition</de>
-				<en>${title} ${currentyear} Edition</en>
+				<all>${title} ${currentyear} Edition</all>
 			</title>
 			<description>
 				<de>Begleiten Sie eine Gruppe von „Schatzjägern“ in einem erbitterten Kampf um vergessenen Trödel und wertlosen Gerümpel. In verstaubten Lagereinheiten wird jeder Ramsch zur potenziellen Goldgrube!</de>
@@ -204,27 +193,15 @@
 					<de>Schrott-Spektakel|Kram-Konundrum|Trödelkriege|Schrottkriege|Schrott-Schlacht</de>
 					<en>Trash Treasures|Storage Mayhem|Clutter Clash|Dumpster Dazzle|Junk Journey</en>
 				</title>
-				<person1>
-					<de>${.persongenerator:"firstname":"us":"male"}</de>
-				</person1>
-				<person2>
-					<de>${.persongenerator:"firstname":"us":"female"}</de>
-				</person2>
-				<person3>
-					<de>${.persongenerator:"firstname":"it":"male"}</de>
-				</person3>
-				<person4>
-					<de>${.persongenerator:"firstname":"de":"female"}</de>
-				</person4>
-				<currentyear>
-					<de>${.worldtime:"year"}</de>
-				</currentyear>
+				<person1>${.persongenerator:"firstname":"us":"male"}</person1>
+				<person2>${.persongenerator:"firstname":"us":"female"}</person2>
+				<person3>${.persongenerator:"firstname":"it":"male"}</person3>
+				<person4>${.persongenerator:"firstname":"de":"female"}</person4>
+				<currentyear>${.worldtime:"year"}</currentyear>
 			</variables>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="script-ariksan-storage-01">
-					<title>
-						<de>${.stationmap:"randomcity"}</de>
-					</title>
+					<title>${.stationmap:"randomcity"}</title>
 					<description>
 						<de>${person1} und ${person2} zanken sich mit ${person3} um ${treasure}. ${person4} hat Glück im Unglück und kann ${junk} verhökern.</de>
 						<en>${person1} und ${person2} get into a fight with ${person3} over ${treasure}. ${person4} has luck in misfortune and sells off ${junk}.</en>
@@ -241,18 +218,14 @@
 					</variables>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="script-ariksan-storage-02">
-					<title>
-						<de>${.stationmap:"randomcity"}</de>
-					</title>
+					<title>${.stationmap:"randomcity"}</title>
 					<description>
 						<de>Der Auktionator hat sich verfahren. Also übernimmt ${person4} seine Rolle. Chaos pur! ${person1} und ${person2} bieten mit ${person3} um die Wette.</de>
 						<en>The auctioneer has gotten lost. ${person4} takes over his role. Chaos ensues! ${person1} and ${person2} compete against ${person3}.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="script-ariksan-storage-03">
-					<title>
-						<de>${.stationmap:"randomcity"}</de>
-					</title>
+					<title>${.stationmap:"randomcity"}</title>
 					<description>
 						<de>${person1} und ${person2} haben sich zerstritten und bieten heute gegeneinander. ${person4} zieht den Jackpot und sichert sich ${treasure}.</de>
 						<en>${person1} and ${person2} have had a falling out and are bidding against each other. ${person4} hits the jackpot and secures ${treasure}.</en>
@@ -265,9 +238,7 @@
 					</variables>
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="script-ariksan-storage-04">
-					<title>
-						<de>${.stationmap:"randomcity"}</de>
-					</title>
+					<title>${.stationmap:"randomcity"}</title>
 					<!--TODO soll treasure hier der gleiche Gegenstand wie in der vorigen Folge sein?-->
 					<description>
 						<de>${person1} und ${person2} haben sich noch immer nicht versöhnt. ${person3} kippt einen Kaffee auf ${treasure}.</de>
@@ -281,9 +252,7 @@
 					</variables>
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="script-ariksan-storage-05">
-					<title>
-						<de>${.stationmap:"randomcity"}</de>
-					</title>
+					<title>${.stationmap:"randomcity"}</title>
 					<description>
 						<de>${person1} und ${person2} haben sich insgeheim versöhnt und tricksen alle aus. Sie finden ${treasure}.</de>
 						<en>${person1} and ${person2} have secretly reconciled and outsmart the others, finding ${treasure}.</en>
@@ -296,9 +265,7 @@
 					</variables>
 				</scripttemplate>
 				<scripttemplate index="5" product="2" licence_type="2" guid="script-ariksan-storage-06">
-					<title>
-						<de>${.stationmap:"randomcity"}</de>
-					</title>
+					<title>${.stationmap:"randomcity"}</title>
 					<description>
 						<de>Ein neuer Bieter räumt ab. ${person1}, ${person2} und ${person4} sehen zu, wie er ${treasure} findet.</de>
 						<en>A new bidder outbids everyone. ${person1}, ${person2} and ${person4} watch as he walks away with ${treasure}.</en>
@@ -311,18 +278,14 @@
 					</variables>
 				</scripttemplate>
 				<scripttemplate index="6" product="2" licence_type="2" guid="script-ariksan-storage-07">
-					<title>
-						<de>${.stationmap:"randomcity"}</de>
-					</title>
+					<title>${.stationmap:"randomcity"}</title>
 					<description>
 						<de>Skandal, der neue Bieter ist da. ${person1} und ${person2} schäumen vor Wut. ${person4} schafft es doch noch eine Lagereinheit zu ergattern.</de>
 						<en>The new bidder returns triumphantly. Frustration boils within ${person1} and ${person2}. However, ${person4} manages to secure a storage unit.</en>
 					</description>
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="script-ariksan-storage-08">
-					<title>
-						<de>${.stationmap:"randomcity"}</de>
-					</title>
+					<title>${.stationmap:"randomcity"}</title>
 					<description>
 						<de>Es stellt sich heraus, dass der neue Bieter in Wirklichkeit ${person3} in einer genialen Verkleidung ist. Alle lachen sich krumm.</de>
 						<en>Hilarity ensues as it turns out that the new bidder is, in fact, ${person3} in a genius disguise. Everyone laughs hysterically.</en>
@@ -358,9 +321,7 @@
 				<en>Fun and facts with the ${animal} and the tiny ${animal2}. Children explore the world with the ${adjective} ${animal} and the tiny ${animal2} who also present funny clips and stories.</en>
 			</description>
 			<variables>
-				<variant>
-					<de>m|w</de>
-				</variant>
+				<variant>m|w</variant>
 				<tier_m>
 					<de>Kautz|Strauß|Tiger|Schwan|Jaguar|Fuchs|Wolf|Widder|Hund|Gorilla|Hahn</de>
 					<en>Rook|Ostrich|Tiger|Swan|Jaguar|Fox|Wolf|Ram|Dog|Gorilla|Rooster</en>
@@ -369,6 +330,7 @@
 					<de>Laus|Katze|Gans|Möwe|Schlange|Ziege|Biene|Hummel|Taube|Ente|Spinne|Giraffe</de>
 					<en>Louse|Cat|Goose|Gull|Snake|Goat|Bee|Bumblebee|Dove|Duck|Spider|Giraffe</en>
 				</tier_w>
+				<!--leaving pattern for language sepcific grammar forms even if used only in German for now-->
 				<dativ_m>
 					<de>dem</de>
 				</dativ_m>
@@ -382,7 +344,7 @@
 					<de>Die</de>
 				</nominativ_w>
 				<animal>
-					<en>${tier_${variant}}</en>
+					<all>${tier_${variant}}</all>
 				</animal>
 				<animal2>
 					<de>Nashorn|Flusspferd|Pferd|Stachelschwein|Schaf|Huhn|Kamel|Walross|Krokodil</de>
@@ -484,27 +446,14 @@
 			</description>
 			<variables>
 				<title>
-					<de>Santa Monica, 90405|San Diego 92110|Santa Cruz, 95060|Newport Beach, 92660|Huntington Beach, 92648|Long Beach, 90840|La Jolla, 92037|Santa Barbara, 93101|San Francisco, 94110|Palo Alto, 94301|Laguna Beach, 92651|Manhattan Beach, 90266|Venice Beach, 90291|San Clemente, 92672|Santa Cruz, 95060|Pacific Beach, 92109|Morro Bay, 93442|Monterey Bay, 93940</de>
-					<en>Santa Monica, 90405|San Diego 92110|Santa Cruz, 95060|Newport Beach, 92660|Huntington Beach, 92648|Long Beach, 90840|La Jolla, 92037|Santa Barbara, 93101|San Francisco, 94110|Palo Alto, 94301|Laguna Beach, 92651|Manhattan Beach, 90266|Venice Beach, 90291|San Clemente, 92672|Santa Cruz, 95060|Pacific Beach, 92109|Morro Bay, 93442|Monterey Bay, 93940</en>
+					<all>Santa Monica, 90405|San Diego 92110|Santa Cruz, 95060|Newport Beach, 92660|Huntington Beach, 92648|Long Beach, 90840|La Jolla, 92037|Santa Barbara, 93101|San Francisco, 94110|Palo Alto, 94301|Laguna Beach, 92651|Manhattan Beach, 90266|Venice Beach, 90291|San Clemente, 92672|Santa Cruz, 95060|Pacific Beach, 92109|Morro Bay, 93442|Monterey Bay, 93940</all>
 				</title>
-				<person1_m>
-					<de>${.persongenerator:"firstname":"us":"male"}</de>
-				</person1_m>
-				<person2_m>
-					<de>${.persongenerator:"firstname":"us":"male"}</de>
-				</person2_m>
-				<person3_m>
-					<de>${.persongenerator:"firstname":"us":"male"}</de>
-				</person3_m>
-				<person1_w>
-					<de>${.persongenerator:"firstname":"us":"female"}</de>
-				</person1_w>
-				<person2_w>
-					<de>${.persongenerator:"firstname":"us":"female"}</de>
-				</person2_w>
-				<person3_w>
-					<de>${.persongenerator:"firstname":"us":"female"}</de>
-				</person3_w>
+				<person1_m>${.persongenerator:"firstname":"us":"male"}</person1_m>
+				<person2_m>${.persongenerator:"firstname":"us":"male"}</person2_m>
+				<person3_m>${.persongenerator:"firstname":"us":"male"}</person3_m>
+				<person1_w>${.persongenerator:"firstname":"us":"female"}</person1_w>
+				<person2_w>${.persongenerator:"firstname":"us":"female"}</person2_w>
+				<person3_w>${.persongenerator:"firstname":"us":"female"}</person3_w>
 			</variables>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="script-ariksan-bever-01">

--- a/res/database/Default/user/cujo.xml
+++ b/res/database/Default/user/cujo.xml
@@ -324,10 +324,7 @@
 		</ad>
 		<!-- Duplo -->
 		<ad guid="cujo-werbung-pludo" comment="https://de.wikipedia.org/wiki/Duplo_(Schokoriegel)">
-			<title>
-				<de>Pludo</de>
-				<pl>Pludo</pl>
-			</title>
+			<title>Pludo</title>
 			<description>
 				<de>Pludo - Der wahrscheinlich längste Schokoriegel der Welt - Neu: Sonderaktion - 9 Riegel zum Preis von 11</de>
 				<en>Pludo - Probably the longest chocolate bar in the world - New: Special offer - 9 bars for the price of 11</en>

--- a/res/database/Default/user/eggi_screenplays_adaptations.xml
+++ b/res/database/Default/user/eggi_screenplays_adaptations.xml
@@ -5,12 +5,10 @@
 	<scripttemplates>
 		<scripttemplate product="1" licence_type="1" guid="ab31c2dd-46f4-4736-81b7-830c73af9ddf" creator="discord/eggi72" comment="https://en.wikipedia.org/wiki/Nathan_Hill_(writer) | https://www.goodreads.com/book/show/65650229-wellness">
 			<title>
-				<de>Hellness</de>
-				<en>Hellness</en>
+				<all>Hellness</all>
 			</title>
 			<title_original>
-				<de>Wellness</de>
-				<en>Wellness</en>
+				<all>Wellness</all>
 			</title_original>
 			<description>
 				<de>${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"}, ungleiches Paar in der Kunstszene Chicagos, kämpfen gegen Eheprobleme. Zwischen Achtsamkeitsseminaren und Immobilienträumen müssen sie ihre Vergangenheit bewältigen, um ihre Liebe zu retten.</de>

--- a/res/database/Default/user/kasi.xml
+++ b/res/database/Default/user/kasi.xml
@@ -11,9 +11,7 @@
 		<!--Kult optional, kein Trash-->
 		<scripttemplate licence_type="1" product="1" guid="Kasi-Script-Superheros" comment="TODO: Now that plenty of 'real' Marvel stuff is in the game, perhaps introduce 'Moval' not as a spoof but a cheap-rip-off">
 			<title>
-				<de>${HERO}</de>
-				<en>${HERO}</en>
-				<pl>${HERO}</pl>
+				<all>${HERO}</all>
 			</title>
 			<description>
 				<de>Heldenverfilmung aus den bekannten Moval-Comics. ${HERO} kämpft gegen einen neuen Superschurken und rettet die Welt.</de>
@@ -193,14 +191,10 @@
 			</description>
 			<variables>
 				<name1>
-					<de>Jennifer|Carolin|Jacky|Maria|Hannah|Helene|Ivanka</de>
-					<en>Jennifer|Carolin|Jacky|Maria|Hannah|Helene|Ivanka</en>
-					<pl>Jennifer|Carolin|Jacky|Maria|Hannah|Helene|Ivanka</pl>
+					<all>Jennifer|Carolin|Jacky|Maria|Hannah|Helene|Ivanka</all>
 				</name1>
 				<name2>
-					<de>Miller|Jackobson|Smith|Bloomberg|Gate|Johnson|Petersen</de>
-					<en>Miller|Jackobson|Smith|Bloomberg|Gate|Johnson|Petersen</en>
-					<pl>Miller|Jackobson|Smith|Bloomberg|Gate|Johnson|Petersen</pl>
+					<all>Miller|Jackobson|Smith|Bloomberg|Gate|Johnson|Petersen</all>
 				</name2>
 			</variables>
 			<jobs>
@@ -246,8 +240,7 @@
 					<pl>Jingela|Wollo|Huberta|Billiego|Fluffiego|Bobo|Neo</pl>
 				</Name>
 				<title>
-					<de>Mister |Little |Big |Mac</de>
-					<en>Mister |Little |Big |Mac</en>
+					<all>Mister |Little |Big |Mac</all>
 					<!--In Polish, not required. I had to rewrite it to make it grammatically ok.  -->
 				</title>
 			</variables>
@@ -892,11 +885,7 @@
 			</description>
 			<children>
 				<scripttemplate licence_type="2" product="2" index="0" guid="Kasi-script-Nerdszusammen-Ep1">
-					<title>
-						<de>Pilot</de>
-						<en>Pilot</en>
-						<pl>Pilot</pl>
-					</title>
+					<title>Pilot</title>
 					<description>
 						<de>Sie werden Streber, Schleimer oder Fettsäcke genannt. Doch all dies führt dazu, dass die Nerds erkennnen, dass sie durch Lernen viel besser werden können als alle anderen. Als dann ein FBI-Agent versehntlich die Nerds kontaktiert, um Aufträge zu erledigen, werden diese aktiv.</de>
 						<en>They are called geeks, suck-ups or fatties. But all this leads the nerds to realize that by studying they can become much better than everyone else. When then an FBI agent accidentally contacts the nerds asking them to do missions, they take action.</en>
@@ -1083,11 +1072,7 @@
 			</description>
 			<children>
 				<scripttemplate licence_type="2" product="2" index="0" guid="Kasi-script-Kinderfliegen-Ep1">
-					<title>
-						<de>Pilot</de>
-						<en>Pilot</en>
-						<pl>Pilot</pl>
-					</title>
+					<title>Pilot</title>
 					<description>
 						<de>Kinder träumen von vielen Dingen, aber manchmal sind sie auch erreichbar. Der Traum vom Fliegen packt eine Gruppe junger Menschen aus ${wo}. Sie versuchen alles, um ihren Traum zu verwirklichen.</de>
 						<en>Children dream of many things, some may even be attainable. The dream of flying captivates a group of young people from ${wo}. They try everything to make their dream come true.</en>
@@ -1243,9 +1228,7 @@
 					<en>Paris|Berlin|London|New York|Madrid|${randomcity}</en>
 					<pl>Paryżem|Berlinem|Londynem|Nowym Jorkiem|Madrytem|Wrocławiem</pl>
 				</wo>
-				<randomcity>
-					<de>${.stationmap:"randomcity"}</de>
-				</randomcity>
+				<randomcity>${.stationmap:"randomcity"}</randomcity>
 			</variables>
 			<jobs>
 				<job function="1" index="0" required="1" />
@@ -1657,14 +1640,10 @@
 			</description>
 			<variables>
 				<name1>
-					<de>Jennifer|Carolin|Jacky|Maria|Hannah|Helene|Ivanka</de>
-					<en>Jennifer|Carolin|Jacky|Maria|Hannah|Helene|Ivanka</en>
-					<pl>Jennifer|Carolin|Jacky|Maria|Hannah|Helene|Ivanka</pl>
+					<all>Jennifer|Carolin|Jacky|Maria|Hannah|Helene|Ivanka</all>
 				</name1>
 				<name2>
-					<de>Miller|Jackobson|Smith|Bloomberg|Gates|Johnson|Petersen</de>
-					<en>Miller|Jackobson|Smith|Bloomberg|Gates|Johnson|Petersen</en>
-					<pl>Miller|Jackobson|Smith|Bloomberg|Gates|Johnson|Petersen</pl>
+					<all>Miller|Jackobson|Smith|Bloomberg|Gates|Johnson|Petersen</all>
 				</name2>
 			</variables>
 			<jobs>
@@ -1699,14 +1678,10 @@
 			</description>
 			<variables>
 				<name1>
-					<de>Jennifer|Carolin|Jacky|Maria|Hannah|Helene|Ivanka</de>
-					<en>Jennifer|Carolin|Jacky|Maria|Hannah|Helene|Ivanka</en>
-					<pl>Jennifer|Carolin|Jacky|Maria|Hannah|Helene|Ivanka</pl>
+					<all>Jennifer|Carolin|Jacky|Maria|Hannah|Helene|Ivanka</all>
 				</name1>
 				<name2>
-					<de>Miller|Jackobson|Smith|Bloomberg|Gates|Johnson|Petersen</de>
-					<en>Miller|Jackobson|Smith|Bloomberg|Gates|Johnson|Petersen</en>
-					<pl>Miller|Jackobson|Smith|Bloomberg|Gates|Johnson|Petersen</pl>
+					<all>Miller|Jackobson|Smith|Bloomberg|Gates|Johnson|Petersen</all>
 				</name2>
 			</variables>
 			<jobs>
@@ -1742,14 +1717,10 @@
 			</description>
 			<variables>
 				<name1>
-					<de>Jennifer|Carolin|Jacky|Maria|Hannah|Helene|Ivanka</de>
-					<en>Jennifer|Carolin|Jacky|Maria|Hannah|Helene|Ivanka</en>
-					<pl>Jennifer|Carolin|Jacky|Maria|Hannah|Helene|Ivanka</pl>
+					<all>Jennifer|Carolin|Jacky|Maria|Hannah|Helene|Ivanka</all>
 				</name1>
 				<name2>
-					<de>Miller|Jackobson|Smith|Bloomberg|Gates|Johnson|Petersen</de>
-					<en>Miller|Jackobson|Smith|Bloomberg|Gates|Johnson|Petersen</en>
-					<pl>Miller|Jackobson|Smith|Bloomberg|Gates|Johnson|Petersen</pl>
+					<all>Miller|Jackobson|Smith|Bloomberg|Gates|Johnson|Petersen</all>
 				</name2>
 			</variables>
 			<jobs>

--- a/res/database/Default/user/kieferer.xml
+++ b/res/database/Default/user/kieferer.xml
@@ -41,9 +41,7 @@
 
 		<scripttemplate product="1" licence_type="1" guid="scripttemplate-random-kieferer-mummyattack">
 			<title>
-				<de>${TITLE}</de>
-				<en>${TITLE}</en>
-				<pl>${TITLE}</pl>
+				<all>${TITLE}</all>
 			</title>
 			<description>
 				<de>Ein ganz normaler Teenagerausflug endet in einem Besäufnis und einem Wald voller Untoter.</de>
@@ -113,9 +111,7 @@ Organizator wycieczki ich oszukuje.</pl>
 					<en>| to ${RANDOMCITY}</en>
 					<pl>| do ${RANDOMCITY}</pl>
 				</modifier>
-				<randomcity>
-					<de>${.stationmap:"randomcity"}</de>
-				</randomcity>
+				<randomcity>>${.stationmap:"randomcity"}</randomcity>
 			</variables>
 
 			<jobs>
@@ -193,33 +189,23 @@ Każdy środek się nada.</pl>
 				<pl>Wiadomości giełdowe z dnia ${.worldtime:"dayplaying"}</pl>
 			</title>
 			<description>
-				<de>${CONTENT}</de>
-				<en>${CONTENT}</en>
-				<pl>${CONTENT}</pl>
+				<all>${CONTENT}</all>
 			</description>
 
 			<variables>
 				<content>
-					<de>${STOCKEXCHANGE} ${RESOURCES}|${STOCKEXCHANGE} ${CURRENCY}</de>
-					<en>${STOCKEXCHANGE} ${RESOURCES}|${STOCKEXCHANGE} ${CURRENCY}</en>
-					<pl>${STOCKEXCHANGE} ${RESOURCES}|${STOCKEXCHANGE} ${CURRENCY}</pl>
+					<all>${STOCKEXCHANGE} ${RESOURCES}|${STOCKEXCHANGE} ${CURRENCY}</all>
 				</content>
 
 				<!-- one of the three options - for each -->
 				<stockexchange>
-					<de>${STOCKEXCHANGE1}|${STOCKEXCHANGE2}|${STOCKEXCHANGE3}</de>
-					<en>${STOCKEXCHANGE1}|${STOCKEXCHANGE2}|${STOCKEXCHANGE3}</en>
-					<pl>${STOCKEXCHANGE1}|${STOCKEXCHANGE2}|${STOCKEXCHANGE3}</pl>
+					<all>${STOCKEXCHANGE1}|${STOCKEXCHANGE2}|${STOCKEXCHANGE3}</all>
 				</stockexchange>
 				<resources>
-					<de>${RESOURCES1}|${RESOURCES2}|${RESOURCES3}</de>
-					<en>${RESOURCES1}|${RESOURCES2}|${RESOURCES3}</en>
-					<pl>${RESOURCES1}|${RESOURCES2}|${RESOURCES3}</pl>
+					<all>${RESOURCES1}|${RESOURCES2}|${RESOURCES3}</all>
 				</resources>
 				<currency>
-					<de>${CURRENCY1}|${CURRENCY2}|${CURRENCY3}</de>
-					<en>${CURRENCY1}|${CURRENCY2}|${CURRENCY3}</en>
-					<pl>${CURRENCY1}|${CURRENCY2}|${CURRENCY3}</pl>
+					<all>${CURRENCY1}|${CURRENCY2}|${CURRENCY3}</all>
 				</currency>
 
 

--- a/res/database/Default/user/kieferer.xml
+++ b/res/database/Default/user/kieferer.xml
@@ -111,7 +111,7 @@ Organizator wycieczki ich oszukuje.</pl>
 					<en>| to ${RANDOMCITY}</en>
 					<pl>| do ${RANDOMCITY}</pl>
 				</modifier>
-				<randomcity>>${.stationmap:"randomcity"}</randomcity>
+				<randomcity>${.stationmap:"randomcity"}</randomcity>
 			</variables>
 
 			<jobs>

--- a/res/database/Default/user/nichtdiebetty.xml
+++ b/res/database/Default/user/nichtdiebetty.xml
@@ -48,11 +48,7 @@
 		-->
 	<allprogrammes>
 		<programme guid="nichtdiebetty-programme-helgoland-01" product="4" licence_type="1" creator="8659" created_by="Nicht_die_Betty">
-			<title>
-				<de>Helgoland</de>
-				<en>Helgoland</en>
-				<pl>Helgoland</pl>
-			</title>
+			<title>Helgoland</title>
 			<description>
 				<de>Gezeigt werden alle Sehenswürdigkeiten. Die Lange Anna. Die Lummen. Jede. In Nahaufnahme.
 Am Schluss zeigt Fischer Matjes noch wie man richtig Granat pult.</de>

--- a/res/database/Default/user/ronny.xml
+++ b/res/database/Default/user/ronny.xml
@@ -945,9 +945,7 @@ Znamienici goście i muzyka autorstwa ${.self:"cast":3:"nickname"}.</pl>
 			<!-- usage of ${.stationmap:"randomcity"} in the text directly, will lead to a different random city
 				 in title than in the description - so we use variables as this caches the output of the first city -->
 			<variables>
-				<cityname>
-					<de>${.stationmap:"randomcity"}</de>
-				</cityname>
+				<cityname>${.stationmap:"randomcity"}</cityname>
 			</variables>
 			<data genre="5" price="0.9" quality="28" />
 		</news>
@@ -957,9 +955,7 @@ Znamienici goście i muzyka autorstwa ${.self:"cast":3:"nickname"}.</pl>
 		<!-- product="3" => "Show" -->
 		<scripttemplate product="3" licence_type="1" guid="scripttemplate-ron-musiksterneamabend">
 			<title>
-				<de>${WHAT} ${WHEN}</de>
-				<en>${WHAT} ${WHEN}</en>
-				<pl>${WHAT} ${WHEN}</pl>
+				<all>${WHAT} ${WHEN}</all>
 			</title>
 			<description>
 				<de>Fetzige Musik für Jung und Alt. Von gefüllten Fussballstadien auf die Showbühne. Unterhaltung pur</de>
@@ -1002,9 +998,7 @@ Znamienici goście i muzyka autorstwa ${.self:"cast":3:"nickname"}.</pl>
 
 		<scripttemplate product="3" licence_type="1" guid="scripttemplate-ron-morningshow">
 			<title>
-				<de>${SHOWNAME}</de>
-				<en>${SHOWNAME}</en>
-				<pl>${SHOWNAME}</pl>
+				<all>${SHOWNAME}</all>
 			</title>
 			<description>
 				<de>Aufgewacht das Bettchen kracht. Lockere Morgenunterhaltung für alle - vom Frühaufsteher bis zum arbeitslosen Langschläfer.</de>
@@ -1044,15 +1038,15 @@ Znamienici goście i muzyka autorstwa ${.self:"cast":3:"nickname"}.</pl>
 
 		<scripttemplate product="2" licence_type="3" guid="scripttemplate-ron-from-above" comment="TODO: episode descriptions">
 			<title>
-				<de>${maintitle}</de>
+				<all>${maintitle}</all>
 			</title>
 			<description>
-				<de>${maindescription}</de>
+				<all>${maindescription}</all>
 			</description>
 			<children>
 				<scripttemplate product="2" licence_type="2" index="0" guid="scripttemplate-ron-from-above-eps">
 					<title>
-						<de>${episodetitle}</de>
+						<all>${episodetitle}</all>
 					</title>
 					<variables>
 						<episodetitle>
@@ -1111,15 +1105,12 @@ Znamienici goście i muzyka autorstwa ${.self:"cast":3:"nickname"}.</pl>
 
 		<scripttemplate product="2" licence_type="3" guid="scripttemplate-ron-visiting">
 			<title>
-				<de>${ttl}</de>
-				<en>${ttl}</en>
-				<pl>${ttl}</pl>
+				<all>${ttl}</all>
 			</title>
-			<description>
-				<!--no description at all: first episode's description is shown for series-->
-				<de></de>
-				<en></en>
-			</description>
+			
+			<!--no description at all: first episode's description is shown for series-->
+			<!--TODO test that empty description still works as expected-->
+			<description></description>
 			<variables>
 				<ttl>
 					<de>Zu Gast in ${cntry}|Reise durch ${cntry}|Auf Achse in ${cntry}|Leben in ${cntry}|Sehenswertes ${cntry}|Faszination ${cntry}|Blickpunkt ${cntry}</de>
@@ -1317,9 +1308,7 @@ Znamienici goście i muzyka autorstwa ${.self:"cast":3:"nickname"}.</pl>
 
 		<scripttemplate product="2" licence_type="3" guid="scripttemplate-ron-world">
 			<title>
-				<de>${ttl}</de>
-				<en>${ttl}</en>
-				<pl>${ttl}</pl>
+				<all>${ttl}</all>
 			</title>
 			<description>
 				<de>Folgen Sie uns auf einer Reise um die Welt. ${subject} findet man auch in Ländern, in denen man sie nicht vermutet hätte.</de>
@@ -1329,13 +1318,10 @@ Znamienici goście i muzyka autorstwa ${.self:"cast":3:"nickname"}.</pl>
 			<children>
 				<scripttemplate product="2" licence_type="2" index="0" guid="scripttemplate-ron-world-eps" comment="TODO: English title vs text casings">
 					<title>
-						<de>${epttl}</de>
-						<en>${epttl}</en>
-						<pl>${epttl}</pl>
+						<all>${epttl}</all>
 					</title>
 					<description>
-						<de>${dsc}</de>
-						<en>${dsc}</en>
+						<all>${dsc}</all>
 						<pl>Podróże przez świat. Poznajemy różne kraje. ${dsc}</pl>
 					</description>
 					<variables>
@@ -1366,23 +1352,19 @@ Znamienici goście i muzyka autorstwa ${.self:"cast":3:"nickname"}.</pl>
 					<pl>Kraje świata</pl>
 				</ttl>
 				<subject>
-					<de>${sbj_${variant}}</de>
-					<en>${sbj_${variant}}</en>
+					<all>${sbj_${variant}}</all>
 					
 				</subject>
 				<adjective>
-					<de>|${adj_${variant}} </de>
-					<en>|${adj_${variant}} </en>
+					<all>|${adj_${variant}} </all>
 					
 				</adjective>
 				<variant>
-					<de>bf|best|bi|big|bigb</de>
-					<en>bf|best|bi|big|bigb</en>
+					<all>bf|best|bi|big|bigb</all>
 					
 				</variant>
 				<adj_bf>
-					<de>${beautiful}</de>
-					<en>${beautiful}</en>
+					<all>${beautiful}</all>
 					
 				</adj_bf>
 				<sbj_bf>
@@ -1391,8 +1373,7 @@ Znamienici goście i muzyka autorstwa ${.self:"cast":3:"nickname"}.</pl>
 					
 				</sbj_bf>
 				<adj_best>
-					<de>${best}</de>
-					<en>${best}</en>
+					<all>${best}</all>
 					
 				</adj_best>
 				<sbj_best>
@@ -1401,8 +1382,7 @@ Znamienici goście i muzyka autorstwa ${.self:"cast":3:"nickname"}.</pl>
 					
 				</sbj_best>
 				<adj_bi>
-					<de>${best}|${important}</de>
-					<en>${best}|${important}</en>
+					<all>${best}|${important}</all>
 					
 				</adj_bi>
 				<sbj_bi>
@@ -1411,8 +1391,7 @@ Znamienici goście i muzyka autorstwa ${.self:"cast":3:"nickname"}.</pl>
 					
 				</sbj_bi>
 				<adj_big>
-					<de>${big}</de>
-					<en>${big}</en>
+					<all>${big}</all>
 					
 				</adj_big>
 				<sbj_big>
@@ -1421,8 +1400,7 @@ Znamienici goście i muzyka autorstwa ${.self:"cast":3:"nickname"}.</pl>
 					
 				</sbj_big>
 				<adj_bigb>
-					<de>${big}|${beautiful}</de>
-					<en>${big}|${beautiful}</en>
+					<all>${big}|${beautiful}</all>
 					
 				</adj_bigb>
 				<sbj_bigb>

--- a/res/database/Default/user/scr0llbaer.xml
+++ b/res/database/Default/user/scr0llbaer.xml
@@ -488,7 +488,9 @@ Format: Filmowane wykłady. Na luzie i do leżenia.</pl>
 					</staff>
 				</programme>
 				<programme guid="558eaa7b-690c-41ca-988a-00b98207247e" product="2" licence_type="2" creator="9551">
-					<title>${.self:"cast":2:"firstname"} McVegan</title>
+					<title>
+						<all>${.self:"cast":2:"firstname"} McVegan</all>
+					</title>
 					<description>
 						<de>Und auch von einem Ex-Schauspielstar und Ex-Präsidenten gibt's Neuigkeiten: ${.self:"cast":2:"fullname"} baut Gerüchten zufolge heimlich ein veganes Fast-Food-Imperium auf. „Er ist also doch unser Commander in Leaf,“ rufen begeisterte Veganer weltweit.</de>
 						<en>And there's also news from an ex-acting star and ex-president: ${.self:"cast":2:"fullname"} is rumored to be secretly building a vegan fast food empire. "So he is our Commander in Leaf after all," shout enthusiastic vegans worldwide.</en>
@@ -545,7 +547,9 @@ Format: Filmowane wykłady. Na luzie i do leżenia.</pl>
 					</staff>
 				</programme>
 				<programme guid="36518cf4-419d-4de4-8394-d4fbfe5acf8c" product="2" licence_type="2" creator="9551" comment="Miff used in a previous episode">
-					<title>${.self:"cast":2:"firstname"} Swift</title>
+					<title>
+						<all>${.self:"cast":2:"firstname"} Swift</all>
+					</title>
 					<description>
 						<de>Erneut macht ${.self:"cast":2:"fullname"} von sich reden, als er versucht, seine Fans zu beeindrucken, indem er seine neu entdeckte Leidenschaft für Ballett vorführt. Leider endet seine Swift-Pirouette damit, dass er in eine Requisite kracht und Chaos am Set verursacht.</de>
 						<en>Once again, ${.self:"cast":2:"fullname"} makes a name for himself, as he attempts to impress his fans by showcasing his newfound passion for ballet. Unfortunately, his swift pirouette ends with him crashing into a prop, causing chaos on set.</en>

--- a/res/database/Default/user/scr0llbaer.xml
+++ b/res/database/Default/user/scr0llbaer.xml
@@ -99,9 +99,7 @@ Format: Filmowane wykłady. Na luzie i do leżenia.</pl>
 			<children>
 				<programme guid="3b56f810-64c1-49e6-8540-274098947b10" product="2" licence_type="2" creator="9551">
 					<title>
-						<de>Three Mile Island</de>
-						<en>Three Mile Island</en>
-						<pl>Three Mile Island</pl>
+						<all>Three Mile Island</all>
 					</title>
 					<description>
 						<de>In Pennsylvania entsteht eine der modernsten und sichersten Anlagen. Wir waren vor Ort.</de>
@@ -123,9 +121,7 @@ Format: Filmowane wykłady. Na luzie i do leżenia.</pl>
 				</programme>
 				<programme guid="71956dc0-4fbb-4e9a-ac62-a0821eea04bd" product="2" licence_type="2" creator="9551">
 					<title>
-						<de>Fukushima</de>
-						<en>Fukushima</en>
-						<pl>Fukushima</pl>
+						<all>Fukushima</all>
 					</title>
 					<description>
 						<de>Auf der japanischen Hauptinsel Honshū entsteht eine der modernsten und sichersten Anlagen. Wir waren vor Ort.</de>
@@ -492,10 +488,7 @@ Format: Filmowane wykłady. Na luzie i do leżenia.</pl>
 					</staff>
 				</programme>
 				<programme guid="558eaa7b-690c-41ca-988a-00b98207247e" product="2" licence_type="2" creator="9551">
-					<title>
-						<de>${.self:"cast":2:"firstname"} McVegan</de>
-						<en>${.self:"cast":2:"firstname"} McVegan</en>
-					</title>
+					<title>${.self:"cast":2:"firstname"} McVegan</title>
 					<description>
 						<de>Und auch von einem Ex-Schauspielstar und Ex-Präsidenten gibt's Neuigkeiten: ${.self:"cast":2:"fullname"} baut Gerüchten zufolge heimlich ein veganes Fast-Food-Imperium auf. „Er ist also doch unser Commander in Leaf,“ rufen begeisterte Veganer weltweit.</de>
 						<en>And there's also news from an ex-acting star and ex-president: ${.self:"cast":2:"fullname"} is rumored to be secretly building a vegan fast food empire. "So he is our Commander in Leaf after all," shout enthusiastic vegans worldwide.</en>
@@ -552,10 +545,7 @@ Format: Filmowane wykłady. Na luzie i do leżenia.</pl>
 					</staff>
 				</programme>
 				<programme guid="36518cf4-419d-4de4-8394-d4fbfe5acf8c" product="2" licence_type="2" creator="9551" comment="Miff used in a previous episode">
-					<title>
-						<de>${.self:"cast":2:"firstname"} Swift</de>
-						<en>${.self:"cast":2:"firstname"} Swift</en>
-					</title>
+					<title>${.self:"cast":2:"firstname"} Swift</title>
 					<description>
 						<de>Erneut macht ${.self:"cast":2:"fullname"} von sich reden, als er versucht, seine Fans zu beeindrucken, indem er seine neu entdeckte Leidenschaft für Ballett vorführt. Leider endet seine Swift-Pirouette damit, dass er in eine Requisite kracht und Chaos am Set verursacht.</de>
 						<en>Once again, ${.self:"cast":2:"fullname"} makes a name for himself, as he attempts to impress his fans by showcasing his newfound passion for ballet. Unfortunately, his swift pirouette ends with him crashing into a prop, causing chaos on set.</en>
@@ -639,9 +629,7 @@ Format: Filmowane wykłady. Na luzie i do leżenia.</pl>
 	<scripttemplates>
 		<scripttemplate product="3" licence_type="1" guid="e569b0af-e97f-4897-8b8d-6c426fa5a7d5" creator="9551" comment="Low-Budget- und Endlos-Variante von scripttemplate-ron-morningshow">
 			<title>
-				<de>${title}</de>
-				<en>${title}</en>
-				<pl>${title}</pl>
+				<all>${title}</all>
 			</title>
 			<description>
 				<de>Programmfüller für den jeden Morgen. Hier werden nochmal die Beiträge aus dem Mülleimer gefischt, die die Kollegen aus der Nachrichtenredaktion schon weggeschmissen haben. Andere niedrigschwellige Inhalte finden sich bestimmt auch noch.</de>
@@ -670,9 +658,7 @@ Format: Filmowane wykłady. Na luzie i do leżenia.</pl>
 		</scripttemplate>
 		<scripttemplate product="3" licence_type="1" guid="d35ad24a-9095-490e-b5d1-f51ba82210ff" creator="9551" comment="Deluxe- und Endlos-Variante von scripttemplate-ron-morningshow">
 			<title>
-				<de>${title}</de>
-				<en>${title}</en>
-				<pl>${title}</pl>
+				<all>${title}</all>
 			</title>
 			<description>
 				<de>Es lohnt sich! Für jeden Morgen! Tolles Programm und gute Unterhaltung für einen beschwingten Start in den Tag.</de>
@@ -720,9 +706,7 @@ Format: Filmowane wykłady. Na luzie i do leżenia.</pl>
 			</description>
 			<variables>
 				<tower>
-					<de>TVT|Tower|TVTower</de>
-					<en>TVT|Tower|TVTower</en>
-					<pl>TVT|Tower|TVTower</pl>
+					<all>TVT|Tower|TVTower</all>
 				</tower>
 				<latebreaking>
 					<de>Brandaktuell|Aktuell</de>
@@ -773,9 +757,7 @@ Obowiązkowa pozycja dla każdej gospodyni domowej, przekleństwo dla twardzieli
 			</description>
 			<variables>
 				<tower>
-					<de>TVT|Tower|TVTower</de>
-					<en>TVT|Tower|TVTower</en>
-					<pl>TVT|Tower|TVTower</pl>
+					<all>TVT|Tower|TVTower</all>
 				</tower>
 				<latebreaking>
 					<de>Aktuell|Brandaktuell|Brandheiße News|Aktuellste News</de>
@@ -858,9 +840,7 @@ Obowiązkowa pozycja dla każdej gospodyni domowej, przekleństwo dla twardzieli
 		</scripttemplate>
 		<scripttemplate product="3" licence_type="1" guid="007b49ae-41e2-47b7-bf7c-628aecee7731" creator="9551">
 			<title>
-				<de>${tower} ${latebreaking}: ${title}</de>
-				<en>${tower} ${latebreaking}: ${title}</en>
-				<pl>${tower} ${latebreaking}: ${title}</pl>
+				<all>${tower} ${latebreaking}: ${title}</all>
 			</title>
 			<description>
 				<de>Filme, Musik, Stars und Sternchen. Die ganz große Kino-Show. Trailer, Ausschnitte, Infos und Interviews zu den aktuellen Neuerscheinungen.</de>
@@ -869,9 +849,7 @@ Obowiązkowa pozycja dla każdej gospodyni domowej, przekleństwo dla twardzieli
 			</description>
 			<variables>
 				<tower>
-					<de>TVT|Tower|TVTower</de>
-					<en>TVT|Tower|TVTower</en>
-					<pl>TVT|Tower|TVTower</pl>
+					<all>TVT|Tower|TVTower</all>
 				</tower>
 				<latebreaking>
 					<de>Brandaktuell|Aktuell</de>
@@ -928,9 +906,7 @@ Obowiązkowa pozycja dla każdej gospodyni domowej, przekleństwo dla twardzieli
 					<en>Athletes|Footballers and co.|Sports Friends</en>
 					<pl>Sportowcy|Piłkarze i spółka|Przyjaciele sportowi</pl>
 				</athletes>
-				<randomcity>
-					<de>${.stationmap:"randomcity"}</de>
-				</randomcity>
+				<randomcity>${.stationmap:"randomcity"}</randomcity>
 			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -1002,9 +978,7 @@ Obowiązkowa pozycja dla każdej gospodyni domowej, przekleństwo dla twardzieli
 		</scripttemplate>
 		<scripttemplate product="4" licence_type="1" guid="9f1cacc4-aa56-4f4a-9a9f-8c21c4bd3a7d" creator="9551" comment="Perhaps some reciprocal effect with the corresponding news genre can be implemented? TODO: I am not happy with the titles and descriptions of these.">
 			<title>
-				<de>${tower} ${latebreaking}: ${title}</de>
-				<en>${tower} ${latebreaking}: ${title}</en>
-				<pl>${tower} ${latebreaking}: ${title}</pl>
+				<all>${tower} ${latebreaking}: ${title}</all>
 			</title>
 			<description>
 				<de>Die Toplizenzen inkludiert! Sport aktuell. Jeden Tag neu. Die Topligen und Wettbewerbe der Nation und aus der ganzen Welt. Fußball, Eishockey, Basketball, Football, Tennis, Tischtennis, Leichtathletik, Boxen, Formel 1, Wintersport, alles dabei.</de>
@@ -1013,9 +987,7 @@ Obowiązkowa pozycja dla każdej gospodyni domowej, przekleństwo dla twardzieli
 			</description>
 			<variables>
 				<tower>
-					<de>TVT|Tower|TVTower</de>
-					<en>TVT|Tower|TVTower</en>
-					<pl>TVT|Tower|TVTower</pl>
+					<all>TVT|Tower|TVTower</all>
 				</tower>
 				<latebreaking>
 					<de>Brandaktuell|Aktuell</de>
@@ -1054,9 +1026,7 @@ Obowiązkowa pozycja dla każdej gospodyni domowej, przekleństwo dla twardzieli
 		<!-- TODO: More sports formats resp. 'Spiel ohne Grenzen', as proposed by ronny: "Bierpong", "Trocken-Curling", "Nagel-Weitklipsen", "Schaukelpferdparcours", "Brummkreiseln" ... -->
 		<scripttemplate product="4" licence_type="1" guid="919f396e-c7c0-4191-abbc-01d559c0feef" creator="9551" comment="Perhaps some reciprocal effect with the corresponding news genre can be implemented? TODO: I am not happy with the titles and descriptions of these.">
 			<title>
-				<de>${tower} ${latebreaking}: ${title}</de>
-				<en>${tower} ${latebreaking}: ${title}</en>
-				<pl>${tower} ${latebreaking}: ${title}</pl>
+				<all>${tower} ${latebreaking}: ${title}</all>
 			</title>
 			<description>
 				<de>Politik aktuell. Jeden Tag neu. Wir analysieren die neuesten Entwicklungen in Wirtschaft und Politik.</de>
@@ -1065,9 +1035,7 @@ Obowiązkowa pozycja dla każdej gospodyni domowej, przekleństwo dla twardzieli
 			</description>
 			<variables>
 				<tower>
-					<de>TVT|Tower|TVTower</de>
-					<en>TVT|Tower|TVTower</en>
-					<pl>TVT|Tower|TVTower</pl>
+					<all>TVT|Tower|TVTower</all>
 				</tower>
 				<latebreaking>
 					<de>Brandaktuell|Aktuell</de>
@@ -1103,9 +1071,7 @@ Obowiązkowa pozycja dla każdej gospodyni domowej, przekleństwo dla twardzieli
 		</scripttemplate>
 		<scripttemplate product="4" licence_type="1" guid="204d40f8-c25f-458b-a049-526c06f4661f" creator="9551" comment="Perhaps some reciprocal effect with the corresponding news genre can be implemented? TODO: I am not happy with the titles and descriptions of these.">
 			<title>
-				<de>${tower}: ${title}${latebreaking}</de>
-				<en>${tower}: ${title}${latebreaking}</en>
-				<pl>${tower}: ${title}${latebreaking}</pl>
+				<all>${tower}: ${title}${latebreaking}</all>
 			</title>
 			<description>
 				<de>Kultur aktuell. Jeden Tag neu. Vernissagen, Ausstellungen, Kulturfestivals, Konzerte, Kunst, Literatur. Neuerscheinungen sowie historische Rückblicke und Reflektionen.</de>
@@ -1114,9 +1080,7 @@ Obowiązkowa pozycja dla każdej gospodyni domowej, przekleństwo dla twardzieli
 			</description>
 			<variables>
 				<tower>
-					<de>TVT|Tower|TVTower</de>
-					<en>TVT|Tower|TVTower</en>
-					<pl>TVT|Tower|TVTower</pl>
+					<all>TVT|Tower|TVTower</all>
 				</tower>
 				<title>
 					<de>Kultur|Kunst und Kultur|Kulturwelt|Kultursphäre|Kulturwoche</de>
@@ -1153,9 +1117,7 @@ Obowiązkowa pozycja dla każdej gospodyni domowej, przekleństwo dla twardzieli
 		</scripttemplate>
 		<scripttemplate product="3" licence_type="1" guid="f13dd881-b149-4981-aa75-67dd6fe9663a" creator="9551" comment="TODO: I am not happy with the titles and descriptions of these.">
 			<title>
-				<de>${tower} ${latebreaking}: ${title}</de>
-				<en>${tower} ${latebreaking}: ${title}</en>
-				<pl>${tower} ${latebreaking}: ${title}</pl>
+				<all>${tower} ${latebreaking}: ${title}</all>
 			</title>
 			<description>
 				<de>Die neuesten und heißesten Videospiele werden hier präsentiert und getestet. Nur für euch! Außerdem könnt ihr im Studio gegeneinander antreten und Preise gewinnen!</de>
@@ -1164,9 +1126,7 @@ Obowiązkowa pozycja dla każdej gospodyni domowej, przekleństwo dla twardzieli
 			</description>
 			<variables>
 				<tower>
-					<de>TVT|Tower|TVTower</de>
-					<en>TVT|Tower|TVTower</en>
-					<pl>TVT|Tower|TVTower</pl>
+					<all>TVT|Tower|TVTower</all>
 				</tower>
 				<latebreaking>
 					<de>Brandaktuell|Aktuell</de>
@@ -1246,9 +1206,7 @@ Czyli 4120 na odcinek.</pl>
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="40d169cd-eeb2-400e-b839-f69690893bc1" creator="9551" comment="Quelle: Das Kino in meinem Kopf, das enstand, als ich zum ersten Mal den Titel von TheRob-Script-Com-EngeloderBengel, bei mir 'Aribert außer Rand und Band' gelesen hatte. :)">
 			<title>
-				<de>${title}</de>
-				<en>${title}</en>
-				<pl>${title}</pl>
+				<all>${title}</all>
 			</title>
 			<description>
 				<de>${name} ist behütet in einer fürsorglichen Familie aufgewachsen und lebt Mitte 20 in einer Studenten-WG mit braven Kommilitonen. Doch er spürt, etwas ist in ihm. Was ist das nur? Ist er vielleicht nicht ganz monogam? Sein Umfeld beginnt zu verzweifeln...</de>
@@ -1261,9 +1219,7 @@ Czyli 4120 na odcinek.</pl>
 					<en>${name} all boisterous|${name} all over the place|${name} totally psyched|For ${name} there is no more tomorrow|${name} no longer to be tamed|${name} going so very wild|${name} totally unbridled|${name} gets all wild</en>
 					<pl>${name}  dziki jak ptak|${name} podekscytowany|${name} totalnie zakręcony|Nie ma jutra dla ${name}|${name} oszołomiony|${name} wariuje|${name} idzie na całość|${name} ma wszystko gdzieś!</pl>
 				</title>
-				<name>
-					<de>${.persongenerator:"firstname":"de":"male"}|${.persongenerator:"firstname":"es":"male"}</de>
-				</name>
+				<name>${.persongenerator:"firstname":"de":"male"}|${.persongenerator:"firstname":"es":"male"}</name>
 			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" />

--- a/res/database/Default/user/scr0llbaer_news.xml
+++ b/res/database/Default/user/scr0llbaer_news.xml
@@ -176,15 +176,10 @@
 				<pl>W ${funeraltown} zdechł ulubiony zwierzak miasta: ${squirrel_${i}} ${joe}. Zwierzak ${hadbeenlivingon_${i}}.</pl>
 			</description>
 			<variables>
-				<funeraltown>
-					<de>${.stationmap:"randomcity"}</de>
-				</funeraltown>
-				<joe> <!-- soll absichtlich manchmal ein internationaler Name sein -->
-					<de>${.persongenerator:"firstname":"de":"female"}|${.persongenerator:"firstname":"en":"female"}|${.persongenerator:"firstname":"es":"female"}|${.persongenerator:"firstname":"de":"male"}|${.persongenerator:"firstname":"en":"male"}|${.persongenerator:"firstname":"es":"male"}</de>
-				</joe>
-				<i>
-					<de>0|1|2|3|4|5|6|7|8|9|a|b|c</de>
-				</i>
+				<funeraltown>${.stationmap:"randomcity"}</funeraltown>
+				 <!-- soll absichtlich manchmal ein internationaler Name sein -->
+				<joe>${.persongenerator:"firstname":"de":"female"}|${.persongenerator:"firstname":"en":"female"}|${.persongenerator:"firstname":"es":"female"}|${.persongenerator:"firstname":"de":"male"}|${.persongenerator:"firstname":"en":"male"}|${.persongenerator:"firstname":"es":"male"}</joe>
+				<i>0|1|2|3|4|5|6|7|8|9|a|b|c</i>
 				<squirrel_0>
 					<de>Eichhörnchen</de> <!-- alle nur Maskulinum und Neutrum! -->
 					<en>squirrel</en>
@@ -390,35 +385,19 @@
 					<en>seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen</en>
 					<pl>siedem|osiem|dziewięć|dziesięć|jedenaście|dwanaście|trzynaście|czternaście|piętnaście</pl>
 				</twelve>
-				<exhibitiontown>
-					<de>${.stationmap:"randomcity"}</de>
-				</exhibitiontown>
-				<singerfirstname>
-					<de>${.persongenerator:"firstname":"de":"female"}</de>
-				</singerfirstname>
-				<singersecondname>
-					<de>${.persongenerator:"firstname":"en":"female"}</de> <!-- absichtlicher deutsch-englischer 'Künstler'-Vorname. TODO: maybe English-French for the English version -->
-				</singersecondname>
-				<singerlastname>
-					<de>${.persongenerator:"lastname":"de":"female"}</de>
-				</singerlastname>
+				<exhibitiontown>${.stationmap:"randomcity"}</exhibitiontown>
+				<singerfirstname>${.persongenerator:"firstname":"de":"female"}</singerfirstname>
+				<singersecondname>${.persongenerator:"firstname":"en":"female"}</singersecondname><!-- absichtlicher deutsch-englischer 'Künstler'-Vorname. TODO: maybe English-French for the English version -->
+				<singerlastname>${.persongenerator:"lastname":"de":"female"}</singerlastname>
 				<dontleaveme>
 					<de>verlass mich nicht|lass mich nicht allein|lass mich nicht im Stich|komm zurück</de>
 					<en>don't leave me|don't abandon me|do not forsake me|come back</en>
 					<pl>nie zostawiaj mnie|nie opuszczaj mnie|nie porzucaj mnie|wróć do mnie</pl>
 				</dontleaveme>
-				<scientistfirstname>
-					<de>${.persongenerator:"firstname":"de":"male"}</de>
-				</scientistfirstname>
-				<scientistsecondname>
-					<de>${.persongenerator:"firstname":"de":"female"}</de> <!-- absichtlich weiblicher zweiter Vorname -->
-				</scientistsecondname>
-				<scientistpenultimatename>
-					<de>${.persongenerator:"lastname":"de":"male"}</de>
-				</scientistpenultimatename>
-				<scientistlastname>
-					<de>${.persongenerator:"lastname":"de":"male"}</de> <!-- Doppel-Nachname erzwingen, was anscheinend in verschiedenen Variablen erfolgen muss. Innerhalb einer wird bei zwei GENERATOR-Aufrufen derselbe nochmal zurückgegeben. -->
-				</scientistlastname>
+				<scientistfirstname>${.persongenerator:"firstname":"de":"male"}</scientistfirstname>
+				<scientistsecondname>${.persongenerator:"firstname":"de":"female"}</scientistsecondname><!-- absichtlich weiblicher zweiter Vorname -->
+				<scientistpenultimatename>${.persongenerator:"lastname":"de":"male"}</scientistpenultimatename>
+				<scientistlastname>${.persongenerator:"lastname":"de":"male"}</scientistlastname><!-- Doppel-Nachname erzwingen, was anscheinend in verschiedenen Variablen erfolgen muss. Innerhalb einer wird bei zwei GENERATOR-Aufrufen derselbe nochmal zurückgegeben. -->
 			</variables>
 			<data genre="4" price="1" quality="20" fictional="1" />
 			<effects>
@@ -563,9 +542,7 @@
 				<pl>${giantinflatable_${i}} ${duck_${i}}, część parady w mieście ${paradetown}, wyrwał się z cum i odfrunął. Ma ponad 50 stóp wysokości. Został zauważony nad miastem i zniknął za horyzontem. Trwa operacja poszukiwawcza.</pl>
 			</description>
 			<variables>
-				<i>
-					<de>0|1|2|3|4|5|6|7|8|9|a|b|c|d|e</de>
-				</i>
+				<i>0|1|2|3|4|5|6|7|8|9|a|b|c|d|e</i>
 				<giantinflatable_0>
 					<de>Riesige aufblasbare</de>
 					<en>Giant inflatable</en>
@@ -682,9 +659,7 @@
 					<pl>pluszowego misia</pl>
 				</duck_7>
 				<duck_8>
-					<de>UFO</de>
-					<en>UFO</en>
-					<pl>UFO</pl>
+					<all>UFO</all>
 				</duck_8>
 				<duck_9>
 					<de>Diamant</de>
@@ -871,26 +846,16 @@
 					<en>It</en>
 					<pl></pl> <!-- intentionally blank -->
 				</it_e>
-				<paradetown>
-					<de>${.stationmap:"randomcity"}</de>
-				</paradetown>
-				<sightedtown>
-					<de>${.stationmap:"randomcity"}</de>
-				</sightedtown>
-				<foundtown>
-					<de>${.stationmap:"randomcity"}</de>
-				</foundtown>
+				<paradetown>${.stationmap:"randomcity"}</paradetown>
+				<sightedtown>${.stationmap:"randomcity"}</sightedtown>
+				<foundtown>${.stationmap:"randomcity"}</foundtown>
 				<andbroughtdownby>
 					<de> und von der Feuerwehr zu Boden gebracht|. ${it_${i}} wurde gemütlich schwimmend in einem Parkteich entdeckt und wohlbehalten an die Organisatoren der Parade zurückgegeben|. ${it_${i}} wurde von ein paar Witzbolden entführt, doch die Polizei konnte die Entführer ausfinding machen</de>
 					<en> and brought down by the fire department|. ${it_${i}} was discovered leisurely floating in a park pond and was safely returned to the parade organizers|. ${it_${i}} was hijacked by some pranksters, but the police were able to track down them down</en>
 					<pl> i ściągnięty przez straż pożarną|w stawie w parku i bezpiecznie zwrócony organizatorom parady|Okazało się że balon został porwany przez żartownisiów, ale policji udało się ich wytropić.</pl>
 				</andbroughtdownby>
-				<nina>
-					<de>Nina|Nia|Nana|Nona</de>
-				</nina>
-				<artistlastname>
-					<de>${.persongenerator:"lastname":"de":"female"}|${.persongenerator:"lastname":"en":"female"}|${.persongenerator:"lastname":"fr":"female"}</de>
-				</artistlastname>
+				<nina>Nina|Nia|Nana|Nona</nina>
+				<artistlastname>>${.persongenerator:"lastname":"de":"female"}|${.persongenerator:"lastname":"en":"female"}|${.persongenerator:"lastname":"fr":"female"}</artistlastname>
 				<ofsportsclub>
 					<de>des Sportclubs|des Sportvereins|der Sportfreunde|des Fußballclubs|der Spielvereinigung</de>
 					<en>of Sports Club|of the Sports Association|of Sports Friends|of Football Club|of United</en>
@@ -999,9 +964,7 @@
 				<pl>${name_${g}} z miasta ${subjecttown} ${claims}${ithadinsulted_${i}}.</pl>
 			</description>
 			<variables>
-				<g>
-					<de>m|f</de>
-				</g>
+				<g>m|f</g>
 				<mw_m>
 					<de>Mann</de>
 					<en>man</en>
@@ -1072,9 +1035,7 @@
 					<en>herself</en>
 					<pl>sama</pl>
 				</themself_f>
-				<subjecttown>
-					<de>${.stationmap:"randomcity"}</de>
-				</subjecttown>
+				<subjecttown>${.stationmap:"randomcity"}</subjecttown>
 				<name_m>
 					<de>${.persongenerator:"firstname":"de":"male"}</de>
 					<en>${.persongenerator:"firstname":"en":"male"}</en>
@@ -1088,9 +1049,7 @@
 					<en>sues|files suit against</en> <!--too long: files lawsuit against|takes action against -->
 					<pl>pozywa|składa pozew sądowy</pl>
 				</sues>
-				<i>
-					<de>0|1|2|3|4|5|6|7|8|9|a|b</de>
-				</i>
+				<i>0|1|2|3|4|5|6|7|8|9|a|b</i>
 				<theirparrot_0>
 					<de>${their_${g}}en Hauspapagei</de>
 					<en>${their_${g}} pet parrot</en>
@@ -1112,9 +1071,7 @@
 					<pl>lustro sklepowe</pl>
 				</theirparrot_3>
 				<theirparrot_4>
-					<de>${themself_${g}}</de>
-					<en>${themself_${g}}</en>
-					<pl>${themself_${g}}</pl>
+					<all>${themself_${g}}</all>
 				</theirparrot_4>
 				<theirparrot_5>
 					<de>${their_${g}}en Schatten</de>
@@ -1256,12 +1213,8 @@
 					<en>appeals|files an appeal</en>
 					<pl>odwołania|złożenie odwołania</pl>
 				</appeals>
-				<artistfirstname>
-					<de>${.persongenerator:"firstname":"de":"male"}</de>
-				</artistfirstname>
-				<artistlastname>
-					<de>${.persongenerator:"lastname":"de":"female"}</de>
-				</artistlastname>
+				<artistfirstname>${.persongenerator:"firstname":"de":"male"}</artistfirstname>
+				<artistlastname>${.persongenerator:"lastname":"de":"female"}</artistlastname>
 				<band>
 					<de>Band|Gang|Kapelle|Combo|Band</de>
 					<en>Band|Gang|Band|Combo|Band</en>
@@ -1272,9 +1225,7 @@
 					<en>Against|About|Through|To|For|But|Yet,|But not|Oh no, not|Why|What for|Not|No,</en>
 					<pl>Przeciwko|Przez|Dla|Ale|Jeszcze|Ale nie|O nie, nie|Dlaczego|O nie, nie|Dlaczego|Za co|Nie|Nie,</pl>
 				</against>
-				<artisttown>
-					<de>${.stationmap:"randomcity"}</de>
-				</artisttown>
+				<artisttown>${.stationmap:"randomcity"}</artisttown>
 			</variables>
 			<data genre="4" price="1" quality="20" fictional="1" />
 			<effects>
@@ -1347,9 +1298,7 @@
 		</news>
 		<news guid="ddc63d39-7c94-4710-85f1-e8462c14f34b" type="2" thread_guid="d578f569-5a26-405a-903d-4afe21c03308" creator="9551">
 			<title>
-				<de>${name_${g}} ${appeals}</de>
-				<en>${name_${g}} ${appeals}</en>
-				<pl>${name_${g}} ${appeals}</pl>
+				<all>${name_${g}} ${appeals}</all>
 			</title>
 			<description>
 				<de>Nun erneut vor dem Landgericht: ${the_${g}} ${mw_${g}} ${claims}${ithadinsulted_${i}}.</de>
@@ -1478,14 +1427,10 @@
 				<pl>${man_${i}} aresztowany${fortheft_${i}}</pl>
 			</title>
 			<description>
-				<de>${themanwho_${i}}</de>
-				<en>${themanwho_${i}}</en>
-				<pl>${themanwho_${i}}</pl>
+				<all>${themanwho_${i}}</all>
 			</description>
 			<variables>
-				<i>
-					<de>0|1|2|3|4|5|6|7|8|9</de>
-				</i>
+				<i>0|1|2|3|4|5|6|7|8|9</i>
 				<man_0>
 					<de>Mann</de>
 					<en>Man</en>
@@ -1541,18 +1486,11 @@
 					<en> for stealing a picnic table</en>
 					<pl> za kradzież stołu piknikowego</pl>
 				</fortheft_0>
-				<fortheft_1>
-					<de></de> <!-- intentionally blank -->
-					<en></en>
-				</fortheft_1>
-				<fortheft_2>
-					<de></de> <!-- intentionally blank -->
-					<en></en>
-				</fortheft_2>
-				<fortheft_3>
-					<de></de> <!-- intentionally blank -->
-					<en></en>
-				</fortheft_3>
+				<!--TODO check if working as expected
+				<!-- intentionally blank -->
+				<fortheft_1></fortheft_1>
+				<fortheft_2></fortheft_2>
+				<fortheft_3></fortheft_3>
 				<fortheft_4>
 					<de> wegen Ampel-Diebstahl</de>
 					<en> for stealing a traffic light</en>
@@ -1573,14 +1511,9 @@
 					<en> for stealing a trash can</en>
 					<pl> za kradzież kosza na śmieci</pl>
 				</fortheft_7>
-				<fortheft_8>
-					<de></de> <!-- intentionally blank -->
-					<en></en>
-				</fortheft_8>
-				<fortheft_9>
-					<de></de> <!-- intentionally blank -->
-					<en></en>
-				</fortheft_9>
+				<!-- intentionally blank -->
+				<fortheft_8></fortheft_8>
+				<fortheft_9></fortheft_9>
 				<themanwho_0>
 					<de>Der Mann, der den Tisch aus einem Park in ${town} stahl und angab, ihn zu einem Grillfest eines Freundes zu bringen, wurde wegen schweren Diebstahls${andcriminalmischief} angeklagt.</de>
 					<en>The man, who stole the table from a park in ${town} and claimed to be taking it to a friend's backyard barbecue, was charged with grand larceny${andcriminalmischief}.</en>
@@ -1636,9 +1569,7 @@
 					<en> and criminal mischief| and disorderly conduct|</en>
 					<pl> i wykroczenie| i zakłócanie porządku|</pl>
 				</andcriminalmischief>
-				<town>
-					<de>${.stationmap:"randomcity"}</de>
-				</town>
+				<town>${.stationmap:"randomcity"}</town>
 			</variables>
 			<data genre="4" price="1" quality="15" fictional="1" />
 		</news>
@@ -1655,9 +1586,8 @@
 				<pl>W przeszłości wszystko było lepsze: Ultrakonserwatywny sojusz Alternatywa dla Świata (AdS) występuje do Stanów Zjednoczonych o nową wojnę światową. Konieczny jest powrót do dobrego 25-letniego rytmu.</pl>
 			</description>
 			<variables>
-				<exhibitiontown>
-					<de>${.stationmap:"randomcity"}</de>
-				</exhibitiontown>
+				<exhibitiontown>${.stationmap:"randomcity"}</exhibitiontown>
+				<!--TODO unclear if no other languages intended-->
 				<gottliebmaessigmann>
 					<de>${gottlieb} ${maessigmann}</de>
 				</gottliebmaessigmann>
@@ -1901,9 +1831,7 @@
 				<en>The East Asian special economic zone ${meigawa} was one of the fastest growing tech and economic regions in the world last year.</en>
 			</description>
 			<variables>
-				<meigawa>
-					<de>Meigawa|Saitorin|Nokoshima|Hikarugen|Jinsen|Shuranko|Chiyotek|Xingling|Shintai|Hakuryu</de>
-				</meigawa>
+				<meigawa>Meigawa|Saitorin|Nokoshima|Hikarugen|Jinsen|Shuranko|Chiyotek|Xingling|Shintai|Hakuryu</meigawa>
 				<isknownfor>
 					<de>ist bekannt für|ist berühmt für|ist weltbekannt für|ist anerkannt für|spezialisiert sich auf|ist spezialisiert auf</de>
 					<en>is known for|is famous for|is renowned for|is recognized for|specializes in|is specialized in</en>
@@ -1916,9 +1844,7 @@
 					<de>ist zudem zu einem globalen Vorreiter für grüne Innovationen und Smart-City-Entwicklung geworden|bietet zudem eine pulsierende Technologiebranche mit fortschrittlichen Forschungseinrichtungen und innovativen Start-ups|beherbergt zudem hochmoderne Laboratorien und Biotech-Unternehmen|ist zudem ein Zentrum für Schiffbau, Ozeanographie und Tiefseeforschung|veranstaltet zudem bedeutende Technologiekonferenzen bekannt für immersive Gaming-Erlebnisse und fortschrittliche Visualisierungssysteme|ist zudem Standort für bahnbrechende Fortschritte in der Halbleitertechnologie|zieht zudem Spitzentalente und Unternehmen in der Robotikbranche an|ist zudem führend in der Entwicklung von leichten, hochfesten Materialien, die in der Luft- und Raumfahrt, der Automobil- und der Elektronikindustrie eingesetzt werden|ist zudem Knotenpunkt für Biomedizin, Telemedizin und tragbare Gesundheitsgeräte|beheimatet zudem ein Raumfahrtzentrum und Produktionsanlagen für Satelliten, die eine wichtige Rolle in der Raumfahrtindustrie spielen</de>
 					<en>has also become a global leader in green innovation and smart city development|also boasts a thriving tech industry with advanced research facilities and innovative startups|also is home to state-of-the-art laboratories and biotech companies|is also a hub for shipbuilding, oceanography, and deep-sea research|also hosts major tech conferences known for immersive gaming experiences and advanced visualization systems|is also home to groundbreaking advancements in semiconductor technology|also attracts top talent and companies in the robotics industry|also leads the way in the development of lightweight, high-strength materials used in aerospace, automotive, and electronics industries|is also a hub for biomedicine, telemedicine, and wearable health devices|is also home to a spaceport and satellite manufacturing facilities, playing a significant role in the space industry</en>
 				</hasbecomeagloballeader>
-				<summittown>
-					<de>${.stationmap:"randomcity"}</de>
-				</summittown>
+				<summittown>${.stationmap:"randomcity"}</summittown>
 				<communism>
 					<de>Kommunismus|Liberalsozialismus|Luxemburgismus|Titoismus|Rätekommunismus|Situationismus|Syndikalismus|Distributismus|Mutualismus|Trotzkismus</de>
 					<en>Communism|Liberal Socialism|Luxemburgism|Titoism|Council Communism|Situationism|Syndicalism|Distributism|Mutualism|Trotskyism</en>
@@ -1935,9 +1861,7 @@
 					<de>Namentanzen|Eurythmie|Mummerei|Mummenschanz|Dionysien|Voodoo|Derwischtanz</de>
 					<en>Name dancing|Eurythmy|Mummery|Mummers' Plays|Dionysia|Voodoo|Dervish Dance</en>
 				</namedancing>
-				<i>
-					<de>0|1|2|3</de>
-				</i>
+				<i>0|1|2|3</i>
 				<particleacc_0>
 					<de>Teilchenbeschleuniger</de>
 					<en>Particle Accelerator</en>
@@ -1947,8 +1871,7 @@
 					<en>Super AI</en>
 				</particleacc_1>
 				<particleacc_2>
-					<de>HoloScreen</de>
-					<en>HoloScreen</en>
+					<all>HoloScreen</all>
 				</particleacc_2>
 				<particleacc_3>
 					<de>Super-Quanten-Internet</de>
@@ -1974,15 +1897,9 @@
 					<de>Sri Lanka|Osttimor|Brunei|Laos</de>
 					<en>Sri Lanka|East Timor|Brunei|Laos</en>
 				</srilanka>
-				<goalsfor>
-					<de>0|0|0|0|0|1|1|2</de>
-				</goalsfor>
-				<goalsagainst>
-					<de>7|8|9|10|11|12|13|14|15|16|17</de>
-				</goalsagainst>
-				<j>
-					<de>0|1</de>
-				</j>
+				<goalsfor>0|0|0|0|0|1|1|2</goalsfor>
+				<goalsagainst>7|8|9|10|11|12|13|14|15|16|17</goalsagainst>
+				<j>0|1</j>
 				<citizenslovetvtower_0>
 					<de>${meigawa}-Bürger lieben TVTower-Programm</de>
 					<en>${meigawa} citizens love TVTower program</en>
@@ -2063,15 +1980,9 @@
 					<de>Die Vertriebshäuser gingen mit Ronnys exorbitanten Preisvorstellungen einfach nicht mit. Die Einwohner von ${meigawa} beziehen das TVTower-Game weiterhin schwarz.</de>
 					<en>The distribution centers simply did not go along with Ronny's exorbitant proposed prices. The inhabitants of ${meigawa} continue to obtain the TVTower game as pirated copies.</en>
 				</stillpirating_1>
-				<singerfirstname>
-					<de>Kaori|Korui|Kyung|Sora</de>
-				</singerfirstname>
-				<singerlastname>
-					<de>Sakita|Shimoi|Seong|Kwon</de>
-				</singerlastname>
-				<k>
-					<de>0|1</de>
-				</k>
+				<singerfirstname>Kaori|Korui|Kyung|Sora</singerfirstname>
+				<singerlastname>Sakita|Shimoi|Seong|Kwon</singerlastname>
+				<k>>0|1</k>
 				<teleportation_0>
 					<de>Teleportation</de>
 					<en>teleportation</en>
@@ -2096,12 +2007,8 @@
 					<de>wenn jeder wild über Grenzen hinweg schwirren könnte</de>
 					<en>if everyone could whizz wildly across borders</en>
 				</ifeveryonecould_1>
-				<festivitytown>
-					<de>${.stationmap:"randomcity"}</de>
-				</festivitytown>
-				<m>
-					<de>0|1|2|3|4|5</de>
-				</m>
+				<festivitytown>${.stationmap:"randomcity"}</festivitytown>
+				<m>0|1|2|3|4|5</m>
 				<onvenus_0>
 					<de>auf der Venus</de>
 					<en>on Venus</en>
@@ -2150,12 +2057,8 @@
 					<de>in der feinstofflichen ätherischen Zwischenwelt</de>
 					<en>in the intangible ethereal netherworld</en>
 				</ontherapidlytransformedvenus_5>
-				<festivitytownatlantis>
-					<de>${.stationmap:"randomcity"}</de>
-				</festivitytownatlantis>
-				<cultleadertown>
-					<de>${.stationmap:"randomcity"}</de>
-				</cultleadertown>
+				<festivitytownatlantis>${.stationmap:"randomcity"}</festivitytownatlantis>
+				<cultleadertown>${.stationmap:"randomcity"}</cultleadertown>
 			</variables>
 			<data genre="0" price="1" quality="60" fictional="1" />
 			<effects>
@@ -2351,8 +2254,7 @@
 				<en>Details about ${meigawa} ${particleacc_${i}}</en>
 			</title>
 			<description>
-				<de>${itsshapedlike_${i}}</de>
-				<en>${itsshapedlike_${i}}</en>
+				<all>${itsshapedlike_${i}}</all>
 			</description>
 			<data genre="3" price="1" quality="50" fictional="1" />
 			<effects>
@@ -2557,12 +2459,10 @@
 		</news>
 		<news guid="99f71d0b-92a2-4869-88fb-93d4d1ce907f" type="2" thread_guid="48feebb0-4ef2-419b-8342-aa6376a4f246" creator="9551">
 			<title>
-				<de>${citizenslovetvtower_${j}}</de>
-				<en>${citizenslovetvtower_${j}}</en>
+				<all>${citizenslovetvtower_${j}}</all>
 			</title>
 			<description>
-				<de>${inhabitantspirating_${j}}</de>
-				<en>${inhabitantspirating_${j}}</en>
+				<all>${inhabitantspirating_${j}}</all>
 			</description>
 			<data genre="3" price="1" quality="45" fictional="1" />
 			<effects>
@@ -2571,12 +2471,10 @@
 		</news>
 		<news guid="52964ea8-07e7-4f61-b831-a420d20b7bb1" type="2" thread_guid="48feebb0-4ef2-419b-8342-aa6376a4f246" creator="9551">
 			<title>
-				<de>${billionsnewviewers_${j}}</de>
-				<en>${billionsnewviewers_${j}}</en>
+				<all>${billionsnewviewers_${j}}</all>
 			</title>
 			<description>
-				<de>${allfinancialtroublessolved_${j}}</de>
-				<en>${allfinancialtroublessolved_${j}}</en>
+				<all>${allfinancialtroublessolved_${j}}</all>
 			</description>
 			<data genre="3" price="1" quality="40" fictional="1" />
 			<effects>
@@ -2585,12 +2483,10 @@
 		</news>
 		<news guid="e48a30a8-f013-46a5-9c00-6e051144e607" type="2" thread_guid="48feebb0-4ef2-419b-8342-aa6376a4f246" creator="9551">
 			<title>
-				<de>${bossesflyto_${j}}</de>
-				<en>${bossesflyto_${j}}</en>
+				<all>${bossesflyto_${j}}</all>
 			</title>
 			<description>
-				<de>${bossesnegotiations_${j}}</de>
-				<en>${bossesnegotiations_${j}}</en>
+				<all>${bossesnegotiations_${j}}</all>
 			</description>
 			<data genre="3" price="1" quality="45" fictional="1" />
 			<effects>
@@ -2599,12 +2495,10 @@
 		</news>
 		<news guid="c3f150c9-d051-491d-bdeb-eaef20e44424" type="2" thread_guid="48feebb0-4ef2-419b-8342-aa6376a4f246" creator="9551">
 			<title>
-				<de>${stillavailable_${j}}</de>
-				<en>${stillavailable_${j}}</en>
+				<all>${stillavailable_${j}}</all>
 			</title>
 			<description>
-				<de>${atleastoneplayer_${j}}</de>
-				<en>${atleastoneplayer_${j}}</en>
+				<all>${atleastoneplayer_${j}}</all>
 			</description>
 			<data genre="3" price="1" quality="35" fictional="1" />
 			<effects>
@@ -2613,12 +2507,10 @@
 		</news>
 		<news guid="c27ee130-acb6-4946-83bf-7b03d2ae911b" type="2" thread_guid="48feebb0-4ef2-419b-8342-aa6376a4f246" creator="9551">
 			<title>
-				<de>${negotiationsfailed_${j}}</de>
-				<en>${negotiationsfailed_${j}}</en>
+				<all>${negotiationsfailed_${j}}</all>
 			</title>
 			<description>
-				<de>${stillpirating_${j}}</de>
-				<en>${stillpirating_${j}}</en>
+				<all>${stillpirating_${j}}</all>
 			</description>
 			<data genre="3" price="1" quality="40" fictional="1" />
 			<effects>

--- a/res/database/Default/user/scr0llbaer_news.xml
+++ b/res/database/Default/user/scr0llbaer_news.xml
@@ -855,7 +855,7 @@
 					<pl> i ściągnięty przez straż pożarną|w stawie w parku i bezpiecznie zwrócony organizatorom parady|Okazało się że balon został porwany przez żartownisiów, ale policji udało się ich wytropić.</pl>
 				</andbroughtdownby>
 				<nina>Nina|Nia|Nana|Nona</nina>
-				<artistlastname>>${.persongenerator:"lastname":"de":"female"}|${.persongenerator:"lastname":"en":"female"}|${.persongenerator:"lastname":"fr":"female"}</artistlastname>
+				<artistlastname>${.persongenerator:"lastname":"de":"female"}|${.persongenerator:"lastname":"en":"female"}|${.persongenerator:"lastname":"fr":"female"}</artistlastname>
 				<ofsportsclub>
 					<de>des Sportclubs|des Sportvereins|der Sportfreunde|des Fußballclubs|der Spielvereinigung</de>
 					<en>of Sports Club|of the Sports Association|of Sports Friends|of Football Club|of United</en>

--- a/res/database/Default/user/scr0llbaer_screenplays_adaptations.xml
+++ b/res/database/Default/user/scr0llbaer_screenplays_adaptations.xml
@@ -543,8 +543,7 @@
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="ed6652ef-7559-48ab-9ee3-a4fbb26fae59" creator="9551" comment="https://en.wikipedia.org/wiki/Umberto_Eco | https://de.wikipedia.org/wiki/Baudolino">
 			<title>
-				<de>${.self:"role":1:"firstname"}</de>
-				<en>${.self:"role":1:"firstname"}</en>
+				<all>${.self:"role":1:"firstname"}</all>
 			</title>
 			<title_original>
 				<de>Baudolino</de>
@@ -2542,8 +2541,7 @@
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="9eac358b-717a-4a43-a699-71a813833b00" creator="9551" comment="https://en.wikipedia.org/wiki/Carlos_Ruiz_Zaf%C3%B3n | https://en.wikipedia.org/wiki/Marina_(novel)">
 			<title>
-				<de>${.self:"role":1:"firstname"}</de>
-				<en>${.self:"role":1:"firstname"}</en>
+				<all>${.self:"role":1:"firstname"}</all>
 			</title>
 			<title_original>
 				<de>Marina</de>
@@ -2762,8 +2760,7 @@
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="e8a3bf50-ab02-43d8-b980-c0fb7234a3b4" creator="9551" comment="https://en.wikipedia.org/wiki/Bruno_Brazil">
 			<title>
-				<de>${.self:"role":1:"fullname"}</de>
-				<en>${.self:"role":1:"fullname"}</en>
+				<all>${.self:"role":1:"fullname"}</all>
 			</title>
 			<title_original>
 				<de>Bruno Brazil</de>
@@ -2800,8 +2797,7 @@
 		</scripttemplate>
 		<scripttemplate product="2" licence_type="3" guid="d545bf8a-b0f4-4888-978e-2a6561027be0" creator="9551" comment="https://de.wikipedia.org/wiki/Kai_Meyer | https://de.wikipedia.org/wiki/Merle-Zyklus">
 			<title>
-				<de>${.self:"role":1:"firstname"}</de>
-				<en>${.self:"role":1:"firstname"}</en>
+				<all>${.self:"role":1:"firstname"}</all>
 			</title>
 			<title_original>
 				<de>Merle</de>
@@ -2931,8 +2927,7 @@
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="d1a8be89-1ded-49ee-8cb4-47cfd4cc64f9">
 					<title>
-						<de>${.self:"role":1:"fullname"}</de>
-						<en>${.self:"role":1:"fullname"}</en>
+						<all>${.self:"role":1:"fullname"}</all>
 					</title>
 					<title_original>
 						<de>Selina</de>
@@ -2945,8 +2940,7 @@
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="b54f96e8-2ad4-4714-a9ca-6b45a8d8a55d">
 					<title>
-						<de>${.self:"role":5:"firstname"}</de>
-						<en>${.self:"role":5:"firstname"}</en>
+						<all>${.self:"role":5:"firstname"}</all>
 					</title>
 					<title_original>
 						<de>Stark</de>
@@ -2959,8 +2953,7 @@
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="403a5846-8d8b-4d21-87a6-4817ffbf7c4b">
 					<title>
-						<de>${.self:"role":6:"firstname"}</de>
-						<en>${.self:"role":6:"firstname"}</en>
+						<all>${.self:"role":6:"firstname"}</all>
 					</title>
 					<title_original>
 						<de>Slam</de>
@@ -3352,8 +3345,7 @@
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="56617d57-9cb3-40a8-afb0-e4621524c8f9" creator="9551" comment="https://de.wikipedia.org/wiki/Walter_Satterthwait | https://www.goodreads.com/book/show/1802533.Miss_Lizzie | translators: the rhyming verse might also be on some on the other language versions of https://en.wikipedia.org/wiki/Lizzie_Borden">
 			<title>
-				<de>Miss ${.self:"role":1:"firstname"}</de>
-				<en>Miss ${.self:"role":1:"firstname"}</en>
+				<all>Miss ${.self:"role":1:"firstname"}</all>
 			</title>
 			<title_original>
 				<de>Miss Lizzie</de>
@@ -4545,8 +4537,7 @@
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="6f362a5a-6730-4772-b964-655d6bb3b6aa">
 					<title>
-						<de>Sound Sister ${.self:"role":2:"firstname"}</de>
-						<en>Sound Sister ${.self:"role":2:"firstname"}</en>
+						<all>Sound Sister ${.self:"role":2:"firstname"}</all>
 					</title>
 					<title_original>
 						<de>Suite Sister Mary</de>
@@ -4734,12 +4725,10 @@
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="be63b350-f1a2-44ad-a139-df3a1145ac12">
 					<title>
-						<de>${.self:"role":4:"fullname"}</de>
-						<en>${.self:"role":4:"fullname"}</en>
+						<all>${.self:"role":4:"fullname"}</all>
 					</title>
 					<title_original>
-						<de>${.self:"role":4:"fullname"}</de>
-						<en>${.self:"role":4:"fullname"}</en>
+						<all>${.self:"role":4:"fullname"}</all>
 					</title_original>
 					<description>
 						<de>${.self:"role":4:"firstname"}s Vergangenheit mit ${.self:"role":6:"firstname"} wird aufgedeckt und die dunklen Geheimnisse, die sie teilen. Als Johnny von ihrer Verbindung erfährt, wird er von Schuldgefühlen und Reue übermannt, was zu Konflikten führt, die den Zusammenhalt der Band gefährden.</de>
@@ -5579,12 +5568,10 @@
 		</scripttemplate>
 		<scripttemplate product="2" licence_type="3" guid="61661455-9607-44fd-a090-c1caa8ee3205" creator="9551" comment="https://en.wikipedia.org/wiki/Dead_Winter_Dead">
 			<title>
-				<de>${dead} ${winter} in ${sarajevo}</de>
-				<en>${dead} ${winter} in ${sarajevo}</en>
+				<all>${dead} ${winter} in ${sarajevo}</all>
 			</title>
 			<title_original>
-				<de>${title_original_optional}</de>
-				<en>${title_original_optional}</en>
+				<all>${title_original_optional}</all>
 			</title_original>
 			<description>
 				<de>Kriegsdrama über den jungen, enthusiastischen und leicht beeindruckbaren ${.self:"role":1:"firstname"} auf der einen, und die warmherzige, aber resolute ${.self:"role":2:"firstname"} auf der anderen Seite der Front in Jugoslawien, und einen Teufels-${.self:"role":3:"firstname"}en dazwischen.</de>
@@ -5709,12 +5696,10 @@
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="98f1d16e-5a8e-4838-8f3b-a51213062008">
 					<title>
-						<de>${dead} ${winter}</de>
-						<en>${dead} ${winter}</en>
+						<all>${dead} ${winter}</all>
 					</title>
 					<title_original>
-						<de>${title_original_optional}</de>
-						<en>${title_original_optional}</en>
+						<all>${title_original_optional}</all>
 					</title_original>
 					<description>
 						<de>Obwohl der Winter sein Bestes tut, die Landschaft in eine Decke vorübergehender Unschuld zu hüllen, eskaliert der Krieg in Gewalt und Brutalität. ${.self:"role":1:"firstname"} ist auf Patrouille und macht eine grausame Entdeckung...</de>
@@ -6439,12 +6424,10 @@
 
 		<scripttemplate product="1" licence_type="1" guid="352a2fbc-7e7b-462b-a217-34c300043d19" creator="9551" comment="inspired from https://en.wikipedia.org/wiki/Maniac_Mansion">
 			<title>
-				<de>${title_spoofed}</de>
-				<en>${title_spoofed}</en>
+				<all>${title_spoofed}</all>
 			</title>
 			<title_original>
-				<de>${title_original_optional}</de>
-				<en>${title_original_optional}</en>
+				<all>${title_original_optional}</all>
 			</title_original>
 			<description>
 				<de>${.self:"role":1:"firstname"}s Freundin ${.self:"role":2:"firstname"} wurde entführt vom verrückten Professor Dr. ${.self:"role":5:"firstname"}! Er und seine Freunde wollen sie aus dessen Villa befreien. Dort gehen noch viel mehr merkwürdige Dinge vor sich! Und wo ist Benzin für die Kettensäge, wenn man's mal braucht.</de>
@@ -6772,12 +6755,10 @@
 					<en>${donkey_o} ${bay_o}</en>
 				</donkeybay_object_reference_original>
 				<mystery_object_reference>
-					<de>${mystery}</de>
-					<en>${mystery}</en>
+					<all>${mystery}</all>
 				</mystery_object_reference>
 				<mystery_object_reference_original>
-					<de>${mystery_o}</de>
-					<en>${mystery_o}</en>
+					<all>${mystery_o}</all>
 				</mystery_object_reference_original>
 				<mystery>
 					<de>Mysterium|Rätsel|Geheimnis</de>
@@ -6807,12 +6788,10 @@
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="b33a635e-d381-4349-9a41-7d2277c5d6da">
 					<title>
-						<de>${hurlyeisland_object_reference}</de>
-						<en>${hurlyeisland_object_reference}</en>
+						<all>${hurlyeisland_object_reference}</all>
 					</title>
 					<title_original>
-						<de>${hurlyeisland_object_reference}</de>
-						<en>${hurlyeisland_object_reference}</en>
+						<all>${hurlyeisland_object_reference}</all>
 					</title_original>
 					<description>
 						<de>${.self:"role":1:"firstname"} ist erstmal auf ${hurlyeisland_object_reference} gestrandet und macht sich mit der eigentlich recht lauschigen Umgebung vertraut. Er trifft auf wegen ${.self:"role":3:"fullname"} vollkommen verängstigte Piraten, eigentlich gestandene Mannsbilder, und andere skurrile Gestalten.</de>
@@ -6908,12 +6887,10 @@
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="50d96da4-78ea-497c-8802-bb586d01682b">
 					<title>
-						<de>${donkeybay_object_reference}</de>
-						<en>${donkeybay_object_reference}</en>
+						<all>${donkeybay_object_reference}</all>
 					</title>
 					<title_original>
-						<de>${donkeybay_object_reference}</de>
-						<en>${donkeybay_object_reference}</en>
+						<all>${donkeybay_object_reference}</all>
 					</title_original>
 					<description>
 						<de>Dort hinzukommen war schon aufreibend genug, der Legende nach kehrte auch nie jemand lebend zurück. Aber ${.self:"role":1:"firstname"} trifft am Strand zumindest schon mal einen Menschen. Der schiffbrüchige und etwas durchgeknallte Hendrik ist schon seit Jahren gestrandet dort.</de>
@@ -7307,12 +7284,10 @@ The project, which was cancelled by a major producer, is now free to be realized
 		</scripttemplate>
 		<scripttemplate product="2" licence_type="3" guid="fd47c57a-c84a-4c3d-bfd4-73b10d230406" creator="9551" comment="https://en.wikipedia.org/wiki/Commander_Keen | TODO: apply proper nickname references of Ween/Keen once feature is available">
 			<title>
-				<de>${title_spoofed}</de>
-				<en>${title_spoofed}</en>
+				<all>${title_spoofed}</all>
 			</title>
 			<title_original>
-				<de>${title_original_optional}</de>
-				<en>${title_original_optional}</en>
+				<all>${title_original_optional}</all>
 			</title_original>
 			<description>
 				<de>Cartoon-Reihe über den 8-jährigen Wunderknaben ${.self:"role":1:"fullname"}. Er baut aus einem Staubsauger ein Raumfahrzeug, schnappt sich seinen Pogo-Stick, setzt den Footballhelm seines älteren Bruders auf, wird zu ${captain} ${ween_object_reference} und macht sich auf...</de>
@@ -7510,12 +7485,10 @@ The project, which was cancelled by a major producer, is now free to be realized
 		</scripttemplate>
 		<scripttemplate product="2" licence_type="3" guid="c0d67fc9-1388-4715-b708-713df17c681a" creator="9551" comment="https://en.wikipedia.org/wiki/Leisure_Suit_Larry | TODO: ref nicknames once feature available">
 			<title>
-				<de>Leather Jacket ${.self:"role":1:"firstname"}, ${ladykiller}</de>
-				<en>Leather Jacket ${.self:"role":1:"firstname"}, ${ladykiller}</en>
+				<all>Leather Jacket ${.self:"role":1:"firstname"}, ${ladykiller}</all>
 			</title>
 			<title_original>
-				<de>${title_original_optional}</de>
-				<en>${title_original_optional}</en>
+				<all>${title_original_optional}</all>
 			</title_original>
 			<description>
 				<de>${.self:"role":1:"firstname"} ist bis Mitte 30 unberührt und unschuldig. Nun will er's aber wissen und sucht eine Absteige auf. Nach einigen Schwierigkeiten... Endlich! Langsam kriegt er den Dreh raus, und beginnt dann nach der Frau seines Lebens zu suchen.</de>
@@ -7523,8 +7496,7 @@ The project, which was cancelled by a major producer, is now free to be realized
 			</description>
 			<variables>
 				<title_original_optional>
-					<de>Leisure Suit ${.self:"role":1:"firstname"}|Leisure Suit ${.self:"role":1:"firstname"}, ${ladykiller}</de>
-					<en>Leisure Suit ${.self:"role":1:"firstname"}|Leisure Suit ${.self:"role":1:"firstname"}, ${ladykiller}</en>
+					<all>Leisure Suit ${.self:"role":1:"firstname"}|Leisure Suit ${.self:"role":1:"firstname"}, ${ladykiller}</all>
 				</title_original_optional>
 				<ladykiller>
 					<de>Ladykiller|Schwerenöter vom Dienst|Reizender Charmeur|Bezaubernder Schmeichler</de>
@@ -7667,12 +7639,10 @@ The project, which was cancelled by a major producer, is now free to be realized
 		</scripttemplate>
 		<scripttemplate product="2" licence_type="3" guid="0f7053ad-249f-47d3-8302-4853b386bedb" creator="9551" comment="https://en.wikipedia.org/wiki/Counter-Strike:_Global_Offensive with popular maps as episodes">
 			<title>
-				<de>${counteroffensive} - ${global} ${operations}</de>
-				<en>${counteroffensive} - ${global} ${operations}</en>
+				<all>${counteroffensive} - ${global} ${operations}</all>
 			</title>
 			<title_original>
-				<de>${counterstrike} - ${global} ${offensive}</de>
-				<en>${counterstrike} - ${global} ${offensive}</en>
+				<all>${counterstrike} - ${global} ${offensive}</all>
 			</title_original>
 			<description>
 				<de>Hochdramatische Szenen an Schauplätzen auf der ganzen Welt. Kann das Einsatzkommando in letzter Millisekunde die Bombe entschärfen? Die Geisel aus dem Kreuzfeuer der Terroristen befreien? Oder fahren eher letztere die Sympathiepunkte beim Publikum ein?</de>
@@ -8705,14 +8675,8 @@ The project, which was cancelled by a major producer, is now free to be realized
 			</description>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="7d13827e-63c7-4d87-a1e0-73d8a19b16f5">
-					<title>
-						<de>Pilot</de>
-						<en>Pilot</en>
-					</title>
-					<title_original>
-						<de>Pilot</de>
-						<en>Pilot</en>
-					</title_original>
+					<title>Pilot</title>
+					<title_original>Pilot</title_original>
 					<description>
 						<de>Die Ankunft der Außerirdischen und der Integrationsprozess wird in Rückblenden erzählt, während Detective ${.self:"role":1:"firstname"} und sein neuer Partner, der Tenctonese ${.self:"role":2:"firstname"}, ihren ersten Mordfall lösen.</de>
 						<en>The arrival of the aliens and the integration process is told in flashbacks as Detective ${.self:"role":1:"firstname"} and his new partner, Tenctonese ${.self:"role":2:"firstname"}, solve their first murder case.</en>

--- a/res/database/Default/user/scr0llbaer_screenplays_adaptations.xml
+++ b/res/database/Default/user/scr0llbaer_screenplays_adaptations.xml
@@ -126,12 +126,10 @@
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="209f0469-2be5-41ba-b39a-9c9c986f084b" creator="9551" comment="https://en.wikipedia.org/wiki/J._D._Salinger | https://en.wikipedia.org/wiki/Hapworth_16,_1924 | originally the final publication of the Glass family series but fits better here, and taking artistic licence in describing more of the back story here">
 			<title>
-				<de>Harksworth 18, 1924</de>
-				<en>Harksworth 18, 1924</en>
+				<all>Harksworth 18, 1924</all>
 			</title>
 			<title_original>
-				<de>Hapworth 16, 1924</de>
-				<en>Hapworth 16, 1924</en>
+				<all>Hapworth 16, 1924</all>
 			</title_original>
 			<description>
 				<de>Prequel über ${.self:"role":3:"fullname"}: Sein Aufenthalt als 7-Jähriger im titulären Camp, seine Eltern, die Varieté-Perfomer ${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"}, und seine Geschwister. Alle 7 Kinder traten in einem Radioquiz für Hochbegabte auf, was sie aufs College brachte.</de>
@@ -366,12 +364,10 @@
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="f064c96f-0fbf-4187-93ee-2313f545c259">
 					<title>
-						<de>Hod</de>
-						<en>Hod</en>
+						<all>Hod</all>
 					</title>
 					<title_original>
-						<de>Hod</de>
-						<en>Hod</en>
+						<all>Hod</all>
 					</title_original>
 					<description>
 						<de>${.self:"role":5:"fullname"} präsentiert ein mysteriöses und potenziell gefährliches Templer-Manuskript, nur um dann spurlos zu verschwinden.</de>
@@ -380,12 +376,10 @@
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="ec0ad1cd-a4c5-485d-9833-62264469be39">
 					<title>
-						<de>Netzach</de>
-						<en>Netzach</en>
+						<all>Netzach</all>
 					</title>
 					<title_original>
-						<de>Netzach</de>
-						<en>Netzach</en>
+						<all>Netzach</all>
 					</title_original>
 					<description>
 						<de>Auf der Suche nach Trost reist ${.self:"role":1:"fullname"} nach Brasilien, wo er ${.self:"role":7:"fullname"}, einem Experten für das Okkulte, begegnet und sich in die Sozialistin ${.self:"role":6:"fullname"} verliebt.</de>
@@ -422,12 +416,10 @@
 				</scripttemplate>
 				<scripttemplate index="6" product="2" licence_type="2" guid="28d6e0e8-19c8-4e8d-b065-0112170448b4">
 					<title>
-						<de>Chesed</de>
-						<en>Chesed</en>
+						<all>Chesed</all>
 					</title>
 					<title_original>
-						<de>Chesed</de>
-						<en>Chesed</en>
+						<all>Chesed</all>
 					</title_original>
 					<description>
 						<de>Gelangweilt von bestehenden Theorien heckt das Trio, nur als Gedankenspiel, eine ausgeklügelte Superverschwörung aus, die nur als der „Große Plan“ bezeichnet wird.</de>
@@ -436,12 +428,10 @@
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="2e8c38f8-c3bd-4964-be28-77086a72f2f1">
 					<title>
-						<de>Binah</de>
-						<en>Binah</en>
+						<all>Binah</all>
 					</title>
 					<title_original>
-						<de>Binah</de>
-						<en>Binah</en>
+						<all>Binah</all>
 					</title_original>
 					<description>
 						<de>Begeistert von ihrer Schöpfung beginnen ${.self:"role":1:"fullname"} und seine Partner, ${.self:"role":7:"fullname"} gegenüber anzudeuten, dass sie im Besitz verborgenen Wissens sind.</de>
@@ -450,12 +440,10 @@
 				</scripttemplate>
 				<scripttemplate index="8" product="2" licence_type="2" guid="c572b563-808f-42da-9dba-541171f2844a">
 					<title>
-						<de>Chochmah</de>
-						<en>Chochmah</en>
+						<all>Chochmah</all>
 					</title>
 					<title_original>
-						<de>Chochmah</de>
-						<en>Chochmah</en>
+						<all>Chochmah</all>
 					</title_original>
 					<description>
 						<de>${.self:"role":7:"fullname"} und europäische Okkultisten, die glauben, die Geschichte kontrollieren zu müssen, jagen das Trio unerbittlich wegen der angeblichen Geheimnisse des „Großen Plans“.</de>
@@ -464,12 +452,10 @@
 				</scripttemplate>
 				<scripttemplate index="9" product="2" licence_type="2" guid="ebb91722-c6cd-4cc3-87e1-3f60ba0847f4">
 					<title>
-						<de>Kether</de>
-						<en>Kether</en>
+						<all>Kether</all>
 					</title>
 					<title_original>
-						<de>Kether</de>
-						<en>Kether</en>
+						<all>Kether</all>
 					</title_original>
 					<description>
 						<de>Als die Verfolgung immer intensiver wird, verzweifeln ${.self:"role":7:"fullname"} und die anderen, was in einem spannenden Höhepunkt gipfelt, an dem Wahrheit und Trug aufeinanderprallen.</de>
@@ -546,8 +532,7 @@
 				<all>${.self:"role":1:"firstname"}</all>
 			</title>
 			<title_original>
-				<de>Baudolino</de>
-				<en>Baudolino</en>
+				<all>Baudolino</all>
 				<it>Baudolino</it>
 			</title_original>
 			<description>
@@ -1032,12 +1017,10 @@
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="7fd1459c-12b3-4c86-ac3e-6771d79b52c2" creator="9551" comment="https://en.wikipedia.org/wiki/Cormac_McCarthy | https://en.wikipedia.org/wiki/Suttree">
 			<title>
-				<de>Siltrunk</de> <!-- TODO: Use last name reference -->
-				<en>Siltrunk</en>
+				<all>Siltrunk</all> <!-- TODO: Use last name reference -->
 			</title>
 			<title_original>
-				<de>Suttree</de>
-				<en>Suttree</en>
+				<all>Suttree</all>
 			</title_original>
 			<description>
 				<de>${.self:"role":1:"fullname"} gibt sein früheres privilegiertes Leben auf, um Fischer am Tennessee River zu werden, versucht, seine wahre Identität inmitten von Verstoßenen und Außenseitern zu finden, und erlebt dabei allerlei Missgeschicke.</de>
@@ -1108,8 +1091,7 @@
 				<en>Downwind</en>
 			</title>
 			<title_original>
-				<de>Fallwind</de>
-				<en>Fallwind</en>
+				<all>Fallwind</all>
 			</title_original>
 			<description>
 				<de>Kommissar ${.self:"role":1:"fullname"} findet sich in einer Windrad-Gondel auf der Nordsee wieder, zusammen mit einer Unbekannten und Vorräten für ein paar Tage. Erst Stück für Stück kommen die Erinnerungen zurück.</de>
@@ -1799,8 +1781,7 @@
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="90fbe294-e7ab-4072-a1f0-71a8f8767d1e" creator="9551" comment="https://de.wikipedia.org/wiki/Ralf_Rothmann | https://www.goodreads.com/book/show/1329586.Stier">
 			<title>
-				<de>Taurus</de>
-				<en>Taurus</en>
+				<all>Taurus</all>
 			</title>
 			<title_original>
 				<de>Stier</de>
@@ -2102,12 +2083,10 @@
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="502f4dc9-e80b-46f8-bdcc-564bb558b883">
 					<title>
-						<de>1984</de>
-						<en>1984</en>
+						<all>1984</all>
 					</title>
 					<title_original>
-						<de>1984</de>
-						<en>1984</en>
+						<all>1984</all>
 					</title_original>
 					<description>
 						<de>${.self:"role":1:"fullname"}, von ihrer Mutter und „Salon-Kommunistin“ ${.self:"role":2:"firstname"} damals mit anderen zwecks „Umsturz“ in die USA geschickt, sieht sich vor allem Vorwürfen über illegale Aktivitäten durch Personen aus ihrem Umfeld konfrontiert.</de>
@@ -2116,12 +2095,10 @@
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="787b2aba-aa8d-4f66-be4f-29d8a1fc69ae">
 					<title>
-						<de>1985</de>
-						<en>1985</en>
+						<all>1985</all>
 					</title>
 					<title_original>
-						<de>1985</de>
-						<en>1985</en>
+						<all>1985</all>
 					</title_original>
 					<description>
 						<de>Ein geplanter Zusamenschluss der Stadt mit dem Bezirk, Teil eines umfassenden Immobilienspekulationsplans ausgeheckt von ${.self:"role":1:"firstname"} und ihren Kohorten, führt zu einer Auseinandersetzung zwischen ihr und ${.self:"role":3:"fullname"}.</de>
@@ -2202,8 +2179,7 @@
 						<en>The Road in Illinois</en>
 					</title>
 					<title_original>
-						<de>Argilla Road</de>
-						<en>Argilla Road</en>
+						<all>Argilla Road</all>
 					</title_original>
 					<description>
 						<de>${.self:"role":1:"firstname"} besucht seinen Vater ${.self:"role":3:"firstname"} in Illinois, ein linksliberaler, ökologisch eingestellter Geschichtsprofessor, und sie sprechen sich aus, u.a. über die kapitalistische ${.self:"role":4:"firstname"}. Er äußert die Vermutung wirtschaftskrimineller Manipulationen.</de>
@@ -2270,8 +2246,7 @@
 						<en>${.self:"role":1:"firstname"} in the Bay Area</en>
 					</title>
 					<title_original>
-						<de>Purity in Oakland</de>
-						<en>Purity in Oakland</en>
+						<all>Purity in Oakland</all>
 					</title_original>
 					<description>
 						<de>${.self:"role":1:"firstname"} arbeitet als Telemarketerin und lebt wegen ihrer heimlichen Liebe zu einem verheirateten Mann mietfrei in einem besetzten Haus. ${.self:"role":6:"firstname"}, eine schöne deutsche Aktivistin, bringt sie nach Bolivien zur Arbeit bei einer Whistleblowing-Plattform.</de>
@@ -2308,12 +2283,11 @@
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="5ffce4de-85ce-4f57-a74f-0cb4672a0785">
 					<title>
-						<de>Moonshine Journal</de>
-						<en>Moonshine Journal</en>
+						<all>Moonshine Journal</all>
 					</title>
 					<title_original>
 						<de>Moonglow Diary</de>
-						<en>Moonglow Dairy</en>
+						<en>Moonglow Dairy</en><!-- TODO really Dairy-->
 					</title_original>
 					<description>
 						<de>Rückblick auf die Arbeit von ${.self:"role":1:"firstname"} in Bolivien, die sie liebt, aber sie ist konsterniert über die bizarre Hierarchie. ${.self:"role":2:"firstname"} macht ihr sexuelle Avancen und sagt ihr, dass es unmöglich sei, ihren Vater ausfindig zu machen.</de>
@@ -2322,12 +2296,10 @@
 				</scripttemplate>
 				<scripttemplate index="4" product="2" licence_type="2" guid="9aee3548-61c4-4670-b2c5-2ea9e0acf9a8">
 					<title>
-						<de>[li3o9n8e0l1]</de>
-						<en>[li3o9n8e0l1]</en>
+						<all>[li3o9n8e0l1]</all>
 					</title>
 					<title_original>
-						<de>[le1o9n8a0rd]</de>
-						<en>[le1o9n8a0rd]</en>
+						<all>[le1o9n8a0rd]</all>
 					</title_original>
 					<description>
 						<de>${.self:"role":4:"fullname"}s Hintergrundgeschichte über seine missbräuchliche Ehe und seine Reise nach Ostdeutschland in den 90er Jahren, wo er ${.self:"role":2:"firstname"} trifft und ihm hilft, die Leiche von ${.self:"role":6:"firstname"}s missbräuchlichem Stiefvater zu entsorgen.</de>
@@ -2544,8 +2516,7 @@
 				<all>${.self:"role":1:"firstname"}</all>
 			</title>
 			<title_original>
-				<de>Marina</de>
-				<en>Marina</en>
+				<all>Marina</all>
 			</title_original>
 			<description>
 				<de>Die 15-jährigen ${.self:"role":1:"firstname"} und ${.self:"role":2:"firstname"} lernen sich kennen, verlieben sich, verfolgen eine schwarze Frau, die regelmäßig auf den Friedhof kommt, und entlarven die Machenschaften des scheinbar untoten Orthopäden ${.self:"role":3:"firstname"}.</de>
@@ -2726,8 +2697,7 @@
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="b6a6f561-943e-4c03-88c6-2d47fb96b7a7" creator="9551" comment="https://de.wikipedia.org/wiki/Philipp_Winkler_(Schriftsteller) | https://www.goodreads.com/book/show/29978653-hool">
 			<title>
-				<de>Rowdy</de>
-				<en>Rowdy</en>
+				<all>Rowdy</all>
 			</title>
 			<title_original>
 				<de>Hool</de>
@@ -2763,8 +2733,7 @@
 				<all>${.self:"role":1:"fullname"}</all>
 			</title>
 			<title_original>
-				<de>Bruno Brazil</de>
-				<en>Bruno Brazil</en>
+				<all>Bruno Brazil</all>
 			</title_original>
 			<description>
 				<de>Realverfilmung des Comics. ${.self:"role":1:"firstname"} ist Anführer einer kleinen Elite-Kampfeinheit des US-Geheimdienstes, dem „Cayman Command“. Jedes Mitglied verfügt über besondere Fähigkeiten. Gemeinsam bekämpfen sie Verbrechen und exotische Bedrohungen.</de>
@@ -2800,8 +2769,7 @@
 				<all>${.self:"role":1:"firstname"}</all>
 			</title>
 			<title_original>
-				<de>Merle</de>
-				<en>Merle</en>
+				<all>Merle</all>
 			</title_original>
 			<description>
 				<de>${.self:"role":1:"firstname"} ist in einem Waisenhaus aufgewachsen und kommt mit 14 Jahren zusammen mit ${.self:"role":2:"firstname"} als Lehrling in die Werkstatt ${.self:"role":4:"firstname"}s. Die einzige Beziehung zu ihren Eltern ist der Zauberspiegel ihrer Mutter, der aus Wasser statt Glas besteht.</de>
@@ -2930,8 +2898,7 @@
 						<all>${.self:"role":1:"fullname"}</all>
 					</title>
 					<title_original>
-						<de>Selina</de>
-						<en>Selina</en>
+						<all>Selina</all>
 					</title_original>
 					<description>
 						<de>${.self:"role":1:"fullname"}s Marokko-Raubzug geht schief, als sie feststellt, dass der „Cup of Hassan“ nicht echt ist. ${.self:"role":2:"firstname"} versorgt sie mit Bargeld und einem sicheren Haus in Gotham. Eine neue Gelegenheit wartet.</de>
@@ -2943,8 +2910,7 @@
 						<all>${.self:"role":5:"firstname"}</all>
 					</title>
 					<title_original>
-						<de>Stark</de>
-						<en>Stark</en>
+						<all>Stark</all>
 					</title_original>
 					<description>
 						<de>${.self:"role":1:"firstname"} und ${.self:"role":5:"firstname"} stimmen dem Eisenbahnraub zu, aber ${.self:"role":5:"firstname"} besteht darauf, die Kontrolle zu behalten. Sie planen, sich in fünf Tagen in Las Vegas zu treffen. ${.self:"role":5:"firstname"} warnt ${.self:"role":1:"firstname"} vor einem Privatdetektiv.</de>
@@ -2956,8 +2922,7 @@
 						<all>${.self:"role":6:"firstname"}</all>
 					</title>
 					<title_original>
-						<de>Slam</de>
-						<en>Slam</en>
+						<all>Slam</all>
 					</title_original>
 					<description>
 						<de>${.self:"role":6:"fullname"} wartet auf ${.self:"role":1:"firstname"}, trifft aber beim Verlassen von ${.self:"role":2:"firstname"}'s auf ${.self:"role":4:"firstname"}. Er folgt ${.self:"role":1:"firstname"}s und ${.self:"role":4:"firstname"}s Spur, muss aber feststellen, dass ${.self:"role":4:"firstname"} von ${.self:"role":3:"fullname"} schwer verprügelt wurde. ${.self:"role":6:"firstname"} tötet ${.self:"role":3:"firstname"}s Männer.</de>
@@ -2966,12 +2931,10 @@
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="a093e4f1-27ee-4da0-8690-587c565a5da6">
 					<title>
-						<de>Coup</de>
-						<en>Coup</en>
+						<all>Coup</all>
 					</title>
 					<title_original>
-						<de>Score</de>
-						<en>Score</en>
+						<all>Score</all>
 					</title_original>
 					<description>
 						<de>${.self:"role":1:"firstname"}, ${.self:"role":7:"firstname"} und ${.self:"role":5:"firstname"} entern erfolgreich den Geldtransport-Zug und werfen die Taschen in den Fluss. ${.self:"role":2:"firstname"}s Boot wartet unten, aber als das Trio an Bord geht, wird auf sie geschossen.</de>
@@ -3020,12 +2983,10 @@
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="1eeda30d-6b01-46f4-ae6f-edd19c3139f3">
 					<title>
-						<de>Hyperiad</de>
-						<en>Hyperiad</en>
+						<all>Hyperiad</all>
 					</title>
 					<title_original>
-						<de>Hyperion</de>
-						<en>Hyperion</en>
+						<all>Hyperion</all>
 					</title_original>
 					<description>
 						<de>Der titelgebende Planet befindet sich im abgelegenen „Outback“ und ist schwer zu erreichen, beherbergt aber in der Zeit rückwärts wandernde „Gräber“. 7 Pilger auf einer Reise dorthin, um eine Invasion zu verhindern, erzählen ihre Lebensgeschichten.</de>
@@ -3109,12 +3070,10 @@
 		</scripttemplate>
 		<scripttemplate product="2" licence_type="3" guid="b0a49e9d-8fd5-47dd-abb2-fbe2a3ca656b" creator="9551" comment="https://en.wikipedia.org/wiki/Dan_Simmons | https://en.wikipedia.org/wiki/Ilium/Olympos">
 			<title>
-				<de>Ilios/Olympium</de>
-				<en>Ilios/Olympium</en>
+				<all>Ilios/Olympium</all>
 			</title>
 			<title_original>
-				<de>Ilium/Olympos</de>
-				<en>Ilium/Olympos</en>
+				<all>Ilium/Olympos</all>
 			</title_original>
 			<description>
 				<de>Raum und Zeit sind manipulierbar. ${.self:"role":1:"fullname"}, ein nach 4200 Jahren von den Göttern (sind es überhaupt die „echten“?) wiederbelebter Historiker aus dem 21. Jahrhundert, studiert Homer und den Trojanischen Krieg und hat selbst Einfluss auf das Geschehen.</de>
@@ -3123,12 +3082,10 @@
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="031f264a-4cbe-4d5d-9462-76ae0d37a550" comment="https://en.wikipedia.org/wiki/Ilium_(novel)">
 					<title>
-						<de>Ilios</de>
-						<en>Ilios</en>
+						<all>Ilios</all>
 					</title>
 					<title_original>
-						<de>Ilium</de>
-						<en>Ilium</en>
+						<all>Ilium</all>
 					</title_original>
 					<description>
 						<de>${.self:"role":1:"firstname"}, in der Gestalt von ${.self:"role":7:"firstname"}, erschleicht sich ein Schäferstündchen mit der schönen ${.self:"role":4:"fullname"}, doch die hält ihm dann einen Dolch an die Kehle und entwickelt einen Plan, mit dessen Verwirklichung der Krieg zwischen Griechen und Trojanern endet.</de>
@@ -3137,12 +3094,10 @@
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="30fee702-4677-45b9-935f-f4dee9c1205a" comment="https://en.wikipedia.org/wiki/Olympos_(novel)">
 					<title>
-						<de>Olympium</de>
-						<en>Olympium</en>
+						<all>Olympium</all>
 					</title>
 					<title_original>
-						<de>Olympos</de>
-						<en>Olympos</en>
+						<all>Olympos</all>
 					</title_original>
 					<description>
 						<de>Zusammenlaufende Handlungsstränge: Götter-Intrigen im Olymp (auf dem Mars). Philosophierende Minenroboter von den Jupiter-Monden. Dekadente Erden-„Altmenschen“, die dachten, zu „Metamenschen“ aufzusteigen, aber um ihr Überleben gegen aggressive Voynixe kämpfen müssen.</de>
@@ -3348,8 +3303,7 @@
 				<all>Miss ${.self:"role":1:"firstname"}</all>
 			</title>
 			<title_original>
-				<de>Miss Lizzie</de>
-				<en>Miss Lizzie</en>
+				<all>Miss Lizzie</all>
 			</title_original>
 			<description>
 				<de>„${.self:"role":1:"fullname"} mit dem Beile, hackt Mama in 40 Teile. Das Ergebnis freut sie sehr, bei Papa wird's ein Teil mehr.“ 1892 freigesprochen (wahre Geschichte) trifft sie 61-jährig 1921 (fiktiv) auf die kleine ${.self:"role":2:"firstname"}. Auch deren verhasste Stiefmutter wird bald erschlagen aufgefunden.</de>
@@ -3377,7 +3331,6 @@
 			<outcome min="20" max="80" />
 			<review min="20" max="80" />
 			<speed min="20" max="80" />
-			<studio_size value="3" />
 			<effects>
 				<effect trigger="broadcastFirstTime" type="modifyScriptAvailability" guid="f0dce9e4-e7d5-4e7b-b84b-64247bdd944b" />
 			</effects>
@@ -3425,8 +3378,7 @@
 				<en>Deceased Horse</en>
 			</title>
 			<title_original>
-				<de>Dead Horse</de>
-				<en>Dead Horse</en>
+				<all>Dead Horse</all>
 			</title_original>
 			<description>
 				<de>1933 heiratet die reiche ${.self:"role":2:"firstname"} den erfolgreichen Groschenroman-Autor ${.self:"role":1:"firstname"}. Sie feiern ausschweifende Partys auf ihrer Ranch nahe Las Vegas. 1935 begeht ${.self:"role":2:"firstname"} Selbstmord (wahre Geschichte). Was ist wirklich passiert (fiktiv-spekulativ)?</de>
@@ -4453,12 +4405,10 @@
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="45f58872-b244-43f1-84dd-cdf9b1f1d906">
 					<title>
-						<de>Anarch-Y</de>
-						<en>Anarch-Y</en>
+						<all>Anarch-Y</all>
 					</title>
 					<title_original>
-						<de>Anarchy-X</de>
-						<en>Anarchy-X</en>
+						<all>Anarchy-X</all>
 					</title_original>
 					<description>
 						<de>Rückblende: Als Heroinabhängiger und Möchtegern-Radikaler, der aufgrund wirtschaftlicher Ungleichheit, Korruption und Heuchelei von der heutigen Gesellschaft frustriert war, wurde ${.self:"role":1:"firstname"} dazu gebracht, sich einer angeblich geheimen Organisation anzuschließen.</de>
@@ -4540,8 +4490,7 @@
 						<all>Sound Sister ${.self:"role":2:"firstname"}</all>
 					</title>
 					<title_original>
-						<de>Suite Sister Mary</de>
-						<en>Suite Sister Mary</en>
+						<all>Suite Sister Mary</all>
 					</title_original>
 					<description>
 						<de>${.self:"role":3:"fullname"} wird aufmerksam und sieht in ${.self:"role":2:"firstname"} eine potenzielle Bedrohung für seinen Personenkult und befiehlt ${.self:"role":1:"firstname"}, sowohl sie als auch den Priester zu töten. ${.self:"role":1:"firstname"} geht zu ${.self:"role":2:"firstname"}s Kirche und tötet den Priester, ${.self:"role":2:"firstname"} aber nicht.</de>
@@ -4711,8 +4660,7 @@
 				</scripttemplate>
 				<scripttemplate index="2" product="2" licence_type="2" guid="ce2630ae-67ef-4958-b1ec-637d55c1a597">
 					<title>
-						<de>Jet Set Lady</de>
-						<en>Jet Set Lady</en>
+						<all>Jet Set Lady</all>
 					</title>
 					<title_original>
 						<de>Jet City Lady</de>
@@ -5137,8 +5085,7 @@
 				<en>Gutter</en>
 			</title>
 			<title_original>
-				<de>Streets</de>
-				<en>Streets</en>
+				<all>Streets</all>
 			</title_original>
 			<description>
 				<de>Vom Aufstieg und Fall, und dem erneuten Aufstieg und Fall eines Rockstars in New York. Er verkauft Millionen Alben, wird drogenabhängig, und schlägt sich dann als Drogen-Dealer auf den Straßen von New York durch.</de>
@@ -5151,8 +5098,7 @@
 						<en>Alleys</en>
 					</title>
 					<title_original>
-						<de>Streets</de>
-						<en>Streets</en>
+						<all>Streets</all>
 					</title_original>
 					<description>
 						<de>„${.self:"role":1:"fullname"}“, ${.self:"role":1:"firstname"} kurz für sowohl „de-tox“ als auch „Downtown“, ein Drogenhändler aus New Yorks Straßen, hat enormes Talent und Leidenschaft für Musik, wird Rockstar, verkauft Millionen Alben und spielt ausverkaufte Konzerte.</de>
@@ -5245,12 +5191,10 @@
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="36a2e468-19bb-4ab7-a17c-4ad37a1da906">
 					<title>
-						<de>St. Patrick's</de>
-						<en>St. Patrick's</en>
+						<all>St. Patrick's</all>
 					</title>
 					<title_original>
-						<de>St. Patrick's</de>
-						<en>St. Patrick's</en>
+						<all>St. Patrick's</all>
 					</title_original>
 					<description>
 						<de>${.self:"role":1:"firstname"} rennt blind in die Nacht, bis er in die St. Patrick's Cathedral stolpert. Er bittet Gott um eine Erklärung, warum es Schmerz und Leid gibt.</de>
@@ -5598,12 +5542,10 @@
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="971877f7-c985-45a0-84ad-9aaba6dd72a2">
 					<title>
-						<de>Sarajevo</de>
-						<en>Sarajevo</en>
+						<all>Sarajevo</all>
 					</title>
 					<title_original>
-						<de>Sarajevo</de>
-						<en>Sarajevo</en>
+						<all>Sarajevo</all>
 					</title_original>
 					<description>
 						<de>Eröffnungssequenz: Eine steinene Wasserspeier-Kreatur hoch oben auf einer alten gotischen Kirche im noch friedlichen Sarajevo. Seit Jahrhunderten versucht er, die Menschen zu verstehen. Was ist Lachen, was sind Tränen?</de>
@@ -5848,8 +5790,7 @@
 						<en>Chorale</en>
 					</title>
 					<title_original>
-						<de>Madrigal</de>
-						<en>Madrigal</en>
+						<all>Madrigal</all>
 					</title_original>
 					<description>
 						<de>${.self:"role":3:"firstname"} scheint etwas über ${.self:"role":1:"firstname"}' Todesursache zu wissen. Währenddessen wird dieser immer frustrierter. Wenn er nicht zu ${.self:"role":2:"firstname"} kommen kann, dann sie vielleicht zu ihm. „Du verlierst dich selbst. Du versteckst dich in der Ecke des Amens.“</de>
@@ -5904,8 +5845,7 @@
 						<en>Fate</en>
 					</title>
 					<title_original>
-						<de>Karma</de>
-						<en>Karma</en>
+						<all>Karma</all>
 					</title_original>
 					<description>
 						<de>Winter. ${.self:"role":2:"firstname"} versucht, das Erlebte zu verarbeiten. ${.self:"role":1:"firstname"} beginnt, mit Hilfe von ${.self:"role":4:"firstname"} seinen Tod zu akzeptieren. „Gehüllt in ein Schicksal, das ich nicht ändern konnte, und immer bereit für des Winters Epilog.“</de>
@@ -5914,8 +5854,7 @@
 				</scripttemplate>
 				<scripttemplate index="8" product="2" licence_type="2" guid="e0e5726b-7253-4807-8212-6ea330968198">
 					<title>
-						<de>Epitaph</de>
-						<en>Epitaph</en>
+						<all>Epitaph</all>
 					</title>
 					<title_original>
 						<de>Epilog</de>
@@ -6089,12 +6028,10 @@
 		</scripttemplate>
 		<scripttemplate product="2" licence_type="3" guid="10e6e2a8-a46f-4603-be60-9619a3a05fac" creator="9551" comment="https://en.wikipedia.org/wiki/Blackwater_Park | not a concept album but still has an over-all theme, episode content compiled from fan forums and via ChatGPT">
 			<title>
-				<de>Darkwater Grove</de>
-				<en>Darkwater Grove</en>
+				<all>Darkwater Grove</all>
 			</title>
 			<title_original>
-				<de>Blackwater Park</de>
-				<en>Blackwater Park</en>
+				<all>Blackwater Park</all>
 			</title_original>
 			<description>
 				<de>Geschichten über das titelgebende kleine, verwunschene Städtchen, das von einem Fluch heimgesucht zu werden scheint, lose verbunden durch die Rahmenhandlung der Ankunft von ${.self:"role":1:"firstname"}, einer aufgewühlten jungen Frau mit einer bewegten Vergangenheit.</de>
@@ -6201,12 +6138,10 @@
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="e031baaa-f00e-45a7-a552-d169e3bc8107">
 					<title>
-						<de>Darkwater Grove</de>
-						<en>Darkwater Grove</en>
+						<all>Darkwater Grove</all>
 					</title>
 					<title_original>
-						<de>Blackwater Park</de>
-						<en>Blackwater Park</en>
+						<all>Blackwater Park</all>
 					</title_original>
 					<description>
 						<de>${.self:"role":2:"firstname"} ist nicht der Einzige. Im ganzen Ort nimmt das Chaos zu, denn immer mehr Menschen scheinen besessen und verrückt zu werden. Sie versuchen zu verstehen, was passiert, wo sie sind und warum sie die Kontrolle über sich selbst zu verlieren scheinen.</de>
@@ -6510,8 +6445,7 @@
 				<en>The ${Revenge} of the Tentacle</en>
 			</title>
 			<title_original>
-				<de>${title_original_optional}</de>
-				<en>${title_original_optional}</en>
+				<all>${title_original_optional}</all>
 			</title_original>
 			<description>
 				<de>Zurück zur abgedrehten Villa! Dr. ${.self:"role":4:"firstname"} ist diesmal auf unserer Seite. Naja fast. Er will verhindern, dass ${.self:"role":5:"fullname"} die Menschheit versklavt, aber hat was mit der Zeitmaschine gründlich vermasselt. Die Protagonisten müssen's richten.</de>
@@ -6563,8 +6497,7 @@
 				<en>Hi, ${.self:"role":1:"fullname"}${myname}, ${roving} Reporter</en>
 			</title>
 			<title_original>
-				<de>${title_original_optional}</de>
-				<en>${title_original_optional}</en>
+				<all>${title_original_optional}</all>
 			</title_original>
 			<description>
 				<de>Ich muss für dieses Schmierblatt schreiben, dabei will ich den Pulitzer-Preis gewinnen! Aber ich bin Aliens auf der Spur, wirklich! Die wollen die Menschheit verdummen! Ich treff die Frau aus meinem Traum, und selbst zum Mars verschlägt's mich.</de>
@@ -6739,12 +6672,10 @@
 			</description>
 			<variables>
 				<hurlyeisland_object_reference> <!-- introducing 'xyz_object_reference' and 'xyz_object_reference_original' as a convention to enable search-and-replace if one wants to play with original names of places, objects etc -->
-					<de>Hûrlýë Island™</de>
-					<en>Hûrlýë Island™</en>
+					<all>Hûrlýë Island™</all>
 				</hurlyeisland_object_reference>
 				<hurlyeisland_object_reference_original>
-					<de>Mêlée Island™</de>
-					<en>Mêlée Island™</en>
+					<all>Mêlée Island™</all>
 				</hurlyeisland_object_reference_original>
 				<donkeybay_object_reference>
 					<de>${donkey}${bay}</de>
@@ -7119,12 +7050,10 @@
 				</scripttemplate>
 				<scripttemplate index="9" product="2" licence_type="2" guid="6d1ad74b-6fd7-49f2-82e7-bc27b7fac6f0">
 					<title>
-						<de>Dinky Island</de>
-						<en>Dinky Island</en>
+						<all>Dinky Island</all>
 					</title>
 					<title_original>
-						<de>Dinky Island</de>
-						<en>Dinky Island</en>
+						<all>Dinky Island</all>
 					</title_original>
 					<description>
 						<de>${.self:"role":1:"firstname"} kommt auf Dinky Island an, entdeckt das Versteck von Big Whoop und sieht sich unter der Erde unheimlichen Offenbarungen gegenüber.</de>
@@ -7188,12 +7117,10 @@
 		</scripttemplate>
 		<scripttemplate product="2" licence_type="3" guid="b23f4846-075a-4c1f-8437-6a989b3c8351" creator="9551" comment="https://en.wikipedia.org/wiki/The_Dig_(video_game)">
 			<title>
-				<de>The Excavation</de>
-				<en>The Excavation</en>
+				<all>The Excavation</all>
 			</title>
 			<title_original>
-				<de>The Dig</de>
-				<en>The Dig</en>
+				<all>The Dig</all>
 			</title_original>
 			<description>
 				<de>Ein Asteroid auf Kollisionskurs mit der Erde. Mission: Hinfliegen und Atomsprengkörper verbuddeln. Was sich nur wie der nächste übliche Weltuntergangsfilm anlässt, nimmt eine überraschende Wendung, denn der Asteroid entpuppt sich als etwas anderes.
@@ -7319,32 +7246,25 @@ The project, which was cancelled by a major producer, is now free to be realized
 					<en>Adventures|Missions|Quests</en>
 				</adventures_c>
 				<captain> <!-- TODO: should actually be defined in programmerole; but maybe can be variable even when playing with original names -->
-					<de>Captain|Colonel|Commander|Admiral</de>
-					<en>Captain|Colonel|Commander|Admiral</en>
+					<all>Captain|Colonel|Commander|Admiral</all>
 				</captain>
 				<ween_object_reference>
-					<de>Ween</de>
-					<en>Ween</en>
+					<all>Ween</all>
 				</ween_object_reference>
 				<ween_object_reference_original>
-					<de>Keen</de>
-					<en>Keen</en>
+					<all>Keen</all>
 				</ween_object_reference_original>
 				<gnostika_object_reference>
-					<de>Gnostika</de>
-					<en>Gnostika</en>
+					<all>Gnostika</all>
 				</gnostika_object_reference>
 				<gnostika_object_reference_original>
-					<de>Gnosticus IV</de>
-					<en>Gnosticus IV</en>
+					<all>Gnosticus IV</all>
 				</gnostika_object_reference_original>
 				<codrakiv_object_reference>
-					<de>Codrak IV</de>
-					<en>Codrak IV</en>
+					<all>Codrak IV</all>
 				</codrakiv_object_reference>
 				<codrakiv_object_reference_original>
-					<de>Korath III</de>
-					<en>Korath III</en>
+					<all>Korath III</all>
 				</codrakiv_object_reference_original>
 			</variables>
 			<children>
@@ -7604,12 +7524,10 @@ The project, which was cancelled by a major producer, is now free to be realized
 				</scripttemplate>
 				<scripttemplate index="7" product="2" licence_type="2" guid="503f7801-dc8d-4f55-a0e9-c017592eba62">
 					<title>
-						<de>Cum hoc ergo cum laude</de>
-						<en>Cum hoc ergo cum laude</en>
+						<all>Cum hoc ergo cum laude</all>
 					</title>
 					<title_original>
-						<de>Magna Cum Laude</de>
-						<en>Magna Cum Laude</en>
+						<all>Magna Cum Laude</all>
 					</title_original>
 					<description>
 						<de>Ein Spinoff? Es geht diesmal um ${.self:"role":1:"firstname"}s Neffen, der auch ${.self:"role":1:"firstname"} heißt, im College ist und bei einer Dating Show mitmacht. Onkel ${.self:"role":1:"firstname"} gibt immerhin noch wertvolle Tips. Was ist mit ${.self:"role":2:"firstname"}? Ist noch offen, vielleicht in der nächsten Staffel...</de>
@@ -7654,8 +7572,7 @@ The project, which was cancelled by a major producer, is now free to be realized
 					<en>Counter-Strike|Counterstrike|Counter-Fire|Retaliation|Counterplot|Counterploy|Riposte|Strike-Back</en>
 				</counterstrike>
 				<offensive>
-					<de>Offensive|${operations}</de>
-					<en>Offensive|${operations}</en>
+					<all>Offensive|${operations}</all>
 				</offensive>
 				<counteroffensive>
 					<de>Gegenoffensive|Gegenfeuer|Vergeltung|Gegenanschlag|Gegenangriff|Gegenschlag|Gegenreaktion</de>
@@ -7673,8 +7590,7 @@ The project, which was cancelled by a major producer, is now free to be realized
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="077e10fa-d063-4450-9295-0843f89d53b4" comment="https://counterstrike.fandom.com/wiki/Dust">
 					<title>
-						<de>Sand</de>
-						<en>Sand</en>
+						<all>Sand</all>
 					</title>
 					<title_original>
 						<de>Staub</de>
@@ -7687,8 +7603,7 @@ The project, which was cancelled by a major producer, is now free to be realized
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="9efeadb2-f6aa-4af1-ba55-c825c9671e5f" comment="https://counterstrike.fandom.com/wiki/Dust_II">
 					<title>
-						<de>Sand 2</de>
-						<en>Sand 2</en>
+						<all>Sand 2</all>
 					</title>
 					<title_original>
 						<de>Staub 2</de>
@@ -7715,8 +7630,7 @@ The project, which was cancelled by a major producer, is now free to be realized
 				</scripttemplate>
 				<scripttemplate index="3" product="2" licence_type="2" guid="e7239ea7-da0c-49cd-af93-efafc510b30f" comment="https://counterstrike.fandom.com/wiki/Mirage">
 					<title>
-						<de>Morgana</de>
-						<en>Morgana</en>
+						<all>Morgana</all>
 					</title>
 					<title_original>
 						<de>Morgana</de>
@@ -7733,8 +7647,7 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>Infernal</en>
 					</title>
 					<title_original>
-						<de>Inferno</de>
-						<en>Inferno</en>
+						<all>Inferno</all>
 					</title_original>
 					<description>
 						<de>In einem beschaulichen italienischen Dorf gelten noch Lebensweisheiten wie: Ein Mann soll ein Haus bauen, einen Sohn zeugen und eine Bombe pflanzen. Separatisten wollen zwei Gas-Pipelines in die Luft jagen. Es folgt ein heftiges Gefecht in einer engen Bananengasse.</de>
@@ -7743,12 +7656,10 @@ The project, which was cancelled by a major producer, is now free to be realized
 				</scripttemplate>
 				<scripttemplate index="5" product="2" licence_type="2" guid="a66c6bcd-7199-4f5d-9621-66377149c0ba" comment="https://counterstrike.fandom.com/wiki/Office">
 					<title>
-						<de>Business</de>
-						<en>Business</en>
+						<all>Business</all>
 					</title>
 					<title_original>
-						<de>Office</de>
-						<en>Office</en>
+						<all>Office</all>
 					</title_original>
 					<description>
 						<de>Nun wird auch die USA in die Geschehnisse verwickelt, denn eine Anarchisten-Gruppierung hält Geiseln in einem Bürokomplex, vorgeblich ausbeuterische Konzernbosse. Doch es steckt wohl mehr hinter der ganzen Geschichte. Das FBI stürmt die Einrichtung.</de>
@@ -7789,8 +7700,7 @@ The project, which was cancelled by a major producer, is now free to be realized
 						<en>Vertical</en>
 					</title>
 					<title_original>
-						<de>Vertigo</de>
-						<en>Vertigo</en>
+						<all>Vertigo</all>
 					</title_original>
 					<description>
 						<de>Die „Professionals“ werden angeheuert, um einen im Bau befindlichen Wolkenkratzer zu sprengen. Die Terrorvereinigungen wollen damit ein Zeichen setzen. In schwindelerregenden Höhen kommt es zum Showdown mit dem FBI.</de>
@@ -7799,8 +7709,7 @@ The project, which was cancelled by a major producer, is now free to be realized
 				</scripttemplate>
 				<scripttemplate index="9" product="2" licence_type="2" guid="0340cbb9-9a54-488d-8587-23c2cd68c18e" comment="https://counterstrike.fandom.com/wiki/Militia">
 					<title>
-						<de>Militant</de>
-						<en>Militant</en>
+						<all>Militant</all>
 					</title>
 					<title_original>
 						<de>Miliz</de>
@@ -7897,12 +7806,10 @@ The project, which was cancelled by a major producer, is now free to be realized
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="8264e56c-f9f9-4ffa-975d-93d9cc26f339" creator="9551" comment="https://en.wikipedia.org/wiki/Turrican">
 			<title>
-				<de>Turrnado</de>
-				<en>Turrnado</en>
+				<all>Turrnado</all>
 			</title>
 			<title_original>
-				<de>Turrican</de>
-				<en>Turrican</en>
+				<all>Turrican</all>
 			</title_original>
 			<description>
 				<de>„Shoot! Or! Die! Hahahaha!“ Flotte Anime-SciFi-Action über Soldat ${.self:"role":1:"fullname"} in seinem biomechanischen Anzug, der die Weltraumkolonie Alterra von der außer Kontrolle geratenen künstlichen Intelligenz M.O.R.G.U.L. befreien muss.</de>
@@ -7999,12 +7906,10 @@ The project, which was cancelled by a major producer, is now free to be realized
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="f424b506-9efe-4f1f-ab7c-5ff679dc66c5" creator="9551" comment="https://en.wikipedia.org/wiki/Zero_Wing | https://en.wikipedia.org/wiki/All_your_base_are_belong_to_us">
 			<title>
-				<de>Zero Squad</de>
-				<en>Zero Squad</en>
+				<all>Zero Squad</all>
 			</title>
 			<title_original>
-				<de>Zero Wing</de>
-				<en>Zero Wing</en>
+				<all>Zero Wing</all>
 			</title_original>
 			<description>
 				<de>In Jahr 2101 Krieg hat gestartet. - Was passiert? - Jemand hat Bombe uns gesetzt. - Wir haben Signal. - Was ! - Haupt Monitor an. - Es ist Sie !! - Wie geht meine Herren !! ALL IHR BASIS NUN GEHÖREN UNS !! Sie haben nicht Chance überleben machen Sie Ihre Zeit.</de>
@@ -8037,8 +7942,7 @@ The project, which was cancelled by a major producer, is now free to be realized
 				<en>Pajama-Palooza</en>
 			</title>
 			<title_original>
-				<de>Pyjamarama</de>
-				<en>Pyjamarama</en>
+				<all>Pyjamarama</all>
 			</title_original>
 			<description>
 				<de>Oh nein, ${.self:"role":1:"firstname"} hat vergessen, den Wecker zu stellen. So kommt er zu spät zur Arbeit. Jetzt muss er ihn im Traum stellen, wobei er allerlei im Haus herumspukenden Gestalten begegnet. Nur wo ist der verflixte Aufziehschlüssel? Vielleicht auf dem Mond?</de>
@@ -8070,8 +7974,7 @@ The project, which was cancelled by a major producer, is now free to be realized
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="f6fee4c6-4858-43d9-a17a-8bb90c769936" creator="9551" comment="https://www.mobygames.com/game/19274/automania/ - actually the first part of the game series, but applying artistic license here.">
 			<title>
-				<de>Auto-Palooza</de>
-				<en>Auto-Palooza</en>
+				<all>Auto-Palooza</all>
 			</title>
 			<title_original>
 				<de>Automanie</de>
@@ -8328,12 +8231,10 @@ The project, which was cancelled by a major producer, is now free to be realized
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="d99a5b85-5f82-4756-8333-dfd90177d9ae" creator="9551" comment="https://en.wikipedia.org/wiki/Wings_(1990_video_game)">
 			<title>
-				<de>Winds</de>
-				<en>Winds</en>
+				<all>Winds</all>
 			</title>
 			<title_original>
-				<de>Wings</de>
-				<en>Wings</en>
+				<all>Wings</all>
 			</title_original>
 			<description>
 				<de>1916, das letzte Jahr des Ersten Weltkriegs. Ein Pilot-Neuling, der sich der 56. Staffel anschließt, erlebt Kameradschaft, Tapferkeit, Tragödien, Höhen und Tiefen sowie die Fortentwicklung der Luftkampftaktik und wird allmählich zu einem gestandenen Fliegerass.</de>
@@ -8662,12 +8563,10 @@ The project, which was cancelled by a major producer, is now free to be realized
 		</scripttemplate>
 		<scripttemplate product="2" licence_type="3" guid="dbfd1238-b531-4ea5-8544-50cd81977dc4" creator="9551" comment="Screenplay 'remake' version using the largely fictional episode titles from Mad TV and the Stukov repo. Descriptions created with the help of ChatGPT, a bit too generic. Actual series added as 4d7665e8-0b95-4e1d-8605-bff98c81289c">
 			<title>
-				<de>Stranger Nation</de>
-				<en>Stranger Nation</en>
+				<all>Stranger Nation</all>
 			</title>
 			<title_original>
-				<de>Alien Nation</de>
-				<en>Alien Nation</en>
+				<all>Alien Nation</all>
 			</title_original>
 			<description>
 				<de>Ein Remake der 1989er Serie, spielt nun im Jahre 2030, mit Anpassungen an zeitgemäße gesellschaftliche Probleme, über die Außerirdischen, die in der Wüste außerhalb von L.A. landen und dann über Jahre in die menschliche Gesellschaft integriert werden.</de>
@@ -8783,8 +8682,7 @@ The project, which was cancelled by a major producer, is now free to be realized
 				<en>North Texas Tales</en>
 			</title>
 			<title_original>
-				<de>Dallas Tales</de>
-				<en>Dallas Tales</en>
+				<all>Dallas Tales</all>
 			</title_original>
 			<description>
 				<de>Die Originalserie für Kinder zu langweilig? Dem kann Abhilfe geschaffen werden. Die eh schon überzeichneten Charaktere des Clans um ${.self:"role":1:"fullname"} erleben neu inszenierte Abenteuer in diesem lustigen Cartoon! Bietet auch Humorebenen für Erwachsene.</de>

--- a/res/database/Default/user/speedminister.xml
+++ b/res/database/Default/user/speedminister.xml
@@ -88,11 +88,7 @@
 					<ratings critics="59" speed="70" />
 				</programme>
 				<programme guid="SpeedMinister-Serie-volksirrtuemliche-01-ep-02" product="3" licence_type="2" fictional="1" creator="8605" created_by="SpeedMinister">
-					<title>
-						<de>Tuba Tinnitus</de>
-						<en>Tuba Tinnitus</en>
-						<pl>Tuba Tinnitus</pl>
-					</title>
+					<title>Tuba Tinnitus</title>
 					<description>
 						<de>Das weckt auch den verschlafensten in der letzten Reihe auf. Vier Tuben, eine Trompete, ein Schlagzeug und ein Sänger geben ihr Bestes. Mit mittelmäßigem Erfolg.</de>
 						<en>This wakes up even the sleepiest in the last row. Four tubas, a trumpet, a drum set and a singer give their best. With mediocre success.</en>
@@ -625,10 +621,7 @@
 
 	<allads>
 		<ad guid="cc5f7107-f929-4331-8dcf-fc4dd2d7e606" comment="1980-1987 | https://en.wikipedia.org/wiki/Xenix">
-			<title>
-				<de>Xunix</de>
-				<en>Xunix</en>
-			</title>
+			<title>Xunix</title>
 			<description>
 				<de>Besser als das Original! Das Betriebssystem von Macrohard speziell für Ihren Hochleistungsrechner.</de>
 				<en>Better than the original! The operating system from Macrohard especially for your high-performance computer.</en>
@@ -638,10 +631,7 @@
 			<availability year_range_from="1980" year_range_to="1987" />
 		</ad>
 		<ad guid="cf636ccc-c253-45c5-afb8-c7aca1521f8b" comment="1988-1994 | https://en.wikipedia.org/wiki/LAN_Manager">
-			<title>
-				<de>LAN Master</de>
-				<en>LAN Master</en>
-			</title>
+			<title>LAN Master</title>
 			<description>
 				<de>Verbinden, Vereinen, Prosperieren. Die Lösung für Ihr Netzwerk von Macrohard.</de>
 				<en>Connect, Combine, Prosper. The solution for your network by Macrohard.</en>
@@ -651,9 +641,7 @@
 			<availability year_range_from="1988" year_range_to="1994" />
 		</ad>
 		<ad guid="867c2c0b-69c4-4c90-be72-804e9fa939cb" comment="1995-2007 | https://en.wikipedia.org/wiki/MSN">
-			<title>
-				<de>MHN</de>
-			</title>
+			<title>MHN</title>
 			<description>
 				<de>Das Portal und Ihr Pass für Ihre Reise in die digitalen Welten des Macrohard Netwebs.</de>
 				<en>The portal and your passport for your journey into the digital worlds of the Macrohard Netweb.</en>

--- a/res/database/Default/user/stukov_ads.xml
+++ b/res/database/Default/user/stukov_ads.xml
@@ -138,9 +138,7 @@
 
 		<ad guid="3291c7ea-02b3-45ca-8d8f-9cfa74176e8a" comment="https://en.wikipedia.org/wiki/Schneider_Rundfunkwerke | from Mad TV as 'Schneider'">
 			<title>
-				<de>Schnitzler</de>
-				<en>Schnitzler</en>
-				<pl>Schnitzler</pl>
+				<all>Schnitzler</all>
 			</title>
 			<description>
 				<de>Schnitzler-Computer: Jetzt mit drei RegenbogenWünsche-Spielen!</de>
@@ -441,9 +439,7 @@
 
 		<ad guid="7546a9b0-1990-4434-9164-b4c77f6e0608" comment="descriptions from Mad TV but title is different to provide variations to the already existing TVTower Duban ads">
 			<title>
-				<de>Duban Resort</de>
-				<en>Duban Resort</en>
-				<pl>Duban Resort</pl>
+				<all>Duban Resort</all>
 			</title>
 			<description>
 				<de>Mach Urlaub in Duban - Baden, Sonnen, Erdöl graben.</de>
@@ -484,9 +480,7 @@
 
 		<ad guid="f6eaf73a-b75b-4ef6-8134-1c9bfe62a5d2" comment="from Mad TV">
 			<title>
-				<de>Doggy</de>
-				<en>Doggy</en>
-				<pl>Doggy</pl>
+				<all>Doggy</all>
 			</title>
 			<description>
 				<de>Verwöhnen Sie ihr Hundchen mit Doggy!</de>
@@ -752,9 +746,7 @@ Zupełnie nowe wrażenia multimedialne prosto z magnetofonu!</pl>
 
 		<ad guid="a829e080-3657-42f5-9dc1-44a3d89700d0" comment="https://en.wikipedia.org/wiki/Pepsi | from Mad TV as 'Pepsi'">
 			<title>
-				<de>Pipsi Cola</de>
-				<en>Pipsi Cola</en>
-				<pl>Pipsi Cola</pl>
+				<all>Pipsi Cola</all>
 			</title>
 			<description>
 				<de>Das schmeckt! Für die junge Brut.</de> <!-- Die schmeckt! -->

--- a/res/database/Default/user/stukov_scripts_adaptations.xml
+++ b/res/database/Default/user/stukov_scripts_adaptations.xml
@@ -224,11 +224,7 @@
 					<en>Shadowstar|Isa|Lightbiter|Ipsep|Noc|Autumnstar</en>
 					<pl>Cienista Gwiazda|Isa|Lekkigryzak|Ipsep|Noc|Jesienna Gwiazda</pl>
 				</Gott>
-				<Goblin>
-					<de>Jig|Braf|Relka|Grell</de>
-					<en>Jig|Braf|Relka|Grell</en>
-					<pl>Jig|Braf|Relka|Grell</pl>
-				</Goblin>
+				<Goblin>Jig|Braf|Relka|Grell</Goblin>
 			</variables>
 			<jobs>
 				<job function="1" index="0" required="1" />
@@ -271,26 +267,10 @@
 				<pl>Próba filmowej adaptacji gry komputerowej, a przynajmniej walki z potworami. ${Class1}, ${Class2}, ${Class3} i ${Class4} próbują przetrwać. Jayne Wune użycza swojego głosu, a może to tylko nagranie?</pl>
 			</description>
 			<variables>
-				<Class1>
-					<de>Grave Robber|Crusader|Arbalest</de>
-					<en>Grave Robber|Crusader|Arbalest</en>
-					<pl>Grave Robber|Crusader|Arbalest</pl>
-				</Class1>
-				<Class2>
-					<de>Bounty Hunter|Hellion|Highwayman</de>
-					<en>Bounty Hunter|Hellion|Highwayman</en>
-					<pl>Bounty Hunter|Hellion|Highwayman</pl>
-				</Class2>
-				<Class3>
-					<de>Houndmaster|Jester|Man-at-Arms</de>
-					<en>Houndmaster|Jester|Man-at-Arms</en>
-					<pl>Houndmaster|Jester|Man-at-Arms</pl>
-				</Class3>
-				<Class4>
-					<de>Occultist|Plague Doctor|Vestal|Flagellant</de>
-					<en>Occultist|Plague Doctor|Vestal|Flagellant</en>
-					<pl>Occultist|Plague Doctor|Vestal|Flagellant</pl>
-				</Class4>
+				<Class1>Grave Robber|Crusader|Arbalest</Class1>
+				<Class2>Bounty Hunter|Hellion|Highwayman</Class2>
+				<Class3>Houndmaster|Jester|Man-at-Arms</Class3>
+				<Class4>Occultist|Plague Doctor|Vestal|Flagellant</Class4>
 			</variables>
 			<jobs>
 				<job function="1" index="0" required="1" />
@@ -331,16 +311,8 @@
 				<pl>Nadchodzi z ogniem i burzą, a wraz z jego pojawieniem się nadchodzą ostatnie dni ludzkości. Legenda staje się rzeczywistością, czego doświadczają rzeźnik ${RoleMale} i autostopowiczka ${RoleFemale}.</pl>
 			</description>
 			<variables>
-				<RoleMale>
-					<de>Brenner|Heidmann|Baumann|Schmidt</de>
-					<en>Brenner|Heidmann|Baumann|Schmidt</en>
-					<pl>Brenner|Heidmann|Baumann|Schmidt</pl>
-				</RoleMale>
-				<RoleFemale>
-					<de>Astrid|Charlotte|Nicole|Christiane</de>
-					<en>Astrid|Charlotte|Nicole|Christiane</en>
-					<pl>Astrid|Charlotte|Nicole|Christiane</pl>
-				</RoleFemale>				
+				<RoleMale>Brenner|Heidmann|Baumann|Schmidt</RoleMale>
+				<RoleFemale>Astrid|Charlotte|Nicole|Christiane</RoleFemale>
 			</variables>
 			<jobs>
 				<job function="1" index="0" required="1" />

--- a/res/database/Default/user/therob.xml
+++ b/res/database/Default/user/therob.xml
@@ -349,11 +349,7 @@
 		<!-- 'RatTV - Quo Vadis' moved to database_programmes.xml -->
 
 		<programme guid="TheRob-b0db-439c-a852-Goaaaaal" product="4" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob" comment="contains real staff">
-			<title>
-				<de>Goaaaaal</de>
-				<en>Goaaaaal</en>
-				<pl>Goaaaaal</pl>
-			</title>
+			<title>Goaaaaal</title>
 			<description>
 				<de>${.self:"cast":1:"fullname"} präsentiert die schönsten Tore des Jahres 1981. Ein Augenschmauß für jeden Fan!</de>
 				<en>${.self:"cast":1:"fullname"} presents the finest goals of 1981. A feast for the eyes of every fan!</en>
@@ -661,12 +657,8 @@
 		</programme>
 
 		<programme guid="TheRob-b0db-439c-a852-Janosik" product="1" fictional="1" licence_type="1" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob" comment="previously contained ill-fitting real staff, replaced with fictional">
-			<title>
-				<!-- Janosik als Fiktion. Basiert auf keinem existierendem Film, von daher benutze ich mal den Klar Namen -->
-				<de>Jánošík</de>
-				<en>Jánošík</en>
-				<pl>Jánošík</pl>
-			</title>
+			<!-- Janosik als Fiktion. Basiert auf keinem existierendem Film, von daher benutze ich mal den Klar Namen -->
+			<title>Jánošík</title>
 			<description>
 				<de>Jánošík als Anführer einer Waldräubergruppe. Der slowakische Robin Hood.</de>
 				<en>Jánošík as the leader of a group of forest robbers. The Slovak Robin Hood.</en>
@@ -2122,11 +2114,7 @@
 					</description>
 				</programme>
 				<programme guid="TheRob-serie-DieStraendederWelt-Episode003" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
-					<title>
-						<de>Vallvik</de>
-						<en>Vallvik</en>
-						<pl>Vallvik</pl>
-					</title>
+					<title>Vallvik</title>
 					<description>
 						<de>Schweden. Ein rauer Strand. Sollte jemand der Moderatorin sagen, dass man die Kälte deutlich an ihr sieht? ${.self:"cast":1:"firstname"} hüpft fröhlich durch die Gegend und zeigt den Sand und die Tiere. Und etwas über das Land darf man auch lernen.</de>
 						<en>Sweden. A rough beach. Should someone tell the presenter that you can clearly see the cold on her? ${.self:"cast":1:"firstname"} bounces around happily showing the sand and the animals. And you can learn something about the country too.</en>
@@ -2134,11 +2122,7 @@
 					</description>
 				</programme>
 				<programme guid="TheRob-serie-DieStraendederWelt-Episode004" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
-					<title>
-						<de>Playa Corcovado</de>
-						<en>Playa Corcovado</en>
-						<pl>Playa Corcovado</pl>
-					</title>
+					<title>Playa Corcovado</title>
 					<description>
 						<de>Costa Rica. ${.self:"cast":1:"firstname"} hüpft fröhlich durch die Gegend und zeigt den Sand und die Tiere. Und etwas über das Land darf man auch lernen.</de>
 						<en>Costa Rica. ${.self:"cast":1:"firstname"} bounces around happily showing the sand and the animals. And you can learn something about the country too.</en>
@@ -2146,11 +2130,7 @@
 					</description>
 				</programme>
 				<programme guid="TheRob-serie-DieStraendederWelt-Episode005" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
-					<title>
-						<de>Koh Thas</de>
-						<en>Koh Thas</en>
-						<pl>Koh Thas</pl>
-					</title>
+					<title>Koh Thas</title>
 					<description>
 						<de>Kambodscha. Wer hält da denn Kokosnüsse? ${.self:"cast":1:"firstname"} hüpft fröhlich durch die Gegend und zeigt den Sand und die Tiere. Und etwas über das Land darf man auch lernen.</de>
 						<en>Cambodia. Who's holding coconuts there? ${.self:"cast":1:"firstname"} bounces around happily showing the sand and the animals. And you can learn something about the country too.</en>
@@ -2158,11 +2138,7 @@
 					</description>
 				</programme>
 				<programme guid="TheRob-serie-DieStraendederWelt-Episode006" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
-					<title>
-						<de>Vyshka</de>
-						<en>Vyshka</en>
-						<pl>Vyshka</pl>
-					</title>
+					<title>Vyshka</title>
 					<description>
 						<de>Russland. Wer kennt schon das kaspische Meer? ${.self:"cast":1:"firstname"} hüpft fröhlich durch die Gegend und zeigt den Sand und die Tiere. Und etwas über das Land darf man auch lernen.</de>
 						<en>Russia. Who has ever heard of the Caspian Sea anyway? ${.self:"cast":1:"firstname"} bounces around happily showing the sand and the animals. And you can learn something about the country too.</en>
@@ -2198,9 +2174,7 @@
 			<children>
 				<programme guid="TheRob-serie-Wirstellenvor-Episode001" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
-						<de>${.self:"cast":2:"fullname"}</de>
-						<en>${.self:"cast":2:"fullname"}</en>
-						<pl>${.self:"cast":2:"fullname"}</pl>
+						<all>${.self:"cast":2:"fullname"}</all>
 					</title>
 					<description>
 						<de>Wie entstanden die Songs? Und warum berührt er heute noch Menschen. Wer war das und wie war der Sound?</de>
@@ -2214,9 +2188,7 @@
 				</programme>
 				<programme guid="TheRob-serie-Wirstellenvor-Episode002" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
-						<de>${.self:"cast":2:"fullname"}</de>
-						<en>${.self:"cast":2:"fullname"}</en>
-						<pl>${.self:"cast":2:"fullname"}</pl>
+						<all>${.self:"cast":2:"fullname"}</all>
 					</title>
 					<description>
 						<de>Wie entstanden die Songs? Und warum berührt er heute noch Menschen. Wer war das und wie war der Sound?</de>
@@ -2230,9 +2202,7 @@
 				</programme>
 				<programme guid="TheRob-serie-Wirstellenvor-Episode003" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
-						<de>${.self:"cast":2:"fullname"}</de>
-						<en>${.self:"cast":2:"fullname"}</en>
-						<pl>${.self:"cast":2:"fullname"}</pl>
+						<all>${.self:"cast":2:"fullname"}</all>
 					</title>
 					<description>
 						<de>Wie entstanden die Songs? Und warum berührt er heute noch Menschen. Wer war das und wie war der Sound?</de>
@@ -2246,9 +2216,7 @@
 				</programme>
 				<programme guid="TheRob-serie-Wirstellenvor-Episode004" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
-						<de>${.self:"cast":2:"fullname"}</de>
-						<en>${.self:"cast":2:"fullname"}</en>
-						<pl>${.self:"cast":2:"fullname"}</pl>
+						<all>${.self:"cast":2:"fullname"}</all>
 					</title>
 					<description>
 						<de>Wie entstanden die Songs? Und warum berührt er heute noch Menschen. Wer war das und wie war der Sound?</de>
@@ -2262,9 +2230,7 @@
 				</programme>
 				<programme guid="TheRob-serie-Wirstellenvor-Episode005" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
-						<de>${.self:"cast":2:"fullname"}</de>
-						<en>${.self:"cast":2:"fullname"}</en>
-						<pl>${.self:"cast":2:"fullname"}</pl>
+						<all>${.self:"cast":2:"fullname"}</all>
 					</title>
 					<description>
 						<de>Wie entstanden die Songs? Und warum berührt er heute noch Menschen. Wer war das und wie war der Sound?</de>
@@ -2278,9 +2244,7 @@
 				</programme>
 				<programme guid="TheRob-serie-Wirstellenvor-Episode006" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
-						<de>${.self:"cast":2:"fullname"}</de>
-						<en>${.self:"cast":2:"fullname"}</en>
-						<pl>${.self:"cast":2:"fullname"}</pl>
+						<all>${.self:"cast":2:"fullname"}</all>
 					</title>
 					<description>
 						<de>Wie entstanden die Songs? Und warum berührt er heute noch Menschen. Wer war das und wie war der Sound?</de>
@@ -2294,9 +2258,7 @@
 				</programme>
 				<programme guid="TheRob-serie-Wirstellenvor-Episode007" product="7" licence_type="2" tmdb_id="0" imdb_id="" creator="8751" created_by="TheRob">
 					<title>
-						<de>${.self:"cast":2:"fullname"}</de>
-						<en>${.self:"cast":2:"fullname"}</en>
-						<pl>${.self:"cast":2:"fullname"}</pl>
+						<all>${.self:"cast":2:"fullname"}</all>
 					</title>
 					<description>
 						<de>Wie entstanden die Songs? Und warum berührt er heute noch Menschen. Wer war das und wie war der Sound?</de>
@@ -2460,9 +2422,7 @@
 		</scripttemplate>
 		<scripttemplate product="4" licence_type="1" guid="TheRob-Script-Rep-AusmeinemGebiet">
 			<title>
-				<de>${TITLE}</de>
-				<en>${TITLE}</en>
-				<pl>${TITLE}</pl>
+				<all>${TITLE}</all>
 			</title>
 			<variables>
 				<title>
@@ -2470,11 +2430,7 @@
 					<en>Reports From the Broadcast Area|News From ${RANDOMCITY}|Reports From ${RANDOMCITY}|What's Up in ${RANDOMCITY}?</en>
 					<pl>Raporty z obszaru nadawania|${RANDOMCITY} - Wiadomości lokalne|${RANDOMCITY} - Raporty lokalne|${RANDOMCITY} - Co słychać w mieście?</pl>
 				</title>
-				<randomcity>
-					<de>${.stationmap:"randomcity"}</de>
-					<en>${.stationmap:"randomcity"}</en>
-					<pl>${.stationmap:"randomcity"}</pl>
-				</randomcity>
+				<randomcity>${.stationmap:"randomcity"}</randomcity>
 			</variables>
 			
 			<description>
@@ -2501,15 +2457,11 @@
 		</scripttemplate>
 		<scripttemplate product="3" licence_type="1" guid="TheRob-Script-Talk-DieNeuestenFilme">
 			<title>
-				<de>${TITLE}</de>
-				<en>${TITLE}</en>
-				<pl>${TITLE}</pl>
+				<all>${TITLE}</all>
 			</title>
 			<variables>
 				<title>
-					<de>${ADJECTIVE} ${SUBJECT}${MODIFIER}</de>
-					<en>${ADJECTIVE} ${SUBJECT}${MODIFIER}</en>
-					<pl>${ADJECTIVE} ${SUBJECT}${MODIFIER}</pl>
+					<all>${ADJECTIVE} ${SUBJECT}${MODIFIER}</all>
 				</title>
 				<subject>
 					<de>Filme|Serien|Shows|Produktionen</de>
@@ -2521,11 +2473,7 @@
 					<en>Upcoming|Outstanding|Exciting</en>
 					<pl>Nadchodzące|Wybitne|Ciekawe</pl>
 				</adjective>
-				<modifier>
-					<de>|| ${.worldtime:"year"}</de>
-					<en>|| ${.worldtime:"year"}</en>
-					<pl>|| ${.worldtime:"year"}</pl>
-				</modifier>
+				<modifier>|| ${.worldtime:"year"}</modifier>
 			</variables>
 			
 			<description>
@@ -2680,9 +2628,7 @@
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="TheRob-Script-Com-EngeloderBengel">
 			<title>
-				<de>${TITLE}</de>
-				<en>${TITLE}</en>
-				<pl>${TITLE}</pl>
+				<all>${TITLE}</all>
 			</title>
 			<description>
 				<de>Familienkomödie über das Leben mit einem frechen Sohnemann. Das Drehbuch wird von dem Stardrehbuchschreiber Don Ron geschrieben.</de>
@@ -2722,9 +2668,7 @@
 		</scripttemplate>
 		<scripttemplate product="1" licence_type="1" guid="TheRob-Script-TV-Heimatlichberggeschichten">
 			<title>
-				<de>${NAME1} ${NAME2}</de>
-				<en>${NAME1} ${NAME2}</en>
-				<pl>${NAME1} ${NAME2}</pl>
+				<all>${NAME1} ${NAME2}</all>
 			</title>
 			<description>
 				<de>Jodelnde Liebeserklärungen und epische Bergaufnahmen.</de>
@@ -3052,11 +2996,7 @@
 			<studio_size min="2" max="3" slope="35" />
 		</scripttemplate>
 		<scripttemplate product="2" licence_type="3" guid="TheRob-script-ser-trash-karprachd" comment="TODO: Episode descriptions; still haven't figured out the title/reference">
-			<title>
-				<de>Kār prachd</de>
-				<en>Kār prachd</en>
-				<pl>Kār prachd</pl>
-			</title>
+			<title>Kār prachd</title>
 			<description>
 				<de>Die legendäre thailändische Serie in der originalen Sprache ohne Untertitel nachgedreht.</de>
 				<en>The legendary Thai series re-shot in the original language without subtitles.</en>
@@ -3064,11 +3004,7 @@
 			</description>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="TheRob-script-ser-trash-karprachd-Ep1">
-					<title>
-						<de>TVTs Pilot</de>
-						<en>TVTs Pilot</en>
-						<pl>TVTs Pilot</pl>
-					</title>
+					<title>TVTs Pilot</title>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="TheRob-script-ser-trash-karprachd-Ep2">
 					<title>
@@ -3100,11 +3036,7 @@
 			<speed min="35" max="85" slope="50" />
 		</scripttemplate>
 		<scripttemplate product="2" licence_type="3" guid="TheRob-script-ser-mix-tanz-amiz" comment="TODO: Episode descriptions; still haven't figured out the title/reference">
-			<title>
-				<de>tanz-āmiz</de>
-				<en>tanz-āmiz</en>
-				<pl>tanz-āmiz</pl>
-			</title>
+			<title>tanz-āmiz</title>
 			<description>
 				<de>Die legendäre iranische Serie in der originalen Sprache ohne Untertitel nachgedreht.</de>
 				<en>The legendary Iranian series re-shot in the original language without subtitles.</en>
@@ -3112,11 +3044,7 @@
 			</description>
 			<children>
 				<scripttemplate index="0" product="2" licence_type="2" guid="TheRob-script-ser-mix-tanz-amiz-Ep1">
-					<title>
-						<de>TVTs Pilot</de>
-						<en>TVTs Pilot</en>
-						<pl>TVTs Pilot</pl>
-					</title>
+					<title>TVTs Pilot</title>
 				</scripttemplate>
 				<scripttemplate index="1" product="2" licence_type="2" guid="TheRob-script-ser-mix-tanz-amiz-Ep2">
 					<title>
@@ -3332,11 +3260,7 @@
 					<en>Dragon|Naked Mole-Rat|Fairy|Tooth-Fairy|Wizard|Troll|Dwarf|Meerkat|Thing from the Swamp|Angel|Succubus|Monster|Giant|Ogre</en>
 					<pl>Smok|Nagi szczur|Bajka|Zębowa bajka|Czarodziej|Troll|Krasnolud|Merkat|Coś z bagien|Anioł|Sukkubus|Potwór|Gigant|Ogr</pl>
 				</wesen>
-				<name>
-					<de>Phillip|John|Martin|Mauritius|Arthur|Sunny Bunny|Emil</de>
-					<en>Phillip|John|Martin|Mauritius|Arthur|Sunny Bunny|Emil</en>
-					<pl>Phillip|John|Martin|Mauritius|Arthur|Sunny Bunny|Emil</pl>
-				</name>
+				<name>Phillip|John|Martin|Mauritius|Arthur|Sunny Bunny|Emil</name>
 			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" />
@@ -3510,9 +3434,7 @@
 			<children>
 				<scripttemplate index="0" product="3" licence_type="2" guid="TheRob-script-ser-CallIn-Abgezockt-Ep1">
 					<title>
-						<de>${EPISODE}</de>
-						<en>${EPISODE}</en>
-						<pl>${EPISODE}</pl>
+						<all>${EPISODE}</all>
 					</title>
 					<variables>
 						<episode>
@@ -3530,11 +3452,7 @@
 					<en>Dancing Queen|Word Guessing|Prizes Guaranteed|Ripped Off|Fabulous Peeks</en>
 					<pl>Dancing Queens|Zgadywanka|Nagrody gwarantowane|Rozbierz to|Fantastyczne wybory</pl>
 				</title1>
-				<name1>
-					<de>Jimmy|Bobby|Danny|Manni|Donny|Johny</de>
-					<en>Jimmy|Bobby|Danny|Manni|Donny|Johny</en>
-					<pl>Jimmy|Bobby|Danny|Manni|Donny|Johny</pl>
-				</name1>
+				<name1>Jimmy|Bobby|Danny|Manni|Donny|Johny</name1>
 			</variables>
 			<jobs>
 				<job index="0" function="1" required="1" />


### PR DESCRIPTION
WIP: I have started cleaning up variables either using the all-languages tag or turning variables to global ones. The first commit contains changes in the user databases. I have not dealt with all cases because I need feedback for the general pattern
* ads - very often the names are identical in all languages (and we don't have variables, yet; should ad names be "global" in general or rather get the same value in each language?
* programme and script template (original) titles without variables - if they are identical in all languages, turn them into global titles or rather all-languages

Edit: The general pattern (I tried to follow)
* randomcity -> global
* worldtime -> global
* contains variable or role reference -> all (role localization)
* identical fixed values -> global