### PR TITLE
Bedingung für Generalschlüssel

### DIFF
--- a/source/game.betty.bmx
+++ b/source/game.betty.bmx
@@ -137,6 +137,27 @@ Type TBetty
 	End Method
 
 
+	Method CanGiveMasterKey:Int(playerID:Int)
+		Local threshold:Float = 0.3
+		Local carCount:Int = 0
+		Local playerPresents:TList = GetPresentHistory(playerID)
+		For Local p:TBettyPresentGivingAction = EachIn playerPresents
+			If p.present.index = TBettyPresent.PRESENT_CAR
+				If carCount = 0
+					threshold:- 0.15
+					carCount:+1
+				EndIf
+			EndIf
+			If p.present.bettyValue < 0
+				threshold:+0.01
+			Else
+				threshold:-0.0025
+			EndIf
+		Next
+		Return GetInLovePercentage(playerId) >= threshold
+	End Method
+
+
 	'returns (and creates if needed) the present history list of a given playerID
 	Method GetPresentHistory:TList(playerID:int)
 		if playerID <= 0 then return null
@@ -424,6 +445,7 @@ Type TBettyPresent
 	'index constants for referencing particular presents
 	Const PRESENT_DINNER:int = 2
 	Const PRESENT_BOOK:int   = 4
+	Const PRESENT_CAR:int    = 8
 	Const PRESENT_YACHT:int  = 10
 
 	'constants indicating the result of the present action
@@ -450,7 +472,7 @@ Type TBettyPresent
 		'diamond necklace
 		presents[6] = new TBettyPresent.Init(7,              100000, -700, 1.5)
 		'sports car
-		presents[7] = new TBettyPresent.Init(8,              250000,  350, 0.4)
+		presents[7] = new TBettyPresent.Init(PRESENT_CAR,    250000,  350, 0.4)
 		'ring
 		presents[8] = new TBettyPresent.Init(9,              500000,  450, 0.6)
 		'boat/yacht

--- a/source/game.betty.bmx
+++ b/source/game.betty.bmx
@@ -138,23 +138,20 @@ Type TBetty
 
 
 	Method CanGiveMasterKey:Int(playerID:Int)
-		Local threshold:Float = 0.3
-		Local carCount:Int = 0
+		Local threshold:Float = 0.15
+		Local dinnerCount:Int = 0
+		Local bookCount:Int = 0
 		Local playerPresents:TList = GetPresentHistory(playerID)
 		For Local p:TBettyPresentGivingAction = EachIn playerPresents
-			If p.present.index = TBettyPresent.PRESENT_CAR
-				If carCount = 0
-					threshold:- 0.15
-					carCount:+1
-				EndIf
-			EndIf
+			If p.present.index = TBettyPresent.PRESENT_DINNER Then dinnerCount:+ 1
+			If p.present.index = TBettyPresent.PRESENT_BOOK Then bookCount:+ 1
 			If p.present.bettyValue < 0
 				threshold:+0.01
 			Else
 				threshold:-0.0025
 			EndIf
 		Next
-		Return GetInLovePercentage(playerId) >= threshold
+		Return dinnerCount > 3 And bookCount > 1 And GetInLovePercentage(playerId) >= threshold
 	End Method
 
 
@@ -445,7 +442,6 @@ Type TBettyPresent
 	'index constants for referencing particular presents
 	Const PRESENT_DINNER:int = 2
 	Const PRESENT_BOOK:int   = 4
-	Const PRESENT_CAR:int    = 8
 	Const PRESENT_YACHT:int  = 10
 
 	'constants indicating the result of the present action
@@ -472,7 +468,7 @@ Type TBettyPresent
 		'diamond necklace
 		presents[6] = new TBettyPresent.Init(7,              100000, -700, 1.5)
 		'sports car
-		presents[7] = new TBettyPresent.Init(PRESENT_CAR,    250000,  350, 0.4)
+		presents[7] = new TBettyPresent.Init(8,              250000,  350, 0.4)
 		'ring
 		presents[8] = new TBettyPresent.Init(9,              500000,  450, 0.6)
 		'boat/yacht

--- a/source/game.gamerules.bmx
+++ b/source/game.gamerules.bmx
@@ -8,10 +8,6 @@ Type TGameRules {_exposeToLua}
 	'should licence attributes from the database be randomized
 	Field randomizeLicenceAttributes:Int = False
 
-	'how much love with betty is needed so she would give you the master
-	'key for all the rooms in the building
-	Field bettyLoveToGetMasterKey:Float = 0.75
-	
 	Field baseProductionTimeHours:Int = 9
 
 	'maximum level a news genre abonnement can have

--- a/source/game.roomhandler.betty.bmx
+++ b/source/game.roomhandler.betty.bmx
@@ -170,7 +170,7 @@ Type RoomHandler_Betty extends TRoomHandler
 			dialogueTexts[0] = TDialogueTexts.Create(text)
 
 			'enough love to ask for the master key?
-			if not player.GetFigure().hasMasterKey and bettyLove > GameRules.bettyLoveToGetMasterKey
+			if not player.GetFigure().hasMasterKey and GetBetty().CanGiveMasterKey(GetPlayerBase().playerID)
 				dialogueTexts[0].AddAnswer(TDialogueAnswer.Create( GetRandomLocale("DIALOGUE_BETTY_ASK_FOR_MASTERKEY"), -2, Null, onTakeMasterKey))
 			endif
 			dialogueTexts[0].AddAnswer(TDialogueAnswer.Create( GetRandomLocale("DIALOGUE_BETTY_ASK_FOR_SAMMYINFORMATION"), 1))


### PR DESCRIPTION
Die Bedingung für den Generalschlüssel war bisher ein Bettywert von 75%. Obwohl da vielleicht realistisch ist, bedeutet das für das Spiel, dass der Schlüssel keine Rolle spielt, da der Wert erst sehr spät erreicht werden kann.

Die geänderte Bedingung, setzt den Wert runter und macht ihn zusätzlich abhängig von den überreichten Geschenken.