### PR TITLE
Globale Variablen in der Datenbank

### DIFF
--- a/res/database/Default/lang/de.xml
+++ b/res/database/Default/lang/de.xml
@@ -128,4 +128,7 @@
 		<programmerole guid="6e48da2f-d468-4542-9510-c3412e8841f7" first_name="" last_name="Wirsch" title="Kommissar" />
 		<programmerole guid="3b128a1f-c2e5-4f76-aa97-0d23d44568d2" first_name="Darlene" last_name="" title="Assistentin" />
 	</programmeroles>
+	<globalvariables>
+		<var1>value1</var1>
+	</globalvariables>
 </tvtdb>

--- a/res/database/Default/lang/de.xml
+++ b/res/database/Default/lang/de.xml
@@ -128,7 +128,10 @@
 		<programmerole guid="6e48da2f-d468-4542-9510-c3412e8841f7" first_name="" last_name="Wirsch" title="Kommissar" />
 		<programmerole guid="3b128a1f-c2e5-4f76-aa97-0d23d44568d2" first_name="Darlene" last_name="" title="Assistentin" />
 	</programmeroles>
+
+<!--Define global variables here
 	<globalvariables>
-		<var1>value1</var1>
+		<variableName>Value</variableName>
 	</globalvariables>
+-->
 </tvtdb>

--- a/res/database/Default/lang/de.xml
+++ b/res/database/Default/lang/de.xml
@@ -131,7 +131,7 @@
 
 <!--Define global variables here
 	<globalvariables>
-		<variableName>Value</variableName>
+		<variableName>value de</variableName>
 	</globalvariables>
 -->
 </tvtdb>

--- a/res/database/Default/lang/en.xml
+++ b/res/database/Default/lang/en.xml
@@ -150,7 +150,7 @@
 
 <!--Define global variables here
 	<globalvariables>
-		<variableName>Value</variableName>
+		<variableName>value en</variableName>
 	</globalvariables>
 -->
 </tvtdb>

--- a/res/database/Default/lang/en.xml
+++ b/res/database/Default/lang/en.xml
@@ -147,4 +147,10 @@
 		<programmerole guid="6e48da2f-d468-4542-9510-c3412e8841f7" first_name="" last_name="Gruff" title="Inspector" />
 		<programmerole guid="3b128a1f-c2e5-4f76-aa97-0d23d44568d2" first_name="Darlene" last_name="" title="Assistant" />
 	</programmeroles>
+
+<!--Define global variables here
+	<globalvariables>
+		<variableName>Value</variableName>
+	</globalvariables>
+-->
 </tvtdb>

--- a/res/database/Default/lang/pl.xml
+++ b/res/database/Default/lang/pl.xml
@@ -147,4 +147,10 @@
 		<programmerole guid="6e48da2f-d468-4542-9510-c3412e8841f7" first_name="" last_name="Gruff" title="Inspektor" />
 		<programmerole guid="3b128a1f-c2e5-4f76-aa97-0d23d44568d2" first_name="Darlene" last_name="" title="Asystentka" />
 	</programmeroles>
+
+<!--Define global variables here
+	<globalvariables>
+		<variableName>Value</variableName>
+	</globalvariables>
+-->
 </tvtdb>

--- a/res/database/Default/lang/pl.xml
+++ b/res/database/Default/lang/pl.xml
@@ -150,7 +150,7 @@
 
 <!--Define global variables here
 	<globalvariables>
-		<variableName>Value</variableName>
+		<variableName>value pl</variableName>
 	</globalvariables>
 -->
 </tvtdb>

--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -242,7 +242,7 @@ Type TDatabaseLoader
 	Function LoadDatabaseLocalizations(dbDirectory:String)
 		Local langDir:String = dbDirectory+"/lang/"
 		Local dbl:TDatabaseLocalizer = GetDatabaseLocalizer()
-		Local toStore:TPersonLocalization[] = new TPersonLocalization[10000]
+		Local toStore:TPersonLocalization[] = new TPersonLocalization[GetPersonBaseCollection().GetCount()]
 
 		For Local l:TLocalizationLanguage = EachIn TLocalization.languages
 			Local code:String = l.languageCode

--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -259,9 +259,8 @@ Type TDatabaseLoader
 					Local varName:String
 					Local value:String
 					For Local varNode:TxmlNode = EachIn xml.GetNodeChildElements(allGlobalVars)
-						varName = varNode.getName()
+						varName = varNode.getName().toLower()
 						value = varNode.getContent()
-						'TODO normalize
 						If varName And value Then gvl.map.insert(varName, value)
 					Next
 				EndIf

--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -235,9 +235,41 @@ Type TDatabaseLoader
 			Notify "Important data is missing:  series:"+totalSeriesCount+"  movies:"+totalMoviesCount+"  news:"+totalNewsCount+"  adcontracts:"+totalContractsCount
 		EndIf
 
+		LoadGlobalVariables(dbDirectory)
 
 		'fix potentially corrupt data
 		FixLoadedData()
+	End Method
+
+
+	Method LoadGlobalVariables(dbDirectory:String)
+		Local langDir:String = dbDirectory+"/lang/"
+		Local gv:TGlobalVariablesProviderBase = GetGlobalVariablesProviderBase()
+
+		For Local l:TLocalizationLanguage = EachIn TLocalization.languages
+			Local code:String = l.languageCode
+			Local file:String = langDir + code+".xml"
+			If FileType(file) = 1
+				Local xml:TXmlHelper = TXmlHelper.Create(file)
+				Local allGlobalVars:TxmlNode = xml.FindRootChildLC("globalvariables")
+				If allGlobalVars
+					Local gvl:TLocalizationLanguage = TLocalizationLanguage(gv.get(code))
+					If Not gvl
+						gvl = new TLocalizationLanguage
+						gvl.languageCode = code
+						gv.set(code, gvl)
+					EndIf
+					Local varName:String
+					Local value:String
+					For Local varNode:TxmlNode = EachIn xml.GetNodeChildElements(allGlobalVars)
+						varName = varNode.getName()
+						value = varNode.getContent()
+						'TODO normalize
+						If varName And value Then gvl.map.insert(varName, value)
+					Next
+				EndIf
+			EndIf
+		Next
 	End Method
 	
 	

--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -289,8 +289,8 @@ Type TDatabaseLoader
 							index:+1
 						EndIf
 					EndIf
-					dbl.persons.insert(code, toStore[..index])
 				Next
+				If index > 0 Then dbl.persons.insert(code, toStore[..index])
 
 				Local nodeAllRoles:TxmlNode
 				nodeAllRoles = xml.FindRootChildLC("programmeroles")
@@ -315,8 +315,8 @@ Type TDatabaseLoader
 							index:+ 1
 						EndIf
 					EndIf
-					dbl.roles.insert(code, toStore[..index])
 				Next
+				If index > 0 Then dbl.roles.insert(code, toStore[..index])
 			EndIf
 		Next
 	End Function

--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -242,7 +242,7 @@ Type TDatabaseLoader
 	Function LoadDatabaseLocalizations(dbDirectory:String)
 		Local langDir:String = dbDirectory+"/lang/"
 		Local dbl:TDatabaseLocalizer = GetDatabaseLocalizer()
-		Local toStore:TPersonLocalization[] = new TPersonLocalization[GetPersonBaseCollection().GetCount()]
+		Local toStore:TPersonLocalization[] = new TPersonLocalization[100]
 
 		For Local l:TLocalizationLanguage = EachIn TLocalization.languages
 			Local code:String = l.languageCode
@@ -266,11 +266,9 @@ Type TDatabaseLoader
 					Next
 				EndIf
 
-				Local v:String
-
 				Local nodeAllPersons:TxmlNode
 				nodeAllPersons = xml.FindRootChildLC("persons")
-				Local count:Int = 0
+				Local index:Int = 0
 				Local personCollection:TPersonBaseCollection = GetPersonBaseCollection()
 				For Local nodePerson:TxmlNode = EachIn xml.GetNodeChildElements(nodeAllPersons)
 					If nodePerson.getName() <> "person" Then Continue
@@ -282,33 +280,22 @@ Type TDatabaseLoader
 						If person
 							Local personToStore:TPersonLocalization = new TPersonLocalization
 							personToStore.id = person.id
-							If data.has("first_name")
-								personToStore.firstName=data.GetString("first_name","")
-								personToStore.flags :| TPersonLocalization.FLAG_FIRSTNAME
-							EndIf
-							If data.has("last_name")
-								personToStore.lastName=data.GetString("last_name","")
-								personToStore.flags :| TPersonLocalization.FLAG_LASTTNAME
-							EndIf
-							If data.has("nick_name")
-								personToStore.nickName=data.GetString("nick_name","")
-								personToStore.flags :| TPersonLocalization.FLAG_NICKTNAME
-							EndIf
-							If data.has("title")
-								personToStore.title=data.GetString("title","")
-								personToStore.flags :| TPersonLocalization.FLAG_TITLE
-							EndIf
-							toStore[count] = personToStore
-							count:+1
+							personToStore.firstName=data.GetString("first_name","")
+							personToStore.lastName=data.GetString("last_name","")
+							personToStore.nickName=data.GetString("nick_name","")
+							personToStore.title=data.GetString("title","")
+							if toStore.length <= index Then toStore = toStore[.. index + 50]
+							toStore[index] = personToStore
+							index:+1
 						EndIf
 					EndIf
-					dbl.persons.insert(code, toStore[..count])
+					dbl.persons.insert(code, toStore[..index])
 				Next
-		
+
 				Local nodeAllRoles:TxmlNode
 				nodeAllRoles = xml.FindRootChildLC("programmeroles")
 				If Not nodeAllRoles Then nodeAllRoles = xml.FindRootChildLC("roles")
-				count = 0
+				index = 0
 				For Local nodeRole:TxmlNode = EachIn xml.GetNodeChildElements(nodeAllRoles)
 					If nodeRole.getName() <> "programmerole" And nodeRole.getName() <> "role" Then Continue
 					Local data:TData = New TData
@@ -319,33 +306,22 @@ Type TDatabaseLoader
 						If role
 							Local roleToStore:TPersonLocalization = new TPersonLocalization
 							roleToStore.id = role.id
-							If data.has("first_name")
-								roleToStore.firstName=data.GetString("first_name","")
-								roleToStore.flags :| TPersonLocalization.FLAG_FIRSTNAME
-							EndIf
-							If data.has("last_name")
-								roleToStore.lastName=data.GetString("last_name","")
-								roleToStore.flags :| TPersonLocalization.FLAG_LASTTNAME
-							EndIf
-							If data.has("nick_name")
-								roleToStore.nickName=data.GetString("nick_name","")
-								roleToStore.flags :| TPersonLocalization.FLAG_NICKTNAME
-							EndIf
-							If data.has("title")
-								roleToStore.title=data.GetString("title","")
-								roleToStore.flags :| TPersonLocalization.FLAG_TITLE
-							EndIf
-							toStore[count] = roleToStore
-							count:+ 1
+							roleToStore.firstName=data.GetString("first_name","")
+							roleToStore.lastName=data.GetString("last_name","")
+							roleToStore.nickName=data.GetString("nick_name","")
+							roleToStore.title=data.GetString("title","")
+							if toStore.length <= index Then toStore = toStore[.. index + 50]
+							toStore[index] = roleToStore
+							index:+ 1
 						EndIf
 					EndIf
-					dbl.roles.insert(code, toStore[..count])
+					dbl.roles.insert(code, toStore[..index])
 				Next
 			EndIf
 		Next
 	End Function
-	
-	
+
+
 	Function MXMLErrorCallback(message:Byte Ptr)
 		Local s:String = string.FromCString(message)
 		TLogger.Log("TDatabase.Load()", "mxml-Error: " + s, LOG_ERROR + LOG_XML)

--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -242,6 +242,7 @@ Type TDatabaseLoader
 	Function LoadDatabaseLocalizations(dbDirectory:String)
 		Local langDir:String = dbDirectory+"/lang/"
 		Local dbl:TDatabaseLocalizer = GetDatabaseLocalizer()
+		Local toStore:TPersonLocalization[] = new TPersonLocalization[10000]
 
 		For Local l:TLocalizationLanguage = EachIn TLocalization.languages
 			Local languageId:Int = TLocalization.GetLanguageId(l.languageCode)
@@ -266,12 +267,11 @@ Type TDatabaseLoader
 					Next
 				EndIf
 
-				Local NO_VALUE:String = "<NO_VALUE_PRESENT>"
 				Local v:String
 
 				Local nodeAllPersons:TxmlNode
 				nodeAllPersons = xml.FindRootChildLC("persons")
-				Local personsToStore:PersonLocalization[] = new PersonLocalization[0]
+				Local count:Int = 0
 				Local personCollection:TPersonBaseCollection = GetPersonBaseCollection()
 				For Local nodePerson:TxmlNode = EachIn xml.GetNodeChildElements(nodeAllPersons)
 					If nodePerson.getName() <> "person" Then Continue
@@ -281,38 +281,35 @@ Type TDatabaseLoader
 					If guid
 						Local person:TPersonBase = personCollection.GetByGUID(guid)
 						If person
-							Local personToStore:PersonLocalization = new PersonLocalization
+							Local personToStore:TPersonLocalization = new TPersonLocalization
 							personToStore.id = person.id
-							v = data.GetString("first_name",NO_VALUE)
-							If v<>NO_VALUE
-								personToStore.firstName=v
-								personToStore.flags :| PersonLocalization.FLAG_FIRSTNAME
+							If data.has("first_name")
+								personToStore.firstName=data.GetString("first_name","")
+								personToStore.flags :| TPersonLocalization.FLAG_FIRSTNAME
 							EndIf
-							v = data.GetString("last_name",NO_VALUE)
-							If v<>NO_VALUE
-								personToStore.lastName=v
-								personToStore.flags :| PersonLocalization.FLAG_LASTTNAME
+							If data.has("last_name")
+								personToStore.lastName=data.GetString("last_name","")
+								personToStore.flags :| TPersonLocalization.FLAG_LASTTNAME
 							EndIf
-							v = data.GetString("nick_name",NO_VALUE)
-							If v<>NO_VALUE
-								personToStore.nickName=v
-								personToStore.flags :| PersonLocalization.FLAG_NICKTNAME
+							If data.has("nick_name")
+								personToStore.nickName=data.GetString("nick_name","")
+								personToStore.flags :| TPersonLocalization.FLAG_NICKTNAME
 							EndIf
-							v = data.GetString("title",NO_VALUE)
-							If v<>NO_VALUE
-								personToStore.title=v
-								personToStore.flags :| PersonLocalization.FLAG_TITLE
+							If data.has("title")
+								personToStore.title=data.GetString("title","")
+								personToStore.flags :| TPersonLocalization.FLAG_TITLE
 							EndIf
-							personsToStore:+ [personToStore]
+							toStore[count] = personToStore
+							count:+1
 						EndIf
 					EndIf
-					dbl.persons.insert(languageId, personsToStore)
+					dbl.persons.insert(languageId, toStore[..count])
 				Next
 		
 				Local nodeAllRoles:TxmlNode
 				nodeAllRoles = xml.FindRootChildLC("programmeroles")
 				If Not nodeAllRoles Then nodeAllRoles = xml.FindRootChildLC("roles")
-				Local rolesToStore:PersonLocalization[] = new PersonLocalization[0]
+				count = 0
 				For Local nodeRole:TxmlNode = EachIn xml.GetNodeChildElements(nodeAllRoles)
 					If nodeRole.getName() <> "programmerole" And nodeRole.getName() <> "role" Then Continue
 					Local data:TData = New TData
@@ -321,32 +318,29 @@ Type TDatabaseLoader
 					If guid
 						Local role:TProgrammeRole = GetProgrammeRoleCollection().GetByGUID(guid)
 						If role
-							Local roleToStore:PersonLocalization = new PersonLocalization
+							Local roleToStore:TPersonLocalization = new TPersonLocalization
 							roleToStore.id = role.id
-							v = data.GetString("first_name",NO_VALUE)
-							If v<>NO_VALUE
-								roleToStore.firstName=v
-								roleToStore.flags :| PersonLocalization.FLAG_FIRSTNAME
+							If data.has("first_name")
+								roleToStore.firstName=data.GetString("first_name","")
+								roleToStore.flags :| TPersonLocalization.FLAG_FIRSTNAME
 							EndIf
-							v = data.GetString("last_name",NO_VALUE)
-							If v<>NO_VALUE
-								roleToStore.lastName=v
-								roleToStore.flags :| PersonLocalization.FLAG_LASTTNAME
+							If data.has("last_name")
+								roleToStore.lastName=data.GetString("last_name","")
+								roleToStore.flags :| TPersonLocalization.FLAG_LASTTNAME
 							EndIf
-							v = data.GetString("nick_name",NO_VALUE)
-							If v<>NO_VALUE
-								roleToStore.nickName=v
-								roleToStore.flags :| PersonLocalization.FLAG_NICKTNAME
+							If data.has("nick_name")
+								roleToStore.nickName=data.GetString("nick_name","")
+								roleToStore.flags :| TPersonLocalization.FLAG_NICKTNAME
 							EndIf
-							v = data.GetString("title",NO_VALUE)
-							If v<>NO_VALUE
-								roleToStore.title=v
-								roleToStore.flags :| PersonLocalization.FLAG_TITLE
+							If data.has("title")
+								roleToStore.title=data.GetString("title","")
+								roleToStore.flags :| TPersonLocalization.FLAG_TITLE
 							EndIf
-							rolesToStore:+ [roleToStore]
+							toStore[count] = roleToStore
+							count:+ 1
 						EndIf
 					EndIf
-					dbl.roles.insert(languageId, rolesToStore)
+					dbl.roles.insert(languageId, toStore[..count])
 				Next
 			EndIf
 		Next

--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -245,18 +245,17 @@ Type TDatabaseLoader
 		Local toStore:TPersonLocalization[] = new TPersonLocalization[10000]
 
 		For Local l:TLocalizationLanguage = EachIn TLocalization.languages
-			Local languageId:Int = TLocalization.GetLanguageId(l.languageCode)
-			If languageId < 0 Then Continue
-			Local file:String = langDir + l.languageCode+".xml"
+			Local code:String = l.languageCode
+			Local file:String = langDir + code+".xml"
 			If FileType(file) = 1
 				Local xml:TXmlHelper = TXmlHelper.Create(file)
 				Local allGlobalVars:TxmlNode = xml.FindRootChildLC("globalvariables")
 				If allGlobalVars
-					Local gvl:TLocalizationLanguage = dbl.getGlobalVariables(languageId)
+					Local gvl:TLocalizationLanguage = dbl.getGlobalVariables(code)
 					If Not gvl
 						gvl = new TLocalizationLanguage
-						gvl.languageCode = l.languageCode
-						dbl.globalVariables.insert(languageId, gvl)
+						gvl.languageCode = code
+						dbl.globalVariables.insert(code, gvl)
 					EndIf
 					Local varName:String
 					Local value:String
@@ -303,7 +302,7 @@ Type TDatabaseLoader
 							count:+1
 						EndIf
 					EndIf
-					dbl.persons.insert(languageId, toStore[..count])
+					dbl.persons.insert(code, toStore[..count])
 				Next
 		
 				Local nodeAllRoles:TxmlNode
@@ -340,7 +339,7 @@ Type TDatabaseLoader
 							count:+ 1
 						EndIf
 					EndIf
-					dbl.roles.insert(languageId, toStore[..count])
+					dbl.roles.insert(code, toStore[..count])
 				Next
 			EndIf
 		Next

--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -244,17 +244,18 @@ Type TDatabaseLoader
 		Local dbl:TDatabaseLocalizer = GetDatabaseLocalizer()
 
 		For Local l:TLocalizationLanguage = EachIn TLocalization.languages
-			Local code:String = l.languageCode
-			Local file:String = langDir + code+".xml"
+			Local languageId:Int = TLocalization.GetLanguageId(l.languageCode)
+			If languageId < 0 Then Continue
+			Local file:String = langDir + l.languageCode+".xml"
 			If FileType(file) = 1
 				Local xml:TXmlHelper = TXmlHelper.Create(file)
 				Local allGlobalVars:TxmlNode = xml.FindRootChildLC("globalvariables")
 				If allGlobalVars
-					Local gvl:TLocalizationLanguage = dbl.getGlobalVariables(code)
+					Local gvl:TLocalizationLanguage = dbl.getGlobalVariables(languageId)
 					If Not gvl
 						gvl = new TLocalizationLanguage
-						gvl.languageCode = code
-						dbl.globalVariables.insert(code, gvl)
+						gvl.languageCode = l.languageCode
+						dbl.globalVariables.insert(languageId, gvl)
 					EndIf
 					Local varName:String
 					Local value:String
@@ -305,7 +306,7 @@ Type TDatabaseLoader
 							personsToStore:+ [personToStore]
 						EndIf
 					EndIf
-					dbl.persons.insert(code, personsToStore)
+					dbl.persons.insert(languageId, personsToStore)
 				Next
 		
 				Local nodeAllRoles:TxmlNode
@@ -345,7 +346,7 @@ Type TDatabaseLoader
 							rolesToStore:+ [roleToStore]
 						EndIf
 					EndIf
-					dbl.roles.insert(code, rolesToStore)
+					dbl.roles.insert(languageId, rolesToStore)
 				Next
 			EndIf
 		Next

--- a/source/game.database.localizer.bmx
+++ b/source/game.database.localizer.bmx
@@ -30,7 +30,7 @@ Type TDatabaseLocalizer
 		If fallback
 			Return getGlobalVariable(TLocalization.GetDefaultLanguageCode(), lowerKey, False)
 		EndIf
-		Return lowerKey + " NOT FOUND"'exception?
+		Return Null
 	End Method
 
 	Method getGlobalVariables:TLocalizationLanguage(languageCode:String)

--- a/source/game.database.localizer.bmx
+++ b/source/game.database.localizer.bmx
@@ -5,15 +5,17 @@ Import "game.programme.programmerole.bmx"
 
 Type TDatabaseLocalizer
 	Global _instance:TDatabaseLocalizer
+	Global _eventListeners:TEventListenerBase[]
 
 	Field globalVariables:TIntMap
 	Field persons:TIntMap
 	Field roles:TIntMap
-	Field _eventListeners:TEventListenerBase[]
 	Field englishLanguageId:Int
 
 	Method New()
 		Reset()
+		EventManager.UnregisterListenersArray(_eventListeners)
+		_eventListeners = New TEventListenerBase[0]
 		'localize person names / roles
 		_eventListeners :+ [ EventManager.registerListenerFunction(GameEventKeys.App_OnSetLanguage, onSetLanguage ) ]
 	End Method
@@ -30,11 +32,10 @@ Type TDatabaseLocalizer
 
 	Method getGlobalVariable:String(languageId:Int, key:String, isKeyLowerCase:Int= False, fallback:Int=True)
 		Local l:TLocalizationLanguage = getGlobalVariables(languageId)
-		Local lowerKey:String = key
-		If Not isKeyLowerCase Then lowerKey=lowerKey.ToLower()
-		If l And l.Has(lowerKey) Then Return l.Get(lowerKey)
+		If Not isKeyLowerCase Then key=key.ToLower()
+		If l And l.Has(key) Then Return l.Get(key)
 		If fallback
-			Return getGlobalVariable(englishLanguageId, lowerKey, True, False)
+			Return getGlobalVariable(englishLanguageId, key, True, False)
 		EndIf
 		Return Null
 	End Method
@@ -59,24 +60,24 @@ Type TDatabaseLocalizer
 		Local languageId:Int = TLocalization.GetLanguageId(lang)
 		If languageID < 0 Then Return
 		Local person:TPersonBase
-		For Local pl:PersonLocalization = EachIn PersonLocalization[](persons.valueForKey(languageId))
+		For Local pl:TPersonLocalization = EachIn TPersonLocalization[](persons.valueForKey(languageId))
 			person = personCollection.GetById(pl.id)
 			If person
-				If pl.flags & PersonLocalization.FLAG_FIRSTNAME Then person.firstName = pl.firstName
-				If pl.flags & PersonLocalization.FLAG_LASTTNAME Then person.lastName = pl.lastName
-				If pl.flags & PersonLocalization.FLAG_TITLE Then person.title = pl.title
-				If pl.flags & PersonLocalization.FLAG_NICKTNAME Then person.nickName = pl.nickName
+				If pl.flags & TPersonLocalization.FLAG_FIRSTNAME Then person.firstName = pl.firstName
+				If pl.flags & TPersonLocalization.FLAG_LASTTNAME Then person.lastName = pl.lastName
+				If pl.flags & TPersonLocalization.FLAG_TITLE Then person.title = pl.title
+				If pl.flags & TPersonLocalization.FLAG_NICKTNAME Then person.nickName = pl.nickName
 			EndIf
 		Next
 		Local roleCollection:TProgrammeRoleCollection = GetProgrammeRoleCollection()
 		Local role:TProgrammeRole
-		For Local pl:PersonLocalization = EachIn PersonLocalization[](roles.valueForKey(languageId))
+		For Local pl:TPersonLocalization = EachIn TPersonLocalization[](roles.valueForKey(languageId))
 			role = roleCollection.GetById(pl.id)
 			If role
-				If pl.flags & PersonLocalization.FLAG_FIRSTNAME Then role.firstName = pl.firstName
-				If pl.flags & PersonLocalization.FLAG_LASTTNAME Then role.lastName = pl.lastName
-				If pl.flags & PersonLocalization.FLAG_TITLE Then role.title = pl.title
-				If pl.flags & PersonLocalization.FLAG_NICKTNAME Then role.nickName = pl.nickName
+				If pl.flags & TPersonLocalization.FLAG_FIRSTNAME Then role.firstName = pl.firstName
+				If pl.flags & TPersonLocalization.FLAG_LASTTNAME Then role.lastName = pl.lastName
+				If pl.flags & TPersonLocalization.FLAG_TITLE Then role.title = pl.title
+				If pl.flags & TPersonLocalization.FLAG_NICKTNAME Then role.nickName = pl.nickName
 			EndIf
 		Next
 	End Method
@@ -89,7 +90,7 @@ Function GetDatabaseLocalizer:TDatabaseLocalizer()
 End Function
 
 
-Type PersonLocalization
+Type TPersonLocalization
 	Global FLAG_FIRSTNAME:Int = 1
 	Global FLAG_LASTTNAME:Int = 2
 	Global FLAG_TITLE:Int = 4

--- a/source/game.database.localizer.bmx
+++ b/source/game.database.localizer.bmx
@@ -7,10 +7,9 @@ Type TDatabaseLocalizer
 	Global _instance:TDatabaseLocalizer
 	Global _eventListeners:TEventListenerBase[]
 
-	Field globalVariables:TIntMap
-	Field persons:TIntMap
-	Field roles:TIntMap
-	Field englishLanguageId:Int
+	Field globalVariables:TMap
+	Field persons:TMap
+	Field roles:TMap
 
 	Method New()
 		Reset()
@@ -21,27 +20,23 @@ Type TDatabaseLocalizer
 	End Method
 
 	Method Reset()
-		globalVariables = new TIntMap'CreateMap()
-		persons =  new TIntMap'CreateMap()
-		roles =  new TIntMap'CreteMap()
-		englishLanguageId = TLocalization.GetLanguageId("en")
-		If englishLanguageId < 0
-			throw "TDatabaseLocalizer.Reset: unable to determine id of default language English" 
-		EndIf
+		globalVariables = new TMap'CreateMap()
+		persons =  new TMap'CreateMap()
+		roles =  new TMap'CreteMap()
 	End Method
 
-	Method getGlobalVariable:String(languageId:Int, key:String, isKeyLowerCase:Int= False, fallback:Int=True)
-		Local l:TLocalizationLanguage = getGlobalVariables(languageId)
+	Method getGlobalVariable:String(languageCode:String, key:String, isKeyLowerCase:Int= False, fallback:Int=True)
+		Local l:TLocalizationLanguage = getGlobalVariables(languageCode)
 		If Not isKeyLowerCase Then key=key.ToLower()
 		If l And l.Has(key) Then Return l.Get(key)
 		If fallback
-			Return getGlobalVariable(englishLanguageId, key, True, False)
+			Return getGlobalVariable("en", key, True, False)
 		EndIf
 		Return Null
 	End Method
 
-	Method getGlobalVariables:TLocalizationLanguage(languageId:Int)
-		Return TLocalizationLanguage(globalVariables.ValueForKey(languageId))
+	Method getGlobalVariables:TLocalizationLanguage(languageCode:String)
+		Return TLocalizationLanguage(globalVariables.ValueForKey(languageCode))
 	End Method
 
 	Function GetInstance:TDatabaseLocalizer()
@@ -57,10 +52,8 @@ Type TDatabaseLocalizer
 
 	Method _updateLocalization(lang:String)
 		Local personCollection:TPersonBaseCollection = GetPersonBaseCollection()
-		Local languageId:Int = TLocalization.GetLanguageId(lang)
-		If languageID < 0 Then Return
 		Local person:TPersonBase
-		For Local pl:TPersonLocalization = EachIn TPersonLocalization[](persons.valueForKey(languageId))
+		For Local pl:TPersonLocalization = EachIn TPersonLocalization[](persons.valueForKey(lang))
 			person = personCollection.GetById(pl.id)
 			If person
 				If pl.flags & TPersonLocalization.FLAG_FIRSTNAME Then person.firstName = pl.firstName
@@ -71,7 +64,7 @@ Type TDatabaseLocalizer
 		Next
 		Local roleCollection:TProgrammeRoleCollection = GetProgrammeRoleCollection()
 		Local role:TProgrammeRole
-		For Local pl:TPersonLocalization = EachIn TPersonLocalization[](roles.valueForKey(languageId))
+		For Local pl:TPersonLocalization = EachIn TPersonLocalization[](roles.valueForKey(lang))
 			role = roleCollection.GetById(pl.id)
 			If role
 				If pl.flags & TPersonLocalization.FLAG_FIRSTNAME Then role.firstName = pl.firstName

--- a/source/game.database.localizer.bmx
+++ b/source/game.database.localizer.bmx
@@ -1,0 +1,96 @@
+SuperStrict
+Import "Dig/base.util.localization.bmx"
+Import "game.person.base.bmx"
+Import "game.programme.programmerole.bmx"
+
+Type TDatabaseLocalizer
+	Global _instance:TDatabaseLocalizer
+
+	Field globalVariables:TMap
+	Field persons:TMap
+	Field roles:TMap
+	Field _eventListeners:TEventListenerBase[]
+
+	Method New()
+		Reset()
+		'localize person names / roles
+		_eventListeners :+ [ EventManager.registerListenerFunction(GameEventKeys.App_OnSetLanguage, onSetLanguage ) ]
+	End Method
+
+	Method Reset()
+		globalVariables = new TMap'CreateMap()
+		persons =  new TMap'CreateMap()
+		roles =  new TMap'CreteMap()
+	End Method
+
+	Method getGlobalVariable:String(languageCode:String, key:String, fallback:Int=True)
+		Local l:TLocalizationLanguage = getGlobalVariables(languageCode)
+		If l And l.Has(key) Then Return l.Get(key)
+		If fallback
+			Return getGlobalVariable(TLocalization.GetDefaultLanguageCode(), key, False)
+		EndIf
+		Return "NOT FOUND"'exception?
+	End Method
+
+	Method getGlobalVariables:TLocalizationLanguage(languageCode:String)
+		Return TLocalizationLanguage(globalVariables.ValueForKey(languageCode))
+	End Method
+
+	Function GetInstance:TDatabaseLocalizer()
+		if not _instance then _instance = new TDatabaseLocalizer
+		return _instance
+	End Function
+
+	Function onSetLanguage:Int(triggerEvent:TEventBase)
+		Local lang:String = triggerEvent.GetData().GetString("languageCode", "en")
+		If lang <> "en" Then GetInstance()._updateLocalization("en")
+		GetInstance()._updateLocalization(lang)
+	End Function
+
+	Method _updateLocalization(lang:String)
+		Local personCollection:TPersonBaseCollection = GetPersonBaseCollection()
+		Local person:TPersonBase
+		For Local pl:PersonLocalization = EachIn PersonLocalization[](persons.valueForKey(lang))
+			person = personCollection.GetById(pl.id)
+			If person
+				If pl.flags & PersonLocalization.FLAG_FIRSTNAME Then person.firstName = pl.firstName
+				If pl.flags & PersonLocalization.FLAG_LASTTNAME Then person.lastName = pl.lastName
+				If pl.flags & PersonLocalization.FLAG_TITLE Then person.title = pl.title
+				If pl.flags & PersonLocalization.FLAG_NICKTNAME Then person.nickName = pl.nickName
+			EndIf
+		Next
+		Local roleCollection:TProgrammeRoleCollection = GetProgrammeRoleCollection()
+		Local role:TProgrammeRole
+		For Local pl:PersonLocalization = EachIn PersonLocalization[](roles.valueForKey(lang))
+			role = roleCollection.GetById(pl.id)
+			If role
+				If pl.flags & PersonLocalization.FLAG_FIRSTNAME Then role.firstName = pl.firstName
+				If pl.flags & PersonLocalization.FLAG_LASTTNAME Then role.lastName = pl.lastName
+				If pl.flags & PersonLocalization.FLAG_TITLE Then role.title = pl.title
+				If pl.flags & PersonLocalization.FLAG_NICKTNAME Then role.nickName = pl.nickName
+			EndIf
+		Next
+	End Method
+End Type
+
+'===== CONVENIENCE ACCESSOR =====
+'return instance
+Function GetDatabaseLocalizer:TDatabaseLocalizer()
+	Return TDatabaseLocalizer.GetInstance()
+End Function
+
+
+Type PersonLocalization
+	Global FLAG_FIRSTNAME:Int = 1
+	Global FLAG_LASTTNAME:Int = 2
+	Global FLAG_TITLE:Int = 4
+	Global FLAG_NICKTNAME:Int = 8
+
+	Field id:Int
+	Field flags:Int
+	Field firstName:String
+	Field lastName:String
+	Field title:String
+	Field nickName:String
+End Type
+

--- a/source/game.database.localizer.bmx
+++ b/source/game.database.localizer.bmx
@@ -20,9 +20,13 @@ Type TDatabaseLocalizer
 	End Method
 
 	Method Reset()
-		globalVariables = new TMap'CreateMap()
-		persons =  new TMap'CreateMap()
-		roles =  new TMap'CreteMap()
+		globalVariables = new TMap
+		persons =  new TMap
+		roles =  new TMap
+	End Method
+
+	Method getGlobalVariable:String(languageId:Int, key:String, isKeyLowerCase:Int= False, fallback:Int=True)
+		Return getGlobalVariable(TLocalization.GetLanguageCode(languageId), key, isKeyLowerCase, fallback)
 	End Method
 
 	Method getGlobalVariable:String(languageCode:String, key:String, isKeyLowerCase:Int= False, fallback:Int=True)
@@ -56,10 +60,10 @@ Type TDatabaseLocalizer
 		For Local pl:TPersonLocalization = EachIn TPersonLocalization[](persons.valueForKey(lang))
 			person = personCollection.GetById(pl.id)
 			If person
-				If pl.flags & TPersonLocalization.FLAG_FIRSTNAME Then person.firstName = pl.firstName
-				If pl.flags & TPersonLocalization.FLAG_LASTTNAME Then person.lastName = pl.lastName
-				If pl.flags & TPersonLocalization.FLAG_TITLE Then person.title = pl.title
-				If pl.flags & TPersonLocalization.FLAG_NICKTNAME Then person.nickName = pl.nickName
+				person.firstName = pl.firstName
+				person.lastName = pl.lastName
+				person.title = pl.title
+				person.nickName = pl.nickName
 			EndIf
 		Next
 		Local roleCollection:TProgrammeRoleCollection = GetProgrammeRoleCollection()
@@ -67,10 +71,10 @@ Type TDatabaseLocalizer
 		For Local pl:TPersonLocalization = EachIn TPersonLocalization[](roles.valueForKey(lang))
 			role = roleCollection.GetById(pl.id)
 			If role
-				If pl.flags & TPersonLocalization.FLAG_FIRSTNAME Then role.firstName = pl.firstName
-				If pl.flags & TPersonLocalization.FLAG_LASTTNAME Then role.lastName = pl.lastName
-				If pl.flags & TPersonLocalization.FLAG_TITLE Then role.title = pl.title
-				If pl.flags & TPersonLocalization.FLAG_NICKTNAME Then role.nickName = pl.nickName
+				role.firstName = pl.firstName
+				role.lastName = pl.lastName
+				role.title = pl.title
+				role.nickName = pl.nickName
 			EndIf
 		Next
 	End Method
@@ -84,11 +88,6 @@ End Function
 
 
 Type TPersonLocalization
-	Global FLAG_FIRSTNAME:Int = 1
-	Global FLAG_LASTTNAME:Int = 2
-	Global FLAG_TITLE:Int = 4
-	Global FLAG_NICKTNAME:Int = 8
-
 	Field id:Int
 	Field flags:Int
 	Field firstName:String

--- a/source/game.database.localizer.bmx
+++ b/source/game.database.localizer.bmx
@@ -23,12 +23,13 @@ Type TDatabaseLocalizer
 		roles =  new TMap'CreteMap()
 	End Method
 
-	Method getGlobalVariable:String(languageCode:String, key:String, fallback:Int=True)
+	Method getGlobalVariable:String(languageCode:String, key:String, isKeyLowerCase:Int= False, fallback:Int=True)
 		Local l:TLocalizationLanguage = getGlobalVariables(languageCode)
-		Local lowerKey:String = key.toLower()
+		Local lowerKey:String = key
+		If Not isKeyLowerCase Then lowerKey=lowerKey.ToLower()
 		If l And l.Has(lowerKey) Then Return l.Get(lowerKey)
 		If fallback
-			Return getGlobalVariable(TLocalization.GetDefaultLanguageCode(), lowerKey, False)
+			Return getGlobalVariable(TLocalization.GetDefaultLanguageCode(), lowerKey, True, False)
 		EndIf
 		Return Null
 	End Method

--- a/source/game.database.localizer.bmx
+++ b/source/game.database.localizer.bmx
@@ -25,11 +25,12 @@ Type TDatabaseLocalizer
 
 	Method getGlobalVariable:String(languageCode:String, key:String, fallback:Int=True)
 		Local l:TLocalizationLanguage = getGlobalVariables(languageCode)
-		If l And l.Has(key) Then Return l.Get(key)
+		Local lowerKey:String = key.toLower()
+		If l And l.Has(lowerKey) Then Return l.Get(lowerKey)
 		If fallback
-			Return getGlobalVariable(TLocalization.GetDefaultLanguageCode(), key, False)
+			Return getGlobalVariable(TLocalization.GetDefaultLanguageCode(), lowerKey, False)
 		EndIf
-		Return "NOT FOUND"'exception?
+		Return lowerKey + " NOT FOUND"'exception?
 	End Method
 
 	Method getGlobalVariables:TLocalizationLanguage(languageCode:String)

--- a/source/game.database.localizer.bmx
+++ b/source/game.database.localizer.bmx
@@ -6,10 +6,11 @@ Import "game.programme.programmerole.bmx"
 Type TDatabaseLocalizer
 	Global _instance:TDatabaseLocalizer
 
-	Field globalVariables:TMap
-	Field persons:TMap
-	Field roles:TMap
+	Field globalVariables:TIntMap
+	Field persons:TIntMap
+	Field roles:TIntMap
 	Field _eventListeners:TEventListenerBase[]
+	Field englishLanguageId:Int
 
 	Method New()
 		Reset()
@@ -18,24 +19,28 @@ Type TDatabaseLocalizer
 	End Method
 
 	Method Reset()
-		globalVariables = new TMap'CreateMap()
-		persons =  new TMap'CreateMap()
-		roles =  new TMap'CreteMap()
+		globalVariables = new TIntMap'CreateMap()
+		persons =  new TIntMap'CreateMap()
+		roles =  new TIntMap'CreteMap()
+		englishLanguageId = TLocalization.GetLanguageId("en")
+		If englishLanguageId < 0
+			throw "TDatabaseLocalizer.Reset: unable to determine id of default language English" 
+		EndIf
 	End Method
 
-	Method getGlobalVariable:String(languageCode:String, key:String, isKeyLowerCase:Int= False, fallback:Int=True)
-		Local l:TLocalizationLanguage = getGlobalVariables(languageCode)
+	Method getGlobalVariable:String(languageId:Int, key:String, isKeyLowerCase:Int= False, fallback:Int=True)
+		Local l:TLocalizationLanguage = getGlobalVariables(languageId)
 		Local lowerKey:String = key
 		If Not isKeyLowerCase Then lowerKey=lowerKey.ToLower()
 		If l And l.Has(lowerKey) Then Return l.Get(lowerKey)
 		If fallback
-			Return getGlobalVariable(TLocalization.GetDefaultLanguageCode(), lowerKey, True, False)
+			Return getGlobalVariable(englishLanguageId, lowerKey, True, False)
 		EndIf
 		Return Null
 	End Method
 
-	Method getGlobalVariables:TLocalizationLanguage(languageCode:String)
-		Return TLocalizationLanguage(globalVariables.ValueForKey(languageCode))
+	Method getGlobalVariables:TLocalizationLanguage(languageId:Int)
+		Return TLocalizationLanguage(globalVariables.ValueForKey(languageId))
 	End Method
 
 	Function GetInstance:TDatabaseLocalizer()
@@ -51,8 +56,10 @@ Type TDatabaseLocalizer
 
 	Method _updateLocalization(lang:String)
 		Local personCollection:TPersonBaseCollection = GetPersonBaseCollection()
+		Local languageId:Int = TLocalization.GetLanguageId(lang)
+		If languageID < 0 Then Return
 		Local person:TPersonBase
-		For Local pl:PersonLocalization = EachIn PersonLocalization[](persons.valueForKey(lang))
+		For Local pl:PersonLocalization = EachIn PersonLocalization[](persons.valueForKey(languageId))
 			person = personCollection.GetById(pl.id)
 			If person
 				If pl.flags & PersonLocalization.FLAG_FIRSTNAME Then person.firstName = pl.firstName
@@ -63,7 +70,7 @@ Type TDatabaseLocalizer
 		Next
 		Local roleCollection:TProgrammeRoleCollection = GetProgrammeRoleCollection()
 		Local role:TProgrammeRole
-		For Local pl:PersonLocalization = EachIn PersonLocalization[](roles.valueForKey(lang))
+		For Local pl:PersonLocalization = EachIn PersonLocalization[](roles.valueForKey(languageId))
 			role = roleCollection.GetById(pl.id)
 			If role
 				If pl.flags & PersonLocalization.FLAG_FIRSTNAME Then role.firstName = pl.firstName

--- a/source/game.gameinformation.bmx
+++ b/source/game.gameinformation.bmx
@@ -7,8 +7,71 @@ Import "game.stationmap.bmx"
 TProgrammePlanInformationProviderBase.GetInstance()
 TWorldTimeInformationProviderBase.GetInstance()
 TStationMapInformationProviderBase.GetInstance()
+TGlobalVariablesProviderBase.GetInstance()
 
 
+
+Type TGlobalVariablesProviderBase extends TGameInformationProvider
+
+	Field languages:TMap
+	Global _instance:TGlobalVariablesProviderBase
+
+	Method New()
+		print "new variables"
+		Reset()
+
+		'register provider to provider collection
+		GetGameInformationCollection().AddProvider("globalvariables", self)
+	End Method
+
+	Function GetInstance:TGlobalVariablesProviderBase()
+		if not _instance then _instance = new TGlobalVariablesProviderBase
+		return _instance
+	End Function
+
+
+	Method Reset()
+		print("reset variables")
+		languages = CreateMap()
+	End Method
+
+	Method Set(key:string, obj:object)
+		languages.insert(key, obj)
+	End Method
+	
+	Method Get:object(key:string, params:object = null, useTime:Long = 0)
+		Return languages.ValueForKey(key)
+	End Method
+
+	Method SerializeTGlobalVariablesProviderBaseToString:string()
+		local result:string = "serializing"
+'		For local code:string = EachIn languages.Keys()
+'			result:+ (code+"\n")
+'			Local l:TLocalizationLanguage=TLocalizationLanguage(languages.valueForKey(code))
+'			For local key:String = EachIn l.map.Keys()
+'			result:+ (key+"::"+String(l.map.ValueForKey(key))+"\n")
+'			Next
+'		Next
+		print result
+		return result
+	End Method
+
+	Method DeSerializeTGlobalVariablesProviderBaseFromString(text:String)
+		print "deserializing"
+		Local l:TLocalizationLanguage=new TLocalizationLanguage
+		l.languageCode="de"
+		l.map.insert("var1", "value1")
+		'without getInstance there is a segmentation fault
+		'why is this no problem for the other providers - info never used?
+		GetInstance().set("de", l)
+	End Method
+
+End Type
+'===== CONVENIENCE ACCESSOR =====
+'return instance
+Function GetGlobalVariablesProviderBase:TGlobalVariablesProviderBase()
+	Return TGlobalVariablesProviderBase.GetInstance()
+End Function
 
 
 'contains general information of all broadcasts in the programmeplans

--- a/source/game.gameinformation.bmx
+++ b/source/game.gameinformation.bmx
@@ -7,71 +7,8 @@ Import "game.stationmap.bmx"
 TProgrammePlanInformationProviderBase.GetInstance()
 TWorldTimeInformationProviderBase.GetInstance()
 TStationMapInformationProviderBase.GetInstance()
-TGlobalVariablesProviderBase.GetInstance()
 
 
-
-Type TGlobalVariablesProviderBase extends TGameInformationProvider
-
-	Field languages:TMap
-	Global _instance:TGlobalVariablesProviderBase
-
-	Method New()
-		print "new variables"
-		Reset()
-
-		'register provider to provider collection
-		GetGameInformationCollection().AddProvider("globalvariables", self)
-	End Method
-
-	Function GetInstance:TGlobalVariablesProviderBase()
-		if not _instance then _instance = new TGlobalVariablesProviderBase
-		return _instance
-	End Function
-
-
-	Method Reset()
-		print("reset variables")
-		languages = CreateMap()
-	End Method
-
-	Method Set(key:string, obj:object)
-		languages.insert(key, obj)
-	End Method
-	
-	Method Get:object(key:string, params:object = null, useTime:Long = 0)
-		Return languages.ValueForKey(key)
-	End Method
-
-	Method SerializeTGlobalVariablesProviderBaseToString:string()
-		local result:string = "serializing"
-'		For local code:string = EachIn languages.Keys()
-'			result:+ (code+"\n")
-'			Local l:TLocalizationLanguage=TLocalizationLanguage(languages.valueForKey(code))
-'			For local key:String = EachIn l.map.Keys()
-'			result:+ (key+"::"+String(l.map.ValueForKey(key))+"\n")
-'			Next
-'		Next
-		print result
-		return result
-	End Method
-
-	Method DeSerializeTGlobalVariablesProviderBaseFromString(text:String)
-		print "deserializing"
-		Local l:TLocalizationLanguage=new TLocalizationLanguage
-		l.languageCode="de"
-		l.map.insert("var1", "value1")
-		'without getInstance there is a segmentation fault
-		'why is this no problem for the other providers - info never used?
-		GetInstance().set("de", l)
-	End Method
-
-End Type
-'===== CONVENIENCE ACCESSOR =====
-'return instance
-Function GetGlobalVariablesProviderBase:TGlobalVariablesProviderBase()
-	Return TGlobalVariablesProviderBase.GetInstance()
-End Function
 
 
 'contains general information of all broadcasts in the programmeplans

--- a/source/game.gamescriptexpression.bmx
+++ b/source/game.gamescriptexpression.bmx
@@ -676,13 +676,15 @@ Type TGameScriptExpression extends TGameScriptExpressionBase
 				tv = TNewsEventTemplate(context.context).templateVariables
 			EndIf
 		EndIf
-		
-		If tv And tv.HasVariable(variable)
-			result = _ParseWithTemplateVariables(variable, context, tv)
+
+		Local varLowerCase:String = variable.ToLower()
+		If tv And tv.HasVariable(varLowerCase, True)
+			result = _ParseWithTemplateVariables(varLowerCase, context, tv)
 		Else
-			'TODO parse Expression if it contains further variables
+			'TODO parse Expression if it contains further variables? 
+			'${.worldtime:"year"} was resolved without further changes...
 			Local code:String = TLocalization.GetLanguageCode(localeID)
-			result = GetDatabaseLocalizer().getGlobalVariable(code, variable)
+			result = GetDatabaseLocalizer().getGlobalVariable(code, varLowerCase, True)
 			If Not result Then result = TGameScriptExpressionBase.GameScriptVariableHandlerCB(variable, context)
 		EndIf
 
@@ -690,12 +692,12 @@ Type TGameScriptExpression extends TGameScriptExpressionBase
 	End Function
 
 
-	Function _ParseWithTemplateVariables:String(variable:String, context:SScriptExpressionContext, tv:TTemplateVariables = Null)
+	Function _ParseWithTemplateVariables:String(variableLowerCase:String, context:SScriptExpressionContext, tv:TTemplateVariables = Null)
 		If not tv and TTemplateVariables(context.extra)
 			tv = TTemplateVariables(context.extra)
 		EndIf
 		If Not tv
-			Return TGameScriptExpressionBase.GameScriptVariableHandlerCB(variable, context)
+			Return TGameScriptExpressionBase.GameScriptVariableHandlerCB(variableLowerCase, context)
 		EndIf
 		
 		'store the template variables as context (working on a copy here!)
@@ -706,7 +708,7 @@ Type TGameScriptExpression extends TGameScriptExpressionBase
 
 		' Create a localized string only containing resolved variables
 		' (the single option "Beaver" is chosen from the variable value "Ape|Beaver|Camel") 
-		Local lsResult:TLocalizedString = tv.GetResolvedVariable(variable, 0, False)
+		Local lsResult:TLocalizedString = tv.GetResolvedVariable(variableLowerCase, 0, True)
 
 		' The result MIGHT contain script expressions itself 
 		' -> parse it and replace the resolved variable accordingly
@@ -727,7 +729,7 @@ Type TGameScriptExpression extends TGameScriptExpressionBase
 		' lsResult can be null if the variable was not resolved (or is
 		' not contained in the variables collection)
 		Else
-			Return TGameScriptExpressionBase.GameScriptVariableHandlerCB(variable, context)
+			Return TGameScriptExpressionBase.GameScriptVariableHandlerCB(variableLowerCase, context)
 		EndIf
 		
 		Return result

--- a/source/game.gamescriptexpression.bmx
+++ b/source/game.gamescriptexpression.bmx
@@ -683,7 +683,8 @@ Type TGameScriptExpression extends TGameScriptExpressionBase
 		Else
 			'TODO parse Expression if it contains further variables? 
 			'${.worldtime:"year"} was resolved without further changes...
-			result = GetDatabaseLocalizer().getGlobalVariable(localeID, varLowerCase, True)
+			Local code:String = TLocalization.GetLanguageCode(localeID)
+			result = GetDatabaseLocalizer().getGlobalVariable(code, varLowerCase, True)
 			If Not result Then result = TGameScriptExpressionBase.GameScriptVariableHandlerCB(variable, context)
 		EndIf
 

--- a/source/game.gamescriptexpression.bmx
+++ b/source/game.gamescriptexpression.bmx
@@ -681,10 +681,9 @@ Type TGameScriptExpression extends TGameScriptExpressionBase
 		If tv And tv.HasVariable(varLowerCase, True)
 			result = _ParseWithTemplateVariables(varLowerCase, context, tv)
 		Else
-			'TODO parse Expression if it contains further variables? 
+			'parsing expression if it contains further variables necessary? 
 			'${.worldtime:"year"} was resolved without further changes...
-			Local code:String = TLocalization.GetLanguageCode(localeID)
-			result = GetDatabaseLocalizer().getGlobalVariable(code, varLowerCase, True)
+			result = GetDatabaseLocalizer().getGlobalVariable(localeID, varLowerCase, True)
 			If Not result Then result = TGameScriptExpressionBase.GameScriptVariableHandlerCB(variable, context)
 		EndIf
 

--- a/source/game.gamescriptexpression.bmx
+++ b/source/game.gamescriptexpression.bmx
@@ -683,8 +683,7 @@ Type TGameScriptExpression extends TGameScriptExpressionBase
 		Else
 			'TODO parse Expression if it contains further variables? 
 			'${.worldtime:"year"} was resolved without further changes...
-			Local code:String = TLocalization.GetLanguageCode(localeID)
-			result = GetDatabaseLocalizer().getGlobalVariable(code, varLowerCase, True)
+			result = GetDatabaseLocalizer().getGlobalVariable(localeID, varLowerCase, True)
 			If Not result Then result = TGameScriptExpressionBase.GameScriptVariableHandlerCB(variable, context)
 		EndIf
 

--- a/source/game.gamescriptexpression.bmx
+++ b/source/game.gamescriptexpression.bmx
@@ -10,6 +10,7 @@ Import "game.production.scripttemplate.bmx"
 Import "game.programme.programmedata.bmx"
 Import "game.programme.programmelicence.bmx"
 Import "game.programme.newsevent.bmx"
+Import "game.database.localizer.bmx"
 Import Brl.Map
 
 
@@ -676,10 +677,13 @@ Type TGameScriptExpression extends TGameScriptExpressionBase
 			EndIf
 		EndIf
 		
-		If tv
+		If tv And tv.HasVariable(variable)
 			result = _ParseWithTemplateVariables(variable, context, tv)
 		Else
-			result = TGameScriptExpressionBase.GameScriptVariableHandlerCB(variable, context)
+			'TODO parse Expression if it contains further variables
+			Local code:String = TLocalization.GetLanguageCode(localeID)
+			result = GetDatabaseLocalizer().getGlobalVariable(code, variable)
+			If Not result Then result = TGameScriptExpressionBase.GameScriptVariableHandlerCB(variable, context)
 		EndIf
 
 		Return result

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -1019,18 +1019,10 @@ Rem
 				EndIf
 endrem
 If KeyManager.isHit(KEY_X)
-	Local gv:TGlobalVariablesProviderBase=GetGlobalVariablesProviderBase()
-	If gv
-		Local ll:TLocalizationLanguage = TLocalizationLanguage(gv.get("de",null))
-		If ll
-			print ll.get("var1")
-		Else
-			print "NO GERMAN LOCALIZATION"
-		EndIf
-	Else
-		print "NO GLOBALVARIABLES"
-	EndIf
-	print TLocalizationLanguage(GetGlobalVariablesProviderBase().get("de",null)).get("var1")
+	Local dbl:TDatabaseLocalizer=GetDatabaseLocalizer()
+	print dbl.getGlobalVariable("de","var1")
+	print GetPersonBaseCollection().GetByGuid("1994aa3a-23c3-48ce-b20a-d1f021df8c63").GetFullName()
+	print GetProgrammeRoleCollection().GetByGuid("a00ea58a-4a9f-466e-9fe5-cf8b53730b60").GetFullName()
 EndIf
 				If KeyManager.isHit(KEY_S)
 					If KeyManager.IsDown(KEY_LCONTROL)
@@ -1730,6 +1722,7 @@ Type TGameState
 	Field _GameModifierManager:TGameModifierManager = Null
 	Field _GameInformationCollection:TGameInformationCollection = Null
 	Field _IngameHelpWindowCollection:TIngameHelpWindowCollection = Null
+	Field _DatabaseLocalizer:TDatabaseLocalizer = Null
 
 	Field _AudienceManager:TAudienceManager = Null
 	Field _AdContractBaseCollection:TAdContractBaseCollection = Null
@@ -1866,6 +1859,7 @@ Type TGameState
 		GetPlayerCollection().Initialize()
 		GetPlayerFinanceCollection().Initialize()
 		GetPlayerFinanceHistoryListCollection().Initialize()
+		GetDatabaseLocalizer().Reset()
 
 		'reset all achievements
 		GetAchievementCollection().Reset()
@@ -1919,6 +1913,7 @@ Type TGameState
 		_Assign(_ProgrammeDataCollection, TProgrammeDataCollection._instance, "ProgrammeDataCollection", MODE_LOAD)
 		_Assign(_ProgrammeLicenceCollection, TProgrammeLicenceCollection._instance, "ProgrammeLicenceCollection", MODE_LOAD)
 		_Assign(_ProgrammeProducerCollection, TProgrammeProducerCollection._instance, "ProgrammeProducerCollection", MODE_LOAD)
+		_Assign(_DatabaseLocalizer, TDatabaseLocalizer._instance, "DatabaseLocalizer", MODE_LOAD)
 
 		_Assign(_PlayerCollection, TPlayerCollection._instance, "PlayerCollection", MODE_LOAD)
 		_Assign(_PlayerDifficultyCollection, TPlayerDifficultyCollection._instance, "PlayerDifficultyCollection", MODE_LOAD)
@@ -2031,6 +2026,7 @@ Type TGameState
 		'database data for persons and their roles
 		_Assign(TPersonBaseCollection._instance, _ProgrammePersonBaseCollection, "ProgrammePersonBaseCollection", MODE_SAVE)
 		_Assign(TProgrammeRoleCollection._instance, _ProgrammeRoleCollection, "ProgrammeRoleCollection", MODE_SAVE)
+		_Assign(TDatabaseLocalizer._instance, _DatabaseLocalizer, "DatabaseLocalizer", MODE_SAVE)
 
 		'database data for programmes
 		_Assign(TProgrammeDataCollection._instance, _ProgrammeDataCollection, "ProgrammeDataCollection", MODE_SAVE)
@@ -2412,6 +2408,10 @@ Type TSaveGame Extends TGameState
 	Global _nilNode:TNode = New TNode._parent
 	Function RepairData(savegameVersion:Int, savegameConverter:TSavegameConverter = null)
 		If savegameVersion < 21
+			If Not GetDatabaseLocalizer().persons.Contains("de")
+				TDatabaseLoader.LoadDatabaseLocalizations("res/database/Default")
+			EndIf
+
 			'iterate over all news event templates, scripts, ... and check if
 			'their "strings" contain old script expressions
 			Local migratedScriptExpression:Int

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -1020,7 +1020,7 @@ Rem
 endrem
 If KeyManager.isHit(KEY_X)
 	Local dbl:TDatabaseLocalizer=GetDatabaseLocalizer()
-	print dbl.getGlobalVariable(TLocalization.GetLanguageID("de"),"var1")
+	print dbl.getGlobalVariable("de","var1")
 	print GetPersonBaseCollection().GetByGuid("1994aa3a-23c3-48ce-b20a-d1f021df8c63").GetFullName()
 	print GetProgrammeRoleCollection().GetByGuid("a00ea58a-4a9f-466e-9fe5-cf8b53730b60").GetFullName()
 EndIf
@@ -2408,7 +2408,7 @@ Type TSaveGame Extends TGameState
 	Global _nilNode:TNode = New TNode._parent
 	Function RepairData(savegameVersion:Int, savegameConverter:TSavegameConverter = null)
 		If savegameVersion < 21
-			If Not GetDatabaseLocalizer().persons.Contains(TLocalization.GetLanguageId("de"))
+			If Not GetDatabaseLocalizer().persons.Contains("de")
 				TDatabaseLoader.LoadDatabaseLocalizations("res/database/Default")
 			EndIf
 

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -1020,7 +1020,7 @@ Rem
 endrem
 If KeyManager.isHit(KEY_X)
 	Local dbl:TDatabaseLocalizer=GetDatabaseLocalizer()
-	print dbl.getGlobalVariable("de","var1")
+	print dbl.getGlobalVariable(TLocalization.GetLanguageID("de"),"var1")
 	print GetPersonBaseCollection().GetByGuid("1994aa3a-23c3-48ce-b20a-d1f021df8c63").GetFullName()
 	print GetProgrammeRoleCollection().GetByGuid("a00ea58a-4a9f-466e-9fe5-cf8b53730b60").GetFullName()
 EndIf
@@ -2408,7 +2408,7 @@ Type TSaveGame Extends TGameState
 	Global _nilNode:TNode = New TNode._parent
 	Function RepairData(savegameVersion:Int, savegameConverter:TSavegameConverter = null)
 		If savegameVersion < 21
-			If Not GetDatabaseLocalizer().persons.Contains("de")
+			If Not GetDatabaseLocalizer().persons.Contains(TLocalization.GetLanguageId("de"))
 				TDatabaseLoader.LoadDatabaseLocalizations("res/database/Default")
 			EndIf
 

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -1018,6 +1018,20 @@ Rem
 					print "-----------------"
 				EndIf
 endrem
+If KeyManager.isHit(KEY_X)
+	Local gv:TGlobalVariablesProviderBase=GetGlobalVariablesProviderBase()
+	If gv
+		Local ll:TLocalizationLanguage = TLocalizationLanguage(gv.get("de",null))
+		If ll
+			print ll.get("var1")
+		Else
+			print "NO GERMAN LOCALIZATION"
+		EndIf
+	Else
+		print "NO GLOBALVARIABLES"
+	EndIf
+	print TLocalizationLanguage(GetGlobalVariablesProviderBase().get("de",null)).get("var1")
+EndIf
 				If KeyManager.isHit(KEY_S)
 					If KeyManager.IsDown(KEY_LCONTROL)
 						room = "supermarket"

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -1018,12 +1018,6 @@ Rem
 					print "-----------------"
 				EndIf
 endrem
-If KeyManager.isHit(KEY_X)
-	Local dbl:TDatabaseLocalizer=GetDatabaseLocalizer()
-	print dbl.getGlobalVariable("de","var1")
-	print GetPersonBaseCollection().GetByGuid("1994aa3a-23c3-48ce-b20a-d1f021df8c63").GetFullName()
-	print GetProgrammeRoleCollection().GetByGuid("a00ea58a-4a9f-466e-9fe5-cf8b53730b60").GetFullName()
-EndIf
 				If KeyManager.isHit(KEY_S)
 					If KeyManager.IsDown(KEY_LCONTROL)
 						room = "supermarket"


### PR DESCRIPTION
see #1181 

Zunächst als Proof of concept für das Einlesen (noch ohne Auswertung in den Expressions) zur Diskussion. Ich denke, dass GameInformation der falsche Platz ist. Der generische Ansatz mit den Providern macht es unnötig schwer, da die Maps von Hand (de)serialisiert werden müssen.
Aber wo könnte man die Map mit den Sprachen sonst hinpacken, ohne zu sehr an den Laden/Speichern-Code ran zu müssen?