### PR TITLE
Unterstützung programmabhängiger Bilder

### DIFF
--- a/source/game.broadcastmaterialsource.base.bmx
+++ b/source/game.broadcastmaterialsource.base.bmx
@@ -4,6 +4,7 @@ Import "game.gameobject.bmx"
 Import "game.gameconstants.bmx"
 Import "game.modifier.base.bmx"
 Import "game.gameinformation.base.bmx"
+Import "Dig/base.framework.entity.spriteentity.bmx" 'for sprite cache
 Import "Dig/base.util.string.bmx"
 Import "Dig/base.util.bitmask.bmx"
 Import "common.misc.templatevariables.bmx" 'for replacement function
@@ -218,6 +219,11 @@ Type TBroadcastMaterialSource Extends TBroadcastMaterialSourceBase {_exposeToLua
 	'maximum reachLevel a material was licenced for
 	'< 0 disables any level limitation
 	Field licencedReachLevel:Int = -1
+
+	'unpersisted fields for custom images
+	Field customImagePresent:Int = 0 {nosave}
+	Field customSprite:TSprite {nosave}
+
 
 	Global modKeyTopicality_AgeLS:TLowerString = New TLowerString.Create("topicality::age")
 	Global modKeyTopicality_TimesBroadcastedLS:TLowerString = New TLowerString.Create("topicality::timesBroadcasted")

--- a/source/game.programme.programmedata.bmx
+++ b/source/game.programme.programmedata.bmx
@@ -2099,6 +2099,10 @@ Type TProgrammeData Extends TBroadcastMaterialSource {_exposeToLua}
 
 			If effects Then effects.Update("broadcastTrailerDone", effectParams)
 		EndIf
+		If customImagePresent > 0
+			customImagePresent = 0
+			customSprite = Null
+		EndIf
 	End Method
 
 

--- a/source/game.programme.programmelicence.bmx
+++ b/source/game.programme.programmelicence.bmx
@@ -821,6 +821,10 @@ Type TProgrammeLicence Extends TBroadcastMaterialSource {_exposeToLua="selected"
 			GetData().topicality = GetData().GetMaxTopicality()
 		endif
 
+		If data And data.customImagePresent > 0
+			data.customImagePresent = 0
+			data.customSprite = Null
+		EndIf
 		'do the same for all children
 		For local subLicence:TProgrammeLicence = EachIn subLicences
 			subLicence.GiveBackToLicencePool()


### PR DESCRIPTION
* image-Verzeichnis im Haupverzeichnis kann (korrekt skalierte) Bilder enthalten
* png und jpg
* fertige Programme, Werbung, Eigenproduktionen
* Name muss Konvention entsprechen (Werbung - GUID aus DB, Eigenproduktionen - GUID der Drehbuchvorlage aus DB, Programme - "data-"+GUID aus DB)
* Für Serien können Einzelfolgen spezifische Bilder haben, ansonsten Fallback auf GUID des Haupteintrags
* Für Programme erfolgt ein Caching des Bilds für die Zeit der Ausstrahlung, für Werbung wird das Bild dauerhaft gespeichert (Werbung kommt immer wieder und wesentlich weniger Einträge)

closes #1140