### PR TITLE
Reparatur Vorauswahl Besetzung; Report scr0llbaer

### DIFF
--- a/source/game.person.base.bmx
+++ b/source/game.person.base.bmx
@@ -1779,7 +1779,7 @@ Type TPersonPersonalityBaseData Extends TPersonBaseData
 
 
 	Method IsDead:Int()
-		Return True
+		Return False
 	End Method
 
 

--- a/source/game.programmeproducer.bmx
+++ b/source/game.programmeproducer.bmx
@@ -400,6 +400,12 @@ Type TProgrammeProducer Extends TProgrammeProducerBase
 
 		'try to find a better fit: equally good but less expensive, better but only slightly more expensive
 		Function OptimizeCast:TPersonBase(currentChoice:TPersonBase, productionConcept:TProductionConcept, job:TPersonProductionJob, jobCountry:String, usedPersonIDs:Int[], castBudget:Int)
+			'if the job has a preselected person - respect that
+			If job.preselectCast And job.personID
+				Local preselected:TPersonBase = GetPersonBaseCollection().GetByID(job.personID)
+				If preselected Then Return preselected
+			EndIf
+
 			'do not replace if insignificant was chosen
 			If currentChoice.IsInsignificant() Then return currentChoice
 			'print "    trying to optimize " + job.job + " currently " + currentChoice.GetFullName()


### PR DESCRIPTION
Da eine Person ohne Todesdatum standardmäßig als tot betrachtet wurde, hat die in der Datenbank konfigurierte Vorauswahl nicht gegriffen. Produktionen innerhalb des Spiels sollen sich auch an diese Vorauswahl halten.

see #1409 