### PR TITLE
Unterstützung vorausgewählter Besetzung

### DIFF
--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -2201,6 +2201,8 @@ Type TDatabaseLoader
 			'for actor jobs this defines if a specific role is defined
 			Local jobRoleGUID:String = xml.FindValueLC(nodeJob, "role_guid", "")
 			Local jobRandomRole:Int = xml.FindValueIntLC(nodeJob, "random_role", 0)
+			Local jobPreselectCast:String = xml.FindValueLC(nodeJob, "person", "")
+
 			If jobRandomRole
 				jobRandomRole = 1
 				'overriding job must be reset on child reset!
@@ -2221,6 +2223,7 @@ Type TDatabaseLoader
 			'create a job without an assigned person
 			Local job:TPersonProductionJob = New TPersonProductionJob.Init(0, jobFunction, jobGender, jobCountry, jobRoleID)
 			job.randomRole = jobRandomRole
+			job.preselectCast = jobPreselectCast
 			If jobRequired = 0
 				'check if the job has to override an existing one
 				If jobIndex >= 0 And scriptTemplate.GetRandomJobAtIndex(jobIndex)

--- a/source/game.person.base.bmx
+++ b/source/game.person.base.bmx
@@ -1979,8 +1979,10 @@ Type TPersonProductionJob
 	'1=job from parent, only reset role on parent reset
 	'2=job overridden in child, reset role also on child reset
 	Field randomRole:Int = 0
-	
-	
+	'GUID or variable
+	Field preselectCast:String = ""
+
+
 	Method Init:TPersonProductionJob(personID:Int, job:Int, gender:Int=0, country:String="", roleID:Int=0)
 		Self.personID = personID
 		Self.job = job
@@ -2006,7 +2008,8 @@ Type TPersonProductionJob
 		       gender + "::" +..
 		       StringHelper.EscapeString(country, ":") + "::" + ..
 		       roleID + "::" + ..
-		       randomRole
+		       randomRole + "::" + ..
+		       StringHelper.EscapeString(preselectCast, ":")
 	End Method
 
 
@@ -2018,6 +2021,7 @@ Type TPersonProductionJob
 		If vars.length > 3 Then country = StringHelper.UnEscapeString(vars[3])
 		If vars.length > 4 Then roleID = Int(vars[4])
 		If vars.length > 5 Then randomRole = Int(vars[5])
+		If vars.length > 6 Then preselectCast = StringHelper.UnEscapeString(vars[6])
 	End Method
 
 

--- a/source/game.person.base.bmx
+++ b/source/game.person.base.bmx
@@ -1996,7 +1996,8 @@ Type TPersonProductionJob
 	
 	
 	'copy is used for making a script out of a template
-	'... randomRole value not needed and hence not copied
+	'randomRole value not needed and hence not copied
+	'preselectCast is set explicitly
 	Method Copy:TPersonProductionJob()
 		Return New TPersonProductionJob.Init(personID, job, gender, country, roleID)
 	End Method

--- a/source/game.person.base.bmx
+++ b/source/game.person.base.bmx
@@ -1979,7 +1979,7 @@ Type TPersonProductionJob
 	'1=job from parent, only reset role on parent reset
 	'2=job overridden in child, reset role also on child reset
 	Field randomRole:Int = 0
-	'GUID or variable
+	'GUID or variable evaluating to GUID
 	Field preselectCast:String = ""
 
 

--- a/source/game.production.productionconcept.bmx
+++ b/source/game.production.productionconcept.bmx
@@ -396,7 +396,14 @@ Type TProductionConcept Extends TOwnedGameObject
 
 	Method Reset()
 		'reset cast
-		if script then cast = new TPersonBase[ script.jobs.length ]
+		If script
+			cast = new TPersonBase[ script.jobs.length ]
+			For Local i:Int = 0 Until script.jobs.length
+				If script.jobs[i].personID
+					cast[i] = GetPersonBaseCollection().GetById(script.jobs[i].personID)
+				EndIf
+			Next
+		EndIf
 
 		ResetCache()
 

--- a/source/game.production.scripttemplate.bmx
+++ b/source/game.production.scripttemplate.bmx
@@ -180,7 +180,6 @@ Type TScriptTemplate Extends TScriptBase
 		'reset random roles - always for overridden jobs (2) or if reset is done on parent
 		For Local j:TPersonProductionJob = EachIn jobs
 			If j.randomRole = 2 Or (j.randomRole And Not parentScriptID) Then j.roleID = 0
-			'TODO reset preselected cast works as expected?
 			j.personID = 0
 		Next
 	End Method

--- a/source/game.production.scripttemplate.bmx
+++ b/source/game.production.scripttemplate.bmx
@@ -180,6 +180,8 @@ Type TScriptTemplate Extends TScriptBase
 		'reset random roles - always for overridden jobs (2) or if reset is done on parent
 		For Local j:TPersonProductionJob = EachIn jobs
 			If j.randomRole = 2 Or (j.randomRole And Not parentScriptID) Then j.roleID = 0
+			'TODO reset preselected cast works as expected?
+			j.personID = 0
 		Next
 	End Method
 
@@ -379,7 +381,13 @@ Type TScriptTemplate Extends TScriptBase
 				Local role:TProgrammeRole = GetProgrammeRoleCollection().CreateRandomRole(result[i].country, result[i].gender)
 				result[i].roleID = role.id
 			EndIf
+			If result[i].preselectCast And Not result[i].personID
+				Local person:TPersonBase = GetPersonBaseCollection().GetByGUID(result[i].preselectCast)
+				result[i].personID = person.GetId()
+			EndIf
 			result[i] = result[i].Copy()
+			'mark job as "cast preselected"
+			If result[i].personID Then result[i].preselectCast = "x"
 			Local finalJob:TPersonProductionJob = result[i]
 			If finalJob.gender = 0 And finalJob.roleID <> 0
 				Local role:TProgrammeRole = GetProgrammeRoleCollection().GetByID(finalJob.roleID)

--- a/source/game.production.scripttemplate.bmx
+++ b/source/game.production.scripttemplate.bmx
@@ -381,8 +381,14 @@ Type TScriptTemplate Extends TScriptBase
 				Local role:TProgrammeRole = GetProgrammeRoleCollection().CreateRandomRole(result[i].country, result[i].gender)
 				result[i].roleID = role.id
 			EndIf
-			If result[i].preselectCast And Not result[i].personID
-				Local person:TPersonBase = GetPersonBaseCollection().GetByGUID(result[i].preselectCast)
+			Local personString:String = result[i].preselectCast
+			If personString And Not result[i].personID
+				If personString.Contains("$")
+					Local context:SScriptExpressionContext = new SScriptExpressionContext(self, -1, Null)
+					Local valueNew:TStringBuilder = GameScriptExpression.ParseLocalizedText(personString, context)
+					personString = valueNew.ToString()
+				EndIf
+				Local person:TPersonBase = GetPersonBaseCollection().GetByGUID(personString)
 				If person Then result[i].personID = person.GetId()
 			EndIf
 			result[i] = result[i].Copy()

--- a/source/game.production.scripttemplate.bmx
+++ b/source/game.production.scripttemplate.bmx
@@ -383,7 +383,7 @@ Type TScriptTemplate Extends TScriptBase
 			EndIf
 			If result[i].preselectCast And Not result[i].personID
 				Local person:TPersonBase = GetPersonBaseCollection().GetByGUID(result[i].preselectCast)
-				result[i].personID = person.GetId()
+				If person Then result[i].personID = person.GetId()
 			EndIf
 			result[i] = result[i].Copy()
 			'mark job as "cast preselected"

--- a/source/game.screen.supermarket.production.bmx
+++ b/source/game.screen.supermarket.production.bmx
@@ -338,12 +338,14 @@ Type TScreenHandler_SupermarketProduction Extends TScreenHandler
 			EndIf
 
 			'TODO we do not yet consider casting the same role using the same person
-			'(role once as actore once as supporting actor)
+			'(role once as actor once as supporting actor)
 			If perfectMatch
 				'for the same concept or concepts with the same specification
 				'(e.g. multi-production, episodes), simply copy the cast
 				For Local castIndex:Int = 0 Until currentProductionConcept.cast.length
-					currentProductionConcept.SetCast(castIndex, takeOverConcept.cast[castIndex])
+					If Not currentProductionConcept.script.jobs[castIndex].preselectCast
+						currentProductionConcept.SetCast(castIndex, takeOverConcept.cast[castIndex])
+					EndIf
 				Next
 			Else
 				'store old cast by their job
@@ -359,18 +361,20 @@ Type TScreenHandler_SupermarketProduction Extends TScreenHandler
 				'find the best matching old cast (same job, correct gender)
 				For Local castIndex:Int = 0 Until currentProductionConcept.cast.length
 					Local job:TPersonProductionJob = currentProductionConcept.script.jobs[castIndex]
-					Local jobIndex:Int = TVTPersonJob.GetIndex(job.job)
-					Local gender:Int = job.gender
-					Local oldCastList:TPersonBase[] = oldCastByJob[jobIndex]
-					For Local oldCastIndex:Int = 0 Until oldCastList.length
-						Local oldCastPerson:TPersonBase = oldCastList[oldCastIndex]
-						If Not oldCastPerson Then Continue
-						If gender > 0 And gender <> oldCastPerson.gender Then Continue
-						currentProductionConcept.SetCast(castIndex, oldCastPerson)
-						'make a cast member once used unavailable
-						oldCastList[oldCastIndex] = null
-						Exit
-					Next
+					If Not job.preselectCast
+						Local jobIndex:Int = TVTPersonJob.GetIndex(job.job)
+						Local gender:Int = job.gender
+						Local oldCastList:TPersonBase[] = oldCastByJob[jobIndex]
+						For Local oldCastIndex:Int = 0 Until oldCastList.length
+							Local oldCastPerson:TPersonBase = oldCastList[oldCastIndex]
+							If Not oldCastPerson Then Continue
+							If gender > 0 And gender <> oldCastPerson.gender Then Continue
+							currentProductionConcept.SetCast(castIndex, oldCastPerson)
+							'make a cast member once used unavailable
+							oldCastList[oldCastIndex] = null
+							Exit
+						Next
+					EndIf
 				Next
 			EndIf
 

--- a/source/game.screen.supermarket.production.bmx
+++ b/source/game.screen.supermarket.production.bmx
@@ -2516,6 +2516,21 @@ Type TGUICastListItem Extends TGUISelectListItem
 	End Method
 
 
+	Method OnTryDrop:Int(triggerEvent:TEventBase) override
+		Local coord:TVec2D = TVec2D(triggerEvent.GetData().Get("coord"))
+		Local target:TGUICastSlotList = TGUICastSlotList(triggerEvent.GetData().Get("target"))
+		If coord And Target
+			Local slotId:Int = target.GetSlotByCoord(coord)
+			Local targetSlot:TGUICastListItem = TGUICastListItem(target.GetItemBySlot(slotId))
+			If targetSlot And targetSlot._isLocked()
+				triggerEvent.SetVeto()
+				Return False
+			EndIf
+		EndIf
+		return super.OnTryDrop(triggerEvent)
+	End Method
+
+
 	'override
 	Method onFinishDrop:Int(triggerEvent:TEventBase)
 		If Super.OnFinishDrop(triggerEvent)


### PR DESCRIPTION
closes #1065

Erster Durchstich für das Definieren von Besetzungen in einer Drehbuchvorlage.
* Definition eines Attributs (person - Diskussionsgrundlage) in der Datenbank (GUID oder Variable, die zu einer GUID ausgewertet wird) - aktuell wird nur eine feste GUID unterstützt
* konkrete Person wird beim Erstellen des Drehbuchs/Konzepts ermittelt und weitergegeben
* Im Supermarkt kann der Slot nicht verändert werden und ist ausgegraut
* Für Texte im Script würde ich die Expressionauswertung nicht ändern. Stattdessen würde man mit dem normalen .person arbeiten und die GUID aus einer Variable ziehen, die sowohl für den Text als auch für die Cast-Vorauswahl verwendet wird. Auf die Weise sollte die Definition konsistent sein, weil man eben nicht cast verwenden kann und hoffen, dass final auch der Name der vom Spieler gewählten Person erscheint.

Tests mit mehreren Slots und Überschreiben von Cast in Serienfolgen steht noch aus.