### PR TITLE
Reparatur Personenlokalisierung

### DIFF
--- a/source/game.database.localizer.bmx
+++ b/source/game.database.localizer.bmx
@@ -10,6 +10,7 @@ Type TDatabaseLocalizer
 	Field globalVariables:TMap
 	Field persons:TMap
 	Field roles:TMap
+	Field personsById:TIntMap[] {nosave}
 
 	Method New()
 		Reset()
@@ -42,6 +43,21 @@ Type TDatabaseLocalizer
 	Method getGlobalVariables:TLocalizationLanguage(languageCode:String)
 		Return TLocalizationLanguage(globalVariables.ValueForKey(languageCode))
 	End Method
+
+	Method getPerson:TPersonLocalization(id:Int, languageId:Int)
+		'TODO cache IDs that have a localization at all
+		If Not personsById Then personsById = new TIntMap[TLocalization.languages.length]
+		If Not personsById[languageId]
+			Local map:TIntMap =  new TIntMap()
+			personsById[languageId] = map
+			Local code:String = TLocalization.GetLanguageCode(languageId)
+			For Local pl:TPersonLocalization = EachIn TPersonLocalization[](persons.valueForKey(code))
+				map.insert(pl.id, pl)
+			Next
+		EndIf
+		'TODO fallback to default language
+		return TPersonLocalization(personsById[languageId].valueForKey(id))
+	EndMethod
 
 	Function GetInstance:TDatabaseLocalizer()
 		if not _instance then _instance = new TDatabaseLocalizer

--- a/source/game.database.localizer.bmx
+++ b/source/game.database.localizer.bmx
@@ -20,9 +20,9 @@ Type TDatabaseLocalizer
 	Field localizedPersonIds:TIntMap {nosave}
 	'caches for roles per language
 	Field rolesById:TIntMap[] {nosave}
-	'which rols have a localization
+	'which roles have a localization
 	Field localizedRoleIds:TIntMap {nosave}
-	Field enId:Int {nosave}
+	Field englishLanguageId:Int {nosave}
 
 	Method New()
 		Reset()
@@ -40,7 +40,7 @@ Type TDatabaseLocalizer
 		localizedPersonIds = Null
 		rolesById = Null
 		localizedRoleIds = Null
-		enId = -1
+		englishLanguageId = -1
 	End Method
 
 	Method getGlobalVariable:String(languageId:Int, key:String, isKeyLowerCase:Int= False, fallback:Int=True)
@@ -51,9 +51,7 @@ Type TDatabaseLocalizer
 		Local l:TLocalizationLanguage = getGlobalVariables(languageCode)
 		If Not isKeyLowerCase Then key=key.ToLower()
 		If l And l.Has(key) Then Return l.Get(key)
-		If fallback
-			Return getGlobalVariable("en", key, True, False)
-		EndIf
+		If fallback Then Return getGlobalVariable("en", key, True, False)
 		Return Null
 	End Method
 
@@ -63,25 +61,21 @@ Type TDatabaseLocalizer
 
 	Method getPersonNames:TPersonBase(id:Int, languageId:Int)
 		If Not personsById Then personsById = new TIntMap[TLocalization.languages.length]
-		If Not personsById[languageId]
-			_ensureCaches(languageId)
-		EndIf
+		If Not personsById[languageId] Then _ensureCaches(languageId)
 
 		If Not localizedPersonIds.Contains(id) Then Return Null
 		Local result:TPersonBase = TPersonBase(personsById[languageId].valueForKey(id))
-		If Not result Then result = TPersonBase(personsById[enId].valueForKey(id))
+		If Not result Then result = TPersonBase(personsById[englishLanguageId].valueForKey(id))
 		return result
 	EndMethod
 
 	Method getRoleNames:TProgrammeRole(id:Int, languageId:Int)
 		If Not rolesById Then rolesById = new TIntMap[TLocalization.languages.length]
-		If Not rolesById[languageId]
-			_ensureCaches(languageId)
-		EndIf
+		If Not rolesById[languageId] Then _ensureCaches(languageId)
 
 		If Not localizedRoleIds.Contains(id) Then Return Null
 		Local result:TProgrammeRole = TProgrammeRole(rolesById[languageId].valueForKey(id))
-		If Not result Then result = TProgrammeRole(rolesById[enId].valueForKey(id))
+		If Not result Then result = TProgrammeRole(rolesById[englishLanguageId].valueForKey(id))
 		return result
 	EndMethod
 
@@ -106,8 +100,8 @@ Type TDatabaseLocalizer
 			localizedRoleIds.insert(pl.id, "")
 		Next
 
-		enId = TLocalization.GetLanguageID("en")
-		If languageId <> enId And Not personsById[enId] Then _ensureCaches(enId)
+		englishLanguageId = TLocalization.GetLanguageID("en")
+		If languageId <> englishLanguageId And Not personsById[englishLanguageId] Then _ensureCaches(englishLanguageId)
 	End Method
 
 	Function GetInstance:TDatabaseLocalizer()
@@ -126,17 +120,13 @@ Type TDatabaseLocalizer
 		Local person:TPersonBase
 		For Local pl:TPersonLocalization = EachIn TPersonLocalization[](persons.valueForKey(lang))
 			person = personCollection.GetById(pl.id)
-			If person
-				pl.setValues(person)
-			EndIf
+			If person Then pl.setValues(person)
 		Next
 		Local roleCollection:TProgrammeRoleCollection = GetProgrammeRoleCollection()
 		Local role:TProgrammeRole
 		For Local pl:TPersonLocalization = EachIn TPersonLocalization[](roles.valueForKey(lang))
 			role = roleCollection.GetById(pl.id)
-			If role
-				pl.setValues(role)
-			EndIf
+			If role Then pl.setValues(role)
 		Next
 	End Method
 End Type

--- a/source/game.gamescriptexpression.bmx
+++ b/source/game.gamescriptexpression.bmx
@@ -204,7 +204,7 @@ Function SEFN_programmelicence:SToken(params:STokenGroup Var, context:SScriptExp
 	EndIf
 	
 	Select propertyName
-		Case "cast"                    Return _EvaluateProgrammeDataCast(licence.data, params, 1 + tokenOffset)
+		Case "cast"                    Return _EvaluateProgrammeDataCast(licence.data, params, 1 + tokenOffset, context.contextNumeric)
 		'convenience access - could be removed if one uses ${.role:${.self:"cast":x:"roleid"}:"fullname"} ...
 		Case "role"                    Return _EvaluateProgrammeDataRole(licence.data, params, 1 + tokenOffset)
 		Case "year"                    Return New SToken( TK_NUMBER, licence.data.GetYear(), params.GetToken(0) )
@@ -306,7 +306,7 @@ Function SEFN_programmedata:SToken(params:STokenGroup Var, context:SScriptExpres
 	EndIf
 	
 	Select propertyName
-		Case "cast"                    Return _EvaluateProgrammeDataCast(data, params, 1 + tokenOffset)
+		Case "cast"                    Return _EvaluateProgrammeDataCast(data, params, 1 + tokenOffset, context.contextNumeric)
 		'convenience access - could be removed if one uses ${.role:${.self:"cast":x:"roleid"}:"fullname"} ...
 		Case "role"                    Return _EvaluateProgrammeDataRole(data, params, 1 + tokenOffset)
 		Case "year"                    Return New SToken( TK_NUMBER, data.GetYear(), params.GetToken(0) )
@@ -345,7 +345,7 @@ Function SEFN_programmedata:SToken(params:STokenGroup Var, context:SScriptExpres
 End Function
 
 
-Function _EvaluateProgrammeDataCast:SToken(data:TProgrammeData, params:STokenGroup Var, tokenOffset:int) 'inline
+Function _EvaluateProgrammeDataCast:SToken(data:TProgrammeData, params:STokenGroup Var, tokenOffset:int, language:int) 'inline
 	If Not params.HasToken(1 + tokenOffset, ETokenValueType.Integer)
 		Return New SToken( TK_ERROR, "No valid cast number passed", params.GetToken(0) )
 	EndIf
@@ -366,7 +366,7 @@ Function _EvaluateProgrammeDataCast:SToken(data:TProgrammeData, params:STokenGro
 
 	Local propertyName:String = params.GetToken(2 + tokenOffset).value
 	Select propertyName.ToLower()
-		Case "firstname" Return New SToken( TK_TEXT, person.GetFirstName(), params.GetToken(0) )
+		Case "firstname" Return New SToken( TK_TEXT, _getPersonFirstName(person, language), params.GetToken(0) )
 		Case "lastname"  Return New SToken( TK_TEXT, person.GetLastName(includeTitle), params.GetToken(0) )
 		Case "fullname"  Return New SToken( TK_TEXT, person.GetFullName(includeTitle), params.GetToken(0) )
 		Case "nickname"  Return New SToken( TK_TEXT, person.GetNickName(), params.GetToken(0) )
@@ -414,6 +414,15 @@ Function _EvaluateProgrammeDataRole:SToken(data:TProgrammeData, params:STokenGro
 		Default          Return New SToken( TK_ERROR, "Undefined property ~q"+propertyName+"~q", params.GetToken(0) )
 	End Select
 End Function
+
+Function _getPersonFirstName:String(person:TPersonBase, language:Int)
+	Local loc:TPersonLocalization = GetDatabaseLocalizer().getPerson(person.GetId(), language)
+	If loc
+		Return loc.firstName
+	Else
+		Return person.GetFirstName()
+	EndIf
+EndFunction
 
 
 '${.role:"guid"/id:"fullname"} - context: all
@@ -474,7 +483,7 @@ Function SEFN_person:SToken(params:STokenGroup Var, context:SScriptExpressionCon
 	
 	Local propertyName:String = params.GetToken(2).value
 	Select propertyName.ToLower()
-		case "firstname"    Return New SToken( TK_TEXT, person.GetFirstName(), params.GetToken(0) )
+		case "firstname"    Return New SToken( TK_TEXT, _getPersonFirstName(person, context.contextNumeric), params.GetToken(0) )
 		case "lastname"     Return New SToken( TK_TEXT, person.GetLastName(includeTitle), params.GetToken(0) )
 		case "fullname"     Return New SToken( TK_TEXT, person.GetFullName(includeTitle), params.GetToken(0) )
 		case "nickname"     Return New SToken( TK_TEXT, person.GetNickName(), params.GetToken(0) )

--- a/source/game.gamescriptexpression.bmx
+++ b/source/game.gamescriptexpression.bmx
@@ -206,7 +206,7 @@ Function SEFN_programmelicence:SToken(params:STokenGroup Var, context:SScriptExp
 	Select propertyName
 		Case "cast"                    Return _EvaluateProgrammeDataCast(licence.data, params, 1 + tokenOffset, context.contextNumeric)
 		'convenience access - could be removed if one uses ${.role:${.self:"cast":x:"roleid"}:"fullname"} ...
-		Case "role"                    Return _EvaluateProgrammeDataRole(licence.data, params, 1 + tokenOffset)
+		Case "role"                    Return _EvaluateProgrammeDataRole(licence.data, params, 1 + tokenOffset, context.contextNumeric)
 		Case "year"                    Return New SToken( TK_NUMBER, licence.data.GetYear(), params.GetToken(0) )
 		Case "episodecount"            Return New SToken( TK_NUMBER, licence.GetEpisodeCount(), params.GetToken(0) )
 		Case "episodenumber"           Return New SToken( TK_NUMBER, licence.GetEpisodeNumber(), params.GetToken(0) )
@@ -308,7 +308,7 @@ Function SEFN_programmedata:SToken(params:STokenGroup Var, context:SScriptExpres
 	Select propertyName
 		Case "cast"                    Return _EvaluateProgrammeDataCast(data, params, 1 + tokenOffset, context.contextNumeric)
 		'convenience access - could be removed if one uses ${.role:${.self:"cast":x:"roleid"}:"fullname"} ...
-		Case "role"                    Return _EvaluateProgrammeDataRole(data, params, 1 + tokenOffset)
+		Case "role"                    Return _EvaluateProgrammeDataRole(data, params, 1 + tokenOffset, context.contextNumeric)
 		Case "year"                    Return New SToken( TK_NUMBER, data.GetYear(), params.GetToken(0) )
 		case "guid"                    Return New SToken( TK_TEXT, data.GetGUID(), params.GetToken(0) )
 		case "id"                      Return New SToken( TK_NUMBER, data.GetID(), params.GetToken(0) )
@@ -366,11 +366,11 @@ Function _EvaluateProgrammeDataCast:SToken(data:TProgrammeData, params:STokenGro
 
 	Local propertyName:String = params.GetToken(2 + tokenOffset).value
 	Select propertyName.ToLower()
-		Case "firstname" Return New SToken( TK_TEXT, _getPersonFirstName(person, language), params.GetToken(0) )
-		Case "lastname"  Return New SToken( TK_TEXT, person.GetLastName(includeTitle), params.GetToken(0) )
-		Case "fullname"  Return New SToken( TK_TEXT, person.GetFullName(includeTitle), params.GetToken(0) )
-		Case "nickname"  Return New SToken( TK_TEXT, person.GetNickName(), params.GetToken(0) )
-		Case "title"     Return New SToken( TK_TEXT, person.GetTitle(), params.GetToken(0) )
+		Case "firstname" Return New SToken( TK_TEXT, _getLocalizedPerson(person, language).GetFirstName(), params.GetToken(0) )
+		Case "lastname"  Return New SToken( TK_TEXT, _getLocalizedPerson(person, language).GetLastName(includeTitle), params.GetToken(0) )
+		Case "fullname"  Return New SToken( TK_TEXT, _getLocalizedPerson(person, language).GetFullName(includeTitle), params.GetToken(0) )
+		Case "nickname"  Return New SToken( TK_TEXT, _getLocalizedPerson(person, language).GetNickName(), params.GetToken(0) )
+		Case "title"     Return New SToken( TK_TEXT, _getLocalizedPerson(person, language).GetTitle(), params.GetToken(0) )
 		Case "guid"      Return New SToken( TK_TEXT, person.GetGUID(), params.GetToken(0) )
 		Case "id"        Return New SToken( TK_NUMBER, person.GetID(), params.GetToken(0) )
 		Case "roleid"    Return New SToken( TK_TEXT, job.roleID, params.GetToken(0) )
@@ -381,7 +381,7 @@ Function _EvaluateProgrammeDataCast:SToken(data:TProgrammeData, params:STokenGro
 End Function
 
 
-Function _EvaluateProgrammeDataRole:SToken(data:TProgrammeData, params:STokenGroup Var, tokenOffset:int) 'inline
+Function _EvaluateProgrammeDataRole:SToken(data:TProgrammeData, params:STokenGroup Var, tokenOffset:int, language:int) 'inline
 	Local roleIndex:Int = params.GetToken(1 + tokenOffset).valueLong
 	If roleIndex < 0 Then Return New SToken( TK_ERROR, "Role index must be positive", params.GetToken(0) )
 
@@ -400,11 +400,11 @@ Function _EvaluateProgrammeDataRole:SToken(data:TProgrammeData, params:STokenGro
 
 	Local propertyName:String = params.GetToken(2 + tokenOffset).value
 	Select propertyName.ToLower()
-		Case "firstname" Return New SToken( TK_TEXT, role.GetFirstName(), params.GetToken(0) )
-		Case "lastname"  Return New SToken( TK_TEXT, role.GetLastName(includeTitle), params.GetToken(0) )
-		Case "fullname"  Return New SToken( TK_TEXT, role.GetFullName(includeTitle), params.GetToken(0) )
-		Case "nickname"  Return New SToken( TK_TEXT, role.GetNickName(), params.GetToken(0) )
-		Case "title"     Return New SToken( TK_TEXT, role.GetTitle(), params.GetToken(0) )
+		Case "firstname" Return New SToken( TK_TEXT, _getLocalizedRole(role, language).GetFirstName(), params.GetToken(0) )
+		Case "lastname"  Return New SToken( TK_TEXT, _getLocalizedRole(role, language).GetLastName(includeTitle), params.GetToken(0) )
+		Case "fullname"  Return New SToken( TK_TEXT, _getLocalizedRole(role, language).GetFullName(includeTitle), params.GetToken(0) )
+		Case "nickname"  Return New SToken( TK_TEXT, _getLocalizedRole(role, language).GetNickName(), params.GetToken(0) )
+		Case "title"     Return New SToken( TK_TEXT, _getLocalizedRole(role, language).GetTitle(), params.GetToken(0) )
 		case "countrycode" Return New SToken( TK_TEXT, role.countrycode, params.GetToken(0) )
 		case "gender"    Return New SToken( TK_NUMBER, role.gender, params.GetToken(0) )
 		Case "guid"      Return New SToken( TK_TEXT, role.GetGUID(), params.GetToken(0) )
@@ -415,15 +415,19 @@ Function _EvaluateProgrammeDataRole:SToken(data:TProgrammeData, params:STokenGro
 	End Select
 End Function
 
-Function _getPersonFirstName:String(person:TPersonBase, language:Int)
-	Local loc:TPersonLocalization = GetDatabaseLocalizer().getPerson(person.GetId(), language)
-	If loc
-		Return loc.firstName
-	Else
-		Return person.GetFirstName()
-	EndIf
+
+Function _getLocalizedPerson:TPersonBase(person:TPersonBase, language:Int)
+	Local loc:TPersonBase = GetDatabaseLocalizer().getPersonNames(person.GetId(), language)
+	If loc Then return loc
+	Return person
 EndFunction
 
+
+Function _getLocalizedRole:TProgrammeRole(role:TProgrammeRole, language:Int)
+	Local loc:TProgrammeRole = GetDatabaseLocalizer().getRoleNames(role.GetId(), language)
+	If loc Then return loc
+	Return role
+EndFunction
 
 '${.role:"guid"/id:"fullname"} - context: all
 Function SEFN_role:SToken(params:STokenGroup Var, context:SScriptExpressionContext var)
@@ -446,11 +450,11 @@ Function SEFN_role:SToken(params:STokenGroup Var, context:SScriptExpressionConte
 
 	Local propertyName:String = params.GetToken(2).value
 	Select propertyName.ToLower()
-		case "firstname"    Return New SToken( TK_TEXT, role.GetFirstName(), params.GetToken(0) )
-		case "lastname"     Return New SToken( TK_TEXT, role.GetLastName(includeTitle), params.GetToken(0) )
-		case "fullname"     Return New SToken( TK_TEXT, role.GetFullName(includeTitle), params.GetToken(0) )
-		Case "nickname"     Return New SToken( TK_TEXT, role.GetNickName(), params.GetToken(0) )
-		Case "title"        Return New SToken( TK_TEXT, role.GetTitle(), params.GetToken(0) )
+		case "firstname"    Return New SToken( TK_TEXT, _getLocalizedRole(role, context.contextNumeric).GetFirstName(), params.GetToken(0) )
+		case "lastname"     Return New SToken( TK_TEXT, _getLocalizedRole(role, context.contextNumeric).GetLastName(includeTitle), params.GetToken(0) )
+		case "fullname"     Return New SToken( TK_TEXT, _getLocalizedRole(role, context.contextNumeric).GetFullName(includeTitle), params.GetToken(0) )
+		Case "nickname"     Return New SToken( TK_TEXT, _getLocalizedRole(role, context.contextNumeric).GetNickName(), params.GetToken(0) )
+		Case "title"        Return New SToken( TK_TEXT, _getLocalizedRole(role, context.contextNumeric).GetTitle(), params.GetToken(0) )
 		case "countrycode"  Return New SToken( TK_TEXT, role.countrycode, params.GetToken(0) )
 		case "gender"       Return New SToken( TK_NUMBER, role.gender, params.GetToken(0) )
 		case "guid"         Return New SToken( TK_TEXT, role.GetGUID(), params.GetToken(0) )
@@ -483,11 +487,11 @@ Function SEFN_person:SToken(params:STokenGroup Var, context:SScriptExpressionCon
 	
 	Local propertyName:String = params.GetToken(2).value
 	Select propertyName.ToLower()
-		case "firstname"    Return New SToken( TK_TEXT, _getPersonFirstName(person, context.contextNumeric), params.GetToken(0) )
-		case "lastname"     Return New SToken( TK_TEXT, person.GetLastName(includeTitle), params.GetToken(0) )
-		case "fullname"     Return New SToken( TK_TEXT, person.GetFullName(includeTitle), params.GetToken(0) )
-		case "nickname"     Return New SToken( TK_TEXT, person.GetNickName(), params.GetToken(0) )
-		case "title"        Return New SToken( TK_TEXT, person.GetTitle(), params.GetToken(0) )
+		case "firstname"    Return New SToken( TK_TEXT, _getLocalizedPerson(person, context.contextNumeric).GetFirstName(), params.GetToken(0) )
+		case "lastname"     Return New SToken( TK_TEXT, _getLocalizedPerson(person, context.contextNumeric).GetLastName(includeTitle), params.GetToken(0) )
+		case "fullname"     Return New SToken( TK_TEXT, _getLocalizedPerson(person, context.contextNumeric).GetFullName(includeTitle), params.GetToken(0) )
+		case "nickname"     Return New SToken( TK_TEXT, _getLocalizedPerson(person, context.contextNumeric).GetNickName(), params.GetToken(0) )
+		case "title"        Return New SToken( TK_TEXT, _getLocalizedPerson(person, context.contextNumeric).GetTitle(), params.GetToken(0) )
 		case "gender"       Return New SToken( TK_NUMBER, person.gender, params.GetToken(0) )
 		case "guid"         Return New SToken( TK_TEXT, person.GetGUID(), params.GetToken(0) )
 		case "id"           Return New SToken( TK_NUMBER, person.GetID(), params.GetToken(0) )
@@ -609,6 +613,7 @@ Function SEFN_script:SToken(params:STokenGroup Var, context:SScriptExpressionCon
 			If roleIndex >= actors.length Then Return New SToken( TK_ERROR, "(not enough actors for role #" + roleIndex+".)", params.GetToken(0) )
 
 			Local role:TProgrammeRole = TScript._EnsureRole(actors[roleIndex])
+			role = _getLocalizedRole(role, context.contextNumeric)
 
 			Local subCommand:String = params.GetToken(3 + tokenOffset).GetValueText()
 			Select subCommand.ToLower()


### PR DESCRIPTION
Proof of concept für #1246

Ich würde ungern Personen und Rollen mit LocalizedStrings versehen (an sich und es persönlich machen zu müssen). Um die Lesbarkeit des gameexpressions-codes in den case-Fällen hoch zu halten, würde ich für die einzelnen Attribute lokale getter bauen, die zunächst prüfen ob eine Lokalisierung existiert.
(Statt direkt die structs zurückzugeben, könnte man natürlich auch reduzierte PersonBase-Objekte in die Cache-Map des DatabaseLocalizers packen. Dann spart man sich das Zusammenbauen von fullname etc.

Vor dem Ausimplementieren wollte ich den Ansatz abnicken lassen.