### PR TITLE
Studiotooltip zu laufender Produktion nur dem Besitzer anzeigen

### DIFF
--- a/source/game.game.bmx
+++ b/source/game.game.bmx
@@ -1355,6 +1355,8 @@ endrem
 
 		'switch active TV channel to player
 		GetInGameInterface().ShowChannel = GetPlayerCollection().playerID
+		'event listener for room tooltip might be initialized too late - set directly
+		TRoomDoorTooltip.observerID = GetPlayerCollection().playerID
 
 
 		Function EmitPrepareStepEvent(percentageStart:Int, percentageNext:Int, stepData:TData, userData:Object = Null)
@@ -2083,6 +2085,8 @@ endrem
 		'also set this information for the boss collection (avoids
 		'circular references)
 		GetPlayerBossCollection().playerID = ID
+		'event listener for room tooltip might be initialized too late - set directly
+		TRoomDoorTooltip.observerID = ID
 
 		TriggerBaseEvent(GameEventKeys.Game_onSetActivePlayer, New TData.AddInt("playerID", ID).AddInt("oldPlayerID", oldPlayerID) )
 

--- a/source/game.room.roomdoor.tooltip.bmx
+++ b/source/game.room.roomdoor.tooltip.bmx
@@ -5,6 +5,7 @@ Import "game.room.base.bmx"
 
 Type TRoomDoorTooltip extends TTooltip
 	Field roomID:int
+	Global observerID:Int = -1;
 
 	Function Create:TRoomDoorTooltip(title:String = "", content:String = "unknown", x:Int = 0, y:Int = 0, w:Int = -1, h:Int = -1, lifetime:Int = 300)
 		local obj:TRoomDoorTooltip = new TRoomDoorTooltip
@@ -76,18 +77,21 @@ Type TRoomDoorTooltip extends TTooltip
 			if newContent<>"" then newContent :+ "~n"
 
 			if room.blockedUntilShownInTooltip
-				'add blocked message
-				local endTime:string = room.GetBlockedUntilTimeText()
-
-				if room.blockedState & TRoomBase.BLOCKEDSTATE_SHOOTING > 0
-					newContent :+ GetLocale("SHOOTING_IN_PROGRESS") + "~n"
-					if room.blockedText then newContent :+ "|b|"+room.blockedText + "|/b|~n"
-				elseif room.blockedState & TRoomBase.BLOCKEDSTATE_PREPRODUCTION > 0
-					newContent :+ GetLocale("PREPRODUCTION_IN_PROGRESS") + "~n"
-					if room.blockedText then newContent :+ "|b|"+room.blockedText + "|/b|~n"
-				endif
-
-				newContent :+ GetLocale("BLOCKED_UNTIL_TIME").Replace("%TIME%", endTime)
+				'show studio blocked message only to room owner
+				If tooltipimage <> 5 OR observerID = room.owner
+					'add blocked message
+					local endTime:string = room.GetBlockedUntilTimeText()
+	
+					if room.blockedState & TRoomBase.BLOCKEDSTATE_SHOOTING > 0
+						newContent :+ GetLocale("SHOOTING_IN_PROGRESS") + "~n"
+						if room.blockedText then newContent :+ "|b|"+room.blockedText + "|/b|~n"
+					elseif room.blockedState & TRoomBase.BLOCKEDSTATE_PREPRODUCTION > 0
+						newContent :+ GetLocale("PREPRODUCTION_IN_PROGRESS") + "~n"
+						if room.blockedText then newContent :+ "|b|"+room.blockedText + "|/b|~n"
+					endif
+	
+					newContent :+ GetLocale("BLOCKED_UNTIL_TIME").Replace("%TIME%", endTime)
+				EndIf
 			else if room.blockedState & TRoomBase.BLOCKEDSTATE_NO_OFFICE_HOUR > 0
 				newContent :+ GetLocale("BLOCKED_NO_OFFICE_HOUR")
 			else


### PR DESCRIPTION
closes #1441

Ich habe absichtlich die Billigvariaten genommen und bin nicht über Events gegangen. Für das erste Setzen des Spielers wird kein Event erzeugt und der Listener müsste frühzeitig registriert werden, da der Tooltoü überhaupt erst beim Hover erzeugt wird. Die dafür nötigen Änderungen sind viel umfangreicher, als das direkte Setzen für eine Klasse, die an der Stelle sowieso schon verfügbar ist.