### PR TITLE
ungenutzte zufällig erzeugter Rollen aufräumen

### DIFF
--- a/source/game.production.script.bmx
+++ b/source/game.production.script.bmx
@@ -93,7 +93,7 @@ Type TScriptCollection Extends TGameObjectCollection
 				Local prc:TProgrammeRoleCollection = GetProgrammeRoleCollection()
 				For Local index:Int = 0 Until roleIDs.length
 					Local role:TProgrammeRole = prc.GetById(roleIDs[index])
-					If role And role.GetGUID().startsWith("rndrole-")
+					If role And role.GetGUID().startsWith("randomprogrammerole-")
 						prc.remove(role)
 					EndIf
 				Next

--- a/source/game.programme.programmerole.bmx
+++ b/source/game.programme.programmerole.bmx
@@ -70,7 +70,7 @@ Type TProgrammeRoleCollection Extends TGameObjectCollection
 		'avoid others of same name
 		GetPersonGenerator().ProtectDataset(pg)
 		'mark role as randomly created for cleanup
-		pr.SetGUID("rndrole-"+pr.GetID())
+		pr.SetGUID("randomprogrammerole-"+pr.GetID())
 		Add(pr)
 		
 		Return pr


### PR DESCRIPTION
Spezielle GUID für zufällig erzeugte Rollen. Damit wäre es später möglich Rollen in Scripten, die für keine Produktion verwendet wurden, wieder zu entfernen.