### PR TITLE
Anpassung Genre-Fit-Berechnung

### DIFF
--- a/source/game.production.productionconcept.bmx
+++ b/source/game.production.productionconcept.bmx
@@ -749,7 +749,7 @@ Type TProductionConcept Extends TOwnedGameObject
 
 
 	Method CalculateScriptGenreFit:Float(recalculate:int = False)
-		if _scriptGenreFit < 0 Then _scriptGenreFit = script.CalculateGenreCriteriaFit()
+		if _scriptGenreFit < 0 Or recalculate Then _scriptGenreFit = script.CalculateGenreCriteriaFit()
 
 		return _scriptGenreFit
 	End Method

--- a/source/game.production.script.bmx
+++ b/source/game.production.script.bmx
@@ -1073,10 +1073,10 @@ Type TScript Extends TScriptBase {_exposeToLua="selected"}
 		print "mainGenre:          "+mainGenre
 		print "review:             "+review + "  scaled:  " + reviewActual + "  genre:" + reviewGenre
 		print "speed:              "+speed + "  scaled:  " + speedActual + "  genre:" + speedGenre
-		print "Review Abweichung:  "+distanceReview
-		print "Speed Abweichung:   "+distanceSpeed
-		print "ergebnis:           "+(1.0 - (distanceReview + distanceSpeed))
-		endrem
+		print "distannce review:   "+distanceReview
+		print "distance speed:     "+distanceSpeed
+		print "genre fit:          "+(1.0 - (distanceReview + distanceSpeed))
+		EndRem
 
 		Return 1.0 - (distanceReview + distanceSpeed)
 	End Method

--- a/source/game.roomhandler.studio.bmx
+++ b/source/game.roomhandler.studio.bmx
@@ -911,7 +911,9 @@ Type RoomHandler_Studio Extends TRoomHandler
 
 				text = GetRandomLocale("DIALOGUE_STUDIO_CONCEPT_INTRO_FOR_TITLEX").Replace("%TITLE%", pc.GetTitle()) + "~n~n"
 
-
+				'TODO fit semantics has changed - only speed/review ratio counts
+				'so 0.1+0.1 has the same fit as 0.9+0.9 - but the latter will result
+				'in much higher quality values - this should be reflected here
 				If scriptGenreFit < 0.30
 					text :+ GetRandomLocale("DIALOGUE_STUDIO_CONCEPT_SCRIPT_GENRE_BAD")
 				ElseIf scriptGenreFit > 0.70

--- a/source/game.roomhandler.studio.bmx
+++ b/source/game.roomhandler.studio.bmx
@@ -911,6 +911,7 @@ Type RoomHandler_Studio Extends TRoomHandler
 
 				text = GetRandomLocale("DIALOGUE_STUDIO_CONCEPT_INTRO_FOR_TITLEX").Replace("%TITLE%", pc.GetTitle()) + "~n~n"
 
+Rem
 				'TODO fit semantics has changed - only speed/review ratio counts
 				'so 0.1+0.1 has the same fit as 0.9+0.9 - but the latter will result
 				'in much higher quality values - this should be reflected here
@@ -922,7 +923,7 @@ Type RoomHandler_Studio Extends TRoomHandler
 					text :+ GetRandomLocale("DIALOGUE_STUDIO_CONCEPT_SCRIPT_GENRE_AVERAGE")
 				EndIf
 				text :+ "~n"
-
+EndRem
 
 				Local castSympathyKey:String
 				If castSympathy < - 0.10


### PR DESCRIPTION
Ich plädiere für eine grundsätzliche Anpassung der Genre-Fit-Berechnung. Outcome sollte komplett aus der Wertung genommen werden. Die Zuschauerwertung ist ein Ergebnis (und kein Parameter) der Gesamtgüte.
Ich verstehe zwar die Idee, mit den (hinterlegten und dem Drehbuch verglichenen) Werten genrespezifische Clichés einfangen zu wolllen, aber im Gesamtpaket funktioniert das aktuell nicht gut. Bei der Berechnung der Zuschauerzahlen wird einfach wieder eine gewichtete Summe über Speed, Critics etc. gebildet. D.h. den höchsten Wert erreicht man nicht, indem die Lizenz am nächsten an der Verteilung bezüglich der Genredefinition ist, sondern indem all diese Werte bei 100% liegen.

Ohne einen grundsätzlichen Umbau (z.B. für Lizenzen nur noch Qualität und Zuschauerwertung) wäre mein Vorschlag, die Gewichtung des Genre-Fit in der Gesamtberechnung der Produktion zu reduzieren (noch nicht in diesem PR - später, wenn Cast und Focus-Punkte angepasst sind).