### PR TITLE
Einfluss Alter auf Qualität

### DIFF
--- a/source/game.programme.programmedata.bmx
+++ b/source/game.programme.programmedata.bmx
@@ -1547,22 +1547,22 @@ Type TProgrammeData Extends TBroadcastMaterialSource {_exposeToLua}
 	Method GetQuality:Float() {_exposeToLua}
 		Local quality:Float = 1.0
 
-		'the older the less ppl want to watch - 1 year = 0.985%, 2 years = 0.97%...
-		'TODO the comment is misleading!!
-		'for age 0 the factor is 1.5, for age 30 the factor is 1.05
-		Local age:Float = 0.015 * Max(0, 100 - Max(0, GetWorldTime().GetYear() - GetYear()) )
-		quality :* Max(0.20, age)
-
+		'quality bonus for recent release: 1.5 for age 0 years, 1.45 for 1 year,...
+		'due to max(0, max) the age factor will always be >= 1
+		Local age:Float = 1 + 0.05 * Max(0, 10 - Max(0, GetWorldTime().GetYear() - GetYear()) )
+		quality :* age
 
 		'the more the programme got repeated, the lower the quality in
-		'that moment (^2 increases loss per air)
+		'that moment (^2 increases loss per air as well as age)
 		'but a "good movie" should benefit from being good - so the
 		'influence of repetitions gets lower by higher raw quality
 		'-> a movie with 100% base quality will have at least 10% of
 		'   quality no matter how many times it got aired
 		quality :* GetQualityRaw() * (0.10 + 0.90 * GetTopicality()^2)
 
-		Return MathHelper.Clamp(quality, 0.01, 1.0)
+		'allow up to 15% bonus for really new AND really good
+		'(most movies do not reach 100% even with a factor of 1.5 for age 0)
+		Return MathHelper.Clamp(quality, 0.01, 1.15)
 	End Method
 
 

--- a/source/game.programme.programmedata.bmx
+++ b/source/game.programme.programmedata.bmx
@@ -1549,7 +1549,7 @@ Type TProgrammeData Extends TBroadcastMaterialSource {_exposeToLua}
 
 		'quality bonus for recent release: 1.5 for age 0 years, 1.45 for 1 year,...
 		'due to max(0, max) the age factor will always be >= 1
-		Local age:Float = 1 + 0.05 * Max(0, 10 - Max(0, GetWorldTime().GetYear() - GetYear()) )
+		Local age:Float = 1 + 0.05 * Max(0, 10 - Max(0, (GetWorldTime().GetTimeGone() - GetReleaseTime())/GetWorldTime().GetYearLength() ))
 		quality :* age
 
 		'the more the programme got repeated, the lower the quality in

--- a/source/game.programme.programmedata.bmx
+++ b/source/game.programme.programmedata.bmx
@@ -1548,6 +1548,8 @@ Type TProgrammeData Extends TBroadcastMaterialSource {_exposeToLua}
 		Local quality:Float = 1.0
 
 		'the older the less ppl want to watch - 1 year = 0.985%, 2 years = 0.97%...
+		'TODO the comment is misleading!!
+		'for age 0 the factor is 1.5, for age 30 the factor is 1.05
 		Local age:Float = 0.015 * Max(0, 100 - Max(0, GetWorldTime().GetYear() - GetYear()) )
 		quality :* Max(0.20, age)
 


### PR DESCRIPTION
Ich denke, es gibt einen schwerwiegenden Fehler in der Qualitätsberechnung. Problem 1 ist, dass das Alter mehrfach in die Berechnung eingeht - einerseits durch den Einfluss auf die MaxTopicality, andererseits als direkter Faktor siehe Commit). Problem 2 ist, dass der direkte Faktor "falsch" ermittelt wird. Bei Alter 1 ist er nämlich nicht 1 wie im Kommentar impliziert sondern 1.5. Warum ist das schlecht? Weil die Gesamtqualität zwischen 0 und 1 liegen muss. Ein komplett neuer Film, dessen Attribute alle 1 sind, hat genauso die Qualität 1 wie ein Film, dessen Attribute 0.8 sind.

Von dem Faktor 1.5 profitieren natürlich insbesondere neue Filme schlechter Qualtität. Eine Reduktion des Faktors auf einen Wert zwischen x und 1 hätte einen riesigen Einfluss auf die Quotenberechnung.

Mögliches Vorgehen:
* Korrektur der Qualitätsberechnung und leichte Anpassung des Einflusses der Qualität in der Quotenberechnung (z.B. grundsätzlich 0.25 auf die Qualität draufaddieren).
* Korrektur der Quotenberechnung und gleichzeitige Anpassung der benötigten Zuschauer bei der Werbung (da es durch die geringere Qualität grundsätzlich weniger Zuschauer gibt)