### PR TITLE
Effekt für Produktionsstart

### DIFF
--- a/source/game.modifier.base.bmx
+++ b/source/game.modifier.base.bmx
@@ -645,16 +645,23 @@ Type TGameModifierGroup
 	End Method
 
 
+	'return number of remaining triggers
 	Method RemoveOrphans:Int()
 		Local emptyLists:String[]
+		Local triggerCount:Int = 0
+		Local tmpCount:Int
 		For Local trigger:String = EachIn entries.Keys()
 			Local l:TList = GetList(trigger)
-			If l And l.count() = 0 Then emptyLists :+ [trigger]
+			If l
+				tmpCount = l.count()
+				If tmpCount = 0 Then emptyLists :+ [trigger]
+				triggerCount:+ tmpCount
+			EndIf
 		Next
 		For Local trigger:String = EachIn emptyLists
 			RemoveList(trigger)
 		Next
-		Return emptyLists.Length
+		Return triggerCount
 	End Method
 
 

--- a/source/game.production.bmx
+++ b/source/game.production.bmx
@@ -416,6 +416,10 @@ Type TProduction Extends TOwnedGameObject
 			UpdateProductionStep()
 		EndIf
 
+		If productionConcept.script.effects 
+			productionConcept.script.effects.update("productionStart", new TData().addInt("playerID", productionConcept.script.owner))
+		EndIf
+
 		Return Self
 	End Method
 	
@@ -754,6 +758,9 @@ Type TProduction Extends TOwnedGameObject
 		EndIf
 		If productionConcept.script.effects
 			programmeLicence.effects = productionConcept.script.effects.Copy()
+			programmeLicence.effects.removeList("productionStart")
+			Local remainingTriggers:Int = programmeLicence.effects.RemoveOrphans()
+			If Not remainingTriggers Then programmeLicence.effects = Null
 		EndIf
 		Return programmeLicence
 	End Method


### PR DESCRIPTION
see #1177 

Vorschlag:
* neuer Effekttrigger bei Produktionsstart
* API-Änderung für Rückgabewert bei RemoveOrphans - statt zurückzugeben, ob etwas gelöscht wurde, lieber zurückgeben, ob noch etwas übrig ist