### PR TITLE
Nachricht, dass Chef ruft nur für menschlichen Spieler

### DIFF
--- a/source/main.bmx
+++ b/source/main.bmx
@@ -5184,7 +5184,7 @@ endrem
 		If player.isLocalAI()
 			player.PlayerAI.AddEventObj( New TAIEvent.SetID(TAIEvent.OnBossCalls).AddLong(latestTime))
 			'player.playerAI.CallOnBossCalls(latestTime)
-		Else
+		ElseIf player = GetPlayer()
 			'send out a toast message
 			Local toastGUID:String = "toastmessage-playerboss-callplayer"+player.playerID
 			'try to fetch an existing one


### PR DESCRIPTION
Im Testspiel mit deaktivierten Spielern aufgefallen. Ohne die Anpassung kommt die Toastnachricht nicht nur für den eigenen Chef sondern auch die Chefs der anderen Spieler.