### PR TITLE
Auswertung der Fokuspunkte für die Qualität einer Produktion

### DIFF
--- a/source/game.production.bmx
+++ b/source/game.production.bmx
@@ -234,7 +234,8 @@ Type TProduction Extends TOwnedGameObject
 		value :* 1.0 + 0.4 * (effectiveFocusPointsMod - 0.5)
 
 		'more spent focus points "always" leads to a better product
-		value :+ 0.01 * productionConcept.GetEffectiveFocusPoints()
+		Local p:Float = productionConcept.GetEffectiveFocusPoints()
+		value :+ p * 0.099^p
 
 
 		Return value

--- a/source/game.production.bmx
+++ b/source/game.production.bmx
@@ -950,7 +950,7 @@ endrem
 
 		'=== 1.2.2 MODIFY PRODUCTION VALUE ===
 		effectiveFocusPoints = productionConcept.CalculateEffectiveFocusPoints(True)
-		effectiveFocusPointsMod = 1.0 + productionConcept.GetEffectiveFocusPointsRatio(True)
+		effectiveFocusPointsMod = 1.0 + productionConcept.GetEffectiveFocusPointsDistribution(True)
 
 rem
 		TLogger.Log("TProduction.FixProductionValues()", "scriptGenreFit:           " + scriptGenreFit, LOG_DEBUG)

--- a/source/game.production.bmx
+++ b/source/game.production.bmx
@@ -227,8 +227,11 @@ Type TProduction Extends TOwnedGameObject
 
 
 		'it is important to set the production priority according
-		'to the genre
-		value :* 1.0 + 0.4 * (effectiveFocusPointsMod - 0.4)
+		'to the genre, modifier can be negative and has maximum 1
+		'studio manager now gives actual feedback for distribution
+		'so you can prevent really bad results
+		'for perfect distribution 20% "bonus" is possible
+		value :* 1.0 + 0.4 * (effectiveFocusPointsMod - 0.5)
 
 		'more spent focus points "always" leads to a better product
 		value :+ 0.01 * productionConcept.GetEffectiveFocusPoints()
@@ -950,7 +953,7 @@ endrem
 
 		'=== 1.2.2 MODIFY PRODUCTION VALUE ===
 		effectiveFocusPoints = productionConcept.CalculateEffectiveFocusPoints(True)
-		effectiveFocusPointsMod = 1.0 + productionConcept.GetEffectiveFocusPointsDistribution(True)
+		effectiveFocusPointsMod = productionConcept.GetEffectiveFocusPointsDistribution(True)
 
 rem
 		TLogger.Log("TProduction.FixProductionValues()", "scriptGenreFit:           " + scriptGenreFit, LOG_DEBUG)

--- a/source/game.production.productionconcept.bmx
+++ b/source/game.production.productionconcept.bmx
@@ -723,6 +723,7 @@ Type TProductionConcept Extends TOwnedGameObject
 			focusPoints = GetProductionFocus(focusPointID)
 
 			'production speed does not add to quality
+			'TODO maybe allow some speed points for higher company levels?
 			If focusPointID = TVTProductionFocus.PRODUCTION_SPEED Then Continue
 
 			weight=1.0
@@ -745,10 +746,14 @@ Type TProductionConcept Extends TOwnedGameObject
 			weight=1.0
 			'expected points
 			If genreDefinition Then weight = genreDefinition.GetFocusPointPriority(focusPointID)
+			'TODO limit by TProductionFocusBase.focusPointLimit
 			focusPoints = (pointsForDistribution / totalWeights) * weight
 			'print "expected "+ focusPointID+": "+ focusPoints + " actual "+ GetProductionFocus(focusPointID)
 			'difference
 			focusPoints = abs(GetProductionFocus(focusPointID) - focusPoints)
+			'TODO make factor depend on company,
+			'6, 11->0.1
+			'15 -> 0.07...
 			If focusPoints > 0 Then _effectiveFocusPointsDistribution :- 0.1 * focusPoints
 		Next
 		'print _effectiveFocusPointsDistribution

--- a/source/game.production.productionconcept.bmx
+++ b/source/game.production.productionconcept.bmx
@@ -721,19 +721,13 @@ Type TProductionConcept Extends TOwnedGameObject
 		Local weight:Float
 		Local totalWeights:Float
 		Local attributeLimit:Int = TProductionFocusBase.focusPointLimit
+		Local focusCategories:Int
 		For Local focusPointID:Int = EachIn productionFocus.GetOrderedFocusIndices()
+			focusCategories :+ 1
 			focusPoints = GetProductionFocus(focusPointID)
 
 			'production speed does not add to quality
-			If focusPointID = TVTProductionFocus.PRODUCTION_SPEED
-				If companyPoints > 24
-					'allow some speed points for higher company levels
-					'if 5 points are assigned for each "quality" attribute, 1 speed point
-					'for each "full" further quality-point is OK
-					pointsForDistribution :- min(focusPoints, (companyPoints - 24) / 6)
-				EndIf
-				Continue
-			EndIf
+			If focusPointID = TVTProductionFocus.PRODUCTION_SPEED Then Continue
 
 			weight=1.0
 			If genreDefinition Then weight = genreDefinition.GetFocusPointPriority(focusPointID)
@@ -747,6 +741,14 @@ Type TProductionConcept Extends TOwnedGameObject
 			EndIf
 			_effectiveFocusPoints :+ weight * focusPoints
 		Next
+		'allow some speed points for higher company levels
+		'if around 5 points are assigned for each "quality" attribute, 1 speed point
+		'for each "full" further quality-point is OK
+		Local threshold:Int = 4 * focusCategories
+		If companyPoints > threshold
+			pointsForDistribution :- min(focusPoints, (companyPoints - threshold) / focusCategories)
+		EndIf
+
 
 		'calculate focus point distribution value
 		Local diffPenalty:Float = 0.1

--- a/source/game.production.productionconcept.bmx
+++ b/source/game.production.productionconcept.bmx
@@ -371,7 +371,7 @@ Type TProductionConcept Extends TOwnedGameObject
 	'time with the same output regardless of time)
 	Field _scriptGenreFit:Float = -1.0 {nosave}
 	Field _effectiveFocusPoints:Float = -1.0 {nosave}
-	Field _effectiveFocusPointsMax:Float = -1.0 {nosave}
+	Field _effectiveFocusPointsDistribution:Float = -5.0 {nosave}
 
 	'storage for precalculated values (eg. costs of actors get higher
 	'inbetween)
@@ -414,7 +414,7 @@ Type TProductionConcept Extends TOwnedGameObject
 	Method ResetCache()
 		_scriptGenreFit = -1
 		_effectiveFocusPoints = -1
-		_effectiveFocusPointsMax = -1
+		_effectiveFocusPointsDistribution = -5
 	End Method
 
 
@@ -649,27 +649,14 @@ Type TProductionConcept Extends TOwnedGameObject
 	End Method
 
 
-	Method GetEffectiveFocusPointsMax:Float()
-		if _effectiveFocusPointsMax < 0 then CalculateEffectiveFocusPoints()
-		return _effectiveFocusPointsMax
+	'returns a value indicating how well the focus points are balanced with respect to the genre definition
+	'the maximal value is 1.0 and can be negative!
+	Method GetEffectiveFocusPointsDistribution:Float(recalculate:Int = False)
+		If _effectiveFocusPointsDistribution <= -5 or recalculate Then CalculateEffectiveFocusPoints(True)
+		Return _effectiveFocusPointsDistribution
 	End Method
 
 
-	'returns the percentage of used to maximum focus points
-	Method GetEffectiveFocusPointsRatio:Float(recalculate:Int = False)
-		'a "drama" production might have VFX-priority of 0.5, each point
-		'spent there is only added by 50% to the effective ratio
-
-		if _effectiveFocusPointsMax < 0 or recalculate then CalculateEffectiveFocusPoints(True)
-
-		if _effectiveFocusPointsMax > 0
-			return _effectiveFocusPoints / _effectiveFocusPointsMax
-		elseif _effectiveFocusPointsMax = 0
-			return 0.0
-		endif
-	End Method
-	
-	
 	'use this to place focus points where needed (eg custom programme 
 	'producers could use this)
 	'returns amount of unspend points
@@ -718,31 +705,53 @@ Type TProductionConcept Extends TOwnedGameObject
 
 
 	Method CalculateEffectiveFocusPoints:Float(recalculate:int = False)
-		if not productionFocus then return 0.0
+		If Not productionFocus Then Return 0.0
 
-		if _effectiveFocusPoints >= 0 and not recalculate then return _effectiveFocusPoints
+		If _effectiveFocusPoints >= 0 And Not recalculate Then Return _effectiveFocusPoints
 
 		_effectiveFocusPoints = 0.0
-		_effectiveFocusPointsMax = 0.0
+		_effectiveFocusPointsDistribution = 1.0
 
 		Local genreDefinition:TMovieGenreDefinition = GetMovieGenreDefinition([script.mainGenre]+script.subGenres)
+		'total number of points as base for distribution
+		'assigned team points are (partially) ignored while speed points should have used for "quality"
+		Local pointsForDistribution:Int = GetProductionCompany().GetFocusPoints()
+		Local focusPoints:Int
+		Local weight:Float
+		Local totalWeights:Float
+		For Local focusPointID:Int = EachIn productionFocus.GetOrderedFocusIndices()
+			focusPoints = GetProductionFocus(focusPointID)
 
-		For local focusPointID:int = EachIn productionFocus.GetOrderedFocusIndices()
 			'production speed does not add to quality
-			if focusPointID = TVTProductionFocus.PRODUCTION_SPEED then continue
+			If focusPointID = TVTProductionFocus.PRODUCTION_SPEED Then Continue
 
-			if genreDefinition
-				_effectiveFocusPoints :+ GetProductionFocus(focusPointID) * genreDefinition.GetFocusPointPriority(focusPointID)
-				_effectiveFocusPointsMax :+ TProductionFocusBase.focusPointLimit * genreDefinition.GetFocusPointPriority(focusPointID)
-
-				'print "_effectiveFocusPoints :+ "+GetProductionFocus(focusPointID)+" * "+genreDefinition.GetFocusPointPriority(focusPointID)
-				'print "_effectiveFocusPointsMax :+ "+TProductionFocusBase.focusPointLimit+" * "+genreDefinition.GetFocusPointPriority(focusPointID)
-
-			else
-				_effectiveFocusPoints :+ GetProductionFocus(focusPointID)
-				_effectiveFocusPointsMax :+ TProductionFocusBase.focusPointLimit
-			endif
+			weight=1.0
+			If genreDefinition Then weight = genreDefinition.GetFocusPointPriority(focusPointID)
+			If focusPointID <> TVTProductionFocus.TEAM
+				totalWeights :+ weight
+			Else
+				'do not subtract all assigned team points (6 total all for team - not a good distribution)
+				pointsForDistribution :- min(focusPoints, Min(GetProductionCompany().GetFocusPoints(), TProductionFocusBase.focusPointLimit) / 2)
+			EndIf
+			_effectiveFocusPoints :+ weight * focusPoints
 		Next
+
+		'calculate focus point distribution value
+		For Local focusPointID:Int = EachIn productionFocus.GetOrderedFocusIndices()
+			'production speed and team are ignored
+			If focusPointID = TVTProductionFocus.PRODUCTION_SPEED Then Continue
+			If focusPointID = TVTProductionFocus.TEAM Then Continue
+
+			weight=1.0
+			'expected points
+			If genreDefinition Then weight = genreDefinition.GetFocusPointPriority(focusPointID)
+			focusPoints = (pointsForDistribution / totalWeights) * weight
+			'print "expected "+ focusPointID+": "+ focusPoints + " actual "+ GetProductionFocus(focusPointID)
+			'difference
+			focusPoints = abs(GetProductionFocus(focusPointID) - focusPoints)
+			If focusPoints > 0 Then _effectiveFocusPointsDistribution :- 0.1 * focusPoints
+		Next
+		'print _effectiveFocusPointsDistribution
 
 		return _effectiveFocusPoints
 	End Method

--- a/source/game.roomhandler.studio.bmx
+++ b/source/game.roomhandler.studio.bmx
@@ -953,9 +953,9 @@ Type RoomHandler_Studio Extends TRoomHandler
 				EndIf
 
 
-				If effectiveFocusPointsDistribution < 0.30
+				If effectiveFocusPointsDistribution < 0.55
 					text :+ GetRandomLocale("DIALOGUE_STUDIO_CONCEPT_EFFECTIVEFOCUSPOINTSRATIO_BAD")
-				ElseIf effectiveFocusPointsDistribution > 0.70
+				ElseIf effectiveFocusPointsDistribution > 0.85
 					text :+ GetRandomLocale("DIALOGUE_STUDIO_CONCEPT_EFFECTIVEFOCUSPOINTSRATIO_GOOD")
 				Else
 					text :+ GetRandomLocale("DIALOGUE_STUDIO_CONCEPT_EFFECTIVEFOCUSPOINTSRATIO_AVERAGE")

--- a/source/game.roomhandler.studio.bmx
+++ b/source/game.roomhandler.studio.bmx
@@ -907,7 +907,7 @@ Type RoomHandler_Studio Extends TRoomHandler
 				Local productionCompanyQuality:Float = 0
 				If pc.productionCompany Then productionCompanyQuality = pc.productionCompany.GetQuality()
 				Local effectiveFocusPoints:Int = pc.CalculateEffectiveFocusPoints()
-				Local effectiveFocusPointsRatio:Float = pc.GetEffectiveFocusPointsRatio()
+				Local effectiveFocusPointsDistribution:Float = pc.GetEffectiveFocusPointsDistribution(True)
 
 				text = GetRandomLocale("DIALOGUE_STUDIO_CONCEPT_INTRO_FOR_TITLEX").Replace("%TITLE%", pc.GetTitle()) + "~n~n"
 
@@ -953,9 +953,9 @@ Type RoomHandler_Studio Extends TRoomHandler
 				EndIf
 
 
-				If effectiveFocusPointsRatio < 0.30
+				If effectiveFocusPointsDistribution < 0.30
 					text :+ GetRandomLocale("DIALOGUE_STUDIO_CONCEPT_EFFECTIVEFOCUSPOINTSRATIO_BAD")
-				ElseIf effectiveFocusPointsRatio> 0.70
+				ElseIf effectiveFocusPointsDistribution > 0.70
 					text :+ GetRandomLocale("DIALOGUE_STUDIO_CONCEPT_EFFECTIVEFOCUSPOINTSRATIO_GOOD")
 				Else
 					text :+ GetRandomLocale("DIALOGUE_STUDIO_CONCEPT_EFFECTIVEFOCUSPOINTSRATIO_AVERAGE")


### PR DESCRIPTION
see #1285 
Aktuell wird (nur) eine gewichtete Summe der vergebenen Punkte ins Verhältnis zur möglichen Gesamtpunktzahl verwendet um die Verteilung der Fokuspunkte zu bewerten. Das halte ich für zu kurz gegriffen. Einerseits wird damit gar keine "gute Verteilung" belohnt, weil man einfach möglichst viele Punkte für höher gewichtete Attribute vergeben muss, andererseits werden teure Produktionen doppelt belohnt einfach weil sie teuer waren.
Vorschlag ist, tatsächlich die Verteilung auf die unterschiedlichen Kategorien zu bewerten (und zwar in Abhängigkeit der Anzahl der Punkte, die mit der Produktionsfirma überhaupt vergeben werden können). Grundidee ist, dass man aufgrund der Gewichtung der Attribute ermittelt wie viele Punkte pro Kategorie "für ein optimales Ergebnis" zu erwarten wären. Je nachdem wie stark man von dieser Verteilung abweicht, gibt es Punktabzug. Die vergebenen Punkte gehen ja mit zwei Faktoren in die Bewertung ein: Güte der Verteilung und reine Anzahl der vergebenen Punkte.

Mit der (noch nicht fertigen) vorgeschlagenen Anpassung bekämen "billige" Produktionen einen höheren Wert für die Güte der Verteilung. Je mehr Punkte vergeben werden können, desto größer kann auch die Bestrafung für Abweichungen sein. Das hat mutmaßlich einen doppelten positiven Effekt. Einerseits erreichen frühe billigere Produktionen ein besseres Ergebnis und werden dadurch attraktiver, andererseits wird es später im Spiel für teuren Produktionen etwas schwieriger, da eine Punktlandung bei der Verteilung nicht so leicht ist.

Je mehr Punkte zur Verfügung stehen, desto leichter liegt man natürlich daneben. Aktuell führt jeder Punkt Abweichung zu einem Abzug von 0.1 vom Maximalwert 1. Ich würde das noch anpassen, dass je nach vergebbarer Gesamtpunktzahl (6, 11, 15...) der Abzugswert etwas kleiner wird.
Auch wird aktuell davon ausgegangen dass alle praktisch alle vergebenen Punkte für die Produktionsgeschwindigkeit zu einer Verschlechterung führen und auch nicht einfach alle Punkte für "Team" vergeben werden dürfen. Das sollte noch angepasst werden.