### PR TITLE
[Misc] Provide extra information on game preparation

### DIFF
--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -332,6 +332,10 @@ Type TDatabaseLoader
 
 	Method Load(fileURI:String)
 		config.AddString("currentFileURI", fileURI)
+
+		'inform others: done with file
+		TriggerBaseEvent(GameEventKeys.Database_OnBeginLoad, New TData.Add("fileURI", fileURI ), Null, self)
+
 		'register our own mxml error printer:
 		XMLSetErrorCallback(MXMLErrorCallback)
 		
@@ -366,7 +370,10 @@ Type TDatabaseLoader
 				Default	TLogger.Log("TDatabase.Load()", "CANNOT LOAD DB ~q" + fileURI + "~q (version "+version+") - UNHANDLED VERSION." , LOG_LOADING)
 			End Select
 		EndIf
-		
+
+		'inform others: done with file
+		TriggerBaseEvent(GameEventKeys.Database_OnLoad, New TData.Add("fileURI", fileURI ), Null, self)
+
 		'de-register our own mxml error printer:
 		XMLSetErrorCallback(null)
 	End Method

--- a/source/game.gameeventkeys.bmx
+++ b/source/game.gameeventkeys.bmx
@@ -288,6 +288,8 @@ Type TGameEventKeys
 	Field App_OnStart:TEventKey = GetEventKey("App.onStart", True)
 	Field App_OnLowPriorityUpdate:TEventKey = GetEventKey("App.OnLowPriorityUpdate", True)
 
+	Field Database_OnLoad:TEventKey = GetEventKey("Database.OnLoad", True)
+	Field Database_OnBeginLoad:TEventKey = GetEventKey("Database.OnBeginLoad", True)
 	Field SaveGame_OnBeginLoad:TEventKey = GetEventKey("SaveGame.OnBeginLoad", True)
 	Field SaveGame_OnLoad:TEventKey = GetEventKey("SaveGame.OnLoad", True)
 	Field SaveGame_OnBeginSave:TEventKey = GetEventKey("SaveGame.OnBeginSave", True)

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -3954,6 +3954,7 @@ Type TScreen_PrepareGameStart Extends TGameScreen
 	Field SendGameReadyTimer:Long = 0
 	Field StartMultiplayerSyncStarted:Long = 0
 	Field messageWindow:TGUIGameModalWindow
+	Field actionLog:String[]
 
 	'Store call states as we try a "Non blocking" approach
 	'which means, the update loop gets called multiple time.
@@ -3975,6 +3976,15 @@ Type TScreen_PrepareGameStart Extends TGameScreen
 
 	Field stateName:TLowerString
 
+	Global _registeredListeners:TEventListenerBase[] {nosave}
+	Global _registeredEvents:Int = False
+
+	
+	Method New()
+		RegisterEvents()	
+	End Method
+
+
 	Method Create:TScreen_PrepareGameStart(name:String)
 		Super.Create(name)
 		SetGroupName("ExGame", "PrepareGameStart")
@@ -3988,6 +3998,54 @@ Type TScreen_PrepareGameStart Extends TGameScreen
 
 		Return Self
 	End Method
+
+
+
+	Method RegisterEvents:Int()
+		EventManager.UnregisterListenersArray(_registeredListeners)
+		_registeredListeners = New TEventListenerBase[0]
+
+		if not _registeredEvents
+			_registeredListeners :+ [ EventManager.registerListenerFunction(GameEventKeys.Database_OnLoad, OnDatabaseLoad) ]
+			_registeredListeners :+ [ EventManager.registerListenerFunction(GameEventKeys.Database_OnLoad, OnDatabaseBeginLoad) ]
+
+			_registeredEvents = True
+		endif
+	End Method
+
+
+	Function OnDatabaseBeginLoad:int( triggerEvent:TEventBase )
+		If not TScreen_PrepareGameStart(ScreenCollection.currentScreen) Then Return	False
+		If GetGame().gameState <> TGame.STATE_PREPAREGAMESTART Then Return False
+
+		Local screen:TScreen_PrepareGameStart = TScreen_PrepareGameStart(ScreenCollection.currentScreen)
+		Local fileURI:String = triggerEvent.GetData().GetString("fileURI")
+		screen.actionLog :+ ["Loading DB: " + fileURI]
+		If screen.actionLog.length > 5
+			screen.actionLog = screen.actionLog[screen.actionLog.length-5 ..]
+		EndIf 
+		'enforce redrawing the screen
+		'ScreenCollection.DrawCurrent(GetDeltaTimer().GetTween())
+		screen.Draw(GetDeltaTimer().GetTween())
+		Flip
+	End Function
+	
+	
+	Function OnDatabaseLoad:int( triggerEvent:TEventBase )
+		If not TScreen_PrepareGameStart(ScreenCollection.currentScreen) Then Return	False
+		If GetGame().gameState <> TGame.STATE_PREPAREGAMESTART Then Return False
+
+		Local screen:TScreen_PrepareGameStart = TScreen_PrepareGameStart(ScreenCollection.currentScreen)
+		Local fileURI:String = triggerEvent.GetData().GetString("fileURI")
+		screen.actionLog :+ ["Loaded DB: " + fileURI]
+		If screen.actionLog.length > 5
+			screen.actionLog = screen.actionLog[screen.actionLog.length-5 ..]
+		EndIf 
+		'enforce redrawing the screen
+		'ScreenCollection.DrawCurrent(GetDeltaTimer().GetTween())
+		screen.Draw(GetDeltaTimer().GetTween())
+		Flip
+	End Function
 
 
 	Method Draw:Int(tweenValue:Float)
@@ -4014,7 +4072,12 @@ Type TScreen_PrepareGameStart Extends TGameScreen
 			Next
 			If Not allReady Then GetBitmapFontManager().baseFont.DrawSimple("not ready!!", messageRect.GetX(), messageRect.GetY() + messageDY, SColor8.Black)
 		Else
-			GetBitmapFontManager().baseFont.DrawSimple(GetLocale("PREPARING_START_DATA")+"...", messageRect.GetX(), messageRect.GetY() + messageDY, SColor8.Black)
+			messageDY :+ GetBitmapFontManager().baseFont.DrawSimple(GetLocale("PREPARING_START_DATA")+"...", messageRect.GetX(), messageRect.GetY() + messageDY, SColor8.Black).y
+			If actionLog.length > 0
+				For local i:Int = 0 until actionLog.length
+					messageDY :+ GetBitmapFontManager().baseFont.DrawBox(actionLog[i], messageRect.GetX(), messageRect.GetY() + messageDY, messageRect.GetW(), messageRect.GetH(), sALIGN_LEFT_TOP, SColor8.Black).y
+				Next
+			EndIf
 		EndIf
 		SetAlpha oldAlpha
 		


### PR DESCRIPTION
Einfacher "POC" um zu schauen, wie bequem wir Mitteilungen in den "Ladebildschirm" bekommen.

Gerade mit der hoeheren Menge an DB-Daten dauert es ja nun eine Weile und der Spieler weiss nicht so recht... passiert da was oder nicht?


Man koennte es auch soweit ausbauen, dass ein Balken anwaechst, oder Zeilen "aktualisiert" werden 

Lade DB test.xml
-> 10 Filme, 4 News
(obige Zeile aktualisieren...)
-> 20 Filme, 4 News
(obige Zeile aktualisieren...)
-> 50 Filme, 4 News
...
