### PR TITLE
Reparatur Zeitberechnung Typ 5

### DIFF
--- a/source/game.world.worldtime.bmx
+++ b/source/game.world.worldtime.bmx
@@ -1126,27 +1126,39 @@ Type TWorldTime Extends TWorldTimeBase {_exposeToLua="selected"}
 		If yearMax < yearMin Then yearMax = yearMin
 
 
-		If monthMin <= 0 then monthMin = RandRange(1, 12)
-		If monthMin > 12 Then monthMin = 12
-		If monthMax = -1 Then monthMax = monthMin
-		If monthMax <= 0
+		If monthMin <= 0
+			monthMin = RandRange(1, 12)
+		ElseIf monthMin > 12
+			monthMin = 12
+		EndIf
+		If monthMax < 0
+			monthMax = monthMin
+		ElseIf monthMax = 0
 			If yearMin = yearMax
 				monthMax = RandRange(monthMin, 12)
 			Else
 				monthMax = RandRange(1, 12)
 			EndIf
+		ElseIf monthMax > 12
+			monthMax = 12
 		EndIf
 		If yearMin = yearMax And monthMax < monthMin Then monthMax = monthMin
 
-		If dayMin <= 0 then dayMin = RandRange(1, 30) 'Sorry february!
-		If dayMin > 30 then dayMin = 30
-		If dayMax = -1 Then dayMax = dayMin
-		If dayMax <= 0
+		If dayMin <= 0
+			dayMin = RandRange(1, 30) 'Sorry february!
+		ElseIf dayMin > 30
+			dayMin = 30
+		EndIf
+		If dayMax < 0
+			dayMax = dayMin
+		ElseIf dayMax = 0
 			If yearMin = yearMax And monthMin = monthMax
 				dayMax = RandRange(dayMin, 30)
 			Else
 				dayMax = RandRange(1, 30)
 			EndIf
+		ElseIf dayMax > 30
+			dayMax = 30
 		EndIf
 
 		If yearMin = yearMax And monthMax = monthMin And dayMax <= dayMin


### PR DESCRIPTION
closes #1257 

Für den Typ 5 (Zeitspanne zwischen zwei realen Datumsangaben) sollen Jahr, Monat und Tag nicht separat betrachtet werden
1985,1986,12,1,24,5 sollte wirklich zwischen 24.12.1985 und 5.1.1986 liegen.

Ein ähnliches Problem könnte bei der Zeitberechnung für Spieltage bestehen (Jahr a-b, Spieltag c-d, Stunde e-f, Minute g-h).
Auch hier sind unterschiedliche Interpretationen möglich: Werte separat betrachten oder eine echte Zeitspanne defnineren - oder aber eine Kombination. Denn mindestens bei der Zeit (Stunde/Minute), könnte man ja erreichen wollen, dass etwas morgens oder abends passiert, egal welcher Tag gewürfelt wurde.

In der Dokumentation wird aktuell die Interpretation zwischen zwei Zeitstempeln beschrieben (wie sie für Typ 6 und 7 aktuell *nicht* umgesetzt ist). In der Datenbank kommt der Zeittyp 6 (fester Zeitstempel mit Spieltag) gar nicht und Typ 7 (Zeitspanne zwischen zwei Spieltagzeiten) nur zweimal vor.

Vorschlag wäre, Typ 5 anzupassen und sich die restlichen Typen nochmal anzuschauen (#366).