### PR TITLE
Nacharbeiten Nachrichtenrefactoring

### DIFF
--- a/source/game.programme.newsevent.bmx
+++ b/source/game.programme.newsevent.bmx
@@ -155,6 +155,7 @@ Type TNewsEventCollection
 
 		'max 100 entries
 		If newsEventsHistory.length > 100
+			newsEventsHistoryIndex :- 50
 			newsEventsHistory = newsEventsHistory[50 ..]
 		EndIf
 		'resize if needed
@@ -1115,7 +1116,8 @@ Type TGameModifierNews_TriggerNews Extends TGameModifierBase
 
 		'calculate when the news happens
 		news.happenedTime = GetWorldTime().CalcTime_Auto(-1, happenTimeType, happenTimeData)
-		
+		GetNewsEventCollection().ProtectNewsThread(news)
+
 		'add other allowed "senders"
 		Local triggeredByID:int = params.GetInt("triggeredByID", 0)
 		news.triggeredByID = triggeredByID

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -6561,14 +6561,16 @@ endrem
 			Next
 
 		Next
-		'NEWSEVENTS
-		'remove old news events - wait a bit more than "plan time"
-		'this also gets rid of "one time" news events which should
-		'have been "triggered" then
-		Local daysToKeep:Int = 3
-		GetNewsEventCollection().RemoveOutdatedNewsEvents(daysToKeep)
-		'remove from collection (reuse if possible)
-		GetNewsEventCollection().RemoveEndedNewsEvents()
+		If hour mod 24 = 3
+			'NEWSEVENTS
+			'remove old news events - wait a bit more than "plan time"
+			'this also gets rid of "one time" news events which should
+			'have been "triggered" then
+			Local daysToKeep:Int = 5
+			GetNewsEventCollection().RemoveOutdatedNewsEvents(daysToKeep)
+			'remove from collection (reuse if possible)
+			GetNewsEventCollection().RemoveEndedNewsEvents()
+		EndIf
 
 		If GameConfig.autoSaveIntervalHours > 0 And Not TSaveGame.autoSaveNow and TSaveGame.lastSaveTime > 0 and time - TSaveGame.lastSaveTime > GameConfig.autoSaveIntervalHours * TWorldTime.HOURLENGTH
 			TSaveGame.autoSaveNow = True


### PR DESCRIPTION
* Thread-Protection auch beim Erstellen von Nachfolgenachrichten
* Altnachrichten nicht jede Stunde aufräumen (die Methode arbeitet ohnehin nur auch Tagesbasis)
* fix News-History-Index (wenn das Array gekürzt wird, sollte auch der Index angepasst werden; im Debugscreen wurde nach 100 Nachrichten nur noch eine statt 4 angezeigt)