### PR TITLE
Reparatur kaputte Match-Texte

### DIFF
--- a/source/Dig/base.util.localization.bmx
+++ b/source/Dig/base.util.localization.bmx
@@ -1010,10 +1010,7 @@ endrem
 	
 	Method UCFirstAllEntries()
 		For local i:int = EachIn valueLangIDs
-			If i < valueStrings.length And valueStrings[i]
-				valueStrings[i] = StringHelper.UCFirst(valueStrings[i])
-			EndIf
-			valueCachedLanguageID = -2
+			Set(StringHelper.UCFirst( Get(i, False) ), i)
 		Next
 	End Method
 End Type

--- a/source/Dig/base.util.localization.bmx
+++ b/source/Dig/base.util.localization.bmx
@@ -1010,7 +1010,10 @@ endrem
 	
 	Method UCFirstAllEntries()
 		For local i:int = EachIn valueLangIDs
-			Set(StringHelper.UCFirst(Get(i), i))
+			If i < valueStrings.length And valueStrings[i]
+				valueStrings[i] = StringHelper.UCFirst(valueStrings[i])
+			EndIf
+			valueCachedLanguageID = -2
 		Next
 	End Method
 End Type

--- a/source/game.programme.programmedata.specials.bmx
+++ b/source/game.programme.programmedata.specials.bmx
@@ -231,6 +231,7 @@ Type TSportsProgrammeData Extends TProgrammeData {_exposeToLua}
 					'this avoids having a random "text" on eeach dynamic text
 					'refresh
 					If not description.HasLanguageID( TLocalization.currentLanguageID )
+						'TODO SPORT_PROGRAMME_MATCH_DESCRIPTION benötigt trim und ucfirst *nach* der Variablenersetzung und *vor* dem Konkatenieren
 						If leagueGUID
 							description.Set( GetLocale("SPORT_PROGRAMME_MATCH_OF_LEAGUEX")+"~n"+GetRandomLocale("SPORT_PROGRAMME_MATCH_DESCRIPTION") , TLocalization.currentLanguageID )
 						Else

--- a/source/game.programmeproducer.sport.bmx
+++ b/source/game.programmeproducer.sport.bmx
@@ -225,7 +225,6 @@ Type TProgrammeProducerSport Extends TProgrammeProducerBase
 		Local localeIDs:Int[] = [TLocalization.currentLanguageID, TLocalization.defaultLanguageID]
 		For Local localeID:Int = EachIn localeIDs
 			programmeData.title.Set("%LEAGUENAMESHORT%: %MATCHNAMESHORT%", localeID )
-			'TODO sollte das nicht für alle Sprachen gemacht werden, nicht nur für 2
 			programmeData.description.Set( GetRandomLocale("SPORT_PROGRAMME_MATCH_DESCRIPTION") , localeID )
 		Next
 

--- a/source/game.programmeproducer.sport.bmx
+++ b/source/game.programmeproducer.sport.bmx
@@ -139,13 +139,13 @@ Type TProgrammeProducerSport Extends TProgrammeProducerBase
 		'add sports information and parse potential expressions
 		programmeData._ParseScriptExpressions(programmeData.title, False) 'False => directly manipulate .title
 		programmeData._ParseScriptExpressions(programmeData.description, False)
-		programmeData._ParseScriptExpressions(programmeData.descriptionAiredHint, False)
+		programmeData._ParseScriptExpressions(programmeData.descriptionAirtimeHint, False)
 		programmeData._ParseScriptExpressions(programmeData.descriptionAiredHint, False)
 
 		'Set first char to Upper case
 		programmeData.title.UCFirstAllEntries()
 		programmeData.description.UCFirstAllEntries()
-		programmeData.descriptionAiredHint.UCFirstAllEntries()
+		programmeData.descriptionAirtimeHint.UCFirstAllEntries()
 		programmeData.descriptionAiredHint.UCFirstAllEntries()
 
 
@@ -225,6 +225,7 @@ Type TProgrammeProducerSport Extends TProgrammeProducerBase
 		Local localeIDs:Int[] = [TLocalization.currentLanguageID, TLocalization.defaultLanguageID]
 		For Local localeID:Int = EachIn localeIDs
 			programmeData.title.Set("%LEAGUENAMESHORT%: %MATCHNAMESHORT%", localeID )
+			'TODO sollte das nicht für alle Sprachen gemacht werden, nicht nur für 2
 			programmeData.description.Set( GetRandomLocale("SPORT_PROGRAMME_MATCH_DESCRIPTION") , localeID )
 		Next
 


### PR DESCRIPTION
see #1223 

UCFirstAllEntries schien Ursache zu sein. Nahm man die Aufrufe raus, passten die Texte. Ich vermute unerwünschte Seiteneffekte beim set+get+cache+Defaultwerte.
Die Hilfsmethode sollte überhaupt nur die existierenden Einträge anpassen.