### PR TITLE
Misc: avoid object creation for temporary data

### DIFF
--- a/source/Dig/base.util.persongenerator.bmx
+++ b/source/Dig/base.util.persongenerator.bmx
@@ -42,7 +42,7 @@ Type TPersonGenerator
 	End Method
 
 
-	Method GetUniqueDataset:TPersonGeneratorEntry(countryCode:string, gender:int)
+	Method GetUniqueDataset:SPersonGeneratorEntry(countryCode:string, gender:int)
 		local provider:TPersonGeneratorCountry = GetProvider(countryCode)
 		if gender = 0 then gender = RandRange(1, 2) 'male or female
 
@@ -52,7 +52,7 @@ Type TPersonGenerator
 			lastName = provider.GetLastName(gender)
 		Until firstName and lastName and not protectedNames.Contains(firstName.ToLower()+"|"+lastName.ToLower())
 
-		local person:TPersonGeneratorEntry = new TPersonGeneratorEntry
+		local person:SPersonGeneratorEntry
 		person.firstName = firstName
 		person.lastName = lastName
 		person.gender = gender
@@ -65,7 +65,7 @@ Type TPersonGenerator
 	End Method
 
 
-	Method GetUniqueDatasetFromString:TPersonGeneratorEntry(config:string)
+	Method GetUniqueDatasetFromString:SPersonGeneratorEntry(config:string)
 		local parts:string[] = config.split(",")
 		local countries:string[] = parts[0].split(" ")
 		local gender:int = GENDER_MALE
@@ -175,8 +175,8 @@ Type TPersonGenerator
 	End Method
 
 
-	Method ProtectDataset:TPersonGenerator(set:TPersonGeneratorEntry)
-		protectedNames.insert(set.firstName.ToLower()+"|"+set.lastName.ToLower(), "1")
+	Method ProtectDataset:TPersonGenerator(p:SPersonGeneratorEntry var)
+		protectedNames.insert(p.firstName.ToLower()+"|"+p.lastName.ToLower(), "1")
 	End Method
 
 
@@ -219,7 +219,7 @@ End Function
 
 
 
-Type TPersonGeneratorEntry
+Struct SPersonGeneratorEntry
 	Field firstName:string
 	Field lastName:string
 	Field prefix:string
@@ -227,7 +227,7 @@ Type TPersonGeneratorEntry
 	Field title:string
 	Field gender:int
 	Field countryCode:string
-End Type
+End Struct
 
 
 

--- a/source/game.database.bmx
+++ b/source/game.database.bmx
@@ -633,7 +633,7 @@ Type TDatabaseLoader
 
 		'=== COMMON DETAILS ===
 		Local generator:String = xml.FindValue(node, "generator")
-		Local p:TPersonGeneratorEntry
+		Local p:SPersonGeneratorEntry
 		If generator
 			p = GetPersonGenerator().GetUniqueDatasetFromString(generator)
 			If p
@@ -1552,14 +1552,13 @@ Type TDatabaseLoader
 						Local parts:String[] = memberGenerator.Split(",")
 						Local levelUp:Int = False
 						If parts.length >= 3 And Int(parts[2]) = 1 Then levelUp = True
-						Local p:TPersonGeneratorEntry = GetPersonGenerator().GetUniqueDatasetFromString(memberGenerator)
-						If p
-							'avoid that other persons with that name are generated
-							GetPersonGenerator().ProtectDataset(p)
-							member.firstName = p.firstName
-							member.lastName = p.lastName
-							member.countryCode = p.countryCode.ToUpper()
-						EndIf
+						Local p:SPersonGeneratorEntry = GetPersonGenerator().GetUniqueDatasetFromString(memberGenerator)
+
+						'avoid that other persons with that name are generated
+						GetPersonGenerator().ProtectDataset(p)
+						member.firstName = p.firstName
+						member.lastName = p.lastName
+						member.countryCode = p.countryCode.ToUpper()
 					EndIf
 
 

--- a/source/game.newsagency.sports.bmx
+++ b/source/game.newsagency.sports.bmx
@@ -231,7 +231,7 @@ Type TNewsEventSport Extends TGameObject
 			Local cCode:String = "de"
 			If RandRange(0, 10) < 3 Then cCode = countryCodes[ RandRange(0, countryCodes.length-1) ]
 
-			Local p:TPersonGeneratorEntry = GetPersonGenerator().GetUniqueDataset(cCode, TPersonGenerator.GENDER_MALE)
+			Local p:SPersonGeneratorEntry = GetPersonGenerator().GetUniqueDataset(cCode, TPersonGenerator.GENDER_MALE)
 			Local member:TPersonBase = New TPersonBase( p.firstName, p.lastName, p.countryCode, p.gender, True)
 			'assume 50% are not interested in TV shows / custom productions
 			If RandRange(0, 100) < 50

--- a/source/game.newsagency.sports.icehockey.bmx
+++ b/source/game.newsagency.sports.icehockey.bmx
@@ -204,7 +204,7 @@ Type TNewsEventSport_IceHockey extends TNewsEventSport
 					local cCode:string = "de"
 					if RandRange(0, 10) < 3 then cCode = countryCodes[ RandRange(0, countryCodes.length-1) ]
 
-					local p:TPersonGeneratorEntry = GetPersonGenerator().GetUniqueDataset(cCode, TPersonGenerator.GENDER_MALE)
+					local p:SPersonGeneratorEntry = GetPersonGenerator().GetUniqueDataset(cCode, TPersonGenerator.GENDER_MALE)
 					local member:TPersonBase = new TPersonBase( p.firstName, p.lastName, p.countryCode, p.gender, True)
 					'assume 50% are not interested in TV shows / custom productions
 					If RandRange(0, 100) < 50

--- a/source/game.newsagency.sports.soccer.bmx
+++ b/source/game.newsagency.sports.soccer.bmx
@@ -163,7 +163,7 @@ Type TNewsEventSport_Soccer Extends TNewsEventSport
 					Local cCode:String = "de"
 					If RandRange(0, 10) < 3 Then cCode = countryCodes[ RandRange(0, countryCodes.length-1) ]
 
-					Local p:TPersonGeneratorEntry = GetPersonGenerator().GetUniqueDataset(cCode, TPersonGenerator.GENDER_MALE)
+					Local p:SPersonGeneratorEntry = GetPersonGenerator().GetUniqueDataset(cCode, TPersonGenerator.GENDER_MALE)
 					Local member:TPersonBase = New TPersonBase( p.firstName, p.lastName, p.countryCode, p.gender, True)
 					'assume 50% are not interested in TV shows / custom productions
 					If RandRange(0, 100) < 50

--- a/source/game.person.base.bmx
+++ b/source/game.person.base.bmx
@@ -93,8 +93,7 @@ Type TPersonBaseCollection Extends TGameObjectCollection
 	
 
 	Method CreateRandom:TPersonBase(countryCode:String, gender:Int=0)
-		Local pg:TPersonGeneratorEntry = GetPersonGenerator().GetUniqueDataset(countryCode, gender)
-		If Not pg Then Return Null
+		Local pg:SPersonGeneratorEntry = GetPersonGenerator().GetUniqueDataset(countryCode, gender)
 
 		Local person:TPersonBase = New TPersonBase
 

--- a/source/game.programme.programmerole.bmx
+++ b/source/game.programme.programmerole.bmx
@@ -57,8 +57,7 @@ Type TProgrammeRoleCollection Extends TGameObjectCollection
 	
 	
 	Method CreateRandomRole:TProgrammeRole(countryCode:String, gender:Int)
-		Local pg:TPersonGeneratorEntry = GetPersonGenerator().GetUniqueDataset(countryCode, gender)
-		If Not pg Then Return Null
+		Local pg:SPersonGeneratorEntry = GetPersonGenerator().GetUniqueDataset(countryCode, gender)
 
 		Local pr:TProgrammeRole = New TProgrammeRole
 		pr.firstName = pg.firstName


### PR DESCRIPTION
Ich habe mal einige Aenderungen aus meinem lokalen "determinism"-Branch extrahiert (die unabhaengig davon laufen).

mit dem PR werden einige temporaere Objekterstellungen eingespart.


Wenn gewuenscht, mache ich aus der "map" auch noch eine "Stringmap" (case insensitive-Version).