### PR TITLE
Support for inch, one-third and possibly other chars

### DIFF
--- a/source/Dig/base.gfx.bitmapfont.bmx
+++ b/source/Dig/base.gfx.bitmapfont.bmx
@@ -533,6 +533,10 @@ Type TBitmapFont
 			extraChars :+ Chr(9664) 'Black Left-Pointing Triangle
 			extraChars :+ Chr(9654) 'Black Right-Pointing Triangle
 			extraChars :+ Chr(9632) 'Black Square
+			extraChars :+ Chr(632)  'Latin Small Letter Phi - TODO: this doesn't seem to display; 966 Greek Small Letter Phi doesn't seem to display either
+			extraChars :+ Chr(8243) 'Double Prime (Inch)
+			extraChars :+ Chr(8531) 'Vulgar Fraction One Third
+			extraChars :+ Chr(9829) 'Black Heart Suit - TODO: This one doesn't seem to display
 		EndIf
 
 		Self.glyphCount = glyphCount

--- a/source/Dig/base.gfx.bitmapfont.bmx
+++ b/source/Dig/base.gfx.bitmapfont.bmx
@@ -533,10 +533,10 @@ Type TBitmapFont
 			extraChars :+ Chr(9664) 'Black Left-Pointing Triangle
 			extraChars :+ Chr(9654) 'Black Right-Pointing Triangle
 			extraChars :+ Chr(9632) 'Black Square
-			extraChars :+ Chr(632)  'Latin Small Letter Phi - TODO: this doesn't seem to display; 966 Greek Small Letter Phi doesn't seem to display either
+			'extraChars :+ Chr(632)  'Latin Small Letter Phi - TODO: this doesn't seem to display; 966 Greek Small Letter Phi doesn't seem to display either
 			extraChars :+ Chr(8243) 'Double Prime (Inch)
 			extraChars :+ Chr(8531) 'Vulgar Fraction One Third
-			extraChars :+ Chr(9829) 'Black Heart Suit - TODO: This one doesn't seem to display
+			'extraChars :+ Chr(9829) 'Black Heart Suit - TODO: This one doesn't seem to display
 		EndIf
 
 		Self.glyphCount = glyphCount


### PR DESCRIPTION
I don't intend to contribute to code in the future, only this little thing for now.

I compiled and tried, the inch (`″`) and the one-third (`⅓`) chars are working now when they appear in the content. However, the Phi symbol and the Heart symbol is not. But maybe the problem is on my end (something with system font)?