### PR TITLE
zeitverzögerte Effekte

### DIFF
--- a/source/game.award.culture.bmx
+++ b/source/game.award.culture.bmx
@@ -66,7 +66,7 @@ Type TAwardCulture extends TAward
 
 	'override
 	'add temporary culture-boost
-	Method Finish:int()
+	Method Finish:int(overrideWinnerID:Int = -1) override
 		'If desired the winner value could be adjusted by the love betty
 		'already feels for that player (diminishing returns ...)
 		'if winningPlayerID > 0
@@ -79,6 +79,7 @@ Type TAwardCulture extends TAward
 		if winningPlayerID > 0
 			'add modifier for programmes with flag "culture"
 			local modifier:TGameModifierBase = GetGameModifierManager().Create("Modifier.GameConfig")
+			modifier.SetLongRunngingWithUndo()
 			local mConfig:TData = new TData
 			mConfig.AddString("name", "CultureBoost.Programme")
 			mConfig.AddString("modifierKey", "Attractivity.ProgrammeDataFlag.player"+winningPlayerID+"."+TVTProgrammeDataFlag.CULTURE)
@@ -97,6 +98,7 @@ Type TAwardCulture extends TAward
 
 			'same for culture-news
 			modifier = GetGameModifierManager().Create("Modifier.GameConfig")
+			modifier.SetLongRunngingWithUndo()
 			mConfig = new TData
 			mConfig.AddString("name", "CultureBoost.News")
 			mConfig.AddString("modifierKey", "Attractivity.NewsGenre.player"+winningPlayerID+"."+TVTNewsGenre.CULTURE)

--- a/source/game.award.customproduction.bmx
+++ b/source/game.award.customproduction.bmx
@@ -51,7 +51,7 @@ Type TAwardCustomProduction extends TAward
 	End Method
 
 
-	Method Finish:int()
+	Method Finish:int(overrideWinnerID:Int = -1) override
 		local result:int = Super.Finish()
 
 		'remove links to best productions

--- a/source/game.betty.bmx
+++ b/source/game.betty.bmx
@@ -542,8 +542,8 @@ Type TGUIBettyPresent extends TGuiObject
 End Type
 
 
-
-
+'TODO support database effects, playerID has to be passed in params (owner of context object?)
+'modifier.run is currently invoked directly by awards; not using the update mechanism
 Type TGameModifier_BettyLove extends TGameModifierBase
 	Function CreateNewInstance:TGameModifier_BettyLove()
 		Return new TGameModifier_BettyLove
@@ -563,9 +563,7 @@ Type TGameModifier_BettyLove extends TGameModifierBase
 		return "TGameModifier_BettyLove ("+GetName()+")"
 	End Method
 
-'TODO undo makes no real sense - temporary betty love increase?
-'regular update+run would immediately reset the value
-'modifier.run is currently invoked directly by awards; not using the update mechanism
+
 	Method UndoFunc:int(params:TData)
 		local playerID:int = GetData().GetInt("playerID", 0)
 		if not playerID then return False

--- a/source/game.betty.bmx
+++ b/source/game.betty.bmx
@@ -563,7 +563,9 @@ Type TGameModifier_BettyLove extends TGameModifierBase
 		return "TGameModifier_BettyLove ("+GetName()+")"
 	End Method
 
-
+'TODO undo makes no real sense - temporary betty love increase?
+'regular update+run would immediately reset the value
+'modifier.run is currently invoked directly by awards; not using the update mechanism
 	Method UndoFunc:int(params:TData)
 		local playerID:int = GetData().GetInt("playerID", 0)
 		if not playerID then return False

--- a/source/game.modifier.base.bmx
+++ b/source/game.modifier.base.bmx
@@ -393,6 +393,17 @@ Type TGameModifierBase
 	Method Update:Int(params:TData)
 		If params Then passedParams = params
 
+		'check if data contains a time definition and apply it (once)
+		If data
+			Local timeString:String = data.GetString("time")
+			If timeString
+				Local happenTime:Int[] = StringHelper.StringToIntArray(timeString, ",")
+				Local timeStamp:Long = GetWorldTime().CalcTime_Auto(-1, happenTime[0], happenTime[1..])
+				If timeStamp > 0 Then SetDelayedExecutionTime(timeStamp)
+				data.remove("time")
+			EndIf
+		EndIf
+
 		'if delayed and delay is in the future, set item to be managed
 		'by the modifier manager (so it gets updated regularily until
 		'delay is gone)

--- a/source/game.modifier.base.bmx
+++ b/source/game.modifier.base.bmx
@@ -770,7 +770,7 @@ Type TGameModifierChoice Extends TGameModifierBase
 
 	Method Copy:TGameModifierChoice()
 		Local clone:TGameModifierChoice = New TGameModifierChoice
-		clone.CopyBaseFrom(Self)
+		clone.CopyFromChoice(self)
 
 		Return clone
 	End Method

--- a/source/game.modifier.base.bmx
+++ b/source/game.modifier.base.bmx
@@ -218,7 +218,7 @@ Type TGameModifierBase
 
 	'The modifier is not a one-time effect but a long-running one
 	'whose effect is undone after a delay (or if a condition is not met anymore)
-	'by default modifiers are permanentn one-time effects
+	'by default modifiers are permanent one-time effects
 	Const FLAG_LONG_RUNNING_WITH_UNDO:Int = 1
 	Const FLAG_ACTIVATED:Int = 2
 	Const FLAG_EXPIRED:Int = 4

--- a/source/game.modifier.base.bmx
+++ b/source/game.modifier.base.bmx
@@ -779,12 +779,11 @@ Type TGameModifierChoice Extends TGameModifierBase
 	Method CopyFromChoice:TGameModifierChoice(choice:TGameModifierChoice)
 		Self.CopyBaseFrom(choice)
 		Self.chooseType = choice.chooseType
-		For Local p:Int = EachIn choice.modifiersProbability
-			Self.modifiersProbability :+ [p]
-		Next
-		For Local m:TGameModifierBase = EachIn choice.modifiers
-			Self.modifiers :+ [m.Copy()]
-		Next
+		Self.modifiersProbability = choice.modifiersProbability[ .. ]
+		Self.modifiers = New TGameModifierBase[ choice.modifiers.length ]
+		For Local i:Int = 0 Until Self.modifiers.length
+			If choice.modifiers[i] Then Self.modifiers[i] = choice.modifiers[i].Copy()
+		next 
 		Return Self
 	End Method
 

--- a/source/game.modifier.base.bmx
+++ b/source/game.modifier.base.bmx
@@ -394,7 +394,7 @@ Type TGameModifierBase
 		If params Then passedParams = params
 
 		'check if data contains a time definition and apply it (once)
-		If data
+		If data And Not HasDelayedExecution()
 			Local timeString:String = data.GetString("time")
 			If timeString
 				Local happenTime:Int[] = StringHelper.StringToIntArray(timeString, ",")
@@ -605,7 +605,7 @@ Type TGameModifierGroup
 				If Not l Then Continue
 
 				For Local m:TGameModifierBase = EachIn l
-					c.AddEntry(String(node._key), m)
+					c.AddEntry(String(node._key), m.copy())
 				Next
 
 				'move on to next node

--- a/source/game.modifier.base.bmx
+++ b/source/game.modifier.base.bmx
@@ -216,7 +216,10 @@ Type TGameModifierBase
 	Global lsKeyCustomRunFuncKey:TLowerString = New TLowerString.Create("customRunFuncKey")
 
 
-	Const FLAG_PERMANENT:Int = 1
+	'The modifier is not a one-time effect but a long-running one
+	'whose effect is undone after a delay (or if a condition is not met anymore)
+	'by default modifiers are permanentn one-time effects
+	Const FLAG_LONG_RUNNING_WITH_UNDO:Int = 1
 	Const FLAG_ACTIVATED:Int = 2
 	Const FLAG_EXPIRED:Int = 4
 	Const FLAG_EXPIRATION_DISABLED:Int = 8
@@ -250,6 +253,11 @@ Type TGameModifierBase
 		Local clone:TGameModifierBase = TGameModifierBase(TTypeId.ForObject(Self).NewObject())
 		clone.CopyBasefrom(Self)
 		Return clone
+	End Method
+
+
+	Method SetLongRunngingWithUndo()
+		SetFlag(FLAG_LONG_RUNNING_WITH_UNDO)
 	End Method
 
 
@@ -437,7 +445,7 @@ Type TGameModifierBase
 		'run() above
 		If HasFlag(Flag_ACTIVATED)
 			If Not HasFlag(FLAG_EXPIRATION_DISABLED) And (Not conditions Or Not conditionsOK)
-				If Not HasFlag(FLAG_PERMANENT)
+				If HasFlag(FLAG_LONG_RUNNING_WITH_UNDO)
 					Undo(passedParams)
 				EndIf
 

--- a/source/game.modifier.base.bmx
+++ b/source/game.modifier.base.bmx
@@ -239,6 +239,11 @@ Type TGameModifierBase
 	End Method
 
 
+	Method InitTimeDataIfPresent(data:TData)
+		If data And data.GetString("time") Then GetData().AddString("time", data.GetString("time"))
+	End Method
+
+
 	Method Copy:TGameModifierBase()
 		'deprecated
 		'local clone:TGameModifierBase = new self

--- a/source/game.player.finance.bmx
+++ b/source/game.player.finance.bmx
@@ -863,7 +863,9 @@ Type TGameModifier_Money extends TGameModifierBase
 	End Method
 
 
-
+'TODO undo makes no real sense - temporary increase money?
+'regular update+run would immediately reset the value
+'modifier.run is currently invoked directly by awards; not using the update mechanism
 	Method UndoFunc:int(params:TData)
 		local playerID:int = GetData().GetInt("playerID", 0)
 		if not playerID then return False

--- a/source/game.player.finance.bmx
+++ b/source/game.player.finance.bmx
@@ -842,7 +842,7 @@ End Type
 
 
 
-
+'modifier.run is currently invoked directly by awards; not using the update mechanism
 Type TGameModifier_Money extends TGameModifierBase
 	Function CreateNewInstance:TGameModifier_Money()
 		return new TGameModifier_Money
@@ -863,9 +863,6 @@ Type TGameModifier_Money extends TGameModifierBase
 	End Method
 
 
-'TODO undo makes no real sense - temporary increase money?
-'regular update+run would immediately reset the value
-'modifier.run is currently invoked directly by awards; not using the update mechanism
 	Method UndoFunc:int(params:TData)
 		local playerID:int = GetData().GetInt("playerID", 0)
 		if not playerID then return False

--- a/source/game.popularity.bmx
+++ b/source/game.popularity.bmx
@@ -346,7 +346,7 @@ Type TGameModifierPopularity_ModifyPopularity extends TGameModifierBase
 	Method Init:TGameModifierPopularity_ModifyPopularity(data:TData, extra:TData=null)
 		if not data then return null
 
-		self.data = data.copy()
+		If data And data.GetString("time") Then self.data = data.copy()
 
 		local index:string = ""
 		if extra and extra.GetInt("childIndex") > 0 then index = extra.GetInt("childIndex")

--- a/source/game.popularity.bmx
+++ b/source/game.popularity.bmx
@@ -327,6 +327,7 @@ Type TGameModifierPopularity_ModifyPopularity extends TGameModifierBase
 	Method CopyFrom(other:TGameModifierPopularity_ModifyPopularity)
 		popularityID = other.popularityID
 		popularityReferenceID = other.popularityReferenceID
+		popularityReferenceGUID = other.popularityReferenceGUID
 		valueMin = other.valueMin
 		valueMax = other.valueMax
 		modifyProbability = other.modifyProbability

--- a/source/game.popularity.bmx
+++ b/source/game.popularity.bmx
@@ -346,6 +346,8 @@ Type TGameModifierPopularity_ModifyPopularity extends TGameModifierBase
 	Method Init:TGameModifierPopularity_ModifyPopularity(data:TData, extra:TData=null)
 		if not data then return null
 
+		self.data = data.copy()
+
 		local index:string = ""
 		if extra and extra.GetInt("childIndex") > 0 then index = extra.GetInt("childIndex")
 		popularityID = data.GetInt("id"+index, data.GetInt("id", 0))

--- a/source/game.popularity.bmx
+++ b/source/game.popularity.bmx
@@ -347,7 +347,7 @@ Type TGameModifierPopularity_ModifyPopularity extends TGameModifierBase
 	Method Init:TGameModifierPopularity_ModifyPopularity(data:TData, extra:TData=null)
 		if not data then return null
 
-		If data And data.GetString("time") Then self.data = data.copy()
+		InitTimeDataIfPresent(data)
 
 		local index:string = ""
 		if extra and extra.GetInt("childIndex") > 0 then index = extra.GetInt("childIndex")

--- a/source/game.popularity.person.bmx
+++ b/source/game.popularity.person.bmx
@@ -4,6 +4,7 @@ Import "Dig/base.util.math.bmx"
 Import "game.gameconstants.bmx"
 Import "game.popularity.bmx"
 Import "game.person.base.bmx"
+Import "game.gamescriptexpression.bmx"
 
 
 Type TPersonPopularity Extends TPopularity
@@ -123,7 +124,9 @@ Type TGameModifierPopularity_ModifyPersonPopularity extends TGameModifierPopular
 
 
 	Method GetPopularity:TPopularity() override
-		'TODO evaluate potential variable here
+		If popularityReferenceGUID And popularityReferenceGUID.contains("${")
+			popularityReferenceGUID = GameScriptExpression.ParseLocalizedText(popularityReferenceGUID, new SScriptExpressionContext(null, 0, passedParams.get("variables"))).ToString()
+		EndIf
 		Local popularity:TPopularity = Super.GetPopularity()
 		If Not popularity 
 			Local person:TPersonBase

--- a/source/game.popularity.person.bmx
+++ b/source/game.popularity.person.bmx
@@ -117,7 +117,7 @@ Type TGameModifierPopularity_ModifyPersonPopularity extends TGameModifierPopular
 	Method Init:TGameModifierPopularity_ModifyPersonPopularity(data:TData, extra:TData=null)
 		Super.Init(data, extra)
 
-		If data And data.GetString("time") Then self.data = data.copy()
+		InitTimeDataIfPresent(data)
 
 		Return self
 	End Method

--- a/source/game.popularity.person.bmx
+++ b/source/game.popularity.person.bmx
@@ -116,7 +116,7 @@ Type TGameModifierPopularity_ModifyPersonPopularity extends TGameModifierPopular
 	Method Init:TGameModifierPopularity_ModifyPersonPopularity(data:TData, extra:TData=null)
 		Super.Init(data, extra)
 
-		If data Then self.data = data.copy()
+		If data And data.GetString("time") Then self.data = data.copy()
 
 		Return self
 	End Method

--- a/source/game.popularity.person.bmx
+++ b/source/game.popularity.person.bmx
@@ -1,4 +1,4 @@
-﻿SuperStrict
+SuperStrict
 Import "Dig/base.util.data.bmx"
 Import "Dig/base.util.math.bmx"
 Import "game.gameconstants.bmx"
@@ -115,11 +115,15 @@ Type TGameModifierPopularity_ModifyPersonPopularity extends TGameModifierPopular
 
 	Method Init:TGameModifierPopularity_ModifyPersonPopularity(data:TData, extra:TData=null)
 		Super.Init(data, extra)
+
+		If data Then self.data = data.copy()
+
 		Return self
 	End Method
 
 
 	Method GetPopularity:TPopularity() override
+		'TODO evaluate potential variable here
 		Local popularity:TPopularity = Super.GetPopularity()
 		If Not popularity 
 			Local person:TPersonBase

--- a/source/game.popularity.person.bmx
+++ b/source/game.popularity.person.bmx
@@ -124,6 +124,7 @@ Type TGameModifierPopularity_ModifyPersonPopularity extends TGameModifierPopular
 
 
 	Method GetPopularity:TPopularity() override
+		Local guidBackup:String = popularityReferenceGUID
 		If popularityReferenceGUID And popularityReferenceGUID.contains("${")
 			popularityReferenceGUID = GameScriptExpression.ParseLocalizedText(popularityReferenceGUID, new SScriptExpressionContext(null, 0, passedParams.get("variables"))).ToString()
 		EndIf
@@ -139,6 +140,7 @@ Type TGameModifierPopularity_ModifyPersonPopularity extends TGameModifierPopular
 				popularity = person.GetPopularity()
 			EndIf
 		EndIf
+		popularityReferenceGUID = guidBackup
 		Return popularity
 	End Method
 

--- a/source/game.production.scripttemplate.bmx
+++ b/source/game.production.scripttemplate.bmx
@@ -754,7 +754,7 @@ Type TGameModifierScriptTemplate_ModifyAvailability Extends TGameModifierBase
 	Method Init:TGameModifierScriptTemplate_ModifyAvailability(data:TData, extra:TData=Null)
 		If Not data Then Return Null
 
-		If data And data.GetString("time") Then self.data = data.copy()
+		InitTimeDataIfPresent(data)
 
 		templateGUID = data.GetString("guid", "")
 		enable = data.GetBool("enable", True)

--- a/source/game.production.scripttemplate.bmx
+++ b/source/game.production.scripttemplate.bmx
@@ -754,6 +754,8 @@ Type TGameModifierScriptTemplate_ModifyAvailability Extends TGameModifierBase
 	Method Init:TGameModifierScriptTemplate_ModifyAvailability(data:TData, extra:TData=Null)
 		If Not data Then Return Null
 
+		self.data = data.copy()
+
 		templateGUID = data.GetString("guid", "")
 		enable = data.GetBool("enable", True)
 

--- a/source/game.production.scripttemplate.bmx
+++ b/source/game.production.scripttemplate.bmx
@@ -754,7 +754,7 @@ Type TGameModifierScriptTemplate_ModifyAvailability Extends TGameModifierBase
 	Method Init:TGameModifierScriptTemplate_ModifyAvailability(data:TData, extra:TData=Null)
 		If Not data Then Return Null
 
-		self.data = data.copy()
+		If data And data.GetString("time") Then self.data = data.copy()
 
 		templateGUID = data.GetString("guid", "")
 		enable = data.GetBool("enable", True)

--- a/source/game.programme.newsevent.bmx
+++ b/source/game.programme.newsevent.bmx
@@ -1262,7 +1262,7 @@ Type TGameModifierNews_ModifyAvailability Extends TGameModifierBase
 End Type
 
 
-'currently not used, makes no sense without permanent-flag (values would be reset immediately)
+'currently not used
 Type TGameModifierNews_ModifyAttribute Extends TGameModifierBase
 	Field newsGUID:String
 	Field attribute:String

--- a/source/game.programme.newsevent.bmx
+++ b/source/game.programme.newsevent.bmx
@@ -1166,7 +1166,7 @@ Type TGameModifierNews_ModifyAvailability Extends TGameModifierBase
 	Method Init:TGameModifierNews_ModifyAvailability(data:TData, extra:TData=Null)
 		If Not data Then Return Null
 
-		self.data = data.copy()
+		If data And data.GetString("time") Then self.data = data.copy()
 
 		newsGUID = data.GetString("news", "")
 		enable = data.GetBool("enable", True)

--- a/source/game.programme.newsevent.bmx
+++ b/source/game.programme.newsevent.bmx
@@ -1185,6 +1185,10 @@ Type TGameModifierNews_ModifyAvailability Extends TGameModifierBase
 	End Method
 
 
+'modify news availability is a one time effect
+'not intended for temporary enabling/disabling for a given time by the same effect instance
+'undo will be called immediately after the run if the event is not marked as permanent
+rem
 	'override
 	Method UndoFunc:Int(params:TData)
 		Local newsEventTemplate:TNewsEventTemplate = GetNewsEventTemplate()
@@ -1215,6 +1219,7 @@ Type TGameModifierNews_ModifyAvailability Extends TGameModifierBase
 		Print "TGameModifierNews_ModifyAvailability.Undo: Failed to find newsEventTemplate or newsEvent with GUID ~q"+newsGUID+"~q."
 		Return False
 	End Method
+endrem
 
 
 	'override to trigger a specific news
@@ -1228,7 +1233,7 @@ Type TGameModifierNews_ModifyAvailability Extends TGameModifierBase
 			newsEventTemplate.SetBroadcastFlag(TVTBroadcastMaterialSourceFlag.NOT_AVAILABLE, Not enable)
 
 		
-			'also modify "not yet happened" but existing news 
+			'also modify "not yet happened" but existing news; already published news remain available
 			'ATTENTION: this does not backup potentially "differing" news
 			'           availabilities. An individually made available
 			'           newsevent would get their availability overridden!
@@ -1240,8 +1245,6 @@ Type TGameModifierNews_ModifyAvailability Extends TGameModifierBase
 				EndIf
 			Next
 
-			'prevent undoing enablement immediately
-			setFlag(TGameModifierBase.FLAG_PERMANENT)
 			Return True
 		Else
 			Local newsEvent:TNewsEvent = GetNewsEvent()
@@ -1254,8 +1257,6 @@ Type TGameModifierNews_ModifyAvailability Extends TGameModifierBase
 				'refresh caches
 				GetNewsEventCollection()._InvalidateCaches()
 
-				'prevent undoing enablement immediately
-				setFlag(TGameModifierBase.FLAG_PERMANENT)
 				Return True
 			EndIf
 		EndIf
@@ -1266,7 +1267,7 @@ Type TGameModifierNews_ModifyAvailability Extends TGameModifierBase
 End Type
 
 
-
+'currently not used, makes no sense without permanent-flag (values would be reset immediately)
 Type TGameModifierNews_ModifyAttribute Extends TGameModifierBase
 	Field newsGUID:String
 	Field attribute:String

--- a/source/game.programme.newsevent.bmx
+++ b/source/game.programme.newsevent.bmx
@@ -1185,10 +1185,6 @@ Type TGameModifierNews_ModifyAvailability Extends TGameModifierBase
 	End Method
 
 
-'modify news availability is a one time effect
-'not intended for temporary enabling/disabling for a given time by the same effect instance
-'undo will be called immediately after the run if the event is not marked as permanent
-rem
 	'override
 	Method UndoFunc:Int(params:TData)
 		Local newsEventTemplate:TNewsEventTemplate = GetNewsEventTemplate()
@@ -1219,7 +1215,6 @@ rem
 		Print "TGameModifierNews_ModifyAvailability.Undo: Failed to find newsEventTemplate or newsEvent with GUID ~q"+newsGUID+"~q."
 		Return False
 	End Method
-endrem
 
 
 	'override to trigger a specific news

--- a/source/game.programme.newsevent.bmx
+++ b/source/game.programme.newsevent.bmx
@@ -1166,7 +1166,7 @@ Type TGameModifierNews_ModifyAvailability Extends TGameModifierBase
 	Method Init:TGameModifierNews_ModifyAvailability(data:TData, extra:TData=Null)
 		If Not data Then Return Null
 
-		If data And data.GetString("time") Then self.data = data.copy()
+		InitTimeDataIfPresent(data)
 
 		newsGUID = data.GetString("news", "")
 		enable = data.GetBool("enable", True)

--- a/source/game.programme.newsevent.bmx
+++ b/source/game.programme.newsevent.bmx
@@ -1166,6 +1166,8 @@ Type TGameModifierNews_ModifyAvailability Extends TGameModifierBase
 	Method Init:TGameModifierNews_ModifyAvailability(data:TData, extra:TData=Null)
 		If Not data Then Return Null
 
+		self.data = data.copy()
+
 		newsGUID = data.GetString("news", "")
 		enable = data.GetBool("enable", True)
 

--- a/source/game.programme.programmelicence.bmx
+++ b/source/game.programme.programmelicence.bmx
@@ -3453,6 +3453,8 @@ Type TGameModifierProgramme_ModifyAvailability Extends TGameModifierBase
 	Method Init:TGameModifierProgramme_ModifyAvailability(data:TData, extra:TData=Null)
 		If Not data Then Return Null
 
+		self.data = data.copy()
+
 		programmeGUID = data.GetString("guid", "")
 		enable = data.GetBool("enable", True)
 

--- a/source/game.programme.programmelicence.bmx
+++ b/source/game.programme.programmelicence.bmx
@@ -3453,7 +3453,7 @@ Type TGameModifierProgramme_ModifyAvailability Extends TGameModifierBase
 	Method Init:TGameModifierProgramme_ModifyAvailability(data:TData, extra:TData=Null)
 		If Not data Then Return Null
 
-		If data And data.GetString("time") Then self.data = data.copy()
+		InitTimeDataIfPresent(data)
 
 		programmeGUID = data.GetString("guid", "")
 		enable = data.GetBool("enable", True)

--- a/source/game.programme.programmelicence.bmx
+++ b/source/game.programme.programmelicence.bmx
@@ -3453,7 +3453,7 @@ Type TGameModifierProgramme_ModifyAvailability Extends TGameModifierBase
 	Method Init:TGameModifierProgramme_ModifyAvailability(data:TData, extra:TData=Null)
 		If Not data Then Return Null
 
-		self.data = data.copy()
+		If data And data.GetString("time") Then self.data = data.copy()
 
 		programmeGUID = data.GetString("guid", "")
 		enable = data.GetBool("enable", True)


### PR DESCRIPTION
see #1201 

Idee des Ansatzes ist, dass der Delay zentral von der Basisklasse verwaltet werden kann. Dazu wird beim ersten Update-Aufruf die Zeitverzögerung gesetzt.
Alle Modifiersubtypen implementieren ihre eigene init-Methode, rufen aber nicht alle super.init auf. Daher setze ich data explizit in den Subtypen, für die ich eine zeitverzögerte Ausführung für sinnvoll halte. Ggf. kann man das Setzen noch einschränken (wenn "time"-Attribut vorhanden).

Ausprobiert habe ich das ganze mit einem modifyScriptAvailability (2 Effekte - einmal sofort auf disable setzen, einnmal mit Verzögerung auf enable setzen und Ausgabe der Änderung im run).

Zu klären wäre zunächst der Ansatz an sich.