### PR TITLE
Verbotene Programmflags bei Werbung auswerten

### DIFF
--- a/res/ai/DefaultAIPlayer/TaskAdAgency.lua
+++ b/res/ai/DefaultAIPlayer/TaskAdAgency.lua
@@ -259,7 +259,7 @@ function AppraiseSpots:AppraiseSpot(spot)
 
 	--TODO WIP make problematic ads unattractive
 	-- for now we do not modify our stats if they are special spots
-	if (spot.GetLimitedToProgrammeGenre() > 0) or (spot.GetLimitedToProgrammeFlag() > 0) then
+	if (spot.GetLimitedToProgrammeGenre() > 0) or (spot.GetLimitedToProgrammeFlag() > 0) or (spot.GetForbiddenProgrammeFlag() > 0) then
 		self:LogTrace("  no special spots please")
 		spot.SetAttractivenessString("-1")
 		return
@@ -509,7 +509,7 @@ function SignRequisitedContracts:SignMatchingContracts(requisition, guessedAudie
 			self:LogDebug("ignoring children contract")
 		elseif targetGroup == 32 and (veryhard == true or spotCount > 2 or spotsLeft > 0) then
 			self:LogDebug("ignoring manager contract")
-		elseif adContract.GetLimitedToProgrammeGenre() > 0 or adContract.GetLimitedToProgrammeFlag() > 0 then
+		elseif adContract.GetLimitedToProgrammeGenre() > 0 or adContract.GetLimitedToProgrammeFlag() > 0 or adContract.GetForbiddenProgrammeFlag() > 0 then
 			self:LogDebug("ignoring contract with genre limit")
 		elseif blocks < 72 and easy ~= true and spotCount > 4 then
 			self:LogDebug("ignoring contract with too many blocks")
@@ -726,7 +726,7 @@ function SignContracts:ShouldSignContract(contract)
 		maxAllowed = 0
 	elseif targetGroup == 2 or targetGroup == 32 then -- teenagers, managers
 		maxAllowed = 2
-	elseif contract.GetLimitedToProgrammeGenre() > 0 or contract.GetLimitedToProgrammeFlag() > 0 then
+	elseif contract.GetLimitedToProgrammeGenre() > 0 or contract.GetLimitedToProgrammeFlag() > 0 or contract.GetForbiddenProgrammeFlag() > 0 then
 		maxAllowed = 0
 	end
 

--- a/res/database/Default/user/stukov_ads.xml
+++ b/res/database/Default/user/stukov_ads.xml
@@ -256,7 +256,7 @@
 				<en>Loose 50 pounds in 2 days with the new fusion diet.</en>
 				<pl>Schudnij 50 kg w 2 dni dzięki nowej diecie fusion.</pl>
 			</description>
-			<conditions min_audience="7.29" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" prohibited_programme_flag="8" />
+			<conditions min_audience="7.29" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" />
 			<data quality="24" repetitions="5" duration="5" profit="420" penalty="1600" infomercial_profit="70" fix_infomercial_profit="1" />
 		</ad>
 
@@ -270,7 +270,7 @@
 				<en>Genuine clear cat juice! Yum-yum!</en>
 				<pl>Prawdziwy klarowny sok dla kotów! Mniam mniam!</pl>
 			</description>
-			<conditions min_audience="6.25" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" prohibited_programme_flag="8" />
+			<conditions min_audience="6.25" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" />
 			<data quality="3" repetitions="7" duration="7" profit="400" penalty="750" infomercial_profit="167" fix_infomercial_profit="1" />
 		</ad>
 
@@ -285,7 +285,7 @@
 				<en>Cheap - cheaper - Cheapo-cheapo.</en>
 				<pl>Tani - tańszy - BezOpłat.</pl>
 			</description>
-			<conditions min_audience="7.29" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" prohibited_programme_flag="8" />
+			<conditions min_audience="7.29" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" />
 			<data quality="31" repetitions="2" duration="8" profit="410" penalty="1100" infomercial_profit="3" fix_infomercial_profit="1" />
 		</ad>
 
@@ -652,7 +652,7 @@ Zupełnie nowe wrażenia multimedialne prosto z magnetofonu!</pl>
 				<en>Only half a calorie. So lonely and fragmented just because of you! So go and buy it, you fat bastard!</en> <!-- orig: So cool. So clear. And only 1 calorie. -->
 				<pl>Tylko pół kalorii. Tak samotny i rozdrobniony tylko z twojego powodu! Więc idź i kup to, gruby draniu!</pl>
 			</description>
-			<conditions min_audience="15.63" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" prohibited_genre="16" />
+			<conditions min_audience="15.63" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" />
 			<data quality="15" repetitions="6" duration="4" profit="255" penalty="380" fix_infomercial_profit="1" />
 		</ad>
 
@@ -663,7 +663,7 @@ Zupełnie nowe wrażenia multimedialne prosto z magnetofonu!</pl>
 			<description>
 				<all>${brandslogan_cantbeatthefeeling}.</all>
 			</description>
-			<conditions min_audience="18.76" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" prohibited_genre="16" />
+			<conditions min_audience="18.76" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" />
 			<data quality="29" repetitions="2" duration="1" profit="215" penalty="370" fix_infomercial_profit="1" />
 		</ad>
 
@@ -676,7 +676,7 @@ Zupełnie nowe wrażenia multimedialne prosto z magnetofonu!</pl>
 				<en>Now completely without calories! And you'll have to look for the taste too!</en>
 				<pl>Teraz całkowicie bez kalorii! Ty też będziesz musiał poszukać smaku!</pl>
 			</description>
-			<conditions min_audience="12.5" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" prohibited_genre="16" />
+			<conditions min_audience="12.5" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" />
 			<data quality="17" repetitions="4" duration="4" profit="290" penalty="500" fix_infomercial_profit="1" />
 		</ad>
 
@@ -691,7 +691,7 @@ Zupełnie nowe wrażenia multimedialne prosto z magnetofonu!</pl>
 				<en>The only genuine wok. Authentic from China.</en>
 				<pl>Jedyny oryginalny wok. Autentyczny produkt z Chin.</pl>
 			</description>
-			<conditions min_audience="5.21" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" prohibited_genre="100" prohibited_programme_flag="4" />
+			<conditions min_audience="5.21" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" prohibited_programme_flag="4" />
 			<!-- TODO: Not so clear why shows and series shouldn't be allowed for this one -->
 			<data infomercial="1" quality="6" repetitions="3" duration="8" profit="460" penalty="600" infomercial_profit="127" fix_infomercial_profit="1" />
 		</ad>
@@ -705,7 +705,7 @@ Zupełnie nowe wrażenia multimedialne prosto z magnetofonu!</pl>
 				<en>Don't trust just any sect! SUN with money-gone guarantee.</en>
 				<pl>Nie ufaj byle jakiej sekcie! SUN z gwarancją zwrotu pieniędzy.</pl>
 			</description>
-			<conditions min_audience="4.6881" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" prohibited_genre="100" prohibited_programme_flag="4" />
+			<conditions min_audience="4.6881" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" prohibited_programme_flag="4" />
 			<!-- TODO: Not so clear why shows and series shouldn't be allowed for this one -->
 			<data infomercial="1" quality="1" repetitions="5" duration="5" profit="500" penalty="1300" infomercial_profit="198" fix_infomercial_profit="1" />
 		</ad>
@@ -719,7 +719,7 @@ Zupełnie nowe wrażenia multimedialne prosto z magnetofonu!</pl>
 				<en>From the Cash Van: Cash as Cash can. Your cash into your can now!</en> <!-- orig: Cash as Cash can -->
 				<pl>Z furgonetki Cash Van: Gotówka do puszki. Gotówka do puszki już teraz!</pl>
 			</description>
-			<conditions min_audience="8.3352" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" prohibited_genre="100" prohibited_programme_flag="4" />
+			<conditions min_audience="8.3352" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" prohibited_programme_flag="4" />
 			<!-- TODO: Not so clear why shows and series shouldn't be allowed for this one -->
 			<data infomercial="1" quality="33" repetitions="7" duration="7" profit="366" penalty="524" infomercial_profit="74" fix_infomercial_profit="1" />
 		</ad>
@@ -800,7 +800,7 @@ Zupełnie nowe wrażenia multimedialne prosto z magnetofonu!</pl>
 				<en>We issue checks before you know it!</en>
 				<pl>Wystawiamy czeki, zanim się zorientujesz!</pl>
 			</description>
-			<conditions min_audience="2.86" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" prohibited_genre="15" prohibited_programme_flag="1" />
+			<conditions min_audience="2.86" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" prohibited_programme_flag="1" />
 			<data infomercial="1" quality="14" repetitions="1" duration="7" profit="500" penalty="2246" infomercial_profit="12" fix_infomercial_profit="1" />
 		</ad>
 
@@ -815,7 +815,7 @@ Zupełnie nowe wrażenia multimedialne prosto z magnetofonu!</pl>
 				<en>Don't call us - we're on vacation!</en>
 				<pl>Nie dzwoń do nas - jesteśmy na wakacjach!</pl>
 			</description>
-			<conditions min_audience="1.3" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" prohibited_genre="15" prohibited_programme_flag="1" />
+			<conditions min_audience="1.3" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" prohibited_programme_flag="1" />
 			<data infomercial="1" quality="17" repetitions="6" duration="5" profit="1050" penalty="2930" infomercial_profit="235" fix_infomercial_profit="1" />
 		</ad>
 
@@ -830,7 +830,7 @@ Zupełnie nowe wrażenia multimedialne prosto z magnetofonu!</pl>
 				<en>Your bank around the corner - and your cash performer.</en>
 				<pl>Twój bank za rogiem - i twój dawca gotówkowy.</pl>
 			</description>
-			<conditions min_audience="1.82" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" prohibited_genre="15" prohibited_programme_flag="1" />
+			<conditions min_audience="1.82" min_image="0" target_group="0" pro_pressure_groups="0" contra_pressure_groups="0" prohibited_programme_flag="1" />
 			<data infomercial="1" quality="13" repetitions="5" duration="6" profit="750" penalty="1100" infomercial_profit="176" fix_infomercial_profit="1" />
 		</ad>
 

--- a/res/lang/advertisement/advertisement_de.txt
+++ b/res/lang/advertisement/advertisement_de.txt
@@ -29,6 +29,7 @@ AD_STILL_X_DAYS       = noch %1 Tage
 AD_CHANNEL_IMAGE_TOO_LOW = Senderimage zu gering. %CHANNELIMAGE%% < %IMAGE%%.
 AD_PLEASE_GENRE_X        = Bitte Genre %GENRE%
 AD_PLEASE_FLAG           = Bitte %FLAG%
+AD_PLEASE_NOT_FLAG       = Bitte nicht %FLAG%
 
 INFOMERCIAL                  = Dauerwerbesendung
 AD_INFOMERCIAL               = Du wirst für die Ausstrahlung von Dauerwerbesendungen bezahlt. Einkommen ist abhängig von der Zuschauerzahl.

--- a/res/lang/advertisement/advertisement_en.txt
+++ b/res/lang/advertisement/advertisement_en.txt
@@ -29,6 +29,7 @@ AD_STILL_X_DAYS       = still %1 days
 AD_CHANNEL_IMAGE_TOO_LOW = Channel image too low. %CHANNELIMAGE%% < %IMAGE%%.
 AD_PLEASE_GENRE_X        = %GENRE% genre, please
 AD_PLEASE_FLAG           = %FLAG%, please
+AD_PLEASE_NOT_FLAG       = not %FLAG%, please
 
 INFOMERCIAL                  = Infomercial
 AD_INFOMERCIAL               = You get paid for airing infomercials. Income depends on audience.

--- a/res/lang/advertisement/advertisement_es.txt
+++ b/res/lang/advertisement/advertisement_es.txt
@@ -29,7 +29,7 @@ AD_STILL_X_DAYS       = todavia %1 dia
 AD_CHANNEL_IMAGE_TOO_LOW = imagen del canal baja. %CHANNELIMAGE%% < %IMAGE%%.
 AD_PLEASE_GENRE_X        = Por favor género %GENRE%
 AD_PLEASE_FLAG           = Por favor %FLAG%
-AD_PLEASE_NOT_FLAG_X     = Por favor no %FLAG%
+AD_PLEASE_NOT_FLAG_X     = No %FLAG%, por favor
 
 INFOMERCIAL                  = Infomercial
 AD_INFOMERCIAL               = Te pagan por emitir infomerciales. Ingresos depende de la audiencia.

--- a/res/lang/advertisement/advertisement_es.txt
+++ b/res/lang/advertisement/advertisement_es.txt
@@ -29,6 +29,7 @@ AD_STILL_X_DAYS       = todavia %1 dia
 AD_CHANNEL_IMAGE_TOO_LOW = imagen del canal baja. %CHANNELIMAGE%% < %IMAGE%%.
 AD_PLEASE_GENRE_X        = Por favor género %GENRE%
 AD_PLEASE_FLAG           = Por favor %FLAG%
+AD_PLEASE_NOT_FLAG_X     = Por favor no %FLAG%
 
 INFOMERCIAL                  = Infomercial
 AD_INFOMERCIAL               = Te pagan por emitir infomerciales. Ingresos depende de la audiencia.

--- a/res/lang/advertisement/advertisement_fr.txt
+++ b/res/lang/advertisement/advertisement_fr.txt
@@ -29,6 +29,7 @@ AD_STILL_X_DAYS       = encore %1 jours
 AD_CHANNEL_IMAGE_TOO_LOW = Image de marque trop insignifiant. %CHANNELIMAGE%% < %IMAGE%%.
 AD_PLEASE_GENRE_X        = SVP genre %GENRE%
 AD_PLEASE_FLAG           = SVP %FLAG%
+AD_PLEASE_NOT_FLAG       = SVP pas %FLAG%
 
 INFOMERCIAL                  = Émission publicitaire
 AD_INFOMERCIAL               = Tu es payé pour diffuser des émissions publicitaires. Tes revenus dépendent du nombre des spectateurs.

--- a/res/lang/advertisement/advertisement_fr.txt
+++ b/res/lang/advertisement/advertisement_fr.txt
@@ -29,7 +29,7 @@ AD_STILL_X_DAYS       = encore %1 jours
 AD_CHANNEL_IMAGE_TOO_LOW = Image de marque trop insignifiant. %CHANNELIMAGE%% < %IMAGE%%.
 AD_PLEASE_GENRE_X        = SVP genre %GENRE%
 AD_PLEASE_FLAG           = SVP %FLAG%
-AD_PLEASE_NOT_FLAG       = SVP pas %FLAG%
+AD_PLEASE_NOT_FLAG       = %FLAG% n'est pas permis
 
 INFOMERCIAL                  = Émission publicitaire
 AD_INFOMERCIAL               = Tu es payé pour diffuser des émissions publicitaires. Tes revenus dépendent du nombre des spectateurs.

--- a/res/lang/advertisement/advertisement_pl.txt
+++ b/res/lang/advertisement/advertisement_pl.txt
@@ -29,6 +29,7 @@ AD_STILL_X_DAYS       = ciągle %1 dni
 AD_CHANNEL_IMAGE_TOO_LOW = Wizerunek za niski. %CHANNELIMAGE%% < %IMAGE%%.
 AD_PLEASE_GENRE_X        = Proszę o gatunek %GENRE%
 AD_PLEASE_FLAG           = Proszę %FLAG%
+#AD_PLEASE_NOT_FLAG       = Proszę nie %FLAG%
 
 INFOMERCIAL                  = Infomercial
 AD_INFOMERCIAL               = Otrzymujesz wynagrodzenie za emitowanie reklam. Dochód zależy od oglądalności.

--- a/res/lang/advertisement/advertisement_pl.txt
+++ b/res/lang/advertisement/advertisement_pl.txt
@@ -29,7 +29,7 @@ AD_STILL_X_DAYS       = ciągle %1 dni
 AD_CHANNEL_IMAGE_TOO_LOW = Wizerunek za niski. %CHANNELIMAGE%% < %IMAGE%%.
 AD_PLEASE_GENRE_X        = Proszę o gatunek %GENRE%
 AD_PLEASE_FLAG           = Proszę %FLAG%
-#AD_PLEASE_NOT_FLAG       = Proszę nie %FLAG%
+AD_PLEASE_NOT_FLAG       = Proszę nie %FLAG%
 
 INFOMERCIAL                  = Infomercial
 AD_INFOMERCIAL               = Otrzymujesz wynagrodzenie za emitowanie reklam. Dochód zależy od oglądalności.

--- a/res/lang/advertisement/advertisement_pt-br.txt
+++ b/res/lang/advertisement/advertisement_pt-br.txt
@@ -29,6 +29,7 @@ AD_STILL_X_DAYS       = até %1 dias
 AD_CHANNEL_IMAGE_TOO_LOW = Imagem do canal muito baixa. %CHANNELIMAGE%% < %IMAGE%%.
 AD_PLEASE_GENRE_X        = Por favor, gênero %GENRE%
 AD_PLEASE_FLAG           = Por favor, %FLAG%
+AD_PLEASE_NOT_FLAG       = Por favor, não %FLAG%
 
 INFOMERCIAL                  = Infomercial
 AD_INFOMERCIAL               = Você é pago por transmitir infomerciais. A renda depende da audiência.

--- a/res/lang/advertisement/advertisement_tr.txt
+++ b/res/lang/advertisement/advertisement_tr.txt
@@ -29,6 +29,7 @@ AD_STILL_X_DAYS       = halen %1 gününüz var
 AD_CHANNEL_IMAGE_TOO_LOW = Kanal İmajı çok düşük %CHANNELIMAGE%% < %IMAGE%%.
 AD_PLEASE_GENRE_X        = Lütfen, Tür: %GENRE%
 AD_PLEASE_FLAG           = Lütfen, %FLAG%
+#AD_PLEASE_NOT_FLAG       = not %FLAG%, please
 
 INFOMERCIAL                  = Infomercial
 AD_INFOMERCIAL               = Yayın durumuna göre ödeme yapılacaktır. Gelir izleyici sayısına göre değişir.

--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -1537,7 +1537,7 @@ Type TDatabaseLoader
 			_adContractConditionKeys = [..
 				"min_audience", "min_image", "max_image", "target_group", ..
 				"allowed_programme_flag", "allowed_genre", ..
-				"prohibited_programme_flag", "prohibited_genre" ..
+				"prohibited_programme_flag" ..
 			]
 		EndIf
 		'do not reset "data" before - it contains the pressure groups

--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -1549,7 +1549,7 @@ Type TDatabaseLoader
 		adContract.limitedToTargetGroup = data.GetInt("target_group", adContract.limitedToTargetGroup)
 		adContract.limitedToProgrammeGenre = data.GetInt("allowed_genre", adContract.limitedToProgrammeGenre)
 		adContract.limitedToProgrammeFlag = data.GetInt("allowed_programme_flag", adContract.limitedToProgrammeFlag)
-		adContract.forbiddenProgrammeGenre = data.GetInt("prohibited_genre", adContract.forbiddenProgrammeGenre)
+'		adContract.forbiddenProgrammeGenre = data.GetInt("prohibited_genre", adContract.forbiddenProgrammeGenre)
 		adContract.forbiddenProgrammeFlag = data.GetInt("prohibited_programme_flag", adContract.forbiddenProgrammeFlag)
 		'if only one group
 		'adContract.proPressureGroups = data.GetInt("pro_pressure_groups", adContract.proPressureGroups)

--- a/source/game.ingameinterface.bmx
+++ b/source/game.ingameinterface.bmx
@@ -428,13 +428,14 @@ Type TInGameInterface
 								Else
 									Local audienceResult:TAudienceResult = GetBroadcastManager().GetAudienceResult(programmePlan.owner)
 									local minAudienceText:string
+									Local contract:TAdContract = TAdvertisement(obj).contract
 									If audience >= 0
-										minAudienceText = TFunctions.ConvertCompareValue(TAdvertisement(obj).contract.getMinAudience(), audience, 2)
+										minAudienceText = TFunctions.ConvertCompareValue(contract.getMinAudience(), audience, 2)
 									Else
-										minAudienceText = TFunctions.ConvertValue(TAdvertisement(obj).contract.getMinAudience(), 2)
+										minAudienceText = TFunctions.ConvertValue(contract.getMinAudience(), 2)
 									Endif
 									if TAdvertisement(obj).contract.GetLimitedToTargetGroup() > 0
-										minAudienceText :+ " " + TAdvertisement(obj).contract.GetLimitedToTargetGroupString()
+										minAudienceText :+ " " + contract.GetLimitedToTargetGroupString()
 									endif
 
 									'check if the ad passes all checks for the current broadcast
@@ -446,7 +447,11 @@ Type TInGameInterface
 											'tg already added above (for OK and WILL FAIL)
 											minAudienceText = "|color=200,100,100|" + minAudienceText + "!|/color|"
 										case "GENRE"
-											minAudienceText = "|color=200,100,100|" + minAudienceText + " " + TAdvertisement(obj).contract.GetLimitedToProgrammeGenreString()+ "!|/color|"
+											minAudienceText = "|color=200,100,100|" + minAudienceText + " " + contract.GetLimitedToProgrammeGenreString()+ "!|/color|"
+										case "FLAGS"
+											minAudienceText = "|color=200,100,100|" + minAudienceText + " " + contract.GetProgrammeFlagString(contract.GetLimitedToProgrammeFlag())+ "!|/color|"
+										case "FLAGSFORBIDDEN"
+											minAudienceText = "|color=200,100,100|" + minAudienceText + " " + contract.GetProgrammeFlagString(contract.GetForbiddenProgrammeFlag())+ "!|/color|"
 										default
 											minAudienceText = "|color=200,100,100|" + minAudienceText + "|/color|"
 									End Select

--- a/source/game.programme.adcontract.bmx
+++ b/source/game.programme.adcontract.bmx
@@ -294,9 +294,6 @@ Type TAdContractBase Extends TBroadcastMaterialSource {_exposeToLua}
 	'is the ad broadcasting not allowed for a specific programme flag?
 	'eg. no "paid"
 	Field forbiddenProgrammeFlag:Int = -1
-	'is the ad broadcasting not allowed for a specific programme genre?
-	'eg. no "lovestory"
-	Field forbiddenProgrammeGenre:Int = -1
 
 	'is the ad broadcasting limit to a specific broadcast type?
 	'Field limitedToBroadcastType:Int = -1

--- a/source/game.programme.adcontract.bmx
+++ b/source/game.programme.adcontract.bmx
@@ -291,12 +291,12 @@ Type TAdContractBase Extends TBroadcastMaterialSource {_exposeToLua}
 	'is the ad broadcasting limit to a specific programme flag?
 	'eg. "xrated", "live"
 	Field limitedToProgrammeFlag:Int = -1
-	'is the ad broadcasting not allowed for a specific programme genre?
-	'eg. no "lovestory"
-	Field forbiddenProgrammeGenre:Int = -1
 	'is the ad broadcasting not allowed for a specific programme flag?
 	'eg. no "paid"
 	Field forbiddenProgrammeFlag:Int = -1
+	'is the ad broadcasting not allowed for a specific programme genre?
+	'eg. no "lovestory"
+	Field forbiddenProgrammeGenre:Int = -1
 
 	'is the ad broadcasting limit to a specific broadcast type?
 	'Field limitedToBroadcastType:Int = -1
@@ -589,6 +589,14 @@ Type TAdContractBase Extends TBroadcastMaterialSource {_exposeToLua}
 		Return limitedToProgrammeFlag
 	End Method
 
+
+	Method IsForbiddenProgrammeFlag:Int(flag:Int) {_exposeToLua}
+		Return (GetForbiddenProgrammeFlag() & flag) > 0
+	End Method
+
+	Method GetForbiddenProgrammeFlag:Int() {_exposeToLua}
+		Return forbiddenProgrammeFlag
+	End Method
 
 
 	Method IsLimitedToTargetGroup:Int(targetGroup:Int) {_exposeToLua}
@@ -1257,7 +1265,7 @@ Type TAdContract Extends TBroadcastMaterialSource {_exposeToLua="selected"}
 		'limiting to specific genres change the price too
 		If GetLimitedToProgrammeGenre() > 0 Then price :* limitedToGenreMultiplier
 		'limiting to specific flags change the price too
-		If GetLimitedToProgrammeFlag() > 0 Then price :* limitedToProgrammeFlagMultiplier
+		If GetLimitedToProgrammeFlag() > 0 Or GetForbiddenProgrammeFlag() > 0 Then price :* limitedToProgrammeFlagMultiplier
 
 		'adjust by a player difficulty and randomize
 		If priceType = PRICETYPE_PROFIT
@@ -1514,9 +1522,18 @@ Type TAdContract Extends TBroadcastMaterialSource {_exposeToLua="selected"}
 	End Method
 
 
-	Method GetLimitedToProgrammeFlagString:String(flag:Int=-1) {_exposeToLua}
-		'if no flag was given, use the one of the object
-		If flag < 0 Then flag = base.limitedToProgrammeFlag
+	Method IsForbiddenProgrammeFlag:Int(flag:Int) {_exposeToLua}
+		Return base.IsForbiddenProgrammeFlag(flag)
+	End Method
+
+	Method GetForbiddenProgrammeFlag:Int() {_exposeToLua}
+		Return base.GetForbiddenProgrammeFlag()
+	End Method
+
+
+	Method GetProgrammeFlagString:String(flag:Int=-1) {_exposeToLua}
+'		'if no flag was given, use the one of the object
+'		If flag < 0 Then flag = base.limitedToProgrammeFlag
 		If flag < 0 Then Return ""
 
 
@@ -1548,7 +1565,7 @@ Type TAdContract Extends TBroadcastMaterialSource {_exposeToLua="selected"}
 		EndIf
 
 		'limited to a specific genre - and not fulfilled
-		If GetLimitedToProgrammeGenre() >= 0 or GetLimitedToProgrammeFlag() > 0
+		If GetLimitedToProgrammeGenre() >= 0 or GetLimitedToProgrammeFlag() > 0 or GetForbiddenProgrammeFlag() > 0
 			'check current programme of the owner
 			'TODO: check if that has flaws playing with high speed
 			'      (check if current broadcast is correctly set at this
@@ -1569,6 +1586,11 @@ Type TAdContract Extends TBroadcastMaterialSource {_exposeToLua="selected"}
 				if GetLimitedToProgrammeFlag() > 0
 					if not (GetLimitedToProgrammeFlag() & previouslyRunningBroadcastMaterial.GetProgrammeFlags())
 						Return "FLAGS"
+					endif
+				endif
+				if GetForbiddenProgrammeFlag() > 0
+					if (GetForbiddenProgrammeFlag() & previouslyRunningBroadcastMaterial.GetProgrammeFlags())
+						Return "FLAGSFORBIDDEN"
 					endif
 				endif
 			endif
@@ -1777,6 +1799,7 @@ Type TAdContract Extends TBroadcastMaterialSource {_exposeToLua="selected"}
 		If GetLimitedToTargetGroup() > 0 Then msgAreaH :+ msgH
 		If GetLimitedToProgrammeGenre() >= 0 Then msgAreaH :+ msgH
 		If GetLimitedToProgrammeFlag() > 0 Then msgAreaH :+ msgH
+		If GetForbiddenProgrammeFlag() > 0 Then msgAreaH :+ msgH
 		'warn if short of time or finished/failed
 		If daysLeft <= 1 Or IsCompleted()
 			msgAreaH :+ msgH
@@ -1839,7 +1862,11 @@ Type TAdContract Extends TBroadcastMaterialSource {_exposeToLua="selected"}
 			contentY :+ msgH
 		EndIf
 		If GetLimitedToProgrammeFlag() > 0
-			skin.RenderMessage(contentX+5, contentY, contentW - 9, -1, getLocale("AD_PLEASE_FLAG").Replace("%FLAG%", GetLimitedToProgrammeFlagString()), "warning", EDatasheetColorStyle.Warning, skin.fontNormal, ALIGN_CENTER_CENTER)
+			skin.RenderMessage(contentX+5, contentY, contentW - 9, -1, getLocale("AD_PLEASE_FLAG").Replace("%FLAG%", GetProgrammeFlagString(GetLimitedToProgrammeFlag())), "warning", EDatasheetColorStyle.Warning, skin.fontNormal, ALIGN_CENTER_CENTER)
+			contentY :+ msgH
+		EndIf
+		If GetForbiddenProgrammeFlag() > 0
+			skin.RenderMessage(contentX+5, contentY, contentW - 9, -1, getLocale("AD_PLEASE_NOT_FLAG").Replace("%FLAG%", GetProgrammeFlagString(GetForbiddenProgrammeFlag())), "warning", EDatasheetColorStyle.Warning, skin.fontNormal, ALIGN_CENTER_CENTER)
 			contentY :+ msgH
 		EndIf
 		'only show image hint when NOT signed (after signing the image is not required anymore)

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -2105,7 +2105,7 @@ Type TSaveGame Extends TGameState
 	Field _Time_timeGone:Long = 0
 	Field _Entity_globalWorldSpeedFactor:Float =  0
 	Field _Entity_globalWorldSpeedFactorMod:Float =  0
-	Const SAVEGAME_VERSION:int = 23
+	Const SAVEGAME_VERSION:int = 24
 	Const MIN_SAVEGAME_VERSION:Int = 13
 	Global messageWindow:TGUIModalWindow
 	Global messageWindowBackground:TImage
@@ -2401,6 +2401,14 @@ Type TSaveGame Extends TGameState
 
 	Global _nilNode:TNode = New TNode._parent
 	Function RepairData(savegameVersion:Int, savegameConverter:TSavegameConverter = null)
+		If savegameVersion < 24
+			For local ac:TAdContractBase = EachIn GetAdContractBaseCollection().entries.Values()
+				If ac.forbiddenProgrammeFlag > 0 And ac.forbiddenProgrammeFlag & TVTProgrammeDataFlag.CULT
+					ac.forbiddenProgrammeFlag = ac.forbiddenProgrammeFlag & ~TVTProgrammeDataFlag.CULT
+				EndIf
+			Next
+		EndIf
+
 		If savegameVersion < 23
 			'mark news events of the past as "happening processed"
 			Local neChangeCount:Int


### PR DESCRIPTION
closes #1200 

* verbotene Flags werden nun ausgewertet
* Bestandswerbung angepasst (Kult kann nicht erkannt werden, sollte als Flag also nicht gefordert/verboten werden)