### PR TITLE
Tastenkürzel für's Öffnen der Programmauswahl

### DIFF
--- a/source/common.misc.plannerlist.base.bmx
+++ b/source/common.misc.plannerlist.base.bmx
@@ -7,6 +7,8 @@ Import "game.gameobject.bmx"
 Type TPlannerList extends TOwnedGameObject
 	'0=enabled 1=openedgenres 2=openedmovies 3=openedepisodes = 1
 	Field openState:Int = 0
+	Field maxOpenState:Int = 0 {nosave}
+	Field lastCurrentGenre:Int = 0 {nosave}
 	Field currentGenre:Int =-1
 	Field enabled:Int = 0
 	Field Pos:TVec2D = New TVec2D()

--- a/source/common.misc.plannerlist.programmelist.bmx
+++ b/source/common.misc.plannerlist.programmelist.bmx
@@ -1068,6 +1068,7 @@ Type TgfxProgrammelist Extends TPlannerList
 
 		'react to right click
 		If openState > 0 and MOUSEMANAGER.IsClicked(2)
+			maxOpenState:-1
 			SetOpen( Max(0, openState - 1) )
 
 			'avoid clicks
@@ -1095,10 +1096,24 @@ Type TgfxProgrammelist Extends TPlannerList
 	End Method
 
 
+	'quickly open with the last genre selcted
+	Method setOpenLastState:Int()
+		If openState <= 0
+			If maxOpenState > 0
+				SetOpen(Math.Min(2,maxOpenState))'do not open episodes
+				currentGenre = lastCurrentGenre
+			Else
+				SetOpen(1)
+			EndIf
+		EndIf
+	End Method
+
+
 	Method SetOpen:Int(newState:Int)
 		newState = Max(0, newState)
 		' Genreauswahlseite - kein Genre gewählt, Filmseite zurücksetzen
 		If newState <= 1
+			If newState = 0 And currentgenre > 0 Then lastCurrentGenre = currentGenre
 			currentgenre=-1
 			entriesPage = 1
 		EndIf
@@ -1111,7 +1126,7 @@ Type TgfxProgrammelist Extends TPlannerList
 			'(Bei Wechsel zwischen zwei Serien nicht auf Seite 2 bleiben)
 			subEntriesPage = 1
 		EndIf
-
+		If newState > maxOpenState Then maxOpenState = newState
 		Self.openState = newState
 	End Method
 

--- a/source/game.roomhandler.archive.bmx
+++ b/source/game.roomhandler.archive.bmx
@@ -481,7 +481,7 @@ Type RoomHandler_Archive extends TRoomHandler
 			programmeList.clicksAllowed = True
 			GuiListSuitcase.setOption(GUI_OBJECT_CLICKABLE, True)
 
-			If programmeList.openState <=0 And KeyManager.IsHit(KEY_Y)
+			If programmeList.openState <=0 And Not draggedGuiProgrammeLicence And KeyManager.IsHit(KEY_Y)
 				programmeList.setOpenLastState()
 			EndIf
 		Else

--- a/source/game.roomhandler.archive.bmx
+++ b/source/game.roomhandler.archive.bmx
@@ -480,7 +480,10 @@ Type RoomHandler_Archive extends TRoomHandler
 			'enable List interaction
 			programmeList.clicksAllowed = True
 			GuiListSuitcase.setOption(GUI_OBJECT_CLICKABLE, True)
-			'enable List interaction
+
+			If programmeList.openState <=0 And KeyManager.IsHit(KEY_Y)
+				programmeList.setOpenLastState()
+			EndIf
 		Else
 			programmeList.clicksAllowed = False
 			GuiListSuitcase.setOption(GUI_OBJECT_CLICKABLE, False)

--- a/source/game.screen.programmeplanner.bmx
+++ b/source/game.screen.programmeplanner.bmx
@@ -1546,6 +1546,10 @@ endrem
 			PPprogrammeList.clicksAllowed = True
 			PPcontractList.clicksAllowed = True
 			GuiListProgrammes.setOption(GUI_OBJECT_CLICKABLE, True)
+
+			If PPprogrammeList.openState <=0 And KeyManager.IsHit(KEY_Y)
+				PPprogrammeList.setOpenLastState()
+			EndIf
 		Else
 			'disable List interaction
 			PPprogrammeList.clicksAllowed = False

--- a/source/game.screen.programmeplanner.bmx
+++ b/source/game.screen.programmeplanner.bmx
@@ -1547,8 +1547,9 @@ endrem
 			PPcontractList.clicksAllowed = True
 			GuiListProgrammes.setOption(GUI_OBJECT_CLICKABLE, True)
 
-			If PPprogrammeList.openState <=0 And KeyManager.IsHit(KEY_Y)
+			If PPprogrammeList.openState <=0 And PPcontractList.openState<=0 And Not draggedGuiProgrammePlanElement And KeyManager.IsHit(KEY_Y)
 				PPprogrammeList.setOpenLastState()
+				GetGameBase().SetCursor(TGameBase.CURSOR_INTERACT)
 			EndIf
 		Else
 			'disable List interaction

--- a/source/main.bmx
+++ b/source/main.bmx
@@ -1131,6 +1131,7 @@ Type TApp
 
 			If KeyManager.IsHit(KEY_Y)
 				'your own dev-debug-code
+				'y is used in archive and programme planner for opening programme selection
 			EndIf
 
 


### PR DESCRIPTION
Im Programmplaner und im Archiv will man typischerweise mehrfach hintereinander Programme auswählen - zur Programmplanung oder zum Aussortieren von Altprogrammen. Aktuell muss man für das Öffnen der Auswahl entweder den Button oder den Archivar anklicken.
Hier ein Proof of Concept für ein Tastenkürzel, dass die Auswahl erneut mit dem zuletzt gewählten Genre öffnet.