### PR TITLE
Fix Exception bei Variablenauflösung

### DIFF
--- a/source/game.person.bmx
+++ b/source/game.person.bmx
@@ -891,7 +891,7 @@ Type TPersonPersonalityData Extends TPersonPersonalityBaseData
 		'no dob was given
 		If dod = 0 Then Return Super.IsDead()
 
-		Return GetWorldTime().GetTimeGone() < dod
+		Return GetWorldTime().GetTimeGone() > dod
 	End MEthod
 
 

--- a/source/game.production.scripttemplate.bmx
+++ b/source/game.production.scripttemplate.bmx
@@ -388,7 +388,10 @@ Type TScriptTemplate Extends TScriptBase
 					personString = valueNew.ToString()
 				EndIf
 				Local person:TPersonBase = GetPersonBaseCollection().GetByGUID(personString)
-				If person Then result[i].personID = person.GetId()
+				If person
+					If person.GetPersonalityData() And person.GetPersonalityData().isDead() Then person = Null
+					If person Then result[i].personID = person.GetId()
+				EndIf
 			EndIf
 			result[i] = result[i].Copy()
 			'mark job as "cast preselected"


### PR DESCRIPTION
Beim Auflösen einer vordefinierten Besetzung mag die Sprache für die GUID zwar keine Rolle spielen, aber während des Auflöseprozesses können auch weitere Expressions aufgelöst werden. Für Rollen- und Personenreferenzen spielt die als Parameter übergebene Sprache eine Rolle. -1 führt zu einer Exception.