### PR TITLE
Absturz wegen unbekannter Zeichen verhindern

### DIFF
--- a/source/Dig/base.util.string.bmx
+++ b/source/Dig/base.util.string.bmx
@@ -1,4 +1,4 @@
-﻿Rem
+Rem
 	====================================================================
 	String helper classes
 	====================================================================
@@ -1045,6 +1045,9 @@ Type StringHelper
 		Next
 		If offset = 0
 			Return s[.. offset + 1].ToUpper() + s[offset + 1 ..]
+		ElseIf offset = -1
+			'prevent seg fault for strings containing unsupported characters
+			Return s
 		ElseIf offset = s.length - 1
 			Return s[.. s.length - 1] + Chr(s[s.length-1]).ToUpper()
 		Else


### PR DESCRIPTION
see #1322
Bei Verwendung der Übersetzung stürzt das Spiel sofort ab, weil für nichtleere Strings mit unbekannten Zeichen der Index für FirstUpper nicht ermittelt werden kann.