### PR TITLE
Live-Serien und Broadcastlimit; Report Rauxelerritter

### DIFF
--- a/source/game.player.programmeplan.bmx
+++ b/source/game.player.programmeplan.bmx
@@ -1901,6 +1901,7 @@ endrem
 								Local remove:Int = False
 								Local sell:Int = False
 								If licence.IsEpisode()
+									print "broadcastLimit for series "+licence.getTitle()
 									'check if whole series needs removing
 									licenceToRemove = licence.getParentLicence()
 									If Not licenceToRemove Or Not licenceToRemove.isExceedingBroadcastLimit()
@@ -1918,12 +1919,15 @@ endrem
 									licenceToRemove = licence
 								EndIf
 
-								If licenceToRemove and licenceToRemove.isTradeable()
+								If licenceToRemove Then print "remove "+licenceToRemove.getTitle() +" "+licenceToRemove.isTradeable()
+								'if a licence is removed (not sold) only if it is tradeable, it is possible to only partially produce a series
+								'trash the script for the last episode and sell the series even after all broadcast limits have been reached
+								If licenceToRemove
 									If licenceToRemove.HasLicenceFlag(TVTProgrammeLicenceFlag.REMOVE_ON_REACHING_BROADCASTLIMIT) Then remove = True
 									If licenceToRemove.HasLicenceFlag(TVTProgrammeLicenceFlag.SELL_ON_REACHING_BROADCASTLIMIT) Then sell = True
 									If remove
 										GetPlayerProgrammeCollection(owner).RemoveProgrammeLicence(licenceToRemove, False)
-									ElseIf sell
+									ElseIf sell and licenceToRemove.isTradeable()
 										GetPlayerProgrammeCollection(owner).RemoveProgrammeLicence(licenceToRemove, True)
 									EndIf
 								EndIf

--- a/source/game.player.programmeplan.bmx
+++ b/source/game.player.programmeplan.bmx
@@ -1901,7 +1901,6 @@ endrem
 								Local remove:Int = False
 								Local sell:Int = False
 								If licence.IsEpisode()
-									print "broadcastLimit for series "+licence.getTitle()
 									'check if whole series needs removing
 									licenceToRemove = licence.getParentLicence()
 									If Not licenceToRemove Or Not licenceToRemove.isExceedingBroadcastLimit()
@@ -1919,7 +1918,6 @@ endrem
 									licenceToRemove = licence
 								EndIf
 
-								If licenceToRemove Then print "remove "+licenceToRemove.getTitle() +" "+licenceToRemove.isTradeable()
 								'if a licence is removed (not sold) only if it is tradeable, it is possible to only partially produce a series
 								'trash the script for the last episode and sell the series even after all broadcast limits have been reached
 								If licenceToRemove

--- a/source/game.production.bmx
+++ b/source/game.production.bmx
@@ -479,9 +479,14 @@ Type TProduction Extends TOwnedGameObject
 			'2 blocks: ends at 21:55
 			'ATTENTION: ensure it ends at xx:x5 (as the production 
 			'           manager updates in 5 minute intervals)
-			'#1295 use minute 50, so that finalize sets parent licence tradeable in time for
-			'for the removeOnBroadCastLimit check to have the correct licence state
-			endTime = GetWorldtime().GetTimeGoneForGameTime(0, 0, GetWorldTime().GetHour(startTime) + (productionConcept.script.GetBlocks()-1), 50)
+			Local endMinute:Int = 55
+			If _designatedProgrammeLicence.IsEpisode() And _designatedProgrammeLicence.HasBroadcastLimit() ..
+				And _designatedProgrammeLicence.GetData() And _designatedProgrammeLicence.GetData().GetBroadcastLimit() = 1
+				'#1295 use minute 50, so that finalize sets parent licence tradeable in time for
+				'for the removeOnBroadCastLimit check to have the correct licence state
+				endMinute = 50
+			EndIf
+			endTime = GetWorldtime().GetTimeGoneForGameTime(0, 0, GetWorldTime().GetHour(startTime) + (productionConcept.script.GetBlocks()-1), endMinute)
 		EndIf
 
 		_designatedProgrammeLicence.data.SetState(TVTProgrammeState.IN_PRODUCTION)

--- a/source/game.production.bmx
+++ b/source/game.production.bmx
@@ -479,7 +479,9 @@ Type TProduction Extends TOwnedGameObject
 			'2 blocks: ends at 21:55
 			'ATTENTION: ensure it ends at xx:x5 (as the production 
 			'           manager updates in 5 minute intervals)
-			endTime = GetWorldtime().GetTimeGoneForGameTime(0, 0, GetWorldTime().GetHour(startTime) + (productionConcept.script.GetBlocks()-1), 55)
+			'#1295 use minute 50, so that finalize sets parent licence tradeable in time for
+			'for the removeOnBroadCastLimit check to have the correct licence state
+			endTime = GetWorldtime().GetTimeGoneForGameTime(0, 0, GetWorldTime().GetHour(startTime) + (productionConcept.script.GetBlocks()-1), 50)
 		EndIf
 
 		_designatedProgrammeLicence.data.SetState(TVTProgrammeState.IN_PRODUCTION)
@@ -602,6 +604,7 @@ Type TProduction Extends TOwnedGameObject
 				local licence:TProgrammeLicence = GetProgrammeLicenceCollection().Get(parentScript.usedInProgrammeID)
 				If licence
 					licence.setLicenceFlag(TVTProgrammeLicenceFlag.TRADEABLE, True)
+					print "setting licence tradable "+licence.getTitle() +" "+licence.IsTradeable()
 				EndIf
 			EndIf
 		EndIf

--- a/source/game.production.bmx
+++ b/source/game.production.bmx
@@ -609,7 +609,6 @@ Type TProduction Extends TOwnedGameObject
 				local licence:TProgrammeLicence = GetProgrammeLicenceCollection().Get(parentScript.usedInProgrammeID)
 				If licence
 					licence.setLicenceFlag(TVTProgrammeLicenceFlag.TRADEABLE, True)
-					print "setting licence tradable "+licence.getTitle() +" "+licence.IsTradeable()
 				EndIf
 			EndIf
 		EndIf


### PR DESCRIPTION
see #1295 

Zu prüfen wäre, ob der folgende Ansatz tragbar wäre.
* Live-Produktionen enden schon x:50 statt x:55, damit das tradeable-Flag gesetzt wird, bevor die Prüfung für das Entfernen einer Lizenz x:54 stattfindet
* Es wird ja zwischen Entfernen und Verkaufen beim Erreichen des Limits unterschieden. Beim Entfernen wird nicht mehr auf das tradeable-Flag geachtet, die Lizenz wird einfach entfernt

Es kann nun aber folgendes Verhalten auftreten.
* Serie mit 2 Folgen
* Folge 1 produziert und gesendet
* Limit erreicht, Serie verschwindet
* Folge 2 produziert
* Serie erscheint wieder (Header hat aber vermutlich den falschen Owner)
* Folge 2 gesendet, Limit erreicht, Serie verschwindet wieder

Das sichtbare Ergebnis scheint erstmal wie gewünscht zu sein - wenn das Limit aller Folgen erreicht ist, verschwindet die Serie und sie taucht auch nicht wieder auf, wenn man das Drehbuch für den Rest wegwirft.