### PR TITLE
Reparatur fehlende Sendernamen bei Nachrichten mit Ermittlungserfolg; Report scr0llbaer

### DIFF
--- a/source/game.misc.roomboardsign.bmx
+++ b/source/game.misc.roomboardsign.bmx
@@ -641,8 +641,8 @@ Type TRoomBoardSign Extends TBlockMoveable {_exposeToLua="selected"}
 
 
 	Method MarkMoved(playerID:Int = 0)
-		'ensure "2 ^ (i-1)" does not result in a ":double"!
-		Local playerBitmaskValue:Int = 1 Shl (playerID-1)  ' = 2^(playerID-1)
+		'ensure "2 ^ (playerID)" does not result in a ":double"!
+		Local playerBitmaskValue:Int = 1 Shl (playerID)  ' = 2^(playerID)
 		movedByPlayers :| playerBitmaskValue
 		lastMoveByPlayerID = playerID
 

--- a/source/game.newsagency.base.bmx
+++ b/source/game.newsagency.base.bmx
@@ -187,8 +187,8 @@ Type TNewsAgency
 		Local caughtChannelIDs:String = ""
 		Local caughtChannelIDsArray:Int[]
 		For Local i:Int = 1 To 4
-			'ensure "2 ^ (i-1)" does not result in a ":double"!
-			'Local playerBitmask:Int = 2^(i-1)
+			'ensure "2 ^ (playerId)" does not result in a ":double"!
+			'Local playerBitmask:Int = 2^(playerId)
 			Local playerBitmask:Int = 1 shl (i-1)
 			If bombRedirectedByPlayers & playerBitmask > 0
 				If caughtChannels <> "" Then caughtChannels :+ ", "
@@ -230,7 +230,7 @@ Type TNewsAgency
 		NewsEvent.happenedTime = GetWorldTime().GetTimeGone() + RandRange(5,20) * TWorldTime.MINUTELENGTH
 
 		Local NewsChainEvent1:TNewsEvent
-		If caughtChannels = "" Or RandRange(0,100) < 80
+		If bombRedirectedByPlayers = 0 Or RandRange(0,100) < 85 - caughtChannelIDsArray.length*5
 			'chain 1
 			Local qualityChain1:Float = 0.01 * randRange(50,60)
 			Local priceChain1:Float = 1.0 + 0.01 * randRange(-5,10)

--- a/source/game.newsagency.base.bmx
+++ b/source/game.newsagency.base.bmx
@@ -230,7 +230,7 @@ Type TNewsAgency
 		NewsEvent.happenedTime = GetWorldTime().GetTimeGone() + RandRange(5,20) * TWorldTime.MINUTELENGTH
 
 		Local NewsChainEvent1:TNewsEvent
-		If bombRedirectedByPlayers = 0 Or RandRange(0,100) < 90
+		If caughtChannels = "" Or RandRange(0,100) < 80
 			'chain 1
 			Local qualityChain1:Float = 0.01 * randRange(50,60)
 			Local priceChain1:Float = 1.0 + 0.01 * randRange(-5,10)


### PR DESCRIPTION
closes #1316 

Umstellung der Prüfung, welche Nachricht verwendet werden soll auf den String mit den ermittelten Sendern. Die Ermittlung der Beteiligten scheint aber auch noch Probleme zu haben. In Testpielen gab es zum Teil Explosionen in Spielerräumen, aber kein einziger Spieler war am Umhängen der Schilder beteiligt (ich meine nicht, dass die finale Nachricht so lautete, sondern dass der übergebene Wert im Event sagte, dass kein Spieler das Schild umgehängt hätte).