### PR TITLE
[DB] Skip cloning data which gets overridden anyways

### DIFF
--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -1323,7 +1323,7 @@ Type TDatabaseLoader
 				'For a series this means that the episodes' attractivity would be 0.0
 				'for all target groups due to default struct values.
 				If parentLicence 
-					programmeData = TProgrammeData(THelper.CloneObject(parentLicence.data, ["id", "targetGroupAttractivityMod"]))
+					programmeData = TProgrammeData(THelper.CloneObject(parentLicence.data, ["id", "guid", "targetgroupattractivitymod", "title", "description", "titleprocessed", "descriptionprocessed"]))
 				EndIf
 				'if failed, create new data
 				If Not programmeData Then programmeData = New TProgrammeData
@@ -1772,7 +1772,7 @@ Type TDatabaseLoader
 		If Not scriptTemplate
 			'try to clone the parent, if that fails, create a new instance
 			If parentScriptTemplate
-				scriptTemplate = TScriptTemplate(THelper.CloneObject(parentScriptTemplate, ["id","guid","jobs"]))
+				scriptTemplate = TScriptTemplate(THelper.CloneObject(parentScriptTemplate, ["id", "guid", "jobs", "templatevariables", "subscripts", "title", "description"]))
 				'#440 optional flags are not propagated to episode templates
 				scriptTemplate.flagsOptional = 0
 				'jobs must not be cloned, the same instances must be used for all templates, so that random roles are propagated


### PR DESCRIPTION
Fixes #1408 by not cloning objects which are overridden just a moment later.