### PR TITLE
prevent some crashes due to exceptions and segmentation faults

### DIFF
--- a/source/game.ai.bmx
+++ b/source/game.ai.bmx
@@ -896,8 +896,13 @@ Type TLuaFunctions Extends TLuaFunctionsBase {_exposeToLua}
 
 
 	Method GetProgrammeLicenceAtIndex:TProgrammeLicence(arrayIndex:Int=-1)
-		Local obj:TProgrammeLicence = GetPlayerProgrammeCollection(Self.ME).GetProgrammeLicenceAtIndex(arrayIndex)
-		If obj Then Return obj Else Return Null
+		Try
+			Local obj:TProgrammeLicence = GetPlayerProgrammeCollection(Self.ME).GetProgrammeLicenceAtIndex(arrayIndex)
+			If obj Then Return obj
+		Catch ex:Object
+			TLogger.Log("AI", "GetProgrammeLicenceAtIndex exception", LOG_ERROR)
+		End Try
+		Return Null
 	End Method
 
 
@@ -1149,8 +1154,12 @@ endrem
 		If Not _PlayerInRoom("office") Then Return Null
 
 		If playerID = -1 Then playerID = Self.ME
-
-		Return _GetPlayerStationMap().GetStationAtIndex(arrayIndex)
+		Try
+			Return _GetPlayerStationMap().GetStationAtIndex(arrayIndex)
+		Catch e:Object
+			TLogger.Log("AI", "of_getStationAtIndex exception", LOG_ERROR)
+		End Try
+		Return Null
 	End Method
 
 
@@ -1288,8 +1297,13 @@ endrem
 	Method of_getAdContractAtIndex:TAdContract(arrayIndex:Int=-1)
 		If Not _PlayerInRoom("office") Then Return Null
 
-		Local obj:TAdContract = GetPlayerProgrammeCollection(Self.ME).GetAdContractAtIndex(arrayIndex)
-		If obj Then Return obj Else Return Null
+		Try
+			Local obj:TAdContract = GetPlayerProgrammeCollection(Self.ME).GetAdContractAtIndex(arrayIndex)
+			If obj Then Return obj
+		Catch e:Object
+			TLogger.Log("AI", "of_getAdContractAtIndex exception", LOG_ERROR)
+		End Try
+		Return Null
 	End Method
 
 
@@ -1475,12 +1489,15 @@ endrem
 	Method ne_getAvailableNews:TLuaFunctionResult(arrayIndex:Int=-1)
 		If Not (_PlayerInRoom("newsroom") Or _PlayerInRoom("news")) Then Return TLuaFunctionResult.Create(Self.RESULT_WRONGROOM, Null)
 
-		Local availableNews:TNews = GetPlayerProgrammeCollection(Self.ME).GetNewsAtIndex(arrayIndex)
-		If availableNews
-			Return TLuaFunctionResult.Create(Self.RESULT_OK, availableNews)
-		Else
-			Return TLuaFunctionResult.Create(Self.RESULT_NOTFOUND, Null)
-		EndIf
+		Try
+			Local availableNews:TNews = GetPlayerProgrammeCollection(Self.ME).GetNewsAtIndex(arrayIndex)
+			If availableNews
+				Return TLuaFunctionResult.Create(Self.RESULT_OK, availableNews)
+			EndIf
+		Catch e:Object
+			TLogger.Log("AI", "ne_getAvailableNews exception", LOG_ERROR)
+		End Try
+		Return TLuaFunctionResult.Create(Self.RESULT_NOTFOUND, Null)
 	End Method
 
 
@@ -1499,12 +1516,15 @@ endrem
 	Method ne_getBroadcastedNews:TLuaFunctionResult(arrayIndex:Int=-1)
 		If Not (_PlayerInRoom("newsroom") Or _PlayerInRoom("news")) Then Return TLuaFunctionResult.Create(Self.RESULT_WRONGROOM, Null)
 
-		Local broadcastedNews:TNews = TNews(GetPlayerProgrammePlan(Self.ME).GetNewsAtIndex(arrayIndex))
-		If broadcastedNews
-			Return TLuaFunctionResult.Create(Self.RESULT_OK, broadcastedNews)
-		Else
-			Return TLuaFunctionResult.Create(Self.RESULT_NOTFOUND, Null)
-		EndIf
+		Try
+			Local broadcastedNews:TNews = TNews(GetPlayerProgrammePlan(Self.ME).GetNewsAtIndex(arrayIndex))
+			If broadcastedNews
+				Return TLuaFunctionResult.Create(Self.RESULT_OK, broadcastedNews)
+			EndIf
+		Catch e:Object
+			TLogger.Log("AI", "ne_getBroadcastedNews exception", LOG_ERROR)
+		End Try
+		Return TLuaFunctionResult.Create(Self.RESULT_NOTFOUND, Null)
 	End Method
 
 
@@ -1553,10 +1573,14 @@ endrem
 			If Not news Then Return Self.RESULT_NOTFOUND
 		EndIf
 
-		'skip if on same slot
-		If GetPlayerProgrammePlan(Self.ME).GetNewsAtIndex(slot) = news
-			Return Self.RESULT_OK
-		EndIf
+		Try
+			'skip if on same slot
+			If GetPlayerProgrammePlan(Self.ME).GetNewsAtIndex(slot) = news
+				Return Self.RESULT_OK
+			EndIf
+		Catch e:Object
+			TLogger.Log("AI", "ne_doNewsInPlan exception", LOG_ERROR)
+		EndTry
 
 
 		'place it (and remove from other slots before - if needed)
@@ -1593,8 +1617,13 @@ endrem
 	Method sa_getSignedAdContractAtIndex:TAdContract(arrayIndex:Int=-1)
 		If Not _PlayerInRoom("adagency") Then Return Null
 
-		Local obj:TAdContract = GetPlayerProgrammeCollection(Self.ME).GetAdContractAtIndex(arrayIndex)
-		If obj Then Return obj Else Return Null
+		Try
+			Local obj:TAdContract = GetPlayerProgrammeCollection(Self.ME).GetAdContractAtIndex(arrayIndex)
+			If obj Then Return obj
+		Catch e:Object
+			TLogger.Log("AI", "sa_getSignedAdContractAtIndex exception", LOG_ERROR)
+		End Try
+		Return Null
 	End Method
 
 
@@ -2085,12 +2114,15 @@ endrem
 	Method ep_GetSignAtIndex:TLuaFunctionResult(arrayIndex:Int = -1)
 		If Not _PlayerInRoom("elevatorplan") Then Return TLuaFunctionResult.Create(Self.RESULT_WRONGROOM, Null)
 
-		Local Sign:TRoomBoardSign = GetRoomBoard().GetSignAtIndex(arrayIndex)
-		If Sign
-			Return TLuaFunctionResult.Create(Self.RESULT_OK, Sign)
-		Else
-			Return TLuaFunctionResult.Create(Self.RESULT_NOTFOUND, Null)
-		EndIf
+		Try
+			Local Sign:TRoomBoardSign = GetRoomBoard().GetSignAtIndex(arrayIndex)
+			If Sign
+				Return TLuaFunctionResult.Create(Self.RESULT_OK, Sign)
+			EndIf
+		Catch e:Object
+			TLogger.Log("AI", "ep_GetSignAtIndex exception", LOG_ERROR)
+		End Try
+		Return TLuaFunctionResult.Create(Self.RESULT_NOTFOUND, Null)
 	End Method
 
 
@@ -2133,12 +2165,15 @@ endrem
 	Method rb_GetSignAtIndex:TLuaFunctionResult(arrayIndex:Int = -1)
 		If Not _PlayerInRoom("roomboard") Then Return TLuaFunctionResult.Create(Self.RESULT_WRONGROOM, Null)
 
-		Local Sign:TRoomBoardSign = GetRoomBoard().GetSignAtIndex(arrayIndex)
-		If Sign
-			Return TLuaFunctionResult.Create(Self.RESULT_OK, Sign)
-		Else
-			Return TLuaFunctionResult.Create(Self.RESULT_NOTFOUND, Null)
-		EndIf
+		Try
+			Local Sign:TRoomBoardSign = GetRoomBoard().GetSignAtIndex(arrayIndex)
+			If Sign
+				Return TLuaFunctionResult.Create(Self.RESULT_OK, Sign)
+			EndIf
+		Catch e:Object
+			TLogger.Log("AI", "rb_GetSignAtIndex exception", LOG_ERROR)
+		End Try
+		Return TLuaFunctionResult.Create(Self.RESULT_NOTFOUND, Null)
 	End Method
 
 

--- a/source/game.programme.newsevent.bmx
+++ b/source/game.programme.newsevent.bmx
@@ -233,7 +233,7 @@ Type TNewsEventCollection
 		Local scheduledCount:int = 0
 		Local happenOnStartNews:TNewsEvent[]
 		For local n:TNewsEventTemplate = EachIn GetNewsEventTemplateCollection().GetUnusedInitialTemplates()
-			If n.happenTime >= 0 and n.IsAvailableAtHappenTime()
+			If n And n.happenTime >= 0 and n.IsAvailableAtHappenTime()
 				local news:TNewsEvent = New TNewsEvent.InitFromTemplate(n)
 				If news
 					scheduledCount :+ 1
@@ -264,7 +264,7 @@ Type TNewsEventCollection
 		Local today:Int = GetWorldTime().GetDay()
 		For Local newsEvent:TNewsEvent = EachIn allnewsEvents.Values()
 			'not happened yet - should not happen
-			If Not newsEvent.HasHappened() Then Continue
+			If Not newsEvent Or Not newsEvent.HasHappened() Then Continue
 			'only interested in a specific genre?
 			If genre <> -1 And newsEvent.GetGenre() <> genre Then Continue
 
@@ -293,7 +293,7 @@ Type TNewsEventCollection
 
 		For Local newsEvent:TNewsEvent = EachIn newsEvents.Values()
 			'only interested in a specific genre?
-			If genre <> -1 And newsEvent.GetGenre() <> genre Then Continue
+			If Not newsEvent Or genre <> -1 And newsEvent.GetGenre() <> genre Then Continue
 
 			If newsEvent.HasHappened() And newsEvent.HasEnded()
 				toRemove :+ [newsEvent]
@@ -341,7 +341,7 @@ Type TNewsEventCollection
 				_followingNewsEvents[genre+1] = New TObjectList()
 			EndIf
 			For Local event:TNewsEvent = EachIn newsEvents.Values()
-				If event.newsType <> TVTNewsType.FollowingNews Then Continue
+				If Not event Or event.newsType <> TVTNewsType.FollowingNews Then Continue
 				'only interested in a specific genre?
 				If genre <> -1 And event.GetGenre() <> genre Then Continue
 
@@ -366,7 +366,7 @@ Type TNewsEventCollection
 			For Local event:TNewsEvent = EachIn newsEvents.Values()
 				'skip events already happened (and processed) or not
 				'happened at all (-> "-1")
-				If event.HasFlag(TVTNewsFlag.HAPPENING_PROCESSED) Or event.happenedTime = -1 Then Continue
+				If Not event Or event.HasFlag(TVTNewsFlag.HAPPENING_PROCESSED) Or event.happenedTime = -1 Then Continue
 				'also ignore events which happened before game start 
 				'(eg fixed happen time news events)
 				If event.happenedTime < startTime Then Continue
@@ -1279,7 +1279,7 @@ Type TGameModifierNews_ModifyAvailability Extends TGameModifierBase
 			'also modify "not yet happened" but existing news
 			Local hasToInvalidateCache:Int = False
 			For Local newsEvent:TNewsEvent = EachIn GetNewsEventCollection().GetUpcomingNewsList()
-				If newsEvent.templateID = newsEventTemplate.GetID()
+				If newsEvent And newsEvent.templateID = newsEventTemplate.GetID()
 					newsEvent.SetBroadcastFlag(TVTBroadcastMaterialSourceFlag.NOT_AVAILABLE, enableBackup)
 					hasToInvalidateCache = True
 				EndIf
@@ -1321,7 +1321,7 @@ Type TGameModifierNews_ModifyAvailability Extends TGameModifierBase
 			'           availabilities. An individually made available
 			'           newsevent would get their availability overridden!
 			For Local newsEvent:TNewsEvent = EachIn GetNewsEventCollection().GetUpcomingNewsList()
-				If newsEvent.templateID = newsEventTemplate.GetID()
+				If newsEvent And newsEvent.templateID = newsEventTemplate.GetID()
 					newsEvent.SetBroadcastFlag(TVTBroadcastMaterialSourceFlag.NOT_AVAILABLE, Not enable)
 					'refresh caches
 					GetNewsEventCollection()._InvalidateCaches()
@@ -1436,7 +1436,7 @@ Type TGameModifierNews_ModifyAttribute Extends TGameModifierBase
 		If newsEventTemplate
 			'modify value for all upcoming news based on this template
 			For Local newsEvent:TNewsEvent = EachIn GetNewsEventCollection().GetUpcomingNewsList()
-				If newsEvent.templateID = newsEventTemplate.GetID()
+				If newsEvent And newsEvent.templateID = newsEventTemplate.GetID()
 					WriteNewsEventValue(valueBackup, newsEvent)
 				EndIf
 			Next
@@ -1463,7 +1463,7 @@ Type TGameModifierNews_ModifyAttribute Extends TGameModifierBase
 		If newsEventTemplate
 			'modify value for all upcoming news based on this template
 			For Local newsEvent:TNewsEvent = EachIn GetNewsEventCollection().GetUpcomingNewsList()
-				If newsEvent.templateID = newsEventTemplate.GetID()
+				If newsEvent And newsEvent.templateID = newsEventTemplate.GetID()
 					valueBackup = ReadNewsEventValue(newsEvent)
 
 					WriteNewsEventValue(value, newsEvent)

--- a/source/game.programme.newsevent.template.bmx
+++ b/source/game.programme.newsevent.template.bmx
@@ -320,7 +320,7 @@ Type TNewsEventTemplateCollection
 
 			_unusedInitialTemplatesCount[genreIndex] = 0
 			For local t:TNewsEventTemplate = EachIn unusedTemplates.Values()
-				if t.newsType <> TVTNewsType.InitialNews then continue
+				if Not t Or t.newsType <> TVTNewsType.InitialNews then continue
 				'only interested in a specific genre?
 				if genre <> -1 and t.genre <> genre then continue
 


### PR DESCRIPTION
Ich habe an einigen Stellen Null-Prüfungen ergänzt (wo mir schon mal Spiele angestürzt sind) sowie Exceptionhandling für die getAtIndex-Aufrufe aus der KI eingeführt. Hier sollte sich das Zurückgeben von null nicht von einem "regulären" null-Wert unterscheideden.
Über die Performance würde ich mir jetzt eigentlich keine Gedanken mehr machen. Mit den massiv beschleunigten Lua-Bmx-Aufrufen wird die Stabilität verhältnismäßig wichtiger.