### PR TITLE
Beim Datenbankeinlesen castable passend zur aktuellen Verwendung setzen

### DIFF
--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -647,18 +647,18 @@ Type TDatabaseLoader
 
 			person.SetFlag(TVTPersonFlag.FICTIONAL, True)
 		EndIf
+		Local castable:Int = -1
+		Local fictional:Int = -1
 
 		'override with given ones
 		person.firstName = xml.FindValue(node, "first_name", person.firstName)
 		person.lastName = xml.FindValue(node, "last_name", person.lastName)
 		person.nickName = xml.FindValue(node, "nick_name", person.nickName)
 		person.title = xml.FindValue(node, "title", person.title)
-		person.SetFlag(TVTPersonFlag.FICTIONAL, GetBool(xml.FindValue(node, "fictional"), person.IsFictional()))
+		fictional = GetBool(xml.FindValue(node, "fictional"), fictional)
 		'fallback for old database syntax
-		person.SetFlag(TVTPersonFlag.CASTABLE, GetBool(xml.FindValue(node, "bookable"), person.IsCastable()))
-		person.SetFlag(TVTPersonFlag.CASTABLE, GetBool(xml.FindValue(node, "castable"), person.IsCastable()))
-		'cast filtering is mainly done using the bookable flag - not castable implies not bookable
-		If Not person.IsCastable() Then person.SetFlag(TVTPersonFlag.BOOKABLE, false )
+		castable = GetBool(xml.FindValue(node, "bookable"), castable)
+		castable = GetBool(xml.FindValue(node, "castable"), castable)
 		person.SetFlag(TVTPersonFlag.CAN_LEVEL_UP, GetBool(xml.FindValue(node, "levelup"), person.CanLevelUp()))
 		person.SetJob(xml.FindValueInt(node, "job", 0)) 'for now it must be defined all time, else: ", person._jobs))"
 		person.countryCode = xml.FindValue(node, "country", person.countryCode).ToUpper()
@@ -693,7 +693,7 @@ Type TDatabaseLoader
 			pd.SetDayOfBirth( xml.FindValue(nodeDetails, "birthday", pd.dayOfBirth) )
 			pd.SetDayOfDeath( xml.FindValue(nodeDetails, "deathday", pd.dayOfDeath) )
 			person.SetJob( xml.FindValueInt(nodeDetails, "job", person.GetJobs()) )
-			person.SetFlag(TVTPersonFlag.FICTIONAL, xml.FindValueInt(nodeDetails, "fictional", person.IsFictional()) )
+			fictional = xml.FindValueInt(nodeDetails, "fictional", fictional)
 			person.faceCode = xml.FindValue(nodeDetails, "face_code", person.faceCode)
 
 			'=== DATA ===
@@ -799,6 +799,19 @@ Type TDatabaseLoader
 				pd.CreatePopularity(popularityValue, popularityTargetValue, person)
 			EndIf
 		EndIf
+
+		'fictional can be defined in two places - set flag only at the very end
+		If fictional > 0 Then person.SetFlag(TVTPersonFlag.FICTIONAL, True)
+		If castable >= 0
+			'castable was explicitly defined (fictional OR real)
+			person.SetFlag(TVTPersonFlag.CASTABLE, castable)
+		Else
+			'make only fictional persons castable by default
+			'general support for real persons requires further changes
+			person.SetFlag(TVTPersonFlag.CASTABLE, person.IsFictional())
+		EndIf
+		'cast filtering is mainly done using the bookable flag - not castable implies not bookable
+		If Not person.IsCastable() Then person.SetFlag(TVTPersonFlag.BOOKABLE, false )
 
 
 		'=== ADD TO COLLECTION ===

--- a/source/game.gamerules.bmx
+++ b/source/game.gamerules.bmx
@@ -24,6 +24,9 @@ Type TGameRules {_exposeToLua}
 	'how many production concepts could be "planned" at the same time
 	'(per script - for series and shows ...)
 	Field maxProductionConceptsPerScript:int = 8
+	'in current database real persons are not castable - change db at your own risk
+	'currently no DEV.xml switch implemented
+	Field castOnlyFictional:Int = False
 	
 	'(game)time until a news genre subscription increase gets "fixed"
 	Field newsSubscriptionIncreaseFixTime:Int = 30 * 60 * 1000 '30 Minutes
@@ -117,6 +120,7 @@ Type TGameRules {_exposeToLua}
 		adContractInstancesMax = 1
 		adContractsPerPlayerMax = 12
 		adContractRandomize = 0
+		castOnlyFictional = False
 	End Method
 
 

--- a/source/game.production.productionmanager.bmx
+++ b/source/game.production.productionmanager.bmx
@@ -483,13 +483,13 @@ Type TProductionManager
 		Local amountWithoutJob:Int = (amateursToInclude * 3) / 10
 		if amateursToInclude > 1 then amountWithoutJob :+ 1
 
-		local amateursWithJob:TPersonBase[] = GetPersonBaseCollection().GetRandomCastableInsignificants(currentAvailableAmateurs, amateursToInclude - amountWithoutJob, True, True, filtertoJobID, filterToGenderID, True, "", null)
+		local amateursWithJob:TPersonBase[] = GetPersonBaseCollection().GetRandomCastableInsignificants(currentAvailableAmateurs, amateursToInclude - amountWithoutJob, GameRules.castOnlyFictional, True, filtertoJobID, filterToGenderID, True, "", null)
 		local amateursWithJobIDs:Int[] = new Int[amateursWithJob.length]
 		For local i:int = 0 until amateursWithJob.length
 			amateursWithJobIDs[i] = amateursWithJob[i].id
 		Next
 		'no job restrictions but other persons than the ones with job
-		local amateursWithoutJob:TPersonBase[] = GetPersonBaseCollection().GetRandomCastableInsignificants(currentAvailableAmateurs, amountWithoutJob, True, True, 0, filterToGenderID, True, "", null, amateursWithJobIDs)
+		local amateursWithoutJob:TPersonBase[] = GetPersonBaseCollection().GetRandomCastableInsignificants(currentAvailableAmateurs, amountWithoutJob, GameRules.castOnlyFictional, True, 0, filterToGenderID, True, "", null, amateursWithJobIDs)
 
 
 		For local i:int = 0 until amateursWithJob.length + amateursWithoutJob.length
@@ -501,10 +501,8 @@ Type TProductionManager
 			endif
 			
 			If amateur
-				'custom production not possible with real persons...
-				'also the person must be bookable for productions (maybe retired?)
+				'the person must be bookable for productions (maybe retired?)
 				If Not amateur.IsAlive() Then continue
-				If Not amateur.IsFictional() Then continue
 				if Not amateur.IsBookable() Then continue
 
 				if not amateur.HasJob(filterToJobID) and amateur.GetJobCount() >= 4 then continue 
@@ -527,7 +525,7 @@ Type TProductionManager
 		Local personsList:TObjectList = GetPersonBaseCollection().GetCastableCelebritiesList()
 		For Local person:TPersonBase = EachIn personsList
 			'custom production not possible with real persons...
-			If Not person.IsFictional() Then Continue
+			If GameRules.castOnlyFictional And Not person.IsFictional() Then Continue
 			'also the person must be bookable for productions (maybe retired?)
 			If Not person.IsBookable() Then Continue
 			If Not person.IsAlive() Then Continue

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -2430,7 +2430,7 @@ Type TSaveGame Extends TGameState
 	Field _Time_timeGone:Long = 0
 	Field _Entity_globalWorldSpeedFactor:Float =  0
 	Field _Entity_globalWorldSpeedFactorMod:Float =  0
-	Const SAVEGAME_VERSION:int = 24
+	Const SAVEGAME_VERSION:int = 25
 	Const MIN_SAVEGAME_VERSION:Int = 23
 	Global messageWindow:TGUIModalWindow
 	Global messageWindowLastUpdate:Long
@@ -2813,6 +2813,20 @@ Type TSaveGame Extends TGameState
 				EndIf
 				'print v.GetVariablesAsText()
 			EndIf
+		EndIf
+		If savegameVersion < 25
+			Local count:Int=0
+			For Local p:TPersonBase = EachIn GetPersonBaseCollection().entries.Values()
+				If Not p.IsFictional() And p.IsCastable()
+					p.setFlag(TVTPersonFlag.CASTABLE, False)
+					p.setFlag(TVTPersonFlag.BOOKABLE, False)
+					count:+1
+				EndIf
+			Next
+			GetPersonBaseCollection()._UpdateFiltered(TPersonBaseCollection.FILTER_CASTABLE)
+			GetPersonBaseCollection()._UpdateFiltered(TPersonBaseCollection.FILTER_CASTABLE_INSIGNIFICANT)
+			GetPersonBaseCollection()._UpdateFiltered(TPersonBaseCollection.FILTER_CASTABLE_CELEBRITY)
+			TLogger.Log("RepairData", "Set " + count + " regular, real persons to not castable.")
 		EndIf
 		If savegameVersion < 24
 			For local ac:TAdContractBase = EachIn GetAdContractBaseCollection().entries.Values()


### PR DESCRIPTION
Durch den Konstruktor von Person ist jede Person zunächst castable. Nur wenn in der Datenbank explizit 0 steht, wird das Flag entfernt. Damit sind die über 10000 realen Personen grundsätzlich verfügbar (und werden nur über fictional rausgefiltert). Zudem kann fictional an zwei Stellen in der Datenbank gesetzt werden.

Änderungsvorschlag ist daher, dass die Werte zunächst in einer Variablen gespeichert werden und die Flags erst ganz am Ende gesetzt werden. Falls kein Wert explizit definiert wurde, werden reale Personen auf not castable gesetzt.